### PR TITLE
mutability-conditionals 1/7: data/compute kinds, conditional collections (coproducts), Case-arm joins, kind inference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,8 @@ Vocabulary, matching `src/ccl/symbolic.rs`:
 
 Types (from `Display for Type` in `src/ccl/mod.rs`):
 
-- **Function**: `(T ⇒ U)`.
+- **Function**: `(T ⇒ U)` for a compute function (capability domain); `(T ⤇ U)` (plain-text `|=>`) for a data function (extent domain — the domain is the data map, joins must be lossless). Kind is inferred by the solver (`FunKind::Var`, resolved at coalesce — see `src/ccl/design/type-inference.md` §4.6) and `Display` renders it live: a data collection shows `⤇`, a capability (and an unresolved kind var) `⇒`. One benign quirk — a comprehension *body* over a **let-bound** source (its extent domain is only reconstructed after coalesce, so the kind var resolves to the conservative `⇒`) can display `⇒` though it denotes a collection: `let x = [1,2,3] in [y + 10 for y in x]` renders `⇒`, while the same comprehension over a literal source renders `⤇`. The denotation is identical; only the displayed arrow differs (aggregate uses still force `Data`, so nothing miscompiles).
+- **Sigma** (in-flight, same stack): `Σ{D0, D1} ⤇ V` — a data function whose extent is exactly one of the listed choices; with a live witness binder, `(Σ n ∈ {D0, D1}. n ⤇ V)`.
 - **Refinement**: `{T | predicate}` — predicate is rendered via `symbolic`.
 - **UIntRange**: `[0, N]`, or `∅` when empty.
 - **Hole**: `_`.
@@ -134,6 +135,7 @@ Use the symbolic forms below in prose and inline pseudo-code (not in fenced code
 
 - **Function type with named binder** (`Type::Fun` with `name: Some(_)`): `(𝑥: 𝐴) ⇒ 𝐵`. `𝑥` is bound in `𝐵`.
 - **Function type with no named binder** (`Type::Fun` with `name: None`): `𝐴 ⇒ 𝐵`.
+- **Data function type** (`FunKind::Data`, kind inferred and rendered live): `𝐴 ⤇ 𝐵`, named-binder form `(𝑥: 𝐴) ⤇ 𝐵` — same associativity as `⇒`; the bar reads "the domain is a fixed extent". **Σ type** (formation live; witness binder still dormant): `Σ 𝑛 ∈ {𝐷₀, 𝐷₁}. 𝑛 ⤇ 𝑉` — a dependent sum over candidate extents; anonymous-witness shorthand `Σ{𝐷₀, 𝐷₁} ⤇ 𝑉`.
 - **Refinement type**: `{𝑥: 𝑇 | 𝑝(𝑥)}` — standard subset-type notation.
 - **Lambda** (term): `λ 𝑥 → body`. The `→` after the binder separates the parameter from the body.
 - **Forward apply** (term level): `𝑎 ▷ 𝑓` means `𝑓(𝑎)`.

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -298,8 +298,14 @@ pub fn cast_target_refinement(target: &Type) -> Option<Refinement> {
 ///
 /// `base_domain` and `codomain` are typically `Type::Hole` at lowering time;
 /// inference fills them in by unifying against the value being cast.
+///
+/// The result is a **data** function (`⤇`): the refined domain is a filtered
+/// *extent* the runtime iterates, so the cast target must carry `Data` kind —
+/// a filtered collection flows into aggregates and joins, which demand `Data`.
+/// Building it as `Compute` would trip the `Compute <: Data` rejection at every
+/// filtered comprehension / groupby.
 pub fn refined_fn_type(base_domain: Type, predicate: Expr, codomain: Type) -> Type {
-    Type::fun(
+    Type::data_fun(
         Type::Refinement(
             Box::new(base_domain),
             Refinement {
@@ -320,14 +326,8 @@ pub(crate) fn strip_refinements(ty: &Type) -> Type {
     match ty {
         Type::Refinement(base, _) => strip_refinements(base),
         Type::Fun {
-            name,
-            domain,
-            codomain,
-        } => Type::Fun {
-            name: name.clone(),
-            domain: Box::new(strip_refinements(domain)),
-            codomain: Box::new(strip_refinements(codomain)),
-        },
+            domain, codomain, ..
+        } => Type::fun_like(ty, strip_refinements(domain), strip_refinements(codomain)),
         Type::Tuple(ts) => Type::Tuple(ts.iter().map(strip_refinements).collect()),
         Type::Record(fs) => Type::Record(
             fs.iter()

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -348,12 +348,17 @@ pub(crate) fn strip_refinements(ty: &Type) -> Type {
             domain: Box::new(strip_refinements(domain)),
             kind: *kind,
         },
+        Type::Sigma(s) => Type::Sigma(Box::new(crate::ccl::ty::SigmaType {
+            witness: s.witness.map_types(strip_refinements),
+            body: Box::new(strip_refinements(&s.body)),
+        })),
         Type::Base(_)
         | Type::UIntRange(_)
         | Type::Hole
         | Type::Infer(_)
         | Type::DataSource(_)
         | Type::ChanDom(..)
+        | Type::Witness
         | Type::Txn => ty.clone(),
     }
 }

--- a/src/ccl/channelize.rs
+++ b/src/ccl/channelize.rs
@@ -691,6 +691,8 @@ fn erase_chan_domains_in_type(ty: &mut Type, map: &HashMap<Name, Type>) {
         let value = std::mem::replace(value.as_mut(), Type::Hole);
         *ty = Type::Fun {
             name: None,
+            // A feed channel is a collection stream: erase History → a data function.
+            kind: crate::ccl::ty::FunKind::Data,
             domain: Box::new(domain),
             codomain: Box::new(value),
         };
@@ -826,16 +828,12 @@ fn assert_no_type_residue(expr: &Expr) {
 fn refine_source_domain(source: &mut Expr, refinement: Refinement, ctx: &DesugarCtx) {
     if ctx.input_typed
         && let Type::Fun {
-            name,
-            domain,
-            codomain,
+            domain, codomain, ..
         } = &source.ty
     {
-        source.ty = Type::Fun {
-            name: name.clone(),
-            domain: Box::new(Type::Refinement(domain.clone(), refinement)),
-            codomain: codomain.clone(),
-        };
+        let refined_domain = Type::Refinement(domain.clone(), refinement);
+        let codomain = (**codomain).clone();
+        source.ty = Type::fun_like(&source.ty, refined_domain, codomain);
         return;
     }
     // A typed-order channel source is always a concrete function type, stamped
@@ -2842,6 +2840,7 @@ mod tests {
             node: TypedExprNode::Lit(Lit::Unit),
             ty: Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Compute,
                 domain: Box::new(Type::Refinement(Box::new(Type::Hole), refinement)),
                 codomain: Box::new(Type::Hole),
             },

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -507,6 +507,8 @@ pub fn compile_program(
             &name,
             Type::Fun {
                 name: None,
+                // A registered data source is a collection: a data function.
+                kind: crate::ccl::ty::FunKind::Data,
                 domain: Box::new(Type::DataSource(name.clone())),
                 codomain: Box::new(output_type),
             },

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -413,6 +413,193 @@ The expected binder is **always globally fresh** (proposal §5.2 verbatim; the �
 
 The pipeline passes downstream of inference treat function types structurally and compare modulo the Pi binder (`Type::without_pi_names`). **Refinement-predicate compilation is deferred out of lambda-elim** (proposal §6.3): predicates ride through inference and lambda-elim in their bare pointful form (a bare boolean over the implicit `REFINEMENT_BINDER`), and **planning** compiles them. Order matters: the group-by / hash-join recognizers run *first*, on the bare form — compiling first would destroy the pointful shapes they match (see the pointful-join-recognizers plan) — and `planning::compile_refinement_predicates` then runs the lambda-elim → simplify sub-pipeline on each remaining predicate (keyed by predicate `Rc` identity) before the generic `iterate`/`restrict` lowering consumes it. This is what lets a refined collection — including a group-by over a *filtered* source (`[sum(x) for x in groupby([y+10 for y in xs if y<6], key)]`) — compile to a runtime `Restrict`/`Filter` rather than reaching op-conversion as an un-compiled predicate. Single-key dependent lookups (`sum(groupby(xs, key)(k))`) and the nested filtered-source group-by both run end-to-end with correct values.
 
+## 4.6 Data vs compute functions and coproduct extent joins
+
+> **Status: implemented.** The `FunKind` marker, lossless coproduct formation at
+> control-flow joins, *and* kind-aware subtyping (the `Compute<:Data` rejection)
+> are all live. One guard is deferred with rationale (Data-domain invariance —
+> see the callout below), and the value-`Case` elimination bridges land in the
+> value-`Case` compilation PR.
+>
+> **Not a dependent sum.** A conditional collection is a **coproduct** — a
+> finite, `Index`-tagged [`Type::Variant`] of data functions built by
+> `Type::extent_coproduct`. A finite, static set of branches needs no witness (a
+> finite Σ degenerates to a coproduct), so there is no `Type::Sigma` here; a
+> genuine dependent Σ (over a runtime/opaque witness — a `List` length, a `Map`
+> key extent) is a separate construct introduced with the collections work,
+> where the witness is real.
+
+The unresolved extent-join corner of §4.5 (O1/O4 — two collections meeting at
+one join point) is resolved by making a missing distinction explicit and
+representing the join as a coproduct of data functions (the finite, non-dependent
+sum — a plain `Variant`).
+
+**The distinction.** A function's domain can mean two things. A **compute
+function** `α ⇒ β` treats it as a *capability* — the inputs accepted; no data
+behind it; shrinking under-promises, so the lossy contravariant meet at a
+join is fine. A **data function** `α ⤇ β` treats it as an *extent* — the
+domain *is* the data map, so a lossy domain is lost data. `Type::Fun` carries
+a `kind: FunKind` (`Compute | Data | Var`). Concrete kinds are stamped at
+introduction: list literals, `++`, registered sources, filtered
+comprehensions/groupby (their cast target, `refined_fn_type`), aggregate
+consumers, and every `History` erasure are `Data`; scalar/combinator builtins
+are `Compute`. A **user lambda mints a kind `Var`** (its kind is
+genuinely use-dependent), resolved by the solver against its uses and, failing
+that, its domain (extent-shaped → `Data`). The audit rule for the *concrete*
+stamps: *an arrow is data iff `extent_of` will drive iteration off its domain*.
+Constructor `data_fun` mints a data arrow directly; `fun_like(exemplar, d, c)`
+rebuilds an arrow copying the exemplar's `name` and `kind`, so a domain/codomain-
+only rewrite (`subst`, `strip_refinements`, source-domain refinement) can never
+silently flip a data arrow to compute or drop its Pi binder. A rebuild that
+*intends* a new binder or mixes two arrows' kinds (the compose-chain rebuild in
+`coalesce_node`, the Pi-adding rebuild in `lambda_elim`) constructs directly and
+sets `kind` explicitly.
+
+> **Kind-aware subtyping (landed).** Kind is a solver-resolved
+> variable (`FunKind::Var`): a lambda
+> mints a fresh kind var, an unconstrained var resolves from its domain at
+> coalesce (extent-shaped → `Data`, else `Compute`), and uses force it either
+> way. The Fun-vs-Fun arm adds a kind edge over `Data ⊑ Compute`: `data <:
+> compute` upcasts, a concrete `compute <: data` is rejected
+> (`ConstrainError::ComputeWhereDataRequired`), and a var picks up
+> `forced_compute`/`forced_data` flags. For a *var*-kinded lambda the violation
+> is invisible at the edge (the flag is merely recorded), so it surfaces at
+> coalesce: a var left `forced_data` over a provably-scalar domain — or
+> `forced_compute ∧ forced_data` — is the same `Compute <: Data` error, reported
+> as `CoalesceError::ComputeWhereDataRequired` (e.g. `sum(f)` for a plain
+> `Int ⇒ Int` lambda `f`). The rejection is **emission-only**: the
+> post-inference check runs a *kind-blind* `ConstrainCache` (`new_kind_blind`),
+> because elimination canonicalizes a map's reconstructed kind to `Compute`
+> (`without_pi_names`) — denotation is preserved, kind representation is not, so
+> a kind-aware re-check would false-reject. `sum([x for x in xs])` and filtered
+> comprehensions/groupby type fine because the cast target and `refined_fn_type`
+> now carry `Data`. **One guard deferred:** Data-domain *invariance* (equating
+> both arrows' domains when both are `Data`) is **not** enabled — a naive
+> strict-equality reverse edge breaks the sound refinement-drop pattern
+> (`{[0, n] | p} ⤇ V` flowing where `[0, n] ⤇ V` is expected demands acquiring a
+> refinement by subsumption, which the lattice forbids); it needs a
+> modulo-refinements, range-aware formulation (kind-inference doc §5, open
+> question B).
+
+**Coproduct types.** A join of two data functions preserves both extents
+instead of meeting them: `α ⤇ τ₀ ⊔ β ⤇ τ₁` = `(α ⤇ (τ₀⊔τ₁)) | (β ⤇ (τ₀⊔τ₁))`,
+represented as the `Index`-tagged `Type::Variant([Index(0): α⤇τ, Index(1):
+β⤇τ])` that `Type::extent_coproduct` builds. This is a plain sum type — the
+value is *one* of the arms, tagged by contribution order — not a dependent sum:
+a finite, static branch set carries no witness. (The witness only becomes
+load-bearing for a genuine dependent Σ over a runtime/opaque extent, which the
+collections work adds separately.) Refinements ride *inside* each arm, so
+differently-refined extents joining at a `Case` carry both predicates and never
+hit `merge_refinements`' positive intersect (which becomes
+capability-domain/codomain/scalar-only by construction).
+
+**Mechanics.** Formation happens at the compact merge: the fun slot is a
+`CompactFun` whose `domains` accumulate alternatives under `union_extents`
+(union + dedup at positive polarity — never a meet); coalesce materializes
+one survivor as a plain data fun, ≥ 2 as a coproduct
+(`Type::extent_coproduct` — one `Index` arm per extent, sharing the joined
+codomain), and a data-⊔-compute collision as a loud coalesce error:
+`ExtentJoinConflict` when ≥ 2 candidate extents would be dropped (a genuine
+coproduct join), `ComputeWhereDataRequired` when a single slot is a capability
+demanded as an extent. Arm order = first-contribution order is a guaranteed
+contract. A conditional collection reaching op-conversion is rejected loudly
+before then (at `lambda_elim`, since value-`Case`s are not yet compilable).
+
+The three subtyping arms (`constrain.rs`) are: **injection** `Fun(Data) <:
+Variant` (a single data function subsumes into the coproduct at the arm with the
+matching extent — the `emit_case` arm-into-result edge); **consume** `Variant <:
+Fun` (a coproduct used as one collection presents as `Fun(Variant({Index(i):
+𝐷ᵢ}), V)`, iterating the discriminated union — a fresh domain var absorbs it,
+a concrete narrower extent is rejected); and **width** `Variant <: Variant`
+(positional). Both new arms fire only when every arm payload is a data function
+(a user tagged-union is not a collection). The extent match on injection is by
+*value* (the arm with the same extent).
+
+> **Deferred — value-`Case` elimination bridges.** The eliminator that
+> compiles a conditional-collection `Case` to a union of restricts — the two
+> bridge rules (a gated partition `Fun{Data, Variant([Index(i) ↦ {𝐷ᵢ | πᵢ}]),
+> 𝑐}` subtyping the coproduct positionally; an exhaustive+disjoint partition
+> union subtyping the plain data fun via a wall-validated `Cast`) — lands with
+> the value-`Case` compilation in a follow-up, where it is exercised end-to-end.
+> Today a conditional-collection `Case` types fine but is rejected at
+> `lambda_elim` (value-`Case`s are not yet compilable).
+
+**`Case` arms join by the lattice.** `emit_case` constrains every value/
+collection arm into a fresh result variable (`require_sub`) instead of
+requiring equality. Homogeneous arms recover the old behavior; data-collection
+arms with distinct extents form the coproduct above. `Mut`/`History` arms are the
+exception — a second-class reference cannot be lattice-joined as a value, so
+they keep `require_eq` (the Case stays a reference and mut-discipline rejects a
+conditional over stores, preserving that deliberate rule).
+
+> **Deferred — heterogeneous-scalar union (follow-up).** The design goal is for
+> heterogeneous scalar arms (`1 if c else "x"`) to coalesce to a union.
+> A global positive-atom union at coalesce is **unsound** — it is
+> indistinguishable there from a binop-operand join (`1 + true`), which must
+> stay a hard error. So heterogeneous scalar arms currently remain an
+> `IncompatibleBounds` error; the sound union needs strict scalar consumers
+> (binops, …) to impose concrete bounds, tracked as a follow-up.
+
+**What the codomain join gives up — and why that is the right default.** The
+coproduct is lossless on the *extent* and lossy on the *codomain*: joining
+`α ⤇ τ₀` with `β ⤇ τ₁` keeps the exact extent set `{α, β}` but coarsens the
+element type of every arm to the shared `τ₀ ⊔ τ₁`, forgetting *which* extent
+pairs with *which* element type. A function returning `[1, 2, 3] if flag else
+["a", "b"]` types as `([0,2] ⤇ (Int|String)) | ([0,1] ⤇ (Int|String))` — the
+type no longer records "length 3 ⟹ all Int." Three points make this the right
+default rather than a leak:
+
+> **Landed vs. deferred here.** The *extent* losslessness is live: a conditional
+> over collections with the **same** element type (`[1,2] if c else [1,2,3]`)
+> forms `([0,1] ⤇ Int) | ([0,2] ⤇ Int)`. The *codomain* union in the
+> `Int | String` example above is the same deferred piece as the
+> heterogeneous-scalar union (`τ₀ ⊔ τ₁` is a positive atom-join), so that
+> specific example currently errors at the codomain until that follow-up lands.
+> The design rationale below is unchanged — it is why the codomain join is the
+> right *default* once the union is sound.
+
+- **The asymmetry is principled.** Loss is forbidden exactly where it is
+  *silent and destroys data* — the domain (dropping an index drops a row, with
+  no trace), which is why extents join into a coproduct and never meet. Loss is
+  permitted exactly where it is *visible and only coarsens type* — the
+  codomain: `Int | String` sits in the type, and a consumer that needs `Int`
+  (say `sum`) fails at *its own* constraint site. The shared-codomain coproduct
+  is a sound **widening** — a supertype of the correlated form (each arm injects
+  into it), so it never admits an unsound program, it only offers less
+  precision.
+- **The correlation is recoverable by construction.** The correlated form keeps
+  each arm's own codomain — `Variant([(Index(0), α ⤇ τ₀), (Index(1), β ⤇ τ₁)])`,
+  the same `Variant` node with per-arm rather than shared codomains. A program
+  that needs a branch-aware consumer introduces the
+  choice *explicitly* (`.Ints(xs) if flag else .Strs(ys)`) and `match`es it;
+  the case-split tax is then paid by the code that benefits from it. The
+  implicit control-flow join carries the ergonomics of the *common* case (a
+  uniform consumer, no case-split), and the explicit variant carries the rare
+  one.
+- **Default-join keeps consumer complexity linear.** If the implicit join
+  preserved correlation, every conditional collection would default to a
+  variant every downstream consumer must destructure, and nested conditionals
+  would multiply the arms through the whole consumer graph — complexity
+  compounding at each control-flow merge. The join collapses codomains so an
+  arbitrary chain of conditionals still presents one collection type; only the
+  extent set (which we must keep) grows.
+
+Two consequences to keep on the record. First, this direction *depends on*
+tagged-variant **surface syntax** (`.Foo(x)` constructors + `match`, the open
+part of [[type-checker-tagged-variants]]): until that ships, the join is a
+*forced* loss with no recovery path, not a chosen one. Second, we are
+deliberately declining **flow-sensitive typing** — an occurrence-typing
+language could keep the arms correlated through the path condition `flag`
+itself, with no tag; Cambra does not narrow on opaque `Bool`s, and the tagged
+variant is the substitute. A genuine dependent Σ *witness* is orthogonal to
+this: it would recover extent↔*value* correlation in a homogeneous-codomain
+data function (e.g. a conditionally-sized collection of in-bounds indices,
+`Σ 𝑛 ∈ {[0,7], [0,3]}. 𝑛 ⤇ {Int | __elem ∈ 𝑛}`), not per-branch element
+*types* — that axis is the coproduct's, and the two partition with no gap. That
+dependent Σ (over a runtime/opaque witness) is not present here — a finite
+conditional collection is a plain coproduct; the witness arrives with the
+collections work.
+
 ---
 
 ## 5. CCL-specific inference rules
@@ -444,6 +631,8 @@ The pipeline passes downstream of inference treat function types structurally an
 ### `Case` inference
 
 For each `Branch { guard, body }`: the guard is constrained to `Type::Base(BaseType::Bool)`; body types across all branches are unified. The overall `Case` type is the unified body type. A 0-branch `Case` is a malformed AST (lowering never produces one) and returns `InferError::EmptyCase`.
+
+The in-flight conditionals stack replaces the arm unification with a genuine lattice join (fresh result variable + per-arm `require_sub`) — see [§4.6](#46-data-vs-compute-functions-and-σ-extent-joins); the strict-equality behavior above is current until that PR lands.
 
 ### Record literals and field access
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -508,17 +508,31 @@ the joined codomain), and a data-⊔-compute collision as a loud coalesce error:
 `ExtentJoinConflict` when ≥ 2 candidate extents would be dropped (a genuine
 extent join), `ComputeWhereDataRequired` when a single slot is a capability
 demanded as an extent. Candidate order = first-contribution order is a
-guaranteed contract. A conditional collection reaching op-conversion is rejected
-loudly before then (at `lambda_elim`, since value-`Case`s are not yet
-compilable). The Sigma witness is the canonical, shared binder `__witness`
-(`ReservedName::Witness`, like the refinement `__elem`), so two
-structurally-equal conditional collections compare equal without α-renaming.
+guaranteed contract: it fixes a deterministic materialization (stable, testable)
+and the discriminant order the deferred value-`Case` fan-out will index by — but
+the subtyping rules below match candidates *by value*, never by position. Nested
+conditionals **flatten**: a Σ re-entering compaction (a sub-conditional's result
+joining a sibling extent) decomposes back into its multi-domain fun slot
+(`compact_go`'s `Sigma` arm), so `union_extents` folds its candidates in —
+`(xs if p else ys) if q else zs` forms one flat `Σ (𝑤 ∈ {xs, ys, zs}). 𝑤 ⤇ V`,
+never a nested Σ. This is why a candidate extent is always a ground
+data-function domain, never itself a Σ. A conditional collection reaching
+op-conversion is rejected loudly before then (at `lambda_elim`, since
+value-`Case`s are not yet compilable). The type-witness is **nullary**
+([`Type::Witness`] — a leaf, no binder), so two structurally-equal conditional
+collections compare equal by the derived structural equality with nothing to
+α-rename.
 
 These are **general dependent-sum rules** (`constrain.rs`), not
 conditional-collection–specific logic: the solver knows Σ, and each rule is
-*realized per witness `Kind`* — the part that genuinely differs (domain
-membership, the presented domain, the subset test) dispatches on `Kind`, while
-the covariant codomain edge is Kind-agnostic (`SigmaType::codomain`/`binder`).
+*realized per witness* — the part that genuinely differs (domain membership, the
+presented domain, the subset test) dispatches on the `Witness`, and for a
+*type*-witness further on its `Kind`. The covariant codomain edge is
+conceptually uniform across witnesses, but because [`SigmaType`]'s `body` is a
+*general* type (only the conditional-collection instance's body is the data
+function `Witness ⤇ V`), each `Kind::Enumerated` realization reads the codomain
+by a local destructure of `body` — guarded by an `unreachable!` that names the
+construction invariant — rather than through a general `SigmaType` accessor.
 Two rules are genuine subtyping; one is elimination — a distinction worth keeping
 precise, because the last is *not* subsumption even though it is discharged
 through the same `<:` solver.
@@ -543,10 +557,21 @@ by that consumer"; the constraints it emits coincide with subtyping the sum's
 *eliminated shape* `(⋃𝐷ᵢ) ⤇ V`, so it composes soundly with the two real
 subtyping rules without ever treating a Σ as substitutable for a function.
 
+Note this type-level rule is **branch-agnostic**: it makes the consumer total
+over the tagged union of *all* candidate extents; it does not pick a branch.
+Runtime branch selection is the deferred value-`Case` fan-out (below), which
+gates each extent `𝐷ᵢ` by its branch predicate `π̂ᵢ` (compiled from the original
+`if`/`elif` conditions) — the gates are exclusive and exhaustive, so exactly one
+restricted leg is non-empty. The witness is what ties the two layers: type-level
+it names *which* extent was taken; at runtime that identity is realized as *which*
+gate passes.
+
 Only the `Kind::Enumerated` realization is wired today (what a conditional
-collection materializes). The `Kind::Any` (`Collection`) and value-witness
-(`List`/`Map`) realizations of each rule are `todo!()` skeletons — present so the
-general shape is visible, unreachable until those Kinds are constructed.
+collection materializes). The other two witnesses each rule dispatches on — the
+`Kind::Any` type-witness (`Collection`) and the value-witness (`List`/`Map`,
+[`Witness::Value`], classified by a *type* rather than a `Kind`) — are `todo!()`
+skeletons, present so the general shape is visible and unreachable until those
+witnesses are constructed.
 
 > **Deferred — value-`Case` elimination compilation.** The type-level
 > elimination rule (`Σ <: Fun`) is live here, so a conditional-collection `Case`
@@ -573,22 +598,30 @@ conditional over stores, preserving that deliberate rule).
 > (binops, …) to impose concrete bounds, tracked as a follow-up.
 
 **What the codomain join gives up — and why that is the right default.** The
-Sigma is lossless on the *extent* and lossy on the *codomain*: joining
-`α ⤇ τ₀` with `β ⤇ τ₁` keeps the exact candidate set `{α, β}` but coarsens the
-shared body's element type to `τ₀ ⊔ τ₁`, forgetting *which* extent pairs with
-*which* element type. A function returning `[1, 2, 3] if flag else ["a", "b"]`
-types as `Σ (𝑤 ∈ {[0,2], [0,1]}). 𝑤 ⤇ (Int|String)` — the type no longer
-records "length 3 ⟹ all Int." Three points make this the right default rather
-than a leak:
+Sigma is lossless on the *extent* and lossy on the *codomain*: the shared body's
+element type is the ordinary covariant lattice join `τ₀ ⊔ τ₁` of the arms'
+codomains (`CompactFun::merge` merges the codomain at `pol`, the domains at
+`!pol`), forgetting *which* extent pairs with *which* element type. This is the
+same lattice join used everywhere else, with the same representability limit:
+where the LUB exists it is a **structured coarsening** that does not error —
+record codomains intersect to their common fields, refinements drop to the shared
+base (the join `merge_records`/`merge_refinements` apply at any positive
+position). Where the LUB is a **scalar union** it is unrepresentable, so it is
+the deferred piece below: a function returning `[1, 2, 3] if flag else ["a", "b"]`
+*would* type as `Σ (𝑤 ∈ {[0,2], [0,1]}). 𝑤 ⤇ (Int|String)` — no longer recording
+"length 3 ⟹ all Int" — but that `Int|String` codomain currently **errors** at
+coalesce, the same `IncompatibleBounds` rejection as `1 + true`. Three points
+make the codomain join the right default rather than a leak:
 
 > **Landed vs. deferred here.** The *extent* losslessness is live: a conditional
 > over collections with the **same** element type (`[1,2] if c else [1,2,3]`)
-> forms `Σ (𝑤 ∈ {[0,1], [0,2]}). 𝑤 ⤇ Int`. The *codomain* union in the
-> `Int | String` example above is the same deferred piece as the
-> heterogeneous-scalar union (`τ₀ ⊔ τ₁` is a positive atom-join), so that
-> specific example currently errors at the codomain until that follow-up lands.
-> The design rationale below is unchanged — it is why the codomain join is the
-> right *default* once the union is sound.
+> forms `Σ (𝑤 ∈ {[0,1], [0,2]}). 𝑤 ⤇ Int`, and a structured-codomain coarsening
+> (record field intersection, refinement drop) lands too. Only the **scalar**
+> codomain union (`Int | String`) is deferred: it is a positive atom-join,
+> indistinguishable at coalesce from `1 + true`, so it errors until strict scalar
+> consumers can bound it (the heterogeneous-scalar follow-up below). The design
+> rationale below is unchanged — it is why the codomain join is the right
+> *default* once the union is sound.
 
 - **The asymmetry is principled.** Loss is forbidden exactly where it is
   *silent and destroys data* — the domain (dropping an index drops a row, with

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -632,7 +632,7 @@ collections work.
 
 For each `Branch { guard, body }`: the guard is constrained to `Type::Base(BaseType::Bool)`; body types across all branches are unified. The overall `Case` type is the unified body type. A 0-branch `Case` is a malformed AST (lowering never produces one) and returns `InferError::EmptyCase`.
 
-The in-flight conditionals stack replaces the arm unification with a genuine lattice join (fresh result variable + per-arm `require_sub`) — see [§4.6](#46-data-vs-compute-functions-and-σ-extent-joins); the strict-equality behavior above is current until that PR lands.
+The in-flight conditionals stack replaces the arm unification with a genuine lattice join (fresh result variable + per-arm `require_sub`) — see [§4.6](#46-data-vs-compute-functions-and-coproduct-extent-joins); the strict-equality behavior above is current until that PR lands.
 
 ### Record literals and field access
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -544,8 +544,8 @@ conditional over stores, preserving that deliberate rule).
 coproduct is lossless on the *extent* and lossy on the *codomain*: joining
 `α ⤇ τ₀` with `β ⤇ τ₁` keeps the exact extent set `{α, β}` but coarsens the
 element type of every arm to the shared `τ₀ ⊔ τ₁`, forgetting *which* extent
-pairs with *which* element type. A function returning `[1, 2, 3] if flag else
-["a", "b"]` types as `([0,2] ⤇ (Int|String)) | ([0,1] ⤇ (Int|String))` — the
+pairs with *which* element type. A function returning `[1, 2, 3] if flag else ["a", "b"]`
+types as `([0,2] ⤇ (Int|String)) | ([0,1] ⤇ (Int|String))` — the
 type no longer records "length 3 ⟹ all Int." Three points make this the right
 default rather than a leak:
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -413,26 +413,33 @@ The expected binder is **always globally fresh** (proposal §5.2 verbatim; the �
 
 The pipeline passes downstream of inference treat function types structurally and compare modulo the Pi binder (`Type::without_pi_names`). **Refinement-predicate compilation is deferred out of lambda-elim** (proposal §6.3): predicates ride through inference and lambda-elim in their bare pointful form (a bare boolean over the implicit `REFINEMENT_BINDER`), and **planning** compiles them. Order matters: the group-by / hash-join recognizers run *first*, on the bare form — compiling first would destroy the pointful shapes they match (see the pointful-join-recognizers plan) — and `planning::compile_refinement_predicates` then runs the lambda-elim → simplify sub-pipeline on each remaining predicate (keyed by predicate `Rc` identity) before the generic `iterate`/`restrict` lowering consumes it. This is what lets a refined collection — including a group-by over a *filtered* source (`[sum(x) for x in groupby([y+10 for y in xs if y<6], key)]`) — compile to a runtime `Restrict`/`Filter` rather than reaching op-conversion as an un-compiled predicate. Single-key dependent lookups (`sum(groupby(xs, key)(k))`) and the nested filtered-source group-by both run end-to-end with correct values.
 
-## 4.6 Data vs compute functions and coproduct extent joins
+## 4.6 Data vs compute functions and conditional-collection extent joins
 
-> **Status: implemented.** The `FunKind` marker, lossless coproduct formation at
-> control-flow joins, *and* kind-aware subtyping (the `Compute<:Data` rejection)
-> are all live. One guard is deferred with rationale (Data-domain invariance —
-> see the callout below), and the value-`Case` elimination bridges land in the
-> value-`Case` compilation PR.
+> **Status: implemented.** The `FunKind` marker, lossless conditional-collection
+> formation at control-flow joins, *and* kind-aware subtyping (the
+> `Compute<:Data` rejection) are all live. One guard is deferred with rationale
+> (Data-domain invariance — see the callout below), and the value-`Case`
+> elimination *compilation* lands in the value-`Case` compilation PR (the
+> type-level elimination rule is live here).
 >
-> **Not a dependent sum.** A conditional collection is a **coproduct** — a
-> finite, `Index`-tagged [`Type::Variant`] of data functions built by
-> `Type::extent_coproduct`. A finite, static set of branches needs no witness (a
-> finite Σ degenerates to a coproduct), so there is no `Type::Sigma` here; a
-> genuine dependent Σ (over a runtime/opaque witness — a `List` length, a `Map`
-> key extent) is a separate construct introduced with the collections work,
-> where the witness is real.
+> **A real dependent sum.** A conditional collection is the dependent sum
+> `Σ (𝑤 ∈ {𝐷ᵢ}). 𝑤 ⤇ V` ([`Type::Sigma`], built by
+> `Type::conditional_collection`). The witness `𝑤` is genuinely load-bearing: it
+> *is* the runtime branch discriminant (which arm was taken), and it is
+> **projected at elimination** — a consumer of the collection distributes over
+> the witness (the value-`Case` fan-out). It is not a coproduct wearing Σ
+> notation: consumption is *elimination* (typed, propagating), not a `Σ <: Fun`
+> coercion, and the witness is referenced in the body's domain position
+> ([`Type::Witness`]). The witness here is a **type**-witness of
+> `Kind::Enumerated` (a static branch set) — the finite instance; the
+> *value*-witness instances (`List` length, `Map` key-set) and the `Kind::Any`
+> universe instance (`Collection`) arrive with the collections work, sharing the
+> same `Type::Sigma` machinery.
 
 The unresolved extent-join corner of §4.5 (O1/O4 — two collections meeting at
 one join point) is resolved by making a missing distinction explicit and
-representing the join as a coproduct of data functions (the finite, non-dependent
-sum — a plain `Variant`).
+representing the join as the dependent sum of data functions over the branch
+extents.
 
 **The distinction.** A function's domain can mean two things. A **compute
 function** `α ⇒ β` treats it as a *capability* — the inputs accepted; no data
@@ -481,53 +488,78 @@ sets `kind` explicitly.
 > modulo-refinements, range-aware formulation (kind-inference doc §5, open
 > question B).
 
-**Coproduct types.** A join of two data functions preserves both extents
-instead of meeting them: `α ⤇ τ₀ ⊔ β ⤇ τ₁` = `(α ⤇ (τ₀⊔τ₁)) | (β ⤇ (τ₀⊔τ₁))`,
-represented as the `Index`-tagged `Type::Variant([Index(0): α⤇τ, Index(1):
-β⤇τ])` that `Type::extent_coproduct` builds. This is a plain sum type — the
-value is *one* of the arms, tagged by contribution order — not a dependent sum:
-a finite, static branch set carries no witness. (The witness only becomes
-load-bearing for a genuine dependent Σ over a runtime/opaque extent, which the
-collections work adds separately.) Refinements ride *inside* each arm, so
-differently-refined extents joining at a `Case` carry both predicates and never
-hit `merge_refinements`' positive intersect (which becomes
-capability-domain/codomain/scalar-only by construction).
+**Conditional-collection Sigma.** A join of two data functions preserves both
+extents instead of meeting them: `α ⤇ τ₀ ⊔ β ⤇ τ₁` = `Σ (𝑤 ∈ {α, β}).
+𝑤 ⤇ (τ₀⊔τ₁)`, the [`Type::Sigma`] that `Type::conditional_collection` builds —
+one shared body `Witness(𝑤) ⤇ (τ₀⊔τ₁)` over the witness, whose candidate domains
+are the branch extents in contribution order (a tested contract). The value is
+*one* branch, discriminated by the witness at elimination. Refinements ride
+*inside* each candidate domain, so differently-refined extents joining at a
+`Case` carry both predicates and never hit `merge_refinements`' positive
+intersect (which becomes capability-domain/codomain/scalar-only by
+construction).
 
 **Mechanics.** Formation happens at the compact merge: the fun slot is a
 `CompactFun` whose `domains` accumulate alternatives under `union_extents`
 (union + dedup at positive polarity — never a meet); coalesce materializes
-one survivor as a plain data fun, ≥ 2 as a coproduct
-(`Type::extent_coproduct` — one `Index` arm per extent, sharing the joined
-codomain), and a data-⊔-compute collision as a loud coalesce error:
+one survivor as a plain data fun, ≥ 2 as a conditional-collection Sigma
+(`Type::conditional_collection` — the candidate domains are the extents, sharing
+the joined codomain), and a data-⊔-compute collision as a loud coalesce error:
 `ExtentJoinConflict` when ≥ 2 candidate extents would be dropped (a genuine
-coproduct join), `ComputeWhereDataRequired` when a single slot is a capability
-demanded as an extent. Arm order = first-contribution order is a guaranteed
-contract. A conditional collection reaching op-conversion is rejected loudly
-before then (at `lambda_elim`, since value-`Case`s are not yet compilable).
+extent join), `ComputeWhereDataRequired` when a single slot is a capability
+demanded as an extent. Candidate order = first-contribution order is a
+guaranteed contract. A conditional collection reaching op-conversion is rejected
+loudly before then (at `lambda_elim`, since value-`Case`s are not yet
+compilable). The Sigma witness is the canonical, shared binder `__witness`
+(`ReservedName::Witness`, like the refinement `__elem`), so two
+structurally-equal conditional collections compare equal without α-renaming.
 
-The three subtyping arms (`constrain.rs`) are: **injection** `Fun(Data) <:
-Variant` (a single data function subsumes into the coproduct at the arm with the
-matching extent — the `emit_case` arm-into-result edge); **consume** `Variant <:
-Fun` (a coproduct used as one collection presents as `Fun(Variant({Index(i):
-𝐷ᵢ}), V)`, iterating the discriminated union — a fresh domain var absorbs it,
-a concrete narrower extent is rejected); and **width** `Variant <: Variant`
-(positional). Both new arms fire only when every arm payload is a data function
-(a user tagged-union is not a collection). The extent match on injection is by
-*value* (the arm with the same extent).
+These are **general dependent-sum rules** (`constrain.rs`), not
+conditional-collection–specific logic: the solver knows Σ, and each rule is
+*realized per witness `Kind`* — the part that genuinely differs (domain
+membership, the presented domain, the subset test) dispatches on `Kind`, while
+the covariant codomain edge is Kind-agnostic (`SigmaType::codomain`/`binder`).
+Two rules are genuine subtyping; one is elimination — a distinction worth keeping
+precise, because the last is *not* subsumption even though it is discharged
+through the same `<:` solver.
 
-> **Deferred — value-`Case` elimination bridges.** The eliminator that
-> compiles a conditional-collection `Case` to a union of restricts — the two
-> bridge rules (a gated partition `Fun{Data, Variant([Index(i) ↦ {𝐷ᵢ | πᵢ}]),
-> 𝑐}` subtyping the coproduct positionally; an exhaustive+disjoint partition
-> union subtyping the plain data fun via a wall-validated `Cast`) — lands with
-> the value-`Case` compilation in a follow-up, where it is exercised end-to-end.
-> Today a conditional-collection `Case` types fine but is rejected at
-> `lambda_elim` (value-`Case`s are not yet compilable).
+The subtyping rules: **injection** `Fun(Data) <: Σ` (a data function is a subtype
+of the sum when its domain is a body-instantiation for some witness the sum
+ranges over — a branch *is-a* sum, `A <: A+B`; the `emit_case` arm-into-result
+edge); and **width** `Σ <: Σ` (the lhs sum's witness domain is a subset of the
+rhs's — a smaller sum *is-a* bigger sum). For a `Kind::Enumerated` witness both
+tests are by *value* over the candidate domains (which land in an arbitrary
+order, so position cannot be relied on).
+
+The elimination rule: **consume** `Σ <: Fun`. This is *not* subsumption — a Σ
+value is *one* branch, total on only one `𝐷ᵢ`, so it is **not** substitutable
+for a function total on `⋃𝐷ᵢ`. Consuming it **eliminates** the sum: the consumer
+distributes over the witness, and for a `Kind::Enumerated` witness the collection
+presents as `Fun(Variant({Index(i): 𝐷ᵢ}), V)`, iterating the discriminated union
+of the candidate extents — a fresh domain var absorbs it, a concrete narrower
+extent is rejected, and the shared codomain flows in one covariant edge. It rides
+the `<:` solver only because that is the plumbing for "this collection is consumed
+by that consumer"; the constraints it emits coincide with subtyping the sum's
+*eliminated shape* `(⋃𝐷ᵢ) ⤇ V`, so it composes soundly with the two real
+subtyping rules without ever treating a Σ as substitutable for a function.
+
+Only the `Kind::Enumerated` realization is wired today (what a conditional
+collection materializes). The `Kind::Any` (`Collection`) and value-witness
+(`List`/`Map`) realizations of each rule are `todo!()` skeletons — present so the
+general shape is visible, unreachable until those Kinds are constructed.
+
+> **Deferred — value-`Case` elimination compilation.** The type-level
+> elimination rule (`Σ <: Fun`) is live here, so a conditional-collection `Case`
+> type-checks and propagates. *Compiling* that elimination — the value-`Case`
+> fan-out that lowers it to a union of restricts — lands with the value-`Case`
+> compilation in a follow-up, where it is exercised end-to-end. Today a
+> conditional-collection `Case` types fine but is rejected at `lambda_elim`
+> (value-`Case`s are not yet compilable).
 
 **`Case` arms join by the lattice.** `emit_case` constrains every value/
 collection arm into a fresh result variable (`require_sub`) instead of
 requiring equality. Homogeneous arms recover the old behavior; data-collection
-arms with distinct extents form the coproduct above. `Mut`/`History` arms are the
+arms with distinct extents form the conditional-collection Sigma above. `Mut`/`History` arms are the
 exception — a second-class reference cannot be lattice-joined as a value, so
 they keep `require_eq` (the Case stays a reference and mut-discipline rejects a
 conditional over stores, preserving that deliberate rule).
@@ -541,17 +573,17 @@ conditional over stores, preserving that deliberate rule).
 > (binops, …) to impose concrete bounds, tracked as a follow-up.
 
 **What the codomain join gives up — and why that is the right default.** The
-coproduct is lossless on the *extent* and lossy on the *codomain*: joining
-`α ⤇ τ₀` with `β ⤇ τ₁` keeps the exact extent set `{α, β}` but coarsens the
-element type of every arm to the shared `τ₀ ⊔ τ₁`, forgetting *which* extent
-pairs with *which* element type. A function returning `[1, 2, 3] if flag else ["a", "b"]`
-types as `([0,2] ⤇ (Int|String)) | ([0,1] ⤇ (Int|String))` — the
-type no longer records "length 3 ⟹ all Int." Three points make this the right
-default rather than a leak:
+Sigma is lossless on the *extent* and lossy on the *codomain*: joining
+`α ⤇ τ₀` with `β ⤇ τ₁` keeps the exact candidate set `{α, β}` but coarsens the
+shared body's element type to `τ₀ ⊔ τ₁`, forgetting *which* extent pairs with
+*which* element type. A function returning `[1, 2, 3] if flag else ["a", "b"]`
+types as `Σ (𝑤 ∈ {[0,2], [0,1]}). 𝑤 ⤇ (Int|String)` — the type no longer
+records "length 3 ⟹ all Int." Three points make this the right default rather
+than a leak:
 
 > **Landed vs. deferred here.** The *extent* losslessness is live: a conditional
 > over collections with the **same** element type (`[1,2] if c else [1,2,3]`)
-> forms `([0,1] ⤇ Int) | ([0,2] ⤇ Int)`. The *codomain* union in the
+> forms `Σ (𝑤 ∈ {[0,1], [0,2]}). 𝑤 ⤇ Int`. The *codomain* union in the
 > `Int | String` example above is the same deferred piece as the
 > heterogeneous-scalar union (`τ₀ ⊔ τ₁` is a positive atom-join), so that
 > specific example currently errors at the codomain until that follow-up lands.
@@ -560,18 +592,17 @@ default rather than a leak:
 
 - **The asymmetry is principled.** Loss is forbidden exactly where it is
   *silent and destroys data* — the domain (dropping an index drops a row, with
-  no trace), which is why extents join into a coproduct and never meet. Loss is
-  permitted exactly where it is *visible and only coarsens type* — the
-  codomain: `Int | String` sits in the type, and a consumer that needs `Int`
-  (say `sum`) fails at *its own* constraint site. The shared-codomain coproduct
+  no trace), which is why extents join into the Sigma's candidate set and never
+  meet. Loss is permitted exactly where it is *visible and only coarsens type* —
+  the codomain: `Int | String` sits in the type, and a consumer that needs `Int`
+  (say `sum`) fails at *its own* constraint site. The shared-codomain Sigma
   is a sound **widening** — a supertype of the correlated form (each arm injects
   into it), so it never admits an unsound program, it only offers less
   precision.
-- **The correlation is recoverable by construction.** The correlated form keeps
-  each arm's own codomain — `Variant([(Index(0), α ⤇ τ₀), (Index(1), β ⤇ τ₁)])`,
-  the same `Variant` node with per-arm rather than shared codomains. A program
-  that needs a branch-aware consumer introduces the
-  choice *explicitly* (`.Ints(xs) if flag else .Strs(ys)`) and `match`es it;
+- **The correlation is recoverable by construction.** The correlated form is a
+  tagged variant with each arm's own codomain — `Variant([(Index(0), α ⤇ τ₀),
+  (Index(1), β ⤇ τ₁)])`. A program that needs a branch-aware consumer introduces
+  the choice *explicitly* (`.Ints(xs) if flag else .Strs(ys)`) and `match`es it;
   the case-split tax is then paid by the code that benefits from it. The
   implicit control-flow join carries the ergonomics of the *common* case (a
   uniform consumer, no case-split), and the explicit variant carries the rare
@@ -582,7 +613,7 @@ default rather than a leak:
   would multiply the arms through the whole consumer graph — complexity
   compounding at each control-flow merge. The join collapses codomains so an
   arbitrary chain of conditionals still presents one collection type; only the
-  extent set (which we must keep) grows.
+  candidate extent set (which we must keep) grows.
 
 Two consequences to keep on the record. First, this direction *depends on*
 tagged-variant **surface syntax** (`.Foo(x)` constructors + `match`, the open
@@ -591,14 +622,15 @@ part of [[type-checker-tagged-variants]]): until that ships, the join is a
 deliberately declining **flow-sensitive typing** — an occurrence-typing
 language could keep the arms correlated through the path condition `flag`
 itself, with no tag; Cambra does not narrow on opaque `Bool`s, and the tagged
-variant is the substitute. A genuine dependent Σ *witness* is orthogonal to
-this: it would recover extent↔*value* correlation in a homogeneous-codomain
-data function (e.g. a conditionally-sized collection of in-bounds indices,
-`Σ 𝑛 ∈ {[0,7], [0,3]}. 𝑛 ⤇ {Int | __elem ∈ 𝑛}`), not per-branch element
-*types* — that axis is the coproduct's, and the two partition with no gap. That
-dependent Σ (over a runtime/opaque witness) is not present here — a finite
-conditional collection is a plain coproduct; the witness arrives with the
-collections work.
+variant is the substitute. Note the codomain loss is orthogonal to the axis the
+conditional-collection Sigma's witness *does* recover: our witness is a
+*type*-witness (`Kind::Enumerated` — which branch extent was taken), so the Sigma
+keeps the exact extent set. A *value*-witness Σ would recover extent↔*value*
+correlation in a homogeneous-codomain data function (e.g. a conditionally-sized
+collection of in-bounds indices, `Σ 𝑛 ∈ Nat. {Int | __elem ∈ [0, 𝑛]} ⤇ …`),
+not per-branch element *types* — a third axis, neither this codomain join's nor
+the type-witness's. That value-witness Σ shares the same `Type::Sigma` machinery
+(the `Witness::Value` case) and arrives with the collections work.
 
 ---
 
@@ -632,7 +664,7 @@ collections work.
 
 For each `Branch { guard, body }`: the guard is constrained to `Type::Base(BaseType::Bool)`; body types across all branches are unified. The overall `Case` type is the unified body type. A 0-branch `Case` is a malformed AST (lowering never produces one) and returns `InferError::EmptyCase`.
 
-The in-flight conditionals stack replaces the arm unification with a genuine lattice join (fresh result variable + per-arm `require_sub`) — see [§4.6](#46-data-vs-compute-functions-and-coproduct-extent-joins); the strict-equality behavior above is current until that PR lands.
+The in-flight conditionals stack replaces the arm unification with a genuine lattice join (fresh result variable + per-arm `require_sub`) — see [§4.6](#46-data-vs-compute-functions-and-conditional-collection-extent-joins); the strict-equality behavior above is current until that PR lands.
 
 ### Record literals and field access
 

--- a/src/ccl/infer/api.rs
+++ b/src/ccl/infer/api.rs
@@ -754,6 +754,16 @@ fn collect_type_errors(
             }
             collect_type_errors(inner, context_sym, strictness, errors, seen_refinements);
         }
+        Type::Sigma(s) => {
+            // Recurse for holes/infers in the witness's type children and the
+            // body; the anonymous type-witness reference (`Type::Witness`) is
+            // bound by this Sigma, so it carries no error.
+            for t in s.witness.types() {
+                collect_type_errors(t, context_sym, strictness, errors, seen_refinements);
+            }
+            collect_type_errors(&s.body, context_sym, strictness, errors, seen_refinements);
+        }
+        Type::Witness => {}
         Type::Base(_) | Type::UIntRange(_) | Type::DataSource(_) | Type::Txn => {}
     }
 }

--- a/src/ccl/infer/api.rs
+++ b/src/ccl/infer/api.rs
@@ -228,9 +228,15 @@ pub enum InferError {
     /// A variable was referenced but not bound in the current scope.
     UnboundVariable(String),
     /// A type mismatch was detected between two solved types.
+    ///
+    /// The two `Type`s are boxed to keep `InferError` under the
+    /// `result_large_err` budget: this is the widest variant (two `Type`s plus
+    /// a `ctx` string), and `Type` grew when [`crate::ccl::ty::FunKind`] gained
+    /// an inference variable. Boxing here keeps every
+    /// `Result<_, InferError>` cheap on the common `Ok` path.
     TypeMismatch {
-        type_a: Type,
-        type_b: Type,
+        type_a: Box<Type>,
+        type_b: Box<Type>,
         ctx: String,
     },
     /// A [`Type::Fun`] was required — e.g. in a function-application or
@@ -680,8 +686,19 @@ fn collect_type_errors(
             }
         }
         Type::Fun {
-            domain, codomain, ..
+            domain,
+            codomain,
+            kind,
+            ..
         } => {
+            // Coalesce resolves every kind var to a concrete `Data`/`Compute`
+            // (`KindMerge::of`); a surviving `FunKind::Var` is a missed resolution
+            // that would silently display `⇒` and behave as `Compute`. Catch it
+            // loudly rather than letting the wrong default ride downstream.
+            debug_assert!(
+                !matches!(kind, crate::ccl::ty::FunKind::Var(_)),
+                "unresolved FunKind::Var survived coalesce at `{context_sym}`"
+            );
             collect_type_errors(domain, context_sym, strictness, errors, seen_refinements);
             collect_type_errors(codomain, context_sym, strictness, errors, seen_refinements);
         }
@@ -1231,6 +1248,7 @@ mod tests {
             ty,
             Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Compute,
                 domain: Box::new(Type::Base(BaseType::Int)),
                 codomain: Box::new(Type::Base(BaseType::Int))
             }
@@ -1263,13 +1281,10 @@ mod tests {
         // [10, 20]  =>  Fun(UIntRange(2), Int)
         let mut expr = Expr::list(vec![Expr::lit(Lit::Int(10)), Expr::lit(Lit::Int(20))]);
         let ty = infer(&mut expr, &mut ctx).unwrap();
+        // A list literal is a **data** function (extent domain).
         assert_eq!(
             ty,
-            Type::Fun {
-                name: None,
-                domain: Box::new(Type::UIntRange(2)),
-                codomain: Box::new(Type::Base(BaseType::Int))
-            }
+            Type::data_fun(Type::UIntRange(2), Type::Base(BaseType::Int))
         );
     }
 
@@ -1280,7 +1295,7 @@ mod tests {
         let ty = infer(&mut expr, &mut ctx).unwrap();
         assert_eq!(
             ty,
-            Type::fun(Type::UIntRange(0), Type::Base(BaseType::Unit))
+            Type::data_fun(Type::UIntRange(0), Type::Base(BaseType::Unit))
         );
     }
 
@@ -1460,6 +1475,7 @@ mod tests {
             ty,
             Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Compute,
                 domain: Box::new(Type::Base(BaseType::Int)),
                 codomain: Box::new(Type::Base(BaseType::Int))
             }
@@ -1646,11 +1662,11 @@ mod tests {
         assert!(
             errs.iter().any(|e| matches!(
                 e,
-                InferError::TypeMismatch {
-                    type_a: Type::Base(BaseType::Int),
-                    type_b: Type::Base(BaseType::String),
-                    ..
-                }
+                InferError::TypeMismatch { type_a, type_b, .. }
+                    if matches!(
+                        (type_a.as_ref(), type_b.as_ref()),
+                        (Type::Base(BaseType::Int), Type::Base(BaseType::String))
+                    )
             )),
             "expected TypeMismatch Int/String, got {errs:?}"
         );
@@ -2136,6 +2152,7 @@ mod tests {
             ty,
             Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Compute,
                 domain: Box::new(Type::Base(BaseType::Int)),
                 codomain: Box::new(Type::Base(BaseType::Unit))
             }
@@ -2155,6 +2172,7 @@ mod tests {
         let mut ctx = TypeInferenceContext::new();
         let source_ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::DataSource("mystream".into())),
             codomain: Box::new(Type::Base(BaseType::String)),
         };
@@ -2181,11 +2199,13 @@ mod tests {
         let mut ctx = TypeInferenceContext::new();
         let int_ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::DataSource("ints".into())),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
         let str_ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::DataSource("strs".into())),
             codomain: Box::new(Type::Base(BaseType::String)),
         };
@@ -2229,11 +2249,11 @@ mod tests {
         assert!(
             errs.iter().any(|e| matches!(
                 e,
-                InferError::TypeMismatch {
-                    type_a: Type::Base(BaseType::Bool),
-                    type_b: Type::Base(BaseType::Int),
-                    ..
-                }
+                InferError::TypeMismatch { type_a, type_b, .. }
+                    if matches!(
+                        (type_a.as_ref(), type_b.as_ref()),
+                        (Type::Base(BaseType::Bool), Type::Base(BaseType::Int))
+                    )
             )),
             "expected TypeMismatch Bool/Int, got {errs:?}"
         );
@@ -2368,6 +2388,7 @@ mod tests {
         })
         .with_ty(Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         });
@@ -2410,6 +2431,7 @@ mod tests {
         })
         .with_ty(Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         });
@@ -2462,6 +2484,7 @@ mod tests {
         })
         .with_ty(Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         });
@@ -2480,6 +2503,7 @@ mod tests {
         // The node type is Fun(Hole, Int) — the Hole is inside the compound type.
         let expr = Expr::lit(Lit::Int(1)).with_ty(Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Hole),
             codomain: Box::new(Type::Base(BaseType::Int)),
         });
@@ -2696,6 +2720,7 @@ mod tests {
         let str_elem = Expr::lit(Lit::String("hello".into())).with_ty(Type::Base(BaseType::String));
         let list_ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::UIntRange(2)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
@@ -2729,6 +2754,7 @@ mod tests {
         })
         .with_ty(Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::String)),
             codomain: Box::new(Type::Base(BaseType::String)),
         });

--- a/src/ccl/infer/check.rs
+++ b/src/ccl/infer/check.rs
@@ -102,7 +102,7 @@ impl Typing for CheckCtx {
         // truth for width/variance and (since refinements ride the lattice as
         // restriction witnesses) witness subsetting. A failure is recorded (not
         // propagated) so the walk continues and reports every error.
-        if let Err(e) = constrain_subtype(sub, sup, &mut ConstrainCache::new()) {
+        if let Err(e) = constrain_subtype(sub, sup, &mut ConstrainCache::new_kind_blind()) {
             self.errors.push(map_constrain_err(e, &at()));
         }
         Ok(())

--- a/src/ccl/infer/context.rs
+++ b/src/ccl/infer/context.rs
@@ -147,11 +147,18 @@ impl InferCtx {
                 domain: Box::new(self.normalize_annotation(domain)),
                 kind: *kind,
             },
+            // Structural recursion: normalize the witness's type children and
+            // the body.
+            Type::Sigma(s) => Type::Sigma(Box::new(crate::ccl::ty::SigmaType {
+                witness: s.witness.map_types(|t| self.normalize_annotation(t)),
+                body: Box::new(self.normalize_annotation(&s.body)),
+            })),
             // Leaves and existing inference vars pass through unchanged.
             Type::Base(_)
             | Type::UIntRange(_)
             | Type::DataSource(_)
             | Type::ChanDom(..)
+            | Type::Witness
             | Type::Txn
             | Type::Infer(_) => ty.clone(),
         }

--- a/src/ccl/infer/context.rs
+++ b/src/ccl/infer/context.rs
@@ -113,10 +113,12 @@ impl InferCtx {
             // normalize any nested holes/refinements.
             Type::Fun {
                 name,
+                kind,
                 domain: d,
                 codomain: c,
             } => Type::Fun {
                 name: name.clone(),
+                kind: kind.clone(),
                 domain: Box::new(self.normalize_annotation(d)),
                 codomain: Box::new(self.normalize_annotation(c)),
             },

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -362,7 +362,13 @@ pub(super) fn emit_lambda<C: Typing>(
     // ordinary functions — coalesce strips it when the codomain does not
     // reference it (see `coalesce_compact_go`) — so monomorphic output is
     // unchanged.
-    Ok(Type::pi(&param.name, param_simple, body_ty))
+    //
+    // The lambda's **kind is inferred**: a user `λ` is a capability
+    // (a scalar function) or a collection map depending on its domain and use,
+    // neither settled at emit, so a fresh kind var is minted and the solver
+    // resolves it. (Kind-blind subtyping currently sets no kind bound, so every
+    // such var resolves to the `Compute` default — output unchanged.)
+    Ok(Type::pi_inferred_kind(&param.name, param_simple, body_ty))
 }
 
 /// Type a [`TypedExprNode::Cast`]: `cast(value, target)` re-views `value` at
@@ -414,15 +420,35 @@ pub(super) fn emit_cast<C: Typing>(
         Some(r) => Type::Refinement(Box::new(d), r),
         None => d,
     };
+    // A cast re-views the value *at* `target`, so the result carries `target`'s
+    // kind: a cast to a filtered-collection target (`refined_fn_type`, `Data`)
+    // yields a `Data` collection even though the underlying value is a `Compute`
+    // element projection (`λ u → u.score`, record ⇒ scalar). Preserving only the
+    // domain refinement while dropping `Data` would make every filtered
+    // comprehension / groupby a compute function again, and the aggregate that
+    // consumes it would reject it as compute-where-data.
+    // Peel refinements: a target that is a *refined function* (`{Fun | p}`)
+    // still carries its arrow's kind, which a match on the raw target would drop
+    // to the `Compute` default.
+    let kind = match peel_refinements_outer(target) {
+        Type::Fun { kind, .. } => kind.clone(),
+        _ => crate::ccl::ty::FunKind::Compute,
+    };
     // Preserve the value's Pi binder so the cast result stays a *named* function.
     // A dependent application of the cast then reconciles binders by the identity
     // correspondence (reusing the binder rather than minting a fresh `__arg`),
     // which is what keeps the O8 contravariant-domain discharge from leaving an
     // undischarged binder in the domain's refinement predicate (design §5.2, O8).
-    match peel_refinements_outer(&value_ty) {
-        Type::Fun { name: Some(k), .. } => Ok(Type::pi(k.clone(), domain, v)),
-        _ => Ok(fun(domain, v)),
-    }
+    let name = match peel_refinements_outer(&value_ty) {
+        Type::Fun { name: Some(k), .. } => Some(k.clone()),
+        _ => None,
+    };
+    Ok(Type::Fun {
+        name,
+        kind,
+        domain: Box::new(domain),
+        codomain: Box::new(v),
+    })
 }
 
 pub(super) fn emit_apply<C: Typing>(
@@ -683,7 +709,9 @@ pub(super) fn emit_collection_union<C: Typing>(
         tags.insert(FieldKey::Index(i), dom);
     }
     let dom_variant = variant_type(tags);
-    Ok(fun(dom_variant, cod_var))
+    // `++` produces a collection — a **data** function over the tagged union of
+    // its operands' extents.
+    Ok(Type::data_fun(dom_variant, cod_var))
 }
 
 /// Aggregate (`Sum`, `Max`): the scheme is the full operator type
@@ -975,7 +1003,7 @@ pub(super) fn emit_proj<C: Typing>(
 
 pub(super) fn emit_list<C: Typing>(elts: &mut [Expr], ctx: &mut C) -> Result<Type, InferError> {
     if elts.is_empty() {
-        return Ok(fun(Type::UIntRange(0), prim(BaseType::Unit)));
+        return Ok(Type::data_fun(Type::UIntRange(0), prim(BaseType::Unit)));
     }
     // Element type: derive from the first; constrain remaining to it.
     let first_ty = ctx.subexpr(&mut elts[0])?;
@@ -988,8 +1016,10 @@ pub(super) fn emit_list<C: Typing>(elts: &mut [Expr], ctx: &mut C) -> Result<Typ
     let n = elts.len();
     // Deref a bare mutable read to its value, as in `emit_tuple`: the list's
     // element (codomain) type takes the dereferenced element type so no `Mut`
-    // appears in the list type.
-    Ok(fun(Type::UIntRange(n), deref_mut(&first_ty)))
+    // appears in the list type. A list literal is a **data** function — its
+    // domain is an extent (the index set), so a join with another collection
+    // is lossless (forms a coproduct), never a lossy meet.
+    Ok(Type::data_fun(Type::UIntRange(n), deref_mut(&first_ty)))
 }
 
 /// Emit constraints for a [`TypedExprNode::Case`] — the unified
@@ -1030,11 +1060,10 @@ pub(super) fn emit_case<C: Typing>(
         ctx.require_sub(&scrut_ty, &expected, &|| "Case scrutinee".to_string())?;
     }
 
-    let mut result_ty: Option<Type> = None;
+    // Emit every arm's body type first (each under its pattern scope, restored
+    // on both paths), then join.
+    let mut arm_tys = Vec::with_capacity(branches.len());
     for b in branches.iter_mut() {
-        // A pattern binds its payload (the var just written to `binding.ty`)
-        // over the branch's guard and body. `scoped` restores the scope on
-        // both the happy and error paths.
         let scope_info = b
             .pattern
             .as_ref()
@@ -1043,12 +1072,47 @@ pub(super) fn emit_case<C: Typing>(
             Some((name, ty)) => ctx.scoped(&name, &ty, |ctx| emit_case_branch(b, ctx))?,
             None => emit_case_branch(b, ctx)?,
         };
-        match &result_ty {
-            None => result_ty = Some(body_ty),
-            Some(prev) => ctx.require_eq(&body_ty, prev, &|| "Case arm".to_string())?,
-        }
+        arm_tys.push(body_ty);
     }
-    Ok(result_ty.expect("non-empty branches"))
+    debug_assert!(
+        !arm_tys.is_empty(),
+        "emit_case: a Case must carry at least one branch"
+    );
+
+    // A `Mut`/`History` arm is a **second-class reference**: it cannot be
+    // lattice-joined as a value (that would form a first-class conditional
+    // reference). So if any arm is history-typed, require the arms *equal* — the
+    // Case stays history-typed, and the mut-discipline pass rejects it as a
+    // non-bare-variable reference (rule 1). This preserves the deliberate
+    // rejection of a conditional over stores.
+    // A second-class reference is a `History` (overwrite *or* feed — one variant)
+    // possibly wrapped in refinements; `peel_refinements_outer` names that shape.
+    // Both `Mut[V, D]` and a feed channel are `History`, so this one check covers
+    // every second-class arm — the load-bearing assumption is that a mutable variable is
+    // never wrapped in anything but `Refinement` before reaching here.
+    let any_history = arm_tys
+        .iter()
+        .any(|t| matches!(peel_refinements_outer(t), Type::History { .. }));
+    if any_history {
+        let first = arm_tys[0].clone();
+        for t in &arm_tys[1..] {
+            ctx.require_eq(t, &first, &|| "Case arm".to_string())?;
+        }
+        return Ok(first);
+    }
+
+    // Value and collection arms join by the **lattice**: each arm's type is a
+    // subtype of one fresh result variable, so the result is their least upper
+    // bound (design/type-inference.md §4.6). Homogeneous arms recover the old
+    // behavior (the var pins to the shared type); data-collection arms with
+    // distinct extents coalesce to a coproduct. (Heterogeneous *scalar* arms remain a
+    // hard `IncompatibleBounds` error — the sound union relaxation for them is
+    // deferred; see `coalesce`.)
+    let result = ctx.fresh();
+    for t in &arm_tys {
+        ctx.require_sub(t, &result, &|| "Case arm".to_string())?;
+    }
+    Ok(result)
 }
 
 /// Emit a single Case branch: its guard must be `Bool`; the node takes the
@@ -1115,8 +1179,22 @@ pub(super) fn emit_compose<C: Typing>(elts: &mut [Expr], ctx: &mut C) -> Result<
         Type::Fun { name, .. } => name.clone(),
         _ => None,
     };
+    // The chain's kind is the **first** morphism's: a chain over a data source
+    // (`xs ≫ f`, a comprehension) is a data collection; a chain of compute
+    // morphisms is compute. When the first morphism is still a bare `Infer`
+    // (the common case in Emit — a comprehension composed over a source whose
+    // type has not yet resolved to a `Fun`), the chain's kind is genuinely
+    // use-dependent: mint a fresh kind var so a `Data`-demanding consumer (an
+    // aggregate) forces it `Data` via `constrain_kind`, and it otherwise
+    // resolves from its (now-concrete) domain at coalesce. Hardcoding `Compute`
+    // here would reject every composed comprehension flowing into an aggregate.
+    let kind = match peel_refinements_outer(&tys[0]) {
+        Type::Fun { kind, .. } => kind.clone(),
+        _ => crate::ccl::ty::FunKind::fresh_var(),
+    };
     Ok(Type::Fun {
         name: last_name,
+        kind,
         domain: Box::new(first_dom),
         codomain: Box::new(prev_cod),
     })

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -265,10 +265,17 @@ fn emit_annotation_predicates(ty: &mut Type, ctx: &mut InferCtx) -> Result<(), I
             emit_annotation_predicates(value, ctx)?;
             emit_annotation_predicates(domain, ctx)
         }
+        Type::Sigma(s) => {
+            for t in s.witness.types_mut() {
+                emit_annotation_predicates(t, ctx)?;
+            }
+            emit_annotation_predicates(&mut s.body, ctx)
+        }
         Type::Base(_)
         | Type::UIntRange(_)
         | Type::DataSource(_)
         | Type::ChanDom(..)
+        | Type::Witness
         | Type::Txn
         | Type::Hole
         | Type::Infer(_) => Ok(()),
@@ -1018,7 +1025,7 @@ pub(super) fn emit_list<C: Typing>(elts: &mut [Expr], ctx: &mut C) -> Result<Typ
     // element (codomain) type takes the dereferenced element type so no `Mut`
     // appears in the list type. A list literal is a **data** function — its
     // domain is an extent (the index set), so a join with another collection
-    // is lossless (forms a coproduct), never a lossy meet.
+    // is lossless (forms a conditional-collection Sigma), never a lossy meet.
     Ok(Type::data_fun(Type::UIntRange(n), deref_mut(&first_ty)))
 }
 
@@ -1105,9 +1112,9 @@ pub(super) fn emit_case<C: Typing>(
     // subtype of one fresh result variable, so the result is their least upper
     // bound (design/type-inference.md §4.6). Homogeneous arms recover the old
     // behavior (the var pins to the shared type); data-collection arms with
-    // distinct extents coalesce to a coproduct. (Heterogeneous *scalar* arms remain a
-    // hard `IncompatibleBounds` error — the sound union relaxation for them is
-    // deferred; see `coalesce`.)
+    // distinct extents coalesce to a conditional-collection Sigma. (Heterogeneous
+    // *scalar* arms remain a hard `IncompatibleBounds` error — the sound union
+    // relaxation for them is deferred; see `coalesce`.)
     let result = ctx.fresh();
     for t in &arm_tys {
         ctx.require_sub(t, &result, &|| "Case arm".to_string())?;

--- a/src/ccl/infer/mod.rs
+++ b/src/ccl/infer/mod.rs
@@ -154,25 +154,34 @@ pub(super) fn map_constrain_err(err: ConstrainError, ctx_label: &str) -> InferEr
             } else {
                 InferError::TypeMismatch {
                     ctx: ctx_label.to_string(),
-                    type_a: lhs_ty,
-                    type_b: rhs_ty,
+                    type_a: Box::new(lhs_ty),
+                    type_b: Box::new(rhs_ty),
                 }
             }
         }
         ConstrainError::MissingField { key, in_type } => InferError::TypeMismatch {
             ctx: format!("{ctx_label} (missing field {key:?})"),
-            type_a: coalesce_for_error(&in_type),
-            type_b: Type::Hole,
+            type_a: Box::new(coalesce_for_error(&in_type)),
+            type_b: Box::new(Type::Hole),
         },
         ConstrainError::ExtraTag { tag, in_type } => InferError::TypeMismatch {
             ctx: format!("{ctx_label} (variant tag .{tag} not accepted)"),
-            type_a: coalesce_for_error(&in_type),
-            type_b: Type::Hole,
+            type_a: Box::new(coalesce_for_error(&in_type)),
+            type_b: Box::new(Type::Hole),
         },
         ConstrainError::NotAFeed { found, required } => InferError::TypeMismatch {
             ctx: format!("{ctx_label} (a feed handle is required here, but the value is not one)"),
-            type_a: coalesce_for_error(&found),
-            type_b: coalesce_for_error(&required),
+            type_a: Box::new(coalesce_for_error(&found)),
+            type_b: Box::new(coalesce_for_error(&required)),
+        },
+        ConstrainError::ComputeWhereDataRequired { lhs, rhs } => InferError::TypeMismatch {
+            ctx: format!(
+                "{ctx_label} (a compute function ⇒ was supplied where a data \
+                 collection ⤇ is required — using a capability as an extent \
+                 would iterate a declared domain the value does not cover)"
+            ),
+            type_a: Box::new(coalesce_for_error(&lhs)),
+            type_b: Box::new(coalesce_for_error(&rhs)),
         },
     }
 }
@@ -197,6 +206,17 @@ pub(super) fn map_coalesce_err(err: CoalesceError, ctx_label: &str) -> InferErro
         },
         CoalesceError::RecursiveType { details } => InferError::Unsupported(format!(
             "recursive type at {}: {} (residual μ-types are forbidden)",
+            ctx_label, details
+        )),
+        CoalesceError::ExtentJoinConflict { details } => InferError::Unsupported(format!(
+            "conditional collection extent conflict at {}: {} \
+             (a data function's extents cannot be dropped by joining with a compute function)",
+            ctx_label, details
+        )),
+        CoalesceError::ComputeWhereDataRequired { details } => InferError::Unsupported(format!(
+            "a compute function ⇒ was supplied where a data collection ⤇ is required at {}: {} \
+             (using a capability as an extent would iterate a declared domain the value \
+             does not cover)",
             ctx_label, details
         )),
     }

--- a/src/ccl/infer/schemes.rs
+++ b/src/ccl/infer/schemes.rs
@@ -103,37 +103,47 @@ impl OperatorSchemes {
         // Not: Bool → Bool
         let not_op = PolyScheme::mono(fun(prim(BaseType::Bool), prim(BaseType::Bool)));
 
-        // Sum: ∀α. (α → Int) → Int. The full operator type: consumes a
-        // collection (a function whose domain α is unconstrained) and folds
-        // its Int codomain to an Int. Inline-built so α gets its own fresh
-        // var even though it's unconstrained.
+        // Sum: ∀α. (α ⤇ Int) → Int. The full operator type: consumes a
+        // **collection** (a data function whose extent α is unconstrained) and
+        // folds its Int codomain to an Int. Inline-built so α gets its own
+        // fresh var even though it's unconstrained.
         let alpha = fresh_var(BODY_LEVEL);
         let aggregate_sum = PolyScheme::poly(
             SCHEME_LEVEL,
-            fun(fun(alpha.clone(), prim(BaseType::Int)), prim(BaseType::Int)),
+            fun(
+                Type::data_fun(alpha.clone(), prim(BaseType::Int)),
+                prim(BaseType::Int),
+            ),
         );
 
-        // Max: ∀α γ. (α → γ) → γ. Consumes a collection and folds its
+        // Max: ∀α γ. (α ⤇ γ) → γ. Consumes a collection and folds its
         // codomain γ to a result of the same type.
         let alpha = fresh_var(BODY_LEVEL);
         let gamma = fresh_var(BODY_LEVEL);
-        let aggregate_max = PolyScheme::poly(SCHEME_LEVEL, fun(fun(alpha, gamma.clone()), gamma));
+        let aggregate_max = PolyScheme::poly(
+            SCHEME_LEVEL,
+            fun(Type::data_fun(alpha, gamma.clone()), gamma),
+        );
 
-        // FinalOrDefault: ∀α β. ((α → β), β) → β
-        // Inline-built (not via `normalize_annotation`) so the codomain of the
-        // stream and the default share one variable `β`.
+        // FinalOrDefault: ∀α β. ((α ⤇ β), β) → β. The first field is a
+        // collection stream. Inline-built (not via `normalize_annotation`) so
+        // the codomain of the stream and the default share one variable `β`.
         let alpha = fresh_var(BODY_LEVEL);
         let beta = fresh_var(BODY_LEVEL);
         let mut tup: BTreeMap<FieldKey, Type> = BTreeMap::new();
-        tup.insert(FieldKey::Index(0), fun(alpha.clone(), beta.clone()));
+        tup.insert(
+            FieldKey::Index(0),
+            Type::data_fun(alpha.clone(), beta.clone()),
+        );
         tup.insert(FieldKey::Index(1), beta.clone());
         let final_or_default = PolyScheme::poly(SCHEME_LEVEL, fun(product(tup), beta));
 
-        // GetPrevSeq: ∀ι ν. ((ι → ν), ι, ν) → ν — history, position, default.
+        // GetPrevSeq: ∀ι ν. ((ι ⤇ ν), ι, ν) → ν — history (a collection),
+        // position, default.
         let iota = fresh_var(BODY_LEVEL);
         let nu = fresh_var(BODY_LEVEL);
         let mut tup: BTreeMap<FieldKey, Type> = BTreeMap::new();
-        tup.insert(FieldKey::Index(0), fun(iota.clone(), nu.clone()));
+        tup.insert(FieldKey::Index(0), Type::data_fun(iota.clone(), nu.clone()));
         tup.insert(FieldKey::Index(1), iota);
         tup.insert(FieldKey::Index(2), nu.clone());
         let get_prev_seq = PolyScheme::poly(SCHEME_LEVEL, fun(product(tup), nu));
@@ -156,7 +166,8 @@ impl OperatorSchemes {
             ("write".to_string(), nu.clone()),
         ]);
         let mut tup: BTreeMap<FieldKey, Type> = BTreeMap::new();
-        tup.insert(FieldKey::Index(0), fun(iota, commit_record));
+        // The commit stream (field 0) is a collection — a data function.
+        tup.insert(FieldKey::Index(0), Type::data_fun(iota, commit_record));
         tup.insert(FieldKey::Index(1), Type::Txn);
         tup.insert(FieldKey::Index(2), nu.clone());
         let get_prev_txn = PolyScheme::poly(SCHEME_LEVEL, fun(product(tup), nu));

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -215,11 +215,13 @@ fn types_agree_modulo_unread(read: &Type, now: &Type) -> bool {
                 name: n1,
                 domain: d1,
                 codomain: c1,
+                ..
             },
             Type::Fun {
                 name: n2,
                 domain: d2,
                 codomain: c2,
+                ..
             },
         ) => n1 == n2 && types_agree_modulo_unread(d1, d2) && types_agree_modulo_unread(c1, c2),
         (Type::Tuple(xs), Type::Tuple(ys)) => {
@@ -280,6 +282,8 @@ fn types_agree_modulo_unread(read: &Type, now: &Type) -> bool {
             crate::ccl::HistoryKind::Append => {
                 let stream = Type::Fun {
                     name: None,
+                    // A feed's read view is a collection stream: a data function.
+                    kind: crate::ccl::ty::FunKind::Data,
                     domain: domain.clone(),
                     codomain: value.clone(),
                 };
@@ -676,7 +680,9 @@ fn coalesce_node(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
             if let (Some(first), Some(last)) = (elts.first(), elts.last())
                 && let (
                     Type::Fun {
-                        domain: first_dom, ..
+                        domain: first_dom,
+                        kind: first_kind,
+                        ..
                     },
                     Type::Fun {
                         name: last_name,
@@ -696,6 +702,9 @@ fn coalesce_node(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
                 // dependence.
                 expr.ty = Type::Fun {
                     name: last_name.clone(),
+                    // Kind is the first morphism's (mirrors `emit_compose`): a
+                    // chain over a data source is a data collection.
+                    kind: first_kind.clone(),
                     domain: Box::new((**first_dom).clone()),
                     codomain: Box::new((**last_cod).clone()),
                 };
@@ -1263,6 +1272,7 @@ pub(super) fn specialize_lambda_domain(lambda: &mut Expr, input: &Type) {
     }
     let Type::Fun {
         name,
+        kind,
         domain: dom,
         codomain: cod,
     } = cur
@@ -1294,6 +1304,7 @@ pub(super) fn specialize_lambda_domain(lambda: &mut Expr, input: &Type) {
         // *shape*; a dependent codomain still refers to the same binder.
         Type::Fun {
             name,
+            kind,
             domain: Box::new(new_dom),
             codomain: cod,
         },
@@ -1492,6 +1503,7 @@ mod tests {
         let mut lam = TypedExpr::lambda("x", Type::Base(BaseType::Int), body);
         lam.ty = Type::Fun {
             name: Some("x".into()),
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(refined_int(TypedExpr::var("x"))),
         };

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -291,6 +291,28 @@ fn types_agree_modulo_unread(read: &Type, now: &Type) -> bool {
             }
             crate::ccl::HistoryKind::Overwrite => types_agree_modulo_unread(value, other),
         },
+        // The anonymous type-witness reference agrees with itself.
+        (Type::Witness, Type::Witness) => true,
+        // Two Sigmas agree iff their witnesses (same flavour, type children
+        // agreeing pairwise, value-binder equal) and bodies agree.
+        (Type::Sigma(a), Type::Sigma(b)) => {
+            use crate::ccl::ty::{Kind, Witness};
+            let witness_agree = match (&a.witness, &b.witness) {
+                (Witness::Type(Kind::Enumerated(xs)), Witness::Type(Kind::Enumerated(ys))) => {
+                    xs.len() == ys.len()
+                        && xs
+                            .iter()
+                            .zip(ys)
+                            .all(|(x, y)| types_agree_modulo_unread(x, y))
+                }
+                (Witness::Type(Kind::Any), Witness::Type(Kind::Any)) => true,
+                (Witness::Value { ty: x, binder: bx }, Witness::Value { ty: y, binder: by }) => {
+                    bx == by && types_agree_modulo_unread(x, y)
+                }
+                _ => false,
+            };
+            witness_agree && types_agree_modulo_unread(&a.body, &b.body)
+        }
         _ => false,
     }
 }
@@ -949,10 +971,18 @@ fn coalesce_type_predicates(ty: &mut Type, level: Level, ctx: &mut CoalesceCtx) 
             coalesce_type_predicates(value, level, ctx);
             coalesce_type_predicates(domain, level, ctx);
         }
+        Type::Sigma(s) => {
+            s.witness
+                .types_mut()
+                .iter_mut()
+                .for_each(|t| coalesce_type_predicates(t, level, ctx));
+            coalesce_type_predicates(&mut s.body, level, ctx);
+        }
         Type::Base(_)
         | Type::UIntRange(_)
         | Type::DataSource(_)
         | Type::ChanDom(..)
+        | Type::Witness
         | Type::Txn
         | Type::Hole
         | Type::Infer(_) => {}
@@ -1421,10 +1451,18 @@ fn retype_in_type(ty: &mut Type, scope: &HashMap<Name, Type>) {
             retype_in_type(value, scope);
             retype_in_type(domain, scope);
         }
+        Type::Sigma(s) => {
+            s.witness
+                .types_mut()
+                .iter_mut()
+                .for_each(|t| retype_in_type(t, scope));
+            retype_in_type(&mut s.body, scope);
+        }
         Type::Base(_)
         | Type::UIntRange(_)
         | Type::DataSource(_)
         | Type::ChanDom(..)
+        | Type::Witness
         | Type::Txn
         | Type::Hole
         | Type::Infer(_) => {}

--- a/src/ccl/infer/solver/coalesce.rs
+++ b/src/ccl/infer/solver/coalesce.rs
@@ -208,7 +208,7 @@ fn coalesce_compact_go(ct: &CompactType, polarity: bool) -> Result<Type, Coalesc
                     // (`Index`-tagged `Variant`) of data functions, one per
                     // candidate extent, sharing the joined codomain. A finite,
                     // static set of branches is a plain sum, not a dependent sum
-                    // (see collections.md); the value is one arm, tagged by
+                    // (see type-inference.md Â§4.6); the value is one arm, tagged by
                     // contribution order, matching the runtime value-`Case` gates.
                     //
                     // Materialization invariant: the choices are ground extents.
@@ -460,7 +460,7 @@ mod tests {
         // A `Data` fun slot carrying two distinct extents with a shared `Int`
         // codomain coalesces to the conditional-collection coproduct
         // `([0,1]⤇Int) | ([0,2]⤇Int)` — a plain (`Index`-tagged) sum of data
-        // functions, one per extent (see collections.md; not a dependent sum).
+        // functions, one per extent (see type-inference.md Â§4.6; not a dependent sum).
         let graph = CompactGraph {
             term: CompactType {
                 fun: Some(CompactFun {

--- a/src/ccl/infer/solver/coalesce.rs
+++ b/src/ccl/infer/solver/coalesce.rs
@@ -56,6 +56,27 @@ pub enum CoalesceError {
         /// Pretty representation of the cycle entry point.
         details: String,
     },
+    /// A data function carrying >= 2 candidate extents (a conditional collection) met a compute
+    /// function at a positive join, so collapsing to the ordinary meet would
+    /// drop extents. Reported loudly rather than silently losing data (no
+    /// current program produces this shape). See `design/type-inference.md`
+    /// §4.6.
+    ExtentJoinConflict {
+        /// Pretty representation of the conflicting function shapes.
+        details: String,
+    },
+    /// A single function slot whose kind resolved contradictorily: it was
+    /// demanded as a data extent (`forced_data`) while being — or being fed as
+    /// — a compute capability (a provably-scalar domain, or `forced_compute`).
+    /// This is the coalesce-time face of `Compute <: Data`, the counterpart of
+    /// [`super::constrain::ConstrainError::ComputeWhereDataRequired`] for the
+    /// case where the violation only becomes provable once the kind variable's
+    /// bounds and domain are resolved (e.g. summing a plain `Int ⇒ Int`
+    /// lambda). See `design/type-inference.md` §4.6.
+    ComputeWhereDataRequired {
+        /// Pretty representation of the offending capability.
+        details: String,
+    },
 }
 
 /// Distinguishes a partial tuple (Index keys) from a partial record
@@ -117,21 +138,93 @@ fn coalesce_compact_go(ct: &CompactType, polarity: bool) -> Result<Type, Coalesc
     if let Some(var) = &ct.var {
         shapes.push(materialize_variant(var, polarity)?);
     }
-    if let Some((name, dom, cod)) = &ct.fun {
-        let d = coalesce_compact_go(dom, !polarity)?;
-        let c = coalesce_compact_go(cod, polarity)?;
+    if let Some(cf) = &ct.fun {
+        use super::compact::KindMerge;
+        // Materialize the codomain once (covariant), and each domain
+        // alternative (contravariant), deduplicating at the `Type` level —
+        // this catches var-level equalities that the compact-time
+        // `CompactType ==` dedup in `union_extents` missed (simplify may have
+        // merged uids after compaction).
+        let c = coalesce_compact_go(&cf.codomain, polarity)?;
+        let mut doms: Vec<Type> = Vec::new();
+        for d in &cf.domains {
+            let dt = coalesce_compact_go(d, !polarity)?;
+            if !doms.contains(&dt) {
+                doms.push(dt);
+            }
+        }
         // Strip the Pi binder unless the codomain's refinement predicates
         // actually reference it (design §3.2 / O10): keeps ordinary functions
-        // `name: None` while a genuinely dependent codomain keeps its binder
-        // bound.
-        let kept_name = name
+        // `name: None` while a genuinely dependent codomain keeps its binder.
+        let kept_name = cf
+            .name
             .clone()
             .filter(|b| crate::ccl::subst::type_free_vars(&c).contains(b));
-        shapes.push(Type::Fun {
-            name: kept_name,
-            domain: Box::new(d),
-            codomain: Box::new(c),
-        });
+        match cf.kind {
+            KindMerge::Conflict => {
+                let doms_s = doms
+                    .iter()
+                    .map(|t| t.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ⊔ ");
+                // A single surviving domain means one function slot whose kind
+                // resolved contradictorily: it was demanded as a data extent
+                // (`forced_data`) while being (or being fed as) a compute
+                // capability — the coalesce-time face of `Compute <: Data`.
+                // Two or more surviving domains mean a conditional collection's candidate extents
+                // would be dropped by collapsing to a compute meet (a genuine
+                // extent-join collision). See `design/type-inference.md` §4.6.
+                if doms.len() <= 1 {
+                    return Err(CoalesceError::ComputeWhereDataRequired {
+                        details: format!("a compute function (capability) over {{{doms_s}}}"),
+                    });
+                }
+                return Err(CoalesceError::ExtentJoinConflict {
+                    details: format!(
+                        "data function over {{{doms_s}}} joined with a compute function"
+                    ),
+                });
+            }
+            KindMerge::Compute => {
+                debug_assert_eq!(doms.len(), 1, "compute fun accumulated domain alternatives");
+                shapes.push(Type::Fun {
+                    name: kept_name,
+                    kind: crate::ccl::ty::FunKind::Compute,
+                    domain: Box::new(doms.into_iter().next().expect("compute fun has one domain")),
+                    codomain: Box::new(c),
+                });
+            }
+            KindMerge::Data => {
+                if doms.len() == 1 {
+                    // Idempotence: a single surviving extent is a plain data fun.
+                    shapes.push(Type::Fun {
+                        name: kept_name,
+                        kind: crate::ccl::ty::FunKind::Data,
+                        domain: Box::new(doms.into_iter().next().expect("len == 1")),
+                        codomain: Box::new(c),
+                    });
+                } else {
+                    // ≥ 2 extents: a **conditional collection** — a coproduct
+                    // (`Index`-tagged `Variant`) of data functions, one per
+                    // candidate extent, sharing the joined codomain. A finite,
+                    // static set of branches is a plain sum, not a dependent sum
+                    // (see collections.md); the value is one arm, tagged by
+                    // contribution order, matching the runtime value-`Case` gates.
+                    //
+                    // Materialization invariant: the choices are ground extents.
+                    // Variant width-subtyping matches arms positionally (by tag),
+                    // and `compact_go`/`extrude` treat the arm domains
+                    // contravariantly (at `!pol`); those agree only while a choice
+                    // carries no inference variable, so an `Infer`-bearing choice
+                    // would record a bound at the wrong polarity. Enforce it.
+                    debug_assert!(
+                        !doms.iter().any(crate::ccl::subst::type_contains_infer),
+                        "conditional collection materialized with an inference variable in an extent"
+                    );
+                    shapes.push(Type::extent_coproduct(doms, kept_name, c));
+                }
+            }
+        }
     }
     if let Some((value, domain, kind)) = &ct.history_slot {
         // Both children materialize at the same polarity (invariant — both
@@ -158,6 +251,15 @@ fn coalesce_compact_go(ct: &CompactType, polarity: bool) -> Result<Type, Coalesc
         1 => all.remove(0),
         _ => {
             // Multiple incompatible contributions. Reject.
+            //
+            // NB: a positive-polarity union relaxation for heterogeneous scalar
+            // `Case` arms (`1 if c else "x"` → `Int | String`) is *not* done
+            // here: it is indistinguishable at coalesce from a binop-operand
+            // join (`1 + true`), which must stay a hard error. A sound version
+            // needs strict scalar consumers (binops, …) to impose concrete
+            // bounds so the union is rejected at *their* site; that is deferred
+            // past the coproduct foundation. Collection arms still join losslessly — that happens in
+            // the `fun` slot above (`union_extents`), not through atoms.
             let pretty = all
                 .iter()
                 .map(|t| format!("{t}"))
@@ -211,7 +313,13 @@ fn dissolve_read_feeds(mut ct: CompactType, polarity: bool) -> CompactType {
         // `fun`-slot CompactType (exactly what the old single-payload slot held)
         // and merge it into the read view.
         let chan = CompactType {
-            fun: Some((None, domain, value)),
+            fun: Some(super::compact::CompactFun {
+                name: None,
+                // A feed's read view is a collection stream: a data function.
+                kind: super::compact::KindMerge::Data,
+                domains: vec![*domain],
+                codomain: value,
+            }),
             ..Default::default()
         };
         ct = CompactType::merge(polarity, ct, chan);
@@ -339,10 +447,153 @@ mod tests {
             t,
             Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Compute,
                 domain: Box::new(Type::Base(BaseType::Int)),
                 codomain: Box::new(Type::Base(BaseType::Bool))
             }
         );
+    }
+
+    #[test]
+    fn coalesce_two_data_extents_form_coproduct() {
+        use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
+        // A `Data` fun slot carrying two distinct extents with a shared `Int`
+        // codomain coalesces to the conditional-collection coproduct
+        // `([0,1]⤇Int) | ([0,2]⤇Int)` — a plain (`Index`-tagged) sum of data
+        // functions, one per extent (see collections.md; not a dependent sum).
+        let graph = CompactGraph {
+            term: CompactType {
+                fun: Some(CompactFun {
+                    name: None,
+                    kind: KindMerge::Data,
+                    domains: vec![
+                        compact_type(&Type::UIntRange(2)).term,
+                        compact_type(&Type::UIntRange(3)).term,
+                    ],
+                    codomain: Box::new(compact_type(&prim(BaseType::Int)).term),
+                }),
+                ..Default::default()
+            },
+            rec_vars: BTreeMap::new(),
+        };
+        assert_eq!(
+            coalesce_compact(&graph).unwrap(),
+            Type::extent_coproduct(
+                vec![Type::UIntRange(2), Type::UIntRange(3)],
+                None,
+                Type::Base(BaseType::Int),
+            )
+        );
+    }
+
+    #[test]
+    fn coalesce_single_data_extent_is_plain_data_fun() {
+        use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
+        // One surviving extent collapses to a plain `Data` fun (idempotence:
+        // `xs if c else xs` types as `xs`).
+        let graph = CompactGraph {
+            term: CompactType {
+                fun: Some(CompactFun {
+                    name: None,
+                    kind: KindMerge::Data,
+                    domains: vec![compact_type(&Type::UIntRange(2)).term],
+                    codomain: Box::new(compact_type(&prim(BaseType::Int)).term),
+                }),
+                ..Default::default()
+            },
+            rec_vars: BTreeMap::new(),
+        };
+        assert_eq!(
+            coalesce_compact(&graph).unwrap(),
+            Type::Fun {
+                name: None,
+                kind: crate::ccl::ty::FunKind::Data,
+                domain: Box::new(Type::UIntRange(2)),
+                codomain: Box::new(Type::Base(BaseType::Int)),
+            }
+        );
+    }
+
+    #[test]
+    fn coalesce_duplicate_data_extents_dedup_to_plain_fun() {
+        use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
+        // Two structurally-equal extents dedup to one → a plain `Data` fun, not
+        // a spurious 2-arm coproduct.
+        let graph = CompactGraph {
+            term: CompactType {
+                fun: Some(CompactFun {
+                    name: None,
+                    kind: KindMerge::Data,
+                    domains: vec![
+                        compact_type(&Type::UIntRange(2)).term,
+                        compact_type(&Type::UIntRange(2)).term,
+                    ],
+                    codomain: Box::new(compact_type(&prim(BaseType::Int)).term),
+                }),
+                ..Default::default()
+            },
+            rec_vars: BTreeMap::new(),
+        };
+        assert_eq!(
+            coalesce_compact(&graph).unwrap(),
+            Type::Fun {
+                name: None,
+                kind: crate::ccl::ty::FunKind::Data,
+                domain: Box::new(Type::UIntRange(2)),
+                codomain: Box::new(Type::Base(BaseType::Int)),
+            }
+        );
+    }
+
+    #[test]
+    fn coalesce_extent_join_conflict_errs() {
+        use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
+        // A `Conflict` kind (a conditional collection met a compute function) is a loud coalesce
+        // error, never a silent extent drop.
+        let graph = CompactGraph {
+            term: CompactType {
+                fun: Some(CompactFun {
+                    name: None,
+                    kind: KindMerge::Conflict,
+                    domains: vec![
+                        compact_type(&Type::UIntRange(2)).term,
+                        compact_type(&Type::UIntRange(3)).term,
+                    ],
+                    codomain: Box::new(compact_type(&prim(BaseType::Int)).term),
+                }),
+                ..Default::default()
+            },
+            rec_vars: BTreeMap::new(),
+        };
+        assert!(matches!(
+            coalesce_compact(&graph),
+            Err(CoalesceError::ExtentJoinConflict { .. })
+        ));
+    }
+
+    #[test]
+    fn coalesce_single_domain_conflict_is_compute_where_data_required() {
+        use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
+        // A `Conflict` over a *single* domain is one function slot demanded as a
+        // data extent while being a compute capability — the coalesce-time face
+        // of `Compute <: Data`, reported as `ComputeWhereDataRequired` rather
+        // than the multi-extent `ExtentJoinConflict`.
+        let graph = CompactGraph {
+            term: CompactType {
+                fun: Some(CompactFun {
+                    name: None,
+                    kind: KindMerge::Conflict,
+                    domains: vec![compact_type(&prim(BaseType::Int)).term],
+                    codomain: Box::new(compact_type(&prim(BaseType::Int)).term),
+                }),
+                ..Default::default()
+            },
+            rec_vars: BTreeMap::new(),
+        };
+        assert!(matches!(
+            coalesce_compact(&graph),
+            Err(CoalesceError::ComputeWhereDataRequired { .. })
+        ));
     }
 
     #[test]

--- a/src/ccl/infer/solver/coalesce.rs
+++ b/src/ccl/infer/solver/coalesce.rs
@@ -204,24 +204,24 @@ fn coalesce_compact_go(ct: &CompactType, polarity: bool) -> Result<Type, Coalesc
                         codomain: Box::new(c),
                     });
                 } else {
-                    // ≥ 2 extents: a **conditional collection** — a coproduct
-                    // (`Index`-tagged `Variant`) of data functions, one per
-                    // candidate extent, sharing the joined codomain. A finite,
-                    // static set of branches is a plain sum, not a dependent sum
-                    // (see type-inference.md Â§4.6); the value is one arm, tagged by
-                    // contribution order, matching the runtime value-`Case` gates.
+                    // ≥ 2 extents: a **conditional collection** — the dependent
+                    // sum `Σ (w ∈ {domsᵢ}). w ⤇ c`, one candidate domain per
+                    // branch extent, sharing the joined codomain `c`. The witness
+                    // is the runtime discriminant (which branch was taken),
+                    // projected at elimination (the value-`Case` fan-out). See
+                    // type-inference.md §4.6.
                     //
                     // Materialization invariant: the choices are ground extents.
-                    // Variant width-subtyping matches arms positionally (by tag),
-                    // and `compact_go`/`extrude` treat the arm domains
-                    // contravariantly (at `!pol`); those agree only while a choice
-                    // carries no inference variable, so an `Infer`-bearing choice
-                    // would record a bound at the wrong polarity. Enforce it.
+                    // The Σ subtyping rules match candidate domains by value, and
+                    // `compact_go`/`extrude` treat them contravariantly (at
+                    // `!pol`); those agree only while a choice carries no
+                    // inference variable, so an `Infer`-bearing choice would
+                    // record a bound at the wrong polarity. Enforce it.
                     debug_assert!(
                         !doms.iter().any(crate::ccl::subst::type_contains_infer),
                         "conditional collection materialized with an inference variable in an extent"
                     );
-                    shapes.push(Type::extent_coproduct(doms, kept_name, c));
+                    shapes.push(Type::conditional_collection(doms, kept_name, c));
                 }
             }
         }
@@ -258,7 +258,7 @@ fn coalesce_compact_go(ct: &CompactType, polarity: bool) -> Result<Type, Coalesc
             // join (`1 + true`), which must stay a hard error. A sound version
             // needs strict scalar consumers (binops, …) to impose concrete
             // bounds so the union is rejected at *their* site; that is deferred
-            // past the coproduct foundation. Collection arms still join losslessly — that happens in
+            // past the conditional-collection foundation. Collection arms still join losslessly — that happens in
             // the `fun` slot above (`union_extents`), not through atoms.
             let pretty = all
                 .iter()
@@ -455,12 +455,12 @@ mod tests {
     }
 
     #[test]
-    fn coalesce_two_data_extents_form_coproduct() {
+    fn coalesce_two_data_extents_form_conditional() {
         use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
         // A `Data` fun slot carrying two distinct extents with a shared `Int`
-        // codomain coalesces to the conditional-collection coproduct
-        // `([0,1]⤇Int) | ([0,2]⤇Int)` — a plain (`Index`-tagged) sum of data
-        // functions, one per extent (see type-inference.md Â§4.6; not a dependent sum).
+        // codomain coalesces to the conditional-collection Sigma
+        // `Σ (w ∈ {[0,2], [0,3]}). w ⤇ Int` — one candidate domain per extent
+        // (see type-inference.md §4.6).
         let graph = CompactGraph {
             term: CompactType {
                 fun: Some(CompactFun {
@@ -478,7 +478,7 @@ mod tests {
         };
         assert_eq!(
             coalesce_compact(&graph).unwrap(),
-            Type::extent_coproduct(
+            Type::conditional_collection(
                 vec![Type::UIntRange(2), Type::UIntRange(3)],
                 None,
                 Type::Base(BaseType::Int),
@@ -518,7 +518,7 @@ mod tests {
     fn coalesce_duplicate_data_extents_dedup_to_plain_fun() {
         use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
         // Two structurally-equal extents dedup to one → a plain `Data` fun, not
-        // a spurious 2-arm coproduct.
+        // a spurious 2-choice conditional collection.
         let graph = CompactGraph {
             term: CompactType {
                 fun: Some(CompactFun {

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -216,7 +216,7 @@ pub struct CompactFun {
 /// The lossless join of two data-function domain-alternative lists: the union
 /// of the alternatives, deduplicated by structural [`CompactType`] equality.
 /// Never a meet — this preserves every extent, which coalesce materializes as
-/// a conditional-collection coproduct ([`crate::ccl::Type::extent_coproduct`]);
+/// a conditional-collection Sigma ([`crate::ccl::Type::conditional_collection`]);
 /// a single surviving extent is a plain data function.
 fn union_extents(mut a: Vec<CompactType>, b: Vec<CompactType>) -> Vec<CompactType> {
     for d in b {
@@ -719,6 +719,60 @@ fn compact_go(
                 history_slot: Some((Box::new(value), Box::new(domain), *kind)),
                 ..Default::default()
             }
+        }
+        // A conditional-collection Sigma re-entering compaction (e.g. a
+        // generalized binding whose scheme carries one, freshened at a use site)
+        // decomposes back into the multi-domain `fun` slot it was materialized
+        // from: one domain alternative per candidate extent, sharing the body's
+        // codomain. Coalesce then re-forms the identical Sigma (`union_extents` →
+        // `conditional_collection`), so this is a faithful round-trip. The
+        // anonymous witness reference (`Type::Witness`) carries no solver content
+        // — the extents live in the `Kind::Enumerated` candidates.
+        Type::Sigma(s) => match &s.witness {
+            crate::ccl::ty::Witness::Type(crate::ccl::ty::Kind::Enumerated(choices)) => {
+                let Type::Fun {
+                    name,
+                    codomain: cod,
+                    ..
+                } = &*s.body
+                else {
+                    unreachable!("conditional-collection Sigma body is a data function")
+                };
+                // Domains are contravariant (matches the single-`Fun` arm above).
+                let domains: Vec<CompactType> = choices
+                    .iter()
+                    .map(|d| compact_go(d, !pol, subst_acc, &BTreeSet::new(), st))
+                    .collect();
+                let cod_acc = match name {
+                    Some(b) => subst_acc.shadow(b),
+                    None => subst_acc.clone(),
+                };
+                let codomain = compact_go(cod, pol, &cod_acc, &BTreeSet::new(), st);
+                CompactType {
+                    fun: Some(CompactFun {
+                        name: name.clone(),
+                        // `conditional_collection` always builds a data function.
+                        kind: KindMerge::Data,
+                        domains,
+                        codomain: Box::new(codomain),
+                    }),
+                    ..Default::default()
+                }
+            }
+            // `Collection` (Kind::Any) and value-witness Sigmas (List/Map) are
+            // introduced with the collections work, not the conditionals path.
+            crate::ccl::ty::Witness::Type(crate::ccl::ty::Kind::Any)
+            | crate::ccl::ty::Witness::Value { .. } => {
+                unimplemented!(
+                    "compaction of Collection / value-witness Sigmas is deferred to the collections work"
+                )
+            }
+        },
+        // A bare witness reference only exists in a Sigma body's domain slot,
+        // which the `Sigma` arm consumes without recursing into — so a `Witness`
+        // reaching the compaction walk on its own is a bug.
+        Type::Witness => {
+            unreachable!("bare Type::Witness reached compaction outside its Sigma binder")
         }
         Type::Infer(state) => {
             let uid = state.uid;

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -82,7 +82,219 @@ impl AtomKey {
 /// neither directly, so [`coalesce_compact`](super::coalesce::coalesce_compact)
 /// picks a single concrete type from these bag-of-types contributions and
 /// errors on conflict.
-#[derive(Debug, Clone, Default)]
+/// The kind of a merged function slot. Three-state so [`CompactType::merge`]
+/// stays infallible: a `Data ⊔ Compute` collision that would collapse a
+/// conditional collection's extents becomes `Conflict` and is reported loudly at coalesce
+/// ([`super::coalesce::CoalesceError::ExtentJoinConflict`]), never a mid-merge
+/// panic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KindMerge {
+    /// Capability domain — the ordinary contravariant meet.
+    Compute,
+    /// Extent domain — joins are lossless (`union_extents`).
+    Data,
+    /// A data/compute or multi-extent collision; deferred to coalesce.
+    Conflict,
+}
+
+impl KindMerge {
+    /// Resolve a function's kind against its (already-compacted) domain. A
+    /// concrete kind passes through; a [`crate::ccl::ty::FunKind::Var`] resolves
+    /// from its bounds over the two-point lattice `Data ⊑ Compute` (a `Compute`
+    /// lower bound → `Compute`, a `Data` upper bound → `Data`, both → the
+    /// `Compute <: Data` conflict), and an **unconstrained** var resolves from
+    /// the domain: an *extent-shaped* domain (a collection index the runtime
+    /// iterates) → `Data`, else the `Compute` capability default. Passing the
+    /// domain is what lets a map/comprehension — a lambda whose kind var picks
+    /// up no bound — resolve `Data`, so two of them join losslessly (`union_extents`)
+    /// rather than colliding as compute meets.
+    fn of(kind: &crate::ccl::ty::FunKind, dom: &CompactType) -> Self {
+        use crate::ccl::ty::FunKind;
+        match kind {
+            FunKind::Compute => KindMerge::Compute,
+            FunKind::Data => KindMerge::Data,
+            FunKind::Var(v) => {
+                let b = v.bounds.borrow();
+                match (b.forced_compute, b.forced_data) {
+                    (true, true) => KindMerge::Conflict,
+                    (false, true) => {
+                        // `forced_data` means this function is demanded where its
+                        // extent is iterated. If the domain is *provably* scalar (a
+                        // primitive or a higher-order capability parameter), the
+                        // demand contradicts the shape: a capability was supplied
+                        // where a data extent is required (`Compute <: Data`). That
+                        // is a real conflict, surfaced loudly at coalesce like the
+                        // two-flag case below — never a silent relabelling of a
+                        // scalar as a collection (which the runtime would then try
+                        // to iterate over a domain the value does not cover).
+                        if is_scalar_domain(dom) {
+                            KindMerge::Conflict
+                        } else {
+                            KindMerge::Data
+                        }
+                    }
+                    (true, false) => KindMerge::Compute,
+                    (false, false) => {
+                        if is_extent_domain(dom) {
+                            KindMerge::Data
+                        } else {
+                            KindMerge::Compute
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Whether a compacted domain is **extent-shaped** — a collection index (which
+/// the runtime iterates), as opposed to a scalar/capability parameter. Used to
+/// resolve an unconstrained kind var: an extent domain means the function is a
+/// data collection (`Data`), a capability domain a compute function (`Compute`).
+///
+/// Extent atoms are `UIntRange` (a list's `[0, n)`), `Source` (a data source's
+/// domain), and `Txn` (a register's commit order). A product/sum of extents (a
+/// multi-generator comprehension's record domain, a union's variant domain) is
+/// itself an extent iff every component is. A scalar (`Prim`), a function-typed
+/// domain (a higher-order capability), or a still-unresolved variable is *not*
+/// an extent — the conservative `Compute` side (a polymorphic-in-kind function
+/// whose domain resolves later is the residual the bounds-based path handles).
+fn is_extent_domain(ct: &CompactType) -> bool {
+    if ct.atoms.iter().any(|a| matches!(a, AtomKey::Prim(_))) {
+        return false;
+    }
+    if ct
+        .atoms
+        .iter()
+        .any(|a| matches!(a, AtomKey::UIntRange(_) | AtomKey::Source(_) | AtomKey::Txn))
+    {
+        return true;
+    }
+    // A higher-order (function-typed) domain is a capability.
+    if ct.fun.is_some() {
+        return false;
+    }
+    // A product / sum of extents is an extent.
+    if let Some(rec) = &ct.rec
+        && !rec.is_empty()
+    {
+        return rec.values().all(is_extent_domain);
+    }
+    if let Some(var) = &ct.var
+        && !var.is_empty()
+    {
+        return var.values().all(is_extent_domain);
+    }
+    // Bare variable / empty shape: unresolved → conservative Compute.
+    false
+}
+
+/// Whether a compacted domain is *provably* scalar/capability-shaped: it carries
+/// a primitive atom or is function-typed. This is stronger than `!is_extent_domain`,
+/// which also holds for a still-unresolved domain (a bare var that may yet resolve
+/// to an extent) — used only to assert the `forced_data`/domain-edge coupling.
+fn is_scalar_domain(ct: &CompactType) -> bool {
+    ct.atoms.iter().any(|a| matches!(a, AtomKey::Prim(_))) || ct.fun.is_some()
+}
+
+/// A merged function shape. `domains` holds one entry for an ordinary function
+/// (the meet of the merged domains); a positive `Data ⊔ Data` join accumulates
+/// ≥ 2 deduplicated alternatives — the candidate extents of a conditional collection, materialized
+/// by coalesce.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompactFun {
+    /// The Pi (element) binder, `na.or(nb)` on merge.
+    pub name: Option<Name>,
+    /// The merged kind.
+    pub kind: KindMerge,
+    /// Domain alternatives — `len == 1` unless a conditional collection formed.
+    pub domains: Vec<CompactType>,
+    /// The codomain (covariant).
+    pub codomain: Box<CompactType>,
+}
+
+/// The lossless join of two data-function domain-alternative lists: the union
+/// of the alternatives, deduplicated by structural [`CompactType`] equality.
+/// Never a meet — this preserves every extent, which coalesce materializes as
+/// a conditional-collection coproduct ([`crate::ccl::Type::extent_coproduct`]);
+/// a single surviving extent is a plain data function.
+fn union_extents(mut a: Vec<CompactType>, b: Vec<CompactType>) -> Vec<CompactType> {
+    for d in b {
+        if !a.contains(&d) {
+            a.push(d);
+        }
+    }
+    a
+}
+
+impl CompactFun {
+    /// Merge two function slots. `pol` is the *outer* polarity; domains merge
+    /// contravariantly (at `!pol`), the codomain covariantly (at `pol`).
+    fn merge(pol: bool, a: CompactFun, b: CompactFun) -> CompactFun {
+        use KindMerge::*;
+        let name = a.name.clone().or_else(|| b.name.clone());
+        let codomain = Box::new(CompactType::merge(pol, *a.codomain, *b.codomain));
+        // The contravariant domain meet, defined only when both sides carry a
+        // single extent (a multi-extent collection has no single domain to meet).
+        let meet = |x: Vec<CompactType>, y: Vec<CompactType>| -> Vec<CompactType> {
+            debug_assert!(
+                x.len() == 1 && y.len() == 1,
+                "meet of a multi-extent domain"
+            );
+            vec![CompactType::merge(
+                !pol,
+                x.into_iter().next().unwrap(),
+                y.into_iter().next().unwrap(),
+            )]
+        };
+        // On any prior conflict, stay conflicted (keep the wider domain list
+        // so coalesce can render diagnostics).
+        let widest = |x: Vec<CompactType>, y: Vec<CompactType>| {
+            if x.len() >= y.len() { x } else { y }
+        };
+        let (kind, domains) = if a.kind == Conflict || b.kind == Conflict {
+            (Conflict, widest(a.domains, b.domains))
+        } else if pol {
+            // Positive (join).
+            match (a.kind, b.kind) {
+                (Data, Data) => (Data, union_extents(a.domains, b.domains)),
+                (Compute, Compute) => (Compute, meet(a.domains, b.domains)),
+                // Data ⊔ Compute: an honest upcast to a callable (Compute) iff
+                // the data side is a single extent; collapsing a conditional collection to a meet
+                // would be multi-extent loss → Conflict.
+                _ => {
+                    if a.domains.len() == 1 && b.domains.len() == 1 {
+                        (Compute, meet(a.domains, b.domains))
+                    } else {
+                        (Conflict, widest(a.domains, b.domains))
+                    }
+                }
+            }
+        } else {
+            // Negative (meet): the stronger contract wins (Data if either is).
+            let k = if a.kind == Data || b.kind == Data {
+                Data
+            } else {
+                Compute
+            };
+            if a.domains.len() == 1 && b.domains.len() == 1 {
+                (k, meet(a.domains, b.domains))
+            } else {
+                // Two multi-extent requirements meeting at a negative position — no current
+                // program produces this; flag it loudly at coalesce.
+                (Conflict, widest(a.domains, b.domains))
+            }
+        };
+        CompactFun {
+            name,
+            kind,
+            domains,
+            codomain,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct CompactType {
     /// Variable contributions from this position. Multiple variables
     /// can co-occur (e.g. when two projection morphisms both flow into
@@ -116,13 +328,11 @@ pub struct CompactType {
     /// the absorbing element (here from intersecting disjoint tag sets at
     /// negative polarity).
     pub var: Option<BTreeMap<FieldKey, CompactType>>,
-    /// Function shape, if any: an optional Pi binder name plus the domain
-    /// and codomain. Recursively merged with polarity flip on the domain.
-    /// The name is preserved so a dependent codomain's refinement predicate
-    /// keeps its binder bound through coalesce; it is stripped at
-    /// materialization when the codomain does not actually reference it
-    /// (keeping ordinary functions `name: None`).
-    pub fun: Option<(Option<Name>, Box<CompactType>, Box<CompactType>)>,
+    /// Function shape, if any: see [`CompactFun`]. Carries the Pi binder, the
+    /// merged [`KindMerge`], the domain alternatives (one, unless a positive
+    /// `Data ⊔ Data` join accumulated alternatives via [`union_extents`]), and the
+    /// codomain. Recursively merged with polarity flip on the domain.
+    pub fun: Option<CompactFun>,
     /// Witness contributions at this position. A set with `==`
     /// membership (deduplicated by [`Refinement`]'s structural `PartialEq`),
     /// stored as a `Vec` in first-insertion order. A refinement-set is
@@ -176,15 +386,7 @@ impl CompactType {
         };
         let fun = match (lhs.fun, rhs.fun) {
             (None, f) | (f, None) => f,
-            (Some((na, la, ra)), Some((nb, lb, rb))) => Some((
-                // Prefer a present binder name; two distinct names at one
-                // position only arise for unrelated functions merging, where
-                // either is as good (the name is stripped at coalesce unless
-                // the codomain references it).
-                na.or(nb),
-                Box::new(Self::merge(!pol, *la, *lb)),
-                Box::new(Self::merge(pol, *ra, *rb)),
-            )),
+            (Some(a), Some(b)) => Some(CompactFun::merge(pol, a, b)),
         };
         let refinements = Self::merge_refinements(pol, lhs.refinements, rhs.refinements);
         // History children merge componentwise at the outer polarity
@@ -430,6 +632,7 @@ fn compact_go(
         Type::Hole => CompactType::empty(),
         Type::Fun {
             name,
+            kind,
             domain: d,
             codomain: c,
         } => {
@@ -446,7 +649,12 @@ fn compact_go(
             };
             let cod = compact_go(c, pol, &cod_acc, &BTreeSet::new(), st);
             CompactType {
-                fun: Some((name.clone(), Box::new(dom), Box::new(cod))),
+                fun: Some(CompactFun {
+                    name: name.clone(),
+                    kind: KindMerge::of(kind, &dom),
+                    domains: vec![dom],
+                    codomain: Box::new(cod),
+                }),
                 ..Default::default()
             }
         }

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -436,7 +436,8 @@ fn constrain_go(
         }
 
         // (Dependent-sum (Σ) rules live just below, after the `Record` arm. They
-        // are general rules on the sum, *realized per witness `Kind`*: the solver
+        // are general rules on the sum, *realized per witness* (dispatch is on the
+        // `Witness`, and for a type-witness further on its `Kind`): the solver
         // knows dependent sums, not any surface concept. Two are genuine subtyping
         // — the injection `Fun(Data) <: Σ` (a branch is-a sum) and the width
         // `Σ <: Σ` (a smaller sum is-a bigger sum). The third, `Σ <: Fun`, is
@@ -487,7 +488,8 @@ fn constrain_go(
         // This is how the `emit_case` join lands — each arm is constrained `<:
         // result`, and `result` coalesces to the Σ, so at the consistency wall
         // each arm re-injects into it. The membership test is realized per
-        // witness `Kind`; the covariant codomain edge is Kind-agnostic.
+        // witness; the codomain then flows covariantly the same way for every
+        // witness.
         (
             Type::Fun {
                 name: pn,
@@ -542,7 +544,7 @@ fn constrain_go(
         // domain var resolves to the union (the common case — `sum`, `[… for x in
         // …]`), a consumer demanding a *concrete narrower* extent fails the edge,
         // so the collection never silently narrows. The presented domain is
-        // realized per witness `Kind`.
+        // realized per witness.
         (
             Type::Sigma(s),
             Type::Fun {
@@ -591,7 +593,7 @@ fn constrain_go(
 
         // **Σ-width** `Σ <: Σ`: the lhs sum's witness domain must be a subset of
         // the rhs's, and the shared codomain flows covariantly. The subset test
-        // is realized per witness `Kind` pair.
+        // is realized per witness pair.
         (Type::Sigma(a), Type::Sigma(b)) => match (&a.witness, &b.witness) {
             // Two conditional collections: every lhs candidate extent must appear
             // among the rhs candidates (matched by *value*, not position — a

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -20,7 +20,7 @@ use std::rc::Rc;
 use smol_str::SmolStr;
 
 use crate::ccl::subst::Subst;
-use crate::ccl::ty::{FunKind, Kind, KindVar, Witness};
+use crate::ccl::ty::{FunKind, FunKindVar, Kind, Witness};
 use crate::ccl::{Bound, HistoryKind, InferVar, InferVarId, Level, Refinement, Type};
 
 use super::type_level;
@@ -186,7 +186,7 @@ pub fn constrain_subtype(
 /// Variable edges set `forced_*` flags, resolved at coalesce
 /// ([`super::compact::KindMerge`]): a compute value flowing *into* a var forces
 /// it `Compute`; a var *demanded* as data forces it `Data`; a var-to-var edge
-/// records a `<:` link ([`KindVar::link`]). Forces propagate transitively along
+/// records a `<:` link ([`FunKindVar::link`]). Forces propagate transitively along
 /// links as they arrive, so ordering does not matter (a force after its link
 /// still reaches the far end). A var that ends up with both flags is the
 /// conflict — surfaced loudly at coalesce, never here.
@@ -209,9 +209,9 @@ fn constrain_kind(k0: &FunKind, k1: &FunKind, kind_aware: bool) -> bool {
             false
         }
         // A var-to-var edge `v0 <: v1`: record the link so a force arriving on
-        // either end *after* this edge still reaches the other. See [`KindVar`].
+        // either end *after* this edge still reaches the other. See [`FunKindVar`].
         (Var(v0), Var(v1)) => {
-            KindVar::link(v0, v1);
+            FunKindVar::link(v0, v1);
             false
         }
     }
@@ -2285,7 +2285,7 @@ mod tests {
         // rejection — the var may still legitimately resolve `Data`); it
         // resolves at coalesce. A compute value flowing into it would set
         // `forced_compute`, and both flags together is the conflict.
-        let v = KindVar::fresh();
+        let v = FunKindVar::fresh();
         let var_fun = Type::Fun {
             name: None,
             kind: FunKind::Var(Rc::clone(&v)),
@@ -2313,9 +2313,9 @@ mod tests {
         // a later edge (`Compute <: v0`). Transitive propagation must carry
         // `forced_compute` up to `v1`; the old one-shot copy dropped it, letting
         // `v1` fall to its (possibly `Data`) domain default — a silent miskind.
-        let v0 = KindVar::fresh();
-        let v1 = KindVar::fresh();
-        let fun_of = |v: &Rc<KindVar>| Type::Fun {
+        let v0 = FunKindVar::fresh();
+        let v1 = FunKindVar::fresh();
+        let fun_of = |v: &Rc<FunKindVar>| Type::Fun {
             name: None,
             kind: FunKind::Var(Rc::clone(v)),
             domain: Box::new(Type::UIntRange(3)),

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -439,7 +439,7 @@ fn constrain_go(
         // `Fun(Data) <: Variant`, the consume `Variant <: Fun`, and the
         // width `Variant <: Variant` — lives with the other `Variant` arms
         // below; a finite conditional collection is a plain coproduct, not a
-        // dependent sum. See `Type::extent_coproduct` and collections.md.)
+        // dependent sum. See `Type::extent_coproduct` and type-inference.md Â§4.6.)
 
         // Tuple: positional width-subtyping. A longer/equal tuple is a
         // subtype, so every position rhs requires must exist in lhs.
@@ -2147,7 +2147,7 @@ mod tests {
         drop(arena);
     }
 
-    // --- Conditional-collection coproduct subtyping (collections.md) ---
+    // --- Conditional-collection coproduct subtyping (type-inference.md Â§4.6) ---
 
     fn coproduct(extents: Vec<Type>) -> Type {
         Type::extent_coproduct(extents, None, prim(BaseType::Int))

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -20,7 +20,7 @@ use std::rc::Rc;
 use smol_str::SmolStr;
 
 use crate::ccl::subst::Subst;
-use crate::ccl::ty::{FunKind, KindVar};
+use crate::ccl::ty::{FunKind, Kind, KindVar, Witness};
 use crate::ccl::{Bound, HistoryKind, InferVar, InferVarId, Level, Refinement, Type};
 
 use super::type_level;
@@ -298,8 +298,8 @@ fn bridge_holder_gap(lo: &Subst, hi: &Subst) -> (Subst, Subst) {
     // constraining different fibers (of one family — g(0) vs g(1) — or of two
     // unrelated families), between which no sound transport exists. This is
     // the extent-join corner (O1/O4); the eventual resolution is the
-    // lossless coproduct extent regime (data-vs-compute functions), under which
-    // both fibers become arms of the one coproduct and the
+    // lossless conditional-collection extent regime (data-vs-compute functions),
+    // under which both fibers become candidate domains of the one Sigma and the
     // question dissolves. Until then: no reachable program produces this
     // shape, so reaching it means a solver bug — refuse loudly rather than
     // corrupt the edge.
@@ -435,11 +435,18 @@ fn constrain_go(
             constrain_go(c0, c1, &cod_sl, sr, cache)
         }
 
-        // (Conditional-collection coproduct subtyping — the injection
-        // `Fun(Data) <: Variant`, the consume `Variant <: Fun`, and the
-        // width `Variant <: Variant` — lives with the other `Variant` arms
-        // below; a finite conditional collection is a plain coproduct, not a
-        // dependent sum. See `Type::extent_coproduct` and type-inference.md Â§4.6.)
+        // (Dependent-sum (Σ) rules live just below, after the `Record` arm. They
+        // are general rules on the sum, *realized per witness `Kind`*: the solver
+        // knows dependent sums, not any surface concept. Two are genuine subtyping
+        // — the injection `Fun(Data) <: Σ` (a branch is-a sum) and the width
+        // `Σ <: Σ` (a smaller sum is-a bigger sum). The third, `Σ <: Fun`, is
+        // **not** subsumption but Σ-*elimination* discharged through this solver:
+        // a Σ value is one branch, not a function total on the union, so it cannot
+        // be subsumed to one — consuming it distributes the consumer over the
+        // witness. Only the `Kind::Enumerated` witness (what a conditional
+        // collection materializes) is wired today; the `Kind::Any` (`Collection`)
+        // and value-witness (`List`/`Map`) realizations are `todo!()` skeletons.
+        // See type-inference.md §4.6.)
 
         // Tuple: positional width-subtyping. A longer/equal tuple is a
         // subtype, so every position rhs requires must exist in lhs.
@@ -474,13 +481,13 @@ fn constrain_go(
             Ok(())
         }
 
-        // A single data function **injected** into a conditional-collection
-        // coproduct (`Type::extent_coproduct`): one branch of the union, matched
-        // to the arm with the same extent. This is how the `emit_case` join
-        // lands — each arm is constrained `<: result`, and `result` coalesces to
-        // the coproduct, so at the consistency wall each arm re-subsumes into it.
-        // The extent match is by *value* (like the old Σ-intro), and only fires
-        // when every arm is a data function.
+        // **Σ-injection** `Fun(Data) <: Σ`: a data function is a subtype of the
+        // sum iff its domain is a body-instantiation for some witness the sum
+        // ranges over, and its codomain then flows into the sum's shared codomain.
+        // This is how the `emit_case` join lands — each arm is constrained `<:
+        // result`, and `result` coalesces to the Σ, so at the consistency wall
+        // each arm re-injects into it. The membership test is realized per
+        // witness `Kind`; the covariant codomain edge is Kind-agnostic.
         (
             Type::Fun {
                 name: pn,
@@ -488,98 +495,111 @@ fn constrain_go(
                 domain,
                 codomain: c0,
             },
-            Type::Variant(arms),
-        ) if !arms.is_empty()
-            && arms.iter().all(|(_, t)| {
-                matches!(
-                    t,
-                    Type::Fun {
-                        kind: FunKind::Data,
-                        ..
-                    }
-                )
-            }) =>
-        {
-            let matched = arms.iter().find_map(|(_, t)| match t {
-                Type::Fun {
-                    name: an,
-                    domain: d,
-                    codomain: ac,
-                    ..
-                } if d.as_ref() == domain.as_ref() => Some((an, ac)),
-                _ => None,
-            });
-            match matched {
-                Some((an, ac)) => {
-                    let cod_sl = match (pn, an) {
-                        (Some(k), Some(x)) => sl.extended_rename(k, x),
-                        _ => sl.clone(),
-                    };
-                    constrain_go(c0, ac, &cod_sl, sr, cache)
+            Type::Sigma(s),
+        ) => {
+            let injects = match &s.witness {
+                // The witness is one of these domains: inject iff `domain` is one.
+                Witness::Type(Kind::Enumerated(candidates)) => {
+                    candidates.iter().any(|d| d == domain.as_ref())
                 }
-                None => Err(ConstrainError::Mismatch {
+                // The universe ranges over every domain, so any data function
+                // injects.
+                Witness::Type(Kind::Any) => {
+                    todo!("Σ-injection into a Collection (Kind::Any): any domain injects")
+                }
+                // Inject iff `domain` is the body refinement instantiated at some
+                // value of the witness type.
+                Witness::Value { .. } => {
+                    todo!("Σ-injection into a value-witness sum (List/Map)")
+                }
+            };
+            if injects {
+                let cod_sl = match (pn, s.binder()) {
+                    (Some(k), Some(x)) => sl.extended_rename(k, x),
+                    _ => sl.clone(),
+                };
+                constrain_go(c0, s.codomain(), &cod_sl, sr, cache)
+            } else {
+                Err(ConstrainError::Mismatch {
                     lhs: lhs.clone(),
                     rhs: rhs.clone(),
-                }),
+                })
             }
         }
 
-        // A **conditional collection** (a coproduct of data functions formed at
-        // a control-flow join — `Type::extent_coproduct`) *consumed* as a plain
-        // collection: whatever arm it turns out to be, iterating it walks the
-        // discriminated union of the arms' extents, so it presents as
-        // `Fun(Variant({Index(i): domainᵢ}), V)` — the same tagged domain the
-        // runtime union tile carries. The consumer's domain edge is
-        // contravariant: a *fresh* domain var resolves to the union (the common
-        // case — `sum`, `[… for x in …]`), a consumer demanding a *concrete
-        // narrower* extent fails the `d1 <: Variant` edge. Each arm's codomain
-        // flows into the consumer codomain (the arms share the joined codomain,
-        // so this is one covariant edge per arm). Fires only when every arm is a
-        // data function; a user tagged-union is not a collection.
+        // **Σ-elimination** `Σ <: Fun`: a sum *consumed* as a plain collection.
+        // Not subsumption — consuming distributes the consumer over the witness;
+        // the domain it sees is the discriminated union of the body-instantiation
+        // domains, and the shared codomain flows into the consumer codomain (one
+        // covariant edge). The consumer's domain edge is contravariant: a *fresh*
+        // domain var resolves to the union (the common case — `sum`, `[… for x in
+        // …]`), a consumer demanding a *concrete narrower* extent fails the edge,
+        // so the collection never silently narrows. The presented domain is
+        // realized per witness `Kind`.
         (
-            Type::Variant(arms),
+            Type::Sigma(s),
             Type::Fun {
                 name: n1,
                 domain: d1,
                 codomain: c1,
                 ..
             },
-        ) if !arms.is_empty()
-            && arms.iter().all(|(_, t)| {
-                matches!(
-                    t,
-                    Type::Fun {
-                        kind: FunKind::Data,
-                        ..
-                    }
-                )
-            }) =>
-        {
-            let extent_variant = Type::Variant(
-                arms.iter()
-                    .map(|(k, t)| {
-                        let Type::Fun { domain, .. } = t else {
-                            unreachable!("guard checked all arms are Fun")
-                        };
-                        (k.clone(), domain.as_ref().clone())
-                    })
-                    .collect(),
-            );
-            constrain_go(d1, &extent_variant, sr, sl, cache)?;
-            for (_, t) in arms {
-                let Type::Fun {
-                    name: pn, codomain, ..
-                } = t
-                else {
-                    unreachable!("guard checked all arms are Fun")
-                };
-                let cod_sl = match (pn, n1) {
+        ) => {
+            let consumed_domain = match &s.witness {
+                // A finite, discriminated union of the candidate extents — the
+                // same tagged domain the runtime union tile carries.
+                Witness::Type(Kind::Enumerated(candidates)) => Type::Variant(
+                    candidates
+                        .iter()
+                        .enumerate()
+                        .map(|(i, d)| (FieldKey::Index(i), d.clone()))
+                        .collect(),
+                ),
+                // The universe is not enumerable, so there is no finite union to
+                // present — elimination is opaque/existential.
+                Witness::Type(Kind::Any) => {
+                    todo!("Σ-elimination of a Collection (Kind::Any): opaque domain")
+                }
+                // The refined key-domain derived from the witness value.
+                Witness::Value { .. } => {
+                    todo!("Σ-elimination of a value-witness sum (List/Map)")
+                }
+            };
+            constrain_go(d1, &consumed_domain, sr, sl, cache)?;
+            let cod_sl = match (s.binder(), n1) {
+                (Some(k), Some(x)) => sl.extended_rename(k, x),
+                _ => sl.clone(),
+            };
+            constrain_go(s.codomain(), c1, &cod_sl, sr, cache)
+        }
+
+        // **Σ-width** `Σ <: Σ`: the lhs sum's witness domain must be a subset of
+        // the rhs's, and the shared codomain flows covariantly. The subset test
+        // is realized per witness `Kind` pair.
+        (Type::Sigma(a), Type::Sigma(b)) => {
+            let witness_subset = match (&a.witness, &b.witness) {
+                // Every lhs candidate extent must appear among the rhs candidates
+                // (matched by *value*, not position — a nested/re-subsumed
+                // conditional's extents land in an arbitrary order).
+                (Witness::Type(Kind::Enumerated(xs)), Witness::Type(Kind::Enumerated(ys))) => {
+                    xs.iter().all(|x| ys.iter().any(|y| y == x))
+                }
+                // Any other witness-Kind pairing (Collection / value-witness, and
+                // cross-Kind relations) is decided with the collections work.
+                _ => todo!("Σ-width for non-enumerated witness Kinds"),
+            };
+            if witness_subset {
+                let cod_sl = match (a.binder(), b.binder()) {
                     (Some(k), Some(x)) => sl.extended_rename(k, x),
                     _ => sl.clone(),
                 };
-                constrain_go(codomain, c1, &cod_sl, sr, cache)?;
+                constrain_go(a.codomain(), b.codomain(), &cod_sl, sr, cache)
+            } else {
+                Err(ConstrainError::Mismatch {
+                    lhs: lhs.clone(),
+                    rhs: rhs.clone(),
+                })
             }
-            Ok(())
         }
 
         // Variant: width-subtyping is the dual. lhs's tags must all appear
@@ -992,6 +1012,17 @@ pub fn extrude(ty: &Type, pol: bool, target_level: Level, cache: &mut ExtrudeCac
             Box::new(extrude(inner, pol, target_level, cache)),
             r.clone(),
         ),
+        // The witness's type children are the real (contravariant) domain, so
+        // they extrude at `!pol` — matching the single-`Fun` domain above; the
+        // body (a data function over the witness) extrudes covariantly. The
+        // anonymous witness reference is at level 0, so it short-circuits.
+        Type::Sigma(s) => Type::Sigma(Box::new(crate::ccl::ty::SigmaType {
+            witness: s
+                .witness
+                .map_types(|t| extrude(t, !pol, target_level, cache)),
+            body: Box::new(extrude(&s.body, pol, target_level, cache)),
+        })),
+        Type::Witness => ty.clone(),
         // Invariant payload: polarity is meaningless under invariance, so
         // both children are extruded with two-way proxies (a history is read
         // *and* written) instead of the polar one-way approximation below.
@@ -2147,20 +2178,21 @@ mod tests {
         drop(arena);
     }
 
-    // --- Conditional-collection coproduct subtyping (type-inference.md Â§4.6) ---
+    // --- Conditional-collection Sigma rules (subtyping: injection + width;
+    //     elimination: consume) — type-inference.md §4.6 ---
 
-    fn coproduct(extents: Vec<Type>) -> Type {
-        Type::extent_coproduct(extents, None, prim(BaseType::Int))
+    fn conditional(extents: Vec<Type>) -> Type {
+        Type::conditional_collection(extents, None, prim(BaseType::Int))
     }
 
     #[test]
-    fn coproduct_width_is_subtype() {
-        // A conditional collection is a coproduct (`Index`-tagged Variant of
-        // data functions); width-subtyping is positional — the lhs's tags
-        // (a prefix) appear in the rhs. The reverse (rhs has an extra tag) is
-        // not a subtype.
-        let sub = coproduct(vec![Type::UIntRange(2), Type::UIntRange(3)]);
-        let sup = coproduct(vec![
+    fn conditional_width_is_subtype() {
+        // A conditional collection is a Sigma over candidate domains;
+        // width-subtyping is by-value subset — every lhs candidate extent
+        // appears among the rhs candidates. The reverse (rhs has an extra
+        // extent the lhs lacks) is not a subtype.
+        let sub = conditional(vec![Type::UIntRange(2), Type::UIntRange(3)]);
+        let sup = conditional(vec![
             Type::UIntRange(2),
             Type::UIntRange(3),
             Type::UIntRange(4),
@@ -2170,11 +2202,11 @@ mod tests {
     }
 
     #[test]
-    fn data_fun_injects_into_coproduct() {
-        // Injection: a single data function whose extent matches one arm is a
-        // subtype of the coproduct (the `emit_case` arm-into-result edge); a
-        // data function over a non-member extent is not.
-        let sup = coproduct(vec![Type::UIntRange(2), Type::UIntRange(3)]);
+    fn data_fun_injects_into_conditional() {
+        // Injection: a single data function whose extent matches a candidate
+        // domain is a subtype of the Sigma (the `emit_case` arm-into-result
+        // edge); a data function over a non-member extent is not.
+        let sup = conditional(vec![Type::UIntRange(2), Type::UIntRange(3)]);
         let member = Type::data_fun(Type::UIntRange(2), prim(BaseType::Int));
         assert!(constrain_subtype(&member, &sup, &mut ConstrainCache::new()).is_ok());
         let nonmember = Type::data_fun(Type::UIntRange(9), prim(BaseType::Int));
@@ -2182,17 +2214,17 @@ mod tests {
     }
 
     #[test]
-    fn coproduct_consumed_as_fun() {
-        // Consume: a conditional collection used as a plain function. A *fresh*
-        // domain var absorbs the discriminated union of the arm extents (the
-        // `sum` / comprehension case).
-        let cop = coproduct(vec![Type::UIntRange(2), Type::UIntRange(3)]);
+    fn conditional_consumed_as_fun() {
+        // Elimination: a conditional collection used as a plain function. A
+        // *fresh* domain var absorbs the discriminated union of the candidate
+        // extents (the `sum` / comprehension case).
+        let cond = conditional(vec![Type::UIntRange(2), Type::UIntRange(3)]);
         let consumer = fun(fresh_var(0), prim(BaseType::Int));
-        assert!(constrain_subtype(&cop, &consumer, &mut ConstrainCache::new()).is_ok());
+        assert!(constrain_subtype(&cond, &consumer, &mut ConstrainCache::new()).is_ok());
         // A consumer demanding a *concrete narrower* extent fails: the
-        // coproduct never silently narrows to a single declared extent.
+        // conditional collection never silently narrows to a single extent.
         let narrow = fun(Type::UIntRange(2), prim(BaseType::Int));
-        assert!(constrain_subtype(&cop, &narrow, &mut ConstrainCache::new()).is_err());
+        assert!(constrain_subtype(&cond, &narrow, &mut ConstrainCache::new()).is_err());
     }
 
     // ----- Kind edge (`FunKind`, the `Compute <: Data` rejection) -----------

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -496,36 +496,43 @@ fn constrain_go(
                 codomain: c0,
             },
             Type::Sigma(s),
-        ) => {
-            let injects = match &s.witness {
-                // The witness is one of these domains: inject iff `domain` is one.
-                Witness::Type(Kind::Enumerated(candidates)) => {
-                    candidates.iter().any(|d| d == domain.as_ref())
-                }
-                // The universe ranges over every domain, so any data function
-                // injects.
-                Witness::Type(Kind::Any) => {
-                    todo!("Σ-injection into a Collection (Kind::Any): any domain injects")
-                }
-                // Inject iff `domain` is the body refinement instantiated at some
-                // value of the witness type.
-                Witness::Value { .. } => {
-                    todo!("Σ-injection into a value-witness sum (List/Map)")
-                }
-            };
-            if injects {
-                let cod_sl = match (pn, s.binder()) {
-                    (Some(k), Some(x)) => sl.extended_rename(k, x),
-                    _ => sl.clone(),
+        ) => match &s.witness {
+            // A conditional collection: inject iff `domain` is one of its
+            // candidate extents, then flow the codomain. Its body is the data
+            // function `Witness ⤇ V` (built by `conditional_collection`), so its
+            // parts are read here, where that shape is guaranteed.
+            Witness::Type(Kind::Enumerated(candidates)) => {
+                let Type::Fun {
+                    name: binder,
+                    codomain: cod,
+                    ..
+                } = &*s.body
+                else {
+                    unreachable!("a conditional collection's body is a data function")
                 };
-                constrain_go(c0, s.codomain(), &cod_sl, sr, cache)
-            } else {
-                Err(ConstrainError::Mismatch {
-                    lhs: lhs.clone(),
-                    rhs: rhs.clone(),
-                })
+                if candidates.iter().any(|d| d == domain.as_ref()) {
+                    let cod_sl = match (pn, binder.as_ref()) {
+                        (Some(k), Some(x)) => sl.extended_rename(k, x),
+                        _ => sl.clone(),
+                    };
+                    constrain_go(c0, cod, &cod_sl, sr, cache)
+                } else {
+                    Err(ConstrainError::Mismatch {
+                        lhs: lhs.clone(),
+                        rhs: rhs.clone(),
+                    })
+                }
             }
-        }
+            // The universe ranges over every domain (any data function injects).
+            Witness::Type(Kind::Any) => {
+                todo!("Σ-injection into a Collection (Kind::Any): any domain injects")
+            }
+            // Inject iff `domain` is the body refinement instantiated at some
+            // value of the witness type.
+            Witness::Value { .. } => {
+                todo!("Σ-injection into a value-witness sum (List/Map)")
+            }
+        },
 
         // **Σ-elimination** `Σ <: Fun`: a sum *consumed* as a plain collection.
         // Not subsumption — consuming distributes the consumer over the witness;
@@ -544,63 +551,86 @@ fn constrain_go(
                 codomain: c1,
                 ..
             },
-        ) => {
-            let consumed_domain = match &s.witness {
-                // A finite, discriminated union of the candidate extents — the
-                // same tagged domain the runtime union tile carries.
-                Witness::Type(Kind::Enumerated(candidates)) => Type::Variant(
+        ) => match &s.witness {
+            // A finite, discriminated union of the candidate extents — the same
+            // tagged domain the runtime union tile carries. The body is the data
+            // function `Witness ⤇ V`, read here where that shape is guaranteed.
+            Witness::Type(Kind::Enumerated(candidates)) => {
+                let Type::Fun {
+                    name: binder,
+                    codomain: cod,
+                    ..
+                } = &*s.body
+                else {
+                    unreachable!("a conditional collection's body is a data function")
+                };
+                let consumed_domain = Type::Variant(
                     candidates
                         .iter()
                         .enumerate()
                         .map(|(i, d)| (FieldKey::Index(i), d.clone()))
                         .collect(),
-                ),
-                // The universe is not enumerable, so there is no finite union to
-                // present — elimination is opaque/existential.
-                Witness::Type(Kind::Any) => {
-                    todo!("Σ-elimination of a Collection (Kind::Any): opaque domain")
-                }
-                // The refined key-domain derived from the witness value.
-                Witness::Value { .. } => {
-                    todo!("Σ-elimination of a value-witness sum (List/Map)")
-                }
-            };
-            constrain_go(d1, &consumed_domain, sr, sl, cache)?;
-            let cod_sl = match (s.binder(), n1) {
-                (Some(k), Some(x)) => sl.extended_rename(k, x),
-                _ => sl.clone(),
-            };
-            constrain_go(s.codomain(), c1, &cod_sl, sr, cache)
-        }
+                );
+                constrain_go(d1, &consumed_domain, sr, sl, cache)?;
+                let cod_sl = match (binder.as_ref(), n1) {
+                    (Some(k), Some(x)) => sl.extended_rename(k, x),
+                    _ => sl.clone(),
+                };
+                constrain_go(cod, c1, &cod_sl, sr, cache)
+            }
+            // The universe is not enumerable, so there is no finite union to
+            // present — elimination is opaque/existential.
+            Witness::Type(Kind::Any) => {
+                todo!("Σ-elimination of a Collection (Kind::Any): opaque domain")
+            }
+            // The refined key-domain derived from the witness value.
+            Witness::Value { .. } => {
+                todo!("Σ-elimination of a value-witness sum (List/Map)")
+            }
+        },
 
         // **Σ-width** `Σ <: Σ`: the lhs sum's witness domain must be a subset of
         // the rhs's, and the shared codomain flows covariantly. The subset test
         // is realized per witness `Kind` pair.
-        (Type::Sigma(a), Type::Sigma(b)) => {
-            let witness_subset = match (&a.witness, &b.witness) {
-                // Every lhs candidate extent must appear among the rhs candidates
-                // (matched by *value*, not position — a nested/re-subsumed
-                // conditional's extents land in an arbitrary order).
-                (Witness::Type(Kind::Enumerated(xs)), Witness::Type(Kind::Enumerated(ys))) => {
-                    xs.iter().all(|x| ys.iter().any(|y| y == x))
-                }
-                // Any other witness-Kind pairing (Collection / value-witness, and
-                // cross-Kind relations) is decided with the collections work.
-                _ => todo!("Σ-width for non-enumerated witness Kinds"),
-            };
-            if witness_subset {
-                let cod_sl = match (a.binder(), b.binder()) {
-                    (Some(k), Some(x)) => sl.extended_rename(k, x),
-                    _ => sl.clone(),
+        (Type::Sigma(a), Type::Sigma(b)) => match (&a.witness, &b.witness) {
+            // Two conditional collections: every lhs candidate extent must appear
+            // among the rhs candidates (matched by *value*, not position — a
+            // nested/re-subsumed conditional's extents land in an arbitrary
+            // order), then the shared codomain flows. Both bodies are data
+            // functions, read here where that shape is guaranteed.
+            (Witness::Type(Kind::Enumerated(xs)), Witness::Type(Kind::Enumerated(ys))) => {
+                let (
+                    Type::Fun {
+                        name: a_binder,
+                        codomain: a_cod,
+                        ..
+                    },
+                    Type::Fun {
+                        name: b_binder,
+                        codomain: b_cod,
+                        ..
+                    },
+                ) = (&*a.body, &*b.body)
+                else {
+                    unreachable!("a conditional collection's body is a data function")
                 };
-                constrain_go(a.codomain(), b.codomain(), &cod_sl, sr, cache)
-            } else {
-                Err(ConstrainError::Mismatch {
-                    lhs: lhs.clone(),
-                    rhs: rhs.clone(),
-                })
+                if xs.iter().all(|x| ys.iter().any(|y| y == x)) {
+                    let cod_sl = match (a_binder.as_ref(), b_binder.as_ref()) {
+                        (Some(k), Some(x)) => sl.extended_rename(k, x),
+                        _ => sl.clone(),
+                    };
+                    constrain_go(a_cod, b_cod, &cod_sl, sr, cache)
+                } else {
+                    Err(ConstrainError::Mismatch {
+                        lhs: lhs.clone(),
+                        rhs: rhs.clone(),
+                    })
+                }
             }
-        }
+            // Any other witness-Kind pairing (Collection / value-witness, and
+            // cross-Kind relations) is decided with the collections work.
+            _ => todo!("Σ-width for non-enumerated witness Kinds"),
+        },
 
         // Variant: width-subtyping is the dual. lhs's tags must all appear
         // in rhs (with a payload subtype check). Payload depth is covariant.

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -20,6 +20,7 @@ use std::rc::Rc;
 use smol_str::SmolStr;
 
 use crate::ccl::subst::Subst;
+use crate::ccl::ty::{FunKind, KindVar};
 use crate::ccl::{Bound, HistoryKind, InferVar, InferVarId, Level, Refinement, Type};
 
 use super::type_level;
@@ -75,6 +76,20 @@ pub enum ConstrainError {
         /// The feed type demanded.
         required: Type,
     },
+    /// A compute function (a capability, `⇒`) was supplied where a data
+    /// collection (an extent, `⤇`) is demanded. `Data <: Compute` is the safe
+    /// upcast — a collection is callable at any index in its extent — but the
+    /// reverse would iterate a *declared* extent the value does not actually
+    /// cover, silently dropping rows. Raised only when the cache is
+    /// kind-aware (constraint emission); the post-inference check is kind-blind
+    /// (see [`ConstrainCache`]), since elimination preserves denotation but not
+    /// kind representation.
+    ComputeWhereDataRequired {
+        /// The supplied compute function.
+        lhs: Type,
+        /// The demanded data collection.
+        rhs: Type,
+    },
 }
 
 /// Cache of in-progress subtyping checks. Breaks cycles introduced through
@@ -94,7 +109,51 @@ pub enum ConstrainError {
 /// (var⇄var) edges are renames over the episode's finite binder set, whose
 /// composites saturate; discharges ride acyclic content edges only (their
 /// composites grow along lexical nesting depth, not around cycles).
-pub type ConstrainCache = HashMap<(Type, Type), Vec<(Subst, Subst)>>;
+///
+/// Carries the `kind_aware` mode flag alongside the edge map. The
+/// `Compute <: Data` kind rejection (a capability supplied where an extent is
+/// demanded — see [`ConstrainError::ComputeWhereDataRequired`]) fires only
+/// during constraint **emission** (inference), where kinds are being inferred
+/// and a mismatch is a real extent-loss bug. The post-inference structural
+/// check is **kind-blind**: lambda elimination is denotation-preserving but not
+/// kind-preserving (`Type::without_pi_names` canonicalizes every reconstructed
+/// arrow to `Compute`), so a point-free map flowing into a `Data` argument is
+/// well-denoted and must not be re-rejected on kind. Kind is an inference-time
+/// property, so the flag rides the cache that is already threaded through the
+/// whole recursion.
+pub struct ConstrainCache {
+    edges: HashMap<(Type, Type), Vec<(Subst, Subst)>>,
+    kind_aware: bool,
+}
+
+impl ConstrainCache {
+    /// A kind-aware cache (constraint emission / inference): the
+    /// `Compute <: Data` rejection is live.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            edges: HashMap::new(),
+            kind_aware: true,
+        }
+    }
+
+    /// A kind-blind cache (the post-inference structural check): kind
+    /// mismatches are ignored (see the type doc).
+    pub fn new_kind_blind() -> Self {
+        Self {
+            edges: HashMap::new(),
+            kind_aware: false,
+        }
+    }
+
+    /// The composite-substitution bridges recorded for a subtyping edge,
+    /// inserting an empty list on first visit. This is the cycle breaker: a
+    /// re-entry on the same `(lhs, rhs)` pair finds its in-progress entry rather
+    /// than recursing forever.
+    fn edge_bridges(&mut self, lhs: Type, rhs: Type) -> &mut Vec<(Subst, Subst)> {
+        self.edges.entry((lhs, rhs)).or_default()
+    }
+}
 
 /// Cache for [`extrude`], keyed by the polar pair (variable uid, polarity).
 ///
@@ -114,6 +173,48 @@ pub fn constrain_subtype(
     cache: &mut ConstrainCache,
 ) -> Result<(), ConstrainError> {
     constrain_go(lhs, rhs, &Subst::id(), &Subst::id(), cache)
+}
+
+/// Constrain the kind edge `k0 <: k1` over the two-point lattice
+/// `Data ⊑ Compute` (`Data` bottom / most specific, `Compute` top).
+///
+/// Concrete edges: `Data <: κ` and `κ <: Compute` always hold; `Compute <: Data`
+/// is the sole failure — returned as `true` (the caller raises
+/// [`ConstrainError::ComputeWhereDataRequired`], having the full function types
+/// for the diagnostic) **iff** `kind_aware` (emission mode).
+///
+/// Variable edges set `forced_*` flags, resolved at coalesce
+/// ([`super::compact::KindMerge`]): a compute value flowing *into* a var forces
+/// it `Compute`; a var *demanded* as data forces it `Data`; a var-to-var edge
+/// records a `<:` link ([`KindVar::link`]). Forces propagate transitively along
+/// links as they arrive, so ordering does not matter (a force after its link
+/// still reaches the far end). A var that ends up with both flags is the
+/// conflict — surfaced loudly at coalesce, never here.
+fn constrain_kind(k0: &FunKind, k1: &FunKind, kind_aware: bool) -> bool {
+    use FunKind::*;
+    match (k0, k1) {
+        // `Data` is bottom, `Compute` is top: these edges always hold.
+        (Data, _) | (_, Compute) => false,
+        // The one rejection — a capability supplied where an extent is demanded.
+        (Compute, Data) => kind_aware,
+        // A compute value flows into this var: it cannot be `Data`. The force
+        // propagates up any `<:` links already drawn to this var.
+        (Compute, Var(v1)) => {
+            v1.force_compute();
+            false
+        }
+        // This var is demanded as data: it cannot be `Compute`. Propagates down.
+        (Var(v0), Data) => {
+            v0.force_data();
+            false
+        }
+        // A var-to-var edge `v0 <: v1`: record the link so a force arriving on
+        // either end *after* this edge still reaches the other. See [`KindVar`].
+        (Var(v0), Var(v1)) => {
+            KindVar::link(v0, v1);
+            false
+        }
+    }
 }
 
 /// Bridge the holder gap when chaining two edges through one variable.
@@ -197,8 +298,8 @@ fn bridge_holder_gap(lo: &Subst, hi: &Subst) -> (Subst, Subst) {
     // constraining different fibers (of one family — g(0) vs g(1) — or of two
     // unrelated families), between which no sound transport exists. This is
     // the extent-join corner (O1/O4); the eventual resolution is the
-    // lossless-Σ extent regime (vault: type-checker-data-vs-compute-functions),
-    // under which both fibers become components of the one Σ-type and the
+    // lossless coproduct extent regime (data-vs-compute functions), under which
+    // both fibers become arms of the one coproduct and the
     // question dissolves. Until then: no reachable program produces this
     // shape, so reaching it means a solver bug — refuse loudly rather than
     // corrupt the edge.
@@ -249,7 +350,7 @@ fn constrain_go(
     // different constraint (see `ConstrainCache`).
     let either_var = matches!(lhs, Type::Infer(_)) || matches!(rhs, Type::Infer(_));
     if either_var {
-        let seen = cache.entry((lhs.clone(), rhs.clone())).or_default();
+        let seen = cache.edge_bridges(lhs.clone(), rhs.clone());
         // Morphisms compare modulo emit-time type slots — the SAME notion of
         // constraint identity the closure bridge uses (`eq_modulo_ty_slots`).
         // Strict `==` here would admit a near-duplicate edge (two captures of
@@ -288,22 +389,57 @@ fn constrain_go(
         (
             Type::Fun {
                 name: n0,
+                kind: k0,
                 domain: d0,
                 codomain: c0,
             },
             Type::Fun {
                 name: n1,
+                kind: k1,
                 domain: d1,
                 codomain: c1,
             },
         ) => {
-            constrain_go(d1, d0, sr, sl, cache)?;
+            // The kind edge over the lattice `Data ⊑ Compute` (see
+            // `constrain_kind`): `Data <: κ` and `κ <: Compute` always hold; a
+            // concrete `Compute <: Data` is the rejection (a capability where an
+            // extent is demanded → silent row loss), live only when the cache is
+            // kind-aware (emission, not the kind-blind post-inference check).
+            // Kind vars accumulate `forced_*` flags here and resolve at coalesce.
+            let kind_aware = cache.kind_aware;
+            if constrain_kind(k0, k1, kind_aware) {
+                return Err(ConstrainError::ComputeWhereDataRequired {
+                    lhs: lhs.clone(),
+                    rhs: rhs.clone(),
+                });
+            }
             let cod_sl = match (n0, n1) {
                 (Some(k), Some(x)) => sl.extended_rename(k, x),
                 _ => sl.clone(),
             };
+            constrain_go(d1, d0, sr, sl, cache)?;
+            // NB: Data-domain **invariance** (equating both arrows' domains when
+            // both are `Data`, to stop a wider collection standing where a
+            // narrower declared extent is expected — the silent-row-drop guard
+            // of design §5) is deliberately *not* enabled here. A naive
+            // strict-equality reverse edge breaks the sound, common pattern of a
+            // *filtered* collection (`{[0, n] | p} ⤇ V`) flowing where the
+            // unfiltered extent (`[0, n] ⤇ V`) is expected: the reverse edge
+            // demands `[0, n] <: {[0, n] | p}`, i.e. acquiring a refinement by
+            // subsumption, which the lattice strictly forbids. Invariance must
+            // therefore be *modulo refinements* (and range-aware — whether
+            // `UIntRange` is already invariant decides if the guard is even
+            // needed); that is a separate design question (§5 open question B),
+            // deferred. The contravariant edge above plus the strict refinement
+            // lattice already reject *acquiring* an extent by subsumption.
             constrain_go(c0, c1, &cod_sl, sr, cache)
         }
+
+        // (Conditional-collection coproduct subtyping — the injection
+        // `Fun(Data) <: Variant`, the consume `Variant <: Fun`, and the
+        // width `Variant <: Variant` — lives with the other `Variant` arms
+        // below; a finite conditional collection is a plain coproduct, not a
+        // dependent sum. See `Type::extent_coproduct` and collections.md.)
 
         // Tuple: positional width-subtyping. A longer/equal tuple is a
         // subtype, so every position rhs requires must exist in lhs.
@@ -334,6 +470,114 @@ fn constrain_go(
                         });
                     }
                 }
+            }
+            Ok(())
+        }
+
+        // A single data function **injected** into a conditional-collection
+        // coproduct (`Type::extent_coproduct`): one branch of the union, matched
+        // to the arm with the same extent. This is how the `emit_case` join
+        // lands — each arm is constrained `<: result`, and `result` coalesces to
+        // the coproduct, so at the consistency wall each arm re-subsumes into it.
+        // The extent match is by *value* (like the old Σ-intro), and only fires
+        // when every arm is a data function.
+        (
+            Type::Fun {
+                name: pn,
+                kind: FunKind::Data,
+                domain,
+                codomain: c0,
+            },
+            Type::Variant(arms),
+        ) if !arms.is_empty()
+            && arms.iter().all(|(_, t)| {
+                matches!(
+                    t,
+                    Type::Fun {
+                        kind: FunKind::Data,
+                        ..
+                    }
+                )
+            }) =>
+        {
+            let matched = arms.iter().find_map(|(_, t)| match t {
+                Type::Fun {
+                    name: an,
+                    domain: d,
+                    codomain: ac,
+                    ..
+                } if d.as_ref() == domain.as_ref() => Some((an, ac)),
+                _ => None,
+            });
+            match matched {
+                Some((an, ac)) => {
+                    let cod_sl = match (pn, an) {
+                        (Some(k), Some(x)) => sl.extended_rename(k, x),
+                        _ => sl.clone(),
+                    };
+                    constrain_go(c0, ac, &cod_sl, sr, cache)
+                }
+                None => Err(ConstrainError::Mismatch {
+                    lhs: lhs.clone(),
+                    rhs: rhs.clone(),
+                }),
+            }
+        }
+
+        // A **conditional collection** (a coproduct of data functions formed at
+        // a control-flow join — `Type::extent_coproduct`) *consumed* as a plain
+        // collection: whatever arm it turns out to be, iterating it walks the
+        // discriminated union of the arms' extents, so it presents as
+        // `Fun(Variant({Index(i): domainᵢ}), V)` — the same tagged domain the
+        // runtime union tile carries. The consumer's domain edge is
+        // contravariant: a *fresh* domain var resolves to the union (the common
+        // case — `sum`, `[… for x in …]`), a consumer demanding a *concrete
+        // narrower* extent fails the `d1 <: Variant` edge. Each arm's codomain
+        // flows into the consumer codomain (the arms share the joined codomain,
+        // so this is one covariant edge per arm). Fires only when every arm is a
+        // data function; a user tagged-union is not a collection.
+        (
+            Type::Variant(arms),
+            Type::Fun {
+                name: n1,
+                domain: d1,
+                codomain: c1,
+                ..
+            },
+        ) if !arms.is_empty()
+            && arms.iter().all(|(_, t)| {
+                matches!(
+                    t,
+                    Type::Fun {
+                        kind: FunKind::Data,
+                        ..
+                    }
+                )
+            }) =>
+        {
+            let extent_variant = Type::Variant(
+                arms.iter()
+                    .map(|(k, t)| {
+                        let Type::Fun { domain, .. } = t else {
+                            unreachable!("guard checked all arms are Fun")
+                        };
+                        (k.clone(), domain.as_ref().clone())
+                    })
+                    .collect(),
+            );
+            constrain_go(d1, &extent_variant, sr, sl, cache)?;
+            for (_, t) in arms {
+                let Type::Fun {
+                    name: pn, codomain, ..
+                } = t
+                else {
+                    unreachable!("guard checked all arms are Fun")
+                };
+                let cod_sl = match (pn, n1) {
+                    (Some(k), Some(x)) => sl.extended_rename(k, x),
+                    _ => sl.clone(),
+                };
+                constrain_go(codomain, c1, &cod_sl, sr, cache)?;
             }
             Ok(())
         }
@@ -499,6 +743,8 @@ fn constrain_go(
         ) => {
             let chan = Type::Fun {
                 name: None,
+                // A feed's read view is a collection stream: a data function.
+                kind: FunKind::Data,
                 domain: domain.clone(),
                 codomain: value.clone(),
             };
@@ -520,6 +766,8 @@ fn constrain_go(
         ) => {
             let chan = Type::Fun {
                 name: None,
+                // A feed's read view is a collection stream: a data function.
+                kind: FunKind::Data,
                 domain: domain.clone(),
                 codomain: value.clone(),
             };
@@ -715,10 +963,12 @@ pub fn extrude(ty: &Type, pol: bool, target_level: Level, cache: &mut ExtrudeCac
         | Type::Hole => ty.clone(),
         Type::Fun {
             name,
+            kind,
             domain: d,
             codomain: c,
         } => Type::Fun {
             name: name.clone(),
+            kind: kind.clone(),
             domain: Box::new(extrude(d, !pol, target_level, cache)),
             codomain: Box::new(extrude(c, pol, target_level, cache)),
         },
@@ -1022,13 +1272,10 @@ mod tests {
         let mut cache = ConstrainCache::new();
         let sid = (Subst::id(), Subst::id());
         cache
-            .entry((a.clone(), prim(BaseType::Int)))
-            .or_default()
+            .edge_bridges(a.clone(), prim(BaseType::Int))
             .push(sid.clone());
         assert!(
-            cache
-                .get(&(b, prim(BaseType::Int)))
-                .is_some_and(|seen| seen.contains(&sid)),
+            cache.edge_bridges(b, prim(BaseType::Int)).contains(&sid),
             "structurally-equal refined key must hit the same cache entry"
         );
 
@@ -1898,5 +2145,165 @@ mod tests {
         };
         assert!(lam().eq_modulo_ty_slots(&lam()));
         drop(arena);
+    }
+
+    // --- Conditional-collection coproduct subtyping (collections.md) ---
+
+    fn coproduct(extents: Vec<Type>) -> Type {
+        Type::extent_coproduct(extents, None, prim(BaseType::Int))
+    }
+
+    #[test]
+    fn coproduct_width_is_subtype() {
+        // A conditional collection is a coproduct (`Index`-tagged Variant of
+        // data functions); width-subtyping is positional — the lhs's tags
+        // (a prefix) appear in the rhs. The reverse (rhs has an extra tag) is
+        // not a subtype.
+        let sub = coproduct(vec![Type::UIntRange(2), Type::UIntRange(3)]);
+        let sup = coproduct(vec![
+            Type::UIntRange(2),
+            Type::UIntRange(3),
+            Type::UIntRange(4),
+        ]);
+        assert!(constrain_subtype(&sub, &sup, &mut ConstrainCache::new()).is_ok());
+        assert!(constrain_subtype(&sup, &sub, &mut ConstrainCache::new()).is_err());
+    }
+
+    #[test]
+    fn data_fun_injects_into_coproduct() {
+        // Injection: a single data function whose extent matches one arm is a
+        // subtype of the coproduct (the `emit_case` arm-into-result edge); a
+        // data function over a non-member extent is not.
+        let sup = coproduct(vec![Type::UIntRange(2), Type::UIntRange(3)]);
+        let member = Type::data_fun(Type::UIntRange(2), prim(BaseType::Int));
+        assert!(constrain_subtype(&member, &sup, &mut ConstrainCache::new()).is_ok());
+        let nonmember = Type::data_fun(Type::UIntRange(9), prim(BaseType::Int));
+        assert!(constrain_subtype(&nonmember, &sup, &mut ConstrainCache::new()).is_err());
+    }
+
+    #[test]
+    fn coproduct_consumed_as_fun() {
+        // Consume: a conditional collection used as a plain function. A *fresh*
+        // domain var absorbs the discriminated union of the arm extents (the
+        // `sum` / comprehension case).
+        let cop = coproduct(vec![Type::UIntRange(2), Type::UIntRange(3)]);
+        let consumer = fun(fresh_var(0), prim(BaseType::Int));
+        assert!(constrain_subtype(&cop, &consumer, &mut ConstrainCache::new()).is_ok());
+        // A consumer demanding a *concrete narrower* extent fails: the
+        // coproduct never silently narrows to a single declared extent.
+        let narrow = fun(Type::UIntRange(2), prim(BaseType::Int));
+        assert!(constrain_subtype(&cop, &narrow, &mut ConstrainCache::new()).is_err());
+    }
+
+    // ----- Kind edge (`FunKind`, the `Compute <: Data` rejection) -----------
+
+    fn data_fun(d: Type, c: Type) -> Type {
+        Type::data_fun(d, c)
+    }
+
+    #[test]
+    fn kind_data_upcasts_to_compute() {
+        // `Data <: Compute` is the safe upcast — a collection is callable at any
+        // index in its extent. `[0, 2] ⤇ Int <: [0, 2] ⇒ Int`.
+        let mut cache = ConstrainCache::new();
+        assert!(
+            constrain_subtype(
+                &data_fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &mut cache,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn kind_compute_where_data_is_rejected() {
+        // `Compute ⋢ Data`: a capability supplied where an extent is demanded is
+        // the rejection (the silent-row-loss guard). `[0, 2] ⇒ Int ⊀ [0, 2] ⤇ Int`.
+        let mut cache = ConstrainCache::new();
+        assert!(matches!(
+            constrain_subtype(
+                &fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &data_fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &mut cache,
+            ),
+            Err(ConstrainError::ComputeWhereDataRequired { .. })
+        ));
+    }
+
+    #[test]
+    fn kind_rejection_is_off_in_the_kind_blind_check() {
+        // The post-inference check is kind-blind: the very `Compute <: Data`
+        // edge the emission cache rejects is accepted here (elimination
+        // preserves denotation, not kind representation).
+        let mut cache = ConstrainCache::new_kind_blind();
+        assert!(
+            constrain_subtype(
+                &fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &data_fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &mut cache,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn kind_var_demanded_as_data_is_forced_data() {
+        // A kind var *demanded* as `Data` acquires `forced_data` (no eager
+        // rejection — the var may still legitimately resolve `Data`); it
+        // resolves at coalesce. A compute value flowing into it would set
+        // `forced_compute`, and both flags together is the conflict.
+        let v = KindVar::fresh();
+        let var_fun = Type::Fun {
+            name: None,
+            kind: FunKind::Var(Rc::clone(&v)),
+            domain: Box::new(Type::UIntRange(3)),
+            codomain: Box::new(prim(BaseType::Int)),
+        };
+        let mut cache = ConstrainCache::new();
+        constrain_subtype(
+            &var_fun,
+            &data_fun(Type::UIntRange(3), prim(BaseType::Int)),
+            &mut cache,
+        )
+        .expect("var <: Data records forced_data, never an eager rejection");
+        assert!(v.bounds.borrow().forced_data, "demanded as data");
+        assert!(
+            !v.bounds.borrow().forced_compute,
+            "no compute value flowed in"
+        );
+    }
+
+    #[test]
+    fn kind_var_link_then_late_force_propagates() {
+        // Regression: a force that arrives *after* a var-var link must still
+        // reach the far end. Draw `v0 <: v1` first, then force `v0` compute via
+        // a later edge (`Compute <: v0`). Transitive propagation must carry
+        // `forced_compute` up to `v1`; the old one-shot copy dropped it, letting
+        // `v1` fall to its (possibly `Data`) domain default — a silent miskind.
+        let v0 = KindVar::fresh();
+        let v1 = KindVar::fresh();
+        let fun_of = |v: &Rc<KindVar>| Type::Fun {
+            name: None,
+            kind: FunKind::Var(Rc::clone(v)),
+            domain: Box::new(Type::UIntRange(3)),
+            codomain: Box::new(prim(BaseType::Int)),
+        };
+        let mut cache = ConstrainCache::new();
+        // Link first: `v0 <: v1`.
+        constrain_subtype(&fun_of(&v0), &fun_of(&v1), &mut cache).expect("var-var link");
+        assert!(!v1.bounds.borrow().forced_compute, "not forced yet");
+        // Force later: a compute function flows into `v0` (`Compute <: v0`).
+        constrain_subtype(
+            &fun(Type::UIntRange(3), prim(BaseType::Int)),
+            &fun_of(&v0),
+            &mut cache,
+        )
+        .expect("compute <: var records forced_compute");
+        assert!(v0.bounds.borrow().forced_compute, "v0 forced compute");
+        assert!(
+            v1.bounds.borrow().forced_compute,
+            "compute force propagates up the link to v1 after the fact"
+        );
     }
 }

--- a/src/ccl/infer/solver/mod.rs
+++ b/src/ccl/infer/solver/mod.rs
@@ -89,6 +89,17 @@ pub fn type_level(ty: &Type) -> Level {
         // instantiation), which reads it directly and is exempted from the
         // `type_level` short-circuit.
         Type::ChanDom(..) => 0,
+        // The witness's type children and the body carry the sum's inference
+        // vars; the anonymous witness reference is a leaf (level 0).
+        Type::Sigma(s) => s
+            .witness
+            .types()
+            .iter()
+            .map(type_level)
+            .max()
+            .unwrap_or(0)
+            .max(type_level(&s.body)),
+        Type::Witness => 0,
         Type::Base(_) | Type::UIntRange(_) | Type::DataSource(_) | Type::Txn | Type::Hole => 0,
     }
 }

--- a/src/ccl/infer/solver/mod.rs
+++ b/src/ccl/infer/solver/mod.rs
@@ -108,6 +108,7 @@ pub fn prim(b: BaseType) -> Type {
 pub fn fun(d: Type, c: Type) -> Type {
     Type::Fun {
         name: None,
+        kind: crate::ccl::ty::FunKind::Compute,
         domain: Box::new(d),
         codomain: Box::new(c),
     }

--- a/src/ccl/infer/solver/scheme.rs
+++ b/src/ccl/infer/solver/scheme.rs
@@ -250,6 +250,16 @@ pub fn freshen_above(
             domain: Box::new(freshen_above(lim, domain, target, cache)),
             kind: *kind,
         },
+        // The witness's type children and the body freshen like any other
+        // position; the witness flavour/binder is preserved by `map_types`.
+        Type::Sigma(s) => Type::Sigma(Box::new(crate::ccl::ty::SigmaType {
+            witness: s
+                .witness
+                .map_types(|t| freshen_above(lim, t, target, cache)),
+            body: Box::new(freshen_above(lim, &s.body, target, cache)),
+        })),
+        // The anonymous witness reference carries no solver content.
+        Type::Witness => ty.clone(),
         Type::Refinement(inner, r) => Type::Refinement(
             Box::new(freshen_above(lim, inner, target, cache)),
             // Faithfully freshen the predicate's own type slots through the same

--- a/src/ccl/infer/solver/scheme.rs
+++ b/src/ccl/infer/solver/scheme.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::ccl::subst::Subst;
-use crate::ccl::ty::{FunKind, KindVar, KindVarId};
+use crate::ccl::ty::{FunKind, FunKindVar, FunKindVarId};
 use crate::ccl::{Bound, InferVar, InferVarId, Level, Refinement, Type, TypedExpr, TypedExprNode};
 
 use super::type_level;
@@ -88,10 +88,10 @@ pub struct FreshenCache {
     /// function's arrow kind ([`FunKind::Var`]) must be decided *per use*, just
     /// like the type it quantifies: two instantiations that flow into differently
     /// -kinded contexts (one demanding `Data`, one `Compute`) must not share a
-    /// `KindVar` cell, or forcing one contaminates the other into a spurious
+    /// `FunKindVar` cell, or forcing one contaminates the other into a spurious
     /// `ExtentJoinConflict`. Freshening mints one `κ'` per original `κ` (bounds
     /// copied so def-intrinsic forcing survives), consistently within a copy.
-    pub kind_vars: HashMap<KindVarId, Rc<KindVar>>,
+    pub kind_vars: HashMap<FunKindVarId, Rc<FunKindVar>>,
 }
 
 impl FreshenCache {
@@ -124,7 +124,7 @@ pub enum FreshenLevel {
 /// original.
 /// Freshen a function's arrow kind at instantiation. A concrete kind
 /// (`Data`/`Compute`) is intrinsic and copies through. An unresolved
-/// [`FunKind::Var`] is *quantified*: mint one fresh `KindVar` per original
+/// [`FunKind::Var`] is *quantified*: mint one fresh `FunKindVar` per original
 /// (cached by `uid` so repeated occurrences of the same `κ` in one copy stay
 /// identified), seeding it with a copy of the original's bounds so any
 /// def-intrinsic forcing is preserved while use-site forcing lands on the fresh
@@ -145,17 +145,17 @@ fn freshen_kind(kind: &FunKind, cache: &mut FreshenCache) -> FunKind {
 /// — from `x`'s `uppers` — while `lowers` are recursed only to guarantee every
 /// linked var is minted; inserting into the cache before recursing terminates a
 /// link cycle on the cache hit.
-fn freshen_kind_var(kv: &Rc<KindVar>, cache: &mut FreshenCache) -> Rc<KindVar> {
+fn freshen_kind_var(kv: &Rc<FunKindVar>, cache: &mut FreshenCache) -> Rc<FunKindVar> {
     if let Some(f) = cache.kind_vars.get(&kv.uid) {
         return f.clone();
     }
-    let f = KindVar::fresh();
+    let f = FunKindVar::fresh();
     *f.bounds.borrow_mut() = *kv.bounds.borrow();
     cache.kind_vars.insert(kv.uid, Rc::clone(&f));
     let (uppers, lowers) = kv.links();
     for u in &uppers {
         let fu = freshen_kind_var(u, cache);
-        KindVar::link(&f, &fu);
+        FunKindVar::link(&f, &fu);
     }
     for l in &lowers {
         // The edge `l <: kv` is drawn from `l`'s side (its `uppers` include
@@ -570,16 +570,16 @@ fn freshen_subst_payloads(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ccl::ty::{FunKind, KindVar};
+    use crate::ccl::ty::{FunKind, FunKindVar};
     use crate::ccl::{BaseType, InferVar};
 
     #[test]
     fn freshening_mints_a_distinct_kind_var_per_instantiation() {
         // A generalized function's arrow kind must be decided per use. Freshening
-        // a Fun whose kind is an unresolved var must mint a *new* KindVar (bounds
+        // a Fun whose kind is an unresolved var must mint a *new* FunKindVar (bounds
         // copied), not share the original — otherwise forcing one instantiation's
         // kind contaminates the other into a spurious `ExtentJoinConflict`.
-        let kv = KindVar::fresh();
+        let kv = FunKindVar::fresh();
         kv.bounds.borrow_mut().forced_data = true; // a def-intrinsic bound to carry
         // A quantified domain (level > lim) so the Fun is instantiated, not
         // early-returned as a captured/monomorphic shape.
@@ -620,9 +620,9 @@ mod tests {
         // freshening, so a use-site force on one instantiation still reaches its
         // sibling. Copying the bounds alone (the flags present at def time) would
         // drop the link and let a later force miss the far end.
-        let lower = KindVar::fresh(); // κ₁
-        let upper = KindVar::fresh(); // κ₂, with κ₁ <: κ₂
-        KindVar::link(&lower, &upper);
+        let lower = FunKindVar::fresh(); // κ₁
+        let upper = FunKindVar::fresh(); // κ₂, with κ₁ <: κ₂
+        FunKindVar::link(&lower, &upper);
         // A higher-order type with κ₁ on the (quantified) domain arrow and κ₂ on
         // the outer arrow; the Infer domain lifts both above `lim` so both are
         // instantiated rather than early-returned.

--- a/src/ccl/infer/solver/scheme.rs
+++ b/src/ccl/infer/solver/scheme.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::ccl::subst::Subst;
+use crate::ccl::ty::{FunKind, KindVar, KindVarId};
 use crate::ccl::{Bound, InferVar, InferVarId, Level, Refinement, Type, TypedExpr, TypedExprNode};
 
 use super::type_level;
@@ -83,6 +84,14 @@ pub struct FreshenCache {
     /// Original quantified channel-domain name → its rename. Seeded by
     /// `specialize_use` with use-site pairings; unpaired names mint fresh.
     pub chan_doms: HashMap<crate::ccl::Name, crate::ccl::Name>,
+    /// Original quantified kind variable → its fresh replacement. A generalized
+    /// function's arrow kind ([`FunKind::Var`]) must be decided *per use*, just
+    /// like the type it quantifies: two instantiations that flow into differently
+    /// -kinded contexts (one demanding `Data`, one `Compute`) must not share a
+    /// `KindVar` cell, or forcing one contaminates the other into a spurious
+    /// `ExtentJoinConflict`. Freshening mints one `κ'` per original `κ` (bounds
+    /// copied so def-intrinsic forcing survives), consistently within a copy.
+    pub kind_vars: HashMap<KindVarId, Rc<KindVar>>,
 }
 
 impl FreshenCache {
@@ -113,6 +122,49 @@ pub enum FreshenLevel {
 /// The bounds of each quantified variable are themselves freshened
 /// (recursively), so the fresh copy carries the same constraints as the
 /// original.
+/// Freshen a function's arrow kind at instantiation. A concrete kind
+/// (`Data`/`Compute`) is intrinsic and copies through. An unresolved
+/// [`FunKind::Var`] is *quantified*: mint one fresh `KindVar` per original
+/// (cached by `uid` so repeated occurrences of the same `κ` in one copy stay
+/// identified), seeding it with a copy of the original's bounds so any
+/// def-intrinsic forcing is preserved while use-site forcing lands on the fresh
+/// cell — decoupling instantiations (see [`FreshenCache::kind_vars`]).
+fn freshen_kind(kind: &FunKind, cache: &mut FreshenCache) -> FunKind {
+    match kind {
+        FunKind::Compute | FunKind::Data => kind.clone(),
+        FunKind::Var(kv) => FunKind::Var(freshen_kind_var(kv, cache)),
+    }
+}
+
+/// Mint (or retrieve, cached by `uid`) the per-instantiation copy of a
+/// quantified kind var, mirroring its def-site `<:` links onto the fresh copies.
+///
+/// Copying the bounds alone is not enough: a `<:` link is load-bearing when a
+/// force arrives *after* instantiation (a use-site force on one instantiation
+/// must still reach a linked sibling). Each edge `x <: y` is drawn exactly once
+/// — from `x`'s `uppers` — while `lowers` are recursed only to guarantee every
+/// linked var is minted; inserting into the cache before recursing terminates a
+/// link cycle on the cache hit.
+fn freshen_kind_var(kv: &Rc<KindVar>, cache: &mut FreshenCache) -> Rc<KindVar> {
+    if let Some(f) = cache.kind_vars.get(&kv.uid) {
+        return f.clone();
+    }
+    let f = KindVar::fresh();
+    *f.bounds.borrow_mut() = *kv.bounds.borrow();
+    cache.kind_vars.insert(kv.uid, Rc::clone(&f));
+    let (uppers, lowers) = kv.links();
+    for u in &uppers {
+        let fu = freshen_kind_var(u, cache);
+        KindVar::link(&f, &fu);
+    }
+    for l in &lowers {
+        // The edge `l <: kv` is drawn from `l`'s side (its `uppers` include
+        // `kv`); recurse only so `l`'s copy exists to carry it.
+        freshen_kind_var(l, cache);
+    }
+    f
+}
+
 pub fn freshen_above(
     lim: Level,
     ty: &Type,
@@ -160,10 +212,12 @@ pub fn freshen_above(
         }
         Type::Fun {
             name,
+            kind,
             domain: d,
             codomain: c,
         } => Type::Fun {
             name: name.clone(),
+            kind: freshen_kind(kind, cache),
             domain: Box::new(freshen_above(lim, d, target, cache)),
             codomain: Box::new(freshen_above(lim, c, target, cache)),
         },
@@ -501,4 +555,108 @@ fn freshen_subst_payloads(
     let mut subst = subst.clone();
     subst.for_each_discharge_term_mut(&mut |t| freshen_expr_type_slots(t, lim, target, cache));
     subst
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccl::ty::{FunKind, KindVar};
+    use crate::ccl::{BaseType, InferVar};
+
+    #[test]
+    fn freshening_mints_a_distinct_kind_var_per_instantiation() {
+        // A generalized function's arrow kind must be decided per use. Freshening
+        // a Fun whose kind is an unresolved var must mint a *new* KindVar (bounds
+        // copied), not share the original — otherwise forcing one instantiation's
+        // kind contaminates the other into a spurious `ExtentJoinConflict`.
+        let kv = KindVar::fresh();
+        kv.bounds.borrow_mut().forced_data = true; // a def-intrinsic bound to carry
+        // A quantified domain (level > lim) so the Fun is instantiated, not
+        // early-returned as a captured/monomorphic shape.
+        let f = Type::Fun {
+            name: None,
+            kind: FunKind::Var(Rc::clone(&kv)),
+            domain: Box::new(Type::Infer(InferVar::fresh(5))),
+            codomain: Box::new(Type::Base(BaseType::Int)),
+        };
+        let mut cache = FreshenCache::new();
+        let fresh = freshen_above(0, &f, FreshenLevel::At(1), &mut cache);
+        let Type::Fun {
+            kind: FunKind::Var(kv2),
+            ..
+        } = fresh
+        else {
+            panic!("expected a kind var on the freshened function");
+        };
+        assert_ne!(
+            kv.uid, kv2.uid,
+            "instantiation must mint a distinct kind var"
+        );
+        assert!(
+            kv2.bounds.borrow().forced_data,
+            "def-intrinsic bounds are copied to the fresh var"
+        );
+        // Forcing the fresh instantiation must not reach back to the original.
+        kv2.force_compute();
+        assert!(
+            !kv.bounds.borrow().forced_compute,
+            "the original var stays decoupled from this instantiation"
+        );
+    }
+
+    #[test]
+    fn freshening_mirrors_kind_var_links_onto_instantiation() {
+        // Two `<:`-linked kind vars in one scheme must stay linked after
+        // freshening, so a use-site force on one instantiation still reaches its
+        // sibling. Copying the bounds alone (the flags present at def time) would
+        // drop the link and let a later force miss the far end.
+        let lower = KindVar::fresh(); // κ₁
+        let upper = KindVar::fresh(); // κ₂, with κ₁ <: κ₂
+        KindVar::link(&lower, &upper);
+        // A higher-order type with κ₁ on the (quantified) domain arrow and κ₂ on
+        // the outer arrow; the Infer domain lifts both above `lim` so both are
+        // instantiated rather than early-returned.
+        let inner = Type::Fun {
+            name: None,
+            kind: FunKind::Var(Rc::clone(&lower)),
+            domain: Box::new(Type::Infer(InferVar::fresh(5))),
+            codomain: Box::new(Type::Base(BaseType::Int)),
+        };
+        let outer = Type::Fun {
+            name: None,
+            kind: FunKind::Var(Rc::clone(&upper)),
+            domain: Box::new(inner),
+            codomain: Box::new(Type::Base(BaseType::Int)),
+        };
+        let mut cache = FreshenCache::new();
+        let fresh = freshen_above(0, &outer, FreshenLevel::At(1), &mut cache);
+        let Type::Fun {
+            kind: FunKind::Var(fresh_upper),
+            domain: fresh_domain,
+            ..
+        } = fresh
+        else {
+            panic!("expected a kind var on the freshened outer function");
+        };
+        let Type::Fun {
+            kind: FunKind::Var(fresh_lower),
+            ..
+        } = *fresh_domain
+        else {
+            panic!("expected a kind var on the freshened inner function");
+        };
+        assert_ne!(fresh_lower.uid, lower.uid);
+        assert_ne!(fresh_upper.uid, upper.uid);
+        // A `Compute` force on the fresh lower must propagate up the mirrored
+        // link to the fresh upper — and not touch the originals.
+        fresh_lower.force_compute();
+        assert!(
+            fresh_upper.bounds.borrow().forced_compute,
+            "the def-site link κ₁ <: κ₂ must be mirrored onto the instantiation"
+        );
+        assert!(
+            !upper.bounds.borrow().forced_compute,
+            "the original vars stay decoupled from the instantiation"
+        );
+    }
 }

--- a/src/ccl/infer/solver/simplify_type.rs
+++ b/src/ccl/infer/solver/simplify_type.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::ccl::InferVarId;
 
-use super::compact::{AtomKey, CompactGraph, CompactType};
+use super::compact::{AtomKey, CompactFun, CompactGraph, CompactType};
 
 // ---------------------------------------------------------------------------
 // Type simplification: co-occurrence analysis
@@ -246,17 +246,19 @@ fn simplify_analyze(
             );
         }
     }
-    if let Some((_, dom, cod)) = &ct.fun {
+    if let Some(cf) = &ct.fun {
+        for dom in &cf.domains {
+            simplify_analyze(
+                dom,
+                !pol,
+                input_rec_vars,
+                all_vars,
+                rec_processed,
+                co_occurrences,
+            );
+        }
         simplify_analyze(
-            dom,
-            !pol,
-            input_rec_vars,
-            all_vars,
-            rec_processed,
-            co_occurrences,
-        );
-        simplify_analyze(
-            cod,
+            &cf.codomain,
             pol,
             input_rec_vars,
             all_vars,
@@ -315,12 +317,15 @@ fn simplify_reconstruct(
             .collect()
     });
 
-    let new_fun = ct.fun.map(|(name, dom, cod)| {
-        (
-            name,
-            Box::new(simplify_reconstruct(*dom, var_subst)),
-            Box::new(simplify_reconstruct(*cod, var_subst)),
-        )
+    let new_fun = ct.fun.map(|cf| CompactFun {
+        name: cf.name,
+        kind: cf.kind,
+        domains: cf
+            .domains
+            .into_iter()
+            .map(|d| simplify_reconstruct(d, var_subst))
+            .collect(),
+        codomain: Box::new(simplify_reconstruct(*cf.codomain, var_subst)),
     });
 
     let new_history_slot = ct.history_slot.map(|(value, domain, kind)| {
@@ -344,8 +349,19 @@ fn simplify_reconstruct(
 
 #[cfg(test)]
 mod tests {
+    use super::super::compact::KindMerge;
     use super::*;
     use crate::ccl::{BaseType, InferVar};
+
+    /// A single-domain compute `fun` slot, for the simplify tests below.
+    fn compute_fun(dom: CompactType, cod: CompactType) -> Option<CompactFun> {
+        Some(CompactFun {
+            name: None,
+            kind: KindMerge::Compute,
+            domains: vec![dom],
+            codomain: Box::new(cod),
+        })
+    }
 
     /// Build a fresh [`InferVarId`] for use in hand-constructed CompactTypes.
     fn fresh_uid() -> InferVarId {
@@ -370,14 +386,16 @@ mod tests {
         };
         let graph = CompactGraph {
             term: CompactType {
-                fun: Some((None, Box::new(dom), Box::new(cod))),
+                fun: compute_fun(dom, cod),
                 ..Default::default()
             },
             rec_vars: BTreeMap::new(),
         };
 
         let simplified = simplify_type(graph);
-        let (_, dom_s, cod_s) = simplified.term.fun.unwrap();
+        let cf = simplified.term.fun.unwrap();
+        let dom_s = &cf.domains[0];
+        let cod_s = &cf.codomain;
         assert!(dom_s.vars.contains(&uid_a), "a kept in dom");
         assert!(cod_s.vars.contains(&uid_a), "a kept in cod");
         assert!(!cod_s.vars.contains(&uid_b), "b eliminated from cod");
@@ -397,18 +415,19 @@ mod tests {
         };
         let graph = CompactGraph {
             term: CompactType {
-                fun: Some((
-                    None,
-                    Box::new(make_side([uid_a].into_iter().collect())),
-                    Box::new(make_side([uid_a].into_iter().collect())),
-                )),
+                fun: compute_fun(
+                    make_side([uid_a].into_iter().collect()),
+                    make_side([uid_a].into_iter().collect()),
+                ),
                 ..Default::default()
             },
             rec_vars: BTreeMap::new(),
         };
 
         let simplified = simplify_type(graph);
-        let (_, dom_s, cod_s) = simplified.term.fun.unwrap();
+        let cf = simplified.term.fun.unwrap();
+        let dom_s = &cf.domains[0];
+        let cod_s = &cf.codomain;
         assert!(dom_s.vars.is_empty(), "a absorbed in dom");
         assert!(cod_s.vars.is_empty(), "a absorbed in cod");
         assert!(dom_s.atoms.contains(&int_key), "Int remains in dom");
@@ -425,24 +444,25 @@ mod tests {
 
         let graph = CompactGraph {
             term: CompactType {
-                fun: Some((
-                    None,
-                    Box::new(CompactType {
+                fun: compute_fun(
+                    CompactType {
                         vars: both.clone(),
                         ..Default::default()
-                    }),
-                    Box::new(CompactType {
+                    },
+                    CompactType {
                         vars: both,
                         ..Default::default()
-                    }),
-                )),
+                    },
+                ),
                 ..Default::default()
             },
             rec_vars: BTreeMap::new(),
         };
 
         let simplified = simplify_type(graph);
-        let (_, dom_s, cod_s) = simplified.term.fun.unwrap();
+        let cf = simplified.term.fun.unwrap();
+        let dom_s = &cf.domains[0];
+        let cod_s = &cf.codomain;
         assert_eq!(dom_s.vars.len(), 1, "one var after merge in dom");
         assert_eq!(cod_s.vars.len(), 1, "one var after merge in cod");
         assert_eq!(dom_s.vars, cod_s.vars, "same representative in dom and cod");
@@ -456,24 +476,25 @@ mod tests {
 
         let graph = CompactGraph {
             term: CompactType {
-                fun: Some((
-                    None,
-                    Box::new(CompactType {
+                fun: compute_fun(
+                    CompactType {
                         vars: [uid_a].into_iter().collect(),
                         ..Default::default()
-                    }),
-                    Box::new(CompactType {
+                    },
+                    CompactType {
                         vars: [uid_a].into_iter().collect(),
                         ..Default::default()
-                    }),
-                )),
+                    },
+                ),
                 ..Default::default()
             },
             rec_vars: BTreeMap::new(),
         };
 
         let simplified = simplify_type(graph);
-        let (_, dom_s, cod_s) = simplified.term.fun.unwrap();
+        let cf = simplified.term.fun.unwrap();
+        let dom_s = &cf.domains[0];
+        let cod_s = &cf.codomain;
         assert!(dom_s.vars.contains(&uid_a), "a preserved in dom");
         assert!(cod_s.vars.contains(&uid_a), "a preserved in cod");
     }

--- a/src/ccl/inline.rs
+++ b/src/ccl/inline.rs
@@ -667,6 +667,7 @@ mod tests {
         // has no finite, enumerable extent.
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
@@ -681,6 +682,7 @@ mod tests {
     fn should_inline_scalar_to_scalar() {
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
@@ -694,9 +696,11 @@ mod tests {
         // eliminates the nested lambda before any `curry` combinator is produced.
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Compute,
                 domain: Box::new(Type::Base(BaseType::Int)),
                 codomain: Box::new(Type::Base(BaseType::Int)),
             }),
@@ -714,11 +718,13 @@ mod tests {
         let refinement = Refinement { predicate: pred };
         let inner_fun = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Refinement(Box::new(inner_fun), refinement)),
         };
@@ -730,6 +736,7 @@ mod tests {
         // UIntRange(3) → Int: iterable domain, don't inline.
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::UIntRange(3)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
@@ -741,6 +748,7 @@ mod tests {
         // (Int, Int) → Int: both components non-iterable, should inline.
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Tuple(vec![
                 Type::Base(BaseType::Int),
                 Type::Base(BaseType::Int),
@@ -756,6 +764,7 @@ mod tests {
         // non-iterable, so this is inlined.
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Tuple(vec![
                 Type::UIntRange(3),
                 Type::Base(BaseType::Int),
@@ -980,6 +989,7 @@ mod tests {
     fn fn_ty(domain: Type, codomain: Type) -> Type {
         Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(domain),
             codomain: Box::new(codomain),
         }

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -341,9 +341,13 @@ fn elim_lambda_impl(
     let body_ty = body.ty.clone();
     let result_ty = match fun_ty_or_hole(param_ty, &body_ty) {
         Type::Fun {
-            domain, codomain, ..
+            domain,
+            codomain,
+            kind,
+            ..
         } if crate::ccl::subst::type_free_vars(&body_ty).contains(param) => Type::Fun {
             name: Some(param.clone()),
+            kind,
             domain,
             codomain,
         },
@@ -927,6 +931,7 @@ mod tests {
     fn fun_ty(a: Type, b: Type) -> Type {
         Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(a),
             codomain: Box::new(b),
         }

--- a/src/ccl/lower/exprs.rs
+++ b/src/ccl/lower/exprs.rs
@@ -475,22 +475,22 @@ mod tests {
     // Variable collection and inline key lambda
     #[case(
         "groupby(xs, lambda x: x)",
-        "λ __gb_k → cast(({_ | __elem ▷ xs ▷ (λ x → x) == __gb_k} ⇒ _), λ __gb_i → __gb_i ▷ xs)"
+        "λ __gb_k → cast(({_ | __elem ▷ xs ▷ (λ x → x) == __gb_k} ⤇ _), λ __gb_i → __gb_i ▷ xs)"
     )]
     // List literal collection with a more complex key
     #[case(
         "groupby([1, 2, 3], lambda x: x // 2)",
-        "λ __gb_k → cast(({_ | __elem ▷ [1, 2, 3] ▷ (λ x → x // 2) == __gb_k} ⇒ _), λ __gb_i → __gb_i ▷ [1, 2, 3])"
+        "λ __gb_k → cast(({_ | __elem ▷ [1, 2, 3] ▷ (λ x → x // 2) == __gb_k} ⤇ _), λ __gb_i → __gb_i ▷ [1, 2, 3])"
     )]
     // Key is a variable reference (pre-defined function)
     #[case(
         "groupby(xs, key_fn)",
-        "λ __gb_k → cast(({_ | __elem ▷ xs ▷ key_fn == __gb_k} ⇒ _), λ __gb_i → __gb_i ▷ xs)"
+        "λ __gb_k → cast(({_ | __elem ▷ xs ▷ key_fn == __gb_k} ⤇ _), λ __gb_i → __gb_i ▷ xs)"
     )]
     // Keyed aggregation
     #[case(
         "[sum(x) for x in groupby(xs, key_fn)]",
-        "λ __iter_record → __iter_record ▷ (λ __gb_k → cast(({_ | __elem ▷ xs ▷ key_fn == __gb_k} ⇒ _), λ __gb_i → __gb_i ▷ xs)) ▷ (λ x → Sum(x))"
+        "λ __iter_record → __iter_record ▷ (λ __gb_k → cast(({_ | __elem ▷ xs ▷ key_fn == __gb_k} ⤇ _), λ __gb_i → __gb_i ▷ xs)) ▷ (λ x → Sum(x))"
     )]
     fn test_lower_groupby(#[case] code: &str, #[case] expected: &str) {
         let expr = parse_expr(code);

--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -913,6 +913,8 @@ pub(super) fn lower_type_annotation(annotation: &Spanned<ChlExpr>) -> Result<Typ
                 // type is the subscript index lowered recursively.
                 "List" => Ok(Type::Fun {
                     name: None,
+                    // A `List[…]` annotation is a collection type: a data function.
+                    kind: crate::ccl::ty::FunKind::Data,
                     domain: Box::new(Type::Hole),
                     codomain: Box::new(lower_type_annotation(index)?),
                 }),

--- a/src/ccl/mod.rs
+++ b/src/ccl/mod.rs
@@ -58,6 +58,7 @@ pub(crate) use ty::eq_refinement_predicate;
 #[cfg(any(test, feature = "test-helpers"))]
 pub fn reset_all_id_counters() {
     reset_infer_var_counter();
+    reset_kind_var_counter();
 }
 
 /// Convenience for the [`TypedExprNode::Error`] match arm in passes that run

--- a/src/ccl/planning/iterate.rs
+++ b/src/ccl/planning/iterate.rs
@@ -412,6 +412,27 @@ pub(super) fn wrap_with_iterate(expr: &mut Expr) {
     // re-mints (each rebuilt as a fresh `Rc`) compare equal structurally,
     // and nothing downstream depends on which term instance the codomain
     // holds.
+    //
+    // Stamp the site's kind `Data`: a `wrap_with_iterate` result is, by
+    // construction, an *iterated collection* — the runtime sweeps its domain
+    // extent — whatever (possibly `Compute`/var) kind the value-producer body
+    // inferred. This is what gives an identity comprehension `[x for x in xs]`
+    // display parity (`⤇`) with the bare list `xs` it denotes: both are the
+    // same collection, so both render the data arrow.
+    let site_ty = match site_ty {
+        Type::Fun {
+            name,
+            domain,
+            codomain,
+            ..
+        } => Type::Fun {
+            name,
+            kind: crate::ccl::ty::FunKind::Data,
+            domain,
+            codomain,
+        },
+        other => other,
+    };
     *expr = typed_compose(elts).with_ty(site_ty);
 }
 

--- a/src/ccl/planning/mod.rs
+++ b/src/ccl/planning/mod.rs
@@ -274,6 +274,7 @@ pub(crate) mod test_helpers {
     pub(crate) fn fun_ty(domain: Type, codomain: Type) -> Type {
         Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(domain),
             codomain: Box::new(codomain),
         }

--- a/src/ccl/simplify.rs
+++ b/src/ccl/simplify.rs
@@ -1002,6 +1002,7 @@ mod tests {
     fn fun_ty(a: Type, b: Type) -> Type {
         Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(a),
             codomain: Box::new(b),
         }
@@ -1023,6 +1024,7 @@ mod tests {
         }
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: fun_tys.first().unwrap().0.clone(),
             codomain: fun_tys.last().unwrap().1.clone(),
         };

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -718,6 +718,7 @@ impl Subst {
                 name: None,
                 domain,
                 codomain,
+                ..
             } => {
                 self.rewrite_type_go(domain, memo);
                 self.rewrite_type_go(codomain, memo);
@@ -727,6 +728,7 @@ impl Subst {
                 name: Some(b),
                 domain,
                 codomain,
+                ..
             } => {
                 self.rewrite_type_go(domain, memo);
                 let restricted = self.shadow(b);
@@ -875,14 +877,12 @@ impl Subst {
                 name: None,
                 domain,
                 codomain,
-            } => Type::Fun {
-                name: None,
-                domain: Box::new(self.apply_type(domain)),
-                codomain: Box::new(self.apply_type(codomain)),
-            },
+                ..
+            } => Type::fun_like(ty, self.apply_type(domain), self.apply_type(codomain)),
 
             Type::Fun {
                 name: Some(b),
+                kind,
                 domain,
                 codomain,
             } => {
@@ -890,6 +890,7 @@ impl Subst {
                 let (b2, inner) = self.under_binder_ty(b, codomain);
                 Type::Fun {
                     name: Some(b2),
+                    kind: kind.clone(),
                     domain,
                     codomain: Box::new(inner),
                 }
@@ -963,6 +964,34 @@ pub fn type_free_vars(ty: &Type) -> BTreeSet<Binder> {
     out
 }
 
+/// Whether `ty`'s structural skeleton contains an unresolved [`Type::Infer`]
+/// leaf. This is the per-type dual of `check_fully_typed`'s whole-program scan:
+/// a cheap "is this type ground" predicate for invariant assertions at pass
+/// boundaries. It walks the type skeleton only — a `Refinement`'s predicate is
+/// a term, not a type, and is not descended into (an `Infer` embedded in a
+/// predicate cast is out of scope and would need a term walk).
+pub fn type_contains_infer(ty: &Type) -> bool {
+    match ty {
+        Type::Base(_)
+        | Type::UIntRange(_)
+        | Type::DataSource(_)
+        | Type::ChanDom(..)
+        | Type::Txn
+        | Type::Hole => false,
+        Type::Infer(_) => true,
+        Type::Fun {
+            domain, codomain, ..
+        } => type_contains_infer(domain) || type_contains_infer(codomain),
+        Type::History { value, domain, .. } => {
+            type_contains_infer(value) || type_contains_infer(domain)
+        }
+        Type::Tuple(ts) => ts.iter().any(type_contains_infer),
+        Type::Record(fs) => fs.iter().any(|(_, t)| type_contains_infer(t)),
+        Type::Variant(tags) => tags.iter().any(|(_, t)| type_contains_infer(t)),
+        Type::Refinement(base, _) => type_contains_infer(base),
+    }
+}
+
 /// Insert each of `names` into `bound` for the duration of `f`, restoring the
 /// set afterward. Only names that were *newly* inserted are removed, so a
 /// binder that shadows an already-in-scope name of the same spelling does not
@@ -1001,6 +1030,7 @@ fn collect_type_fv(
             name,
             domain,
             codomain,
+            ..
         } => {
             collect_type_fv(domain, bound, visited, out);
             // A `Some` name is the Pi binder, bound in the codomain.

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -45,7 +45,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
 use crate::ccl::ccl_utils::is_free;
-use crate::ccl::{Branch, Name, PredicateId, Type, TypedExpr, TypedExprNode};
+use crate::ccl::{Branch, Name, PredicateId, SigmaType, Type, TypedExpr, TypedExprNode, Witness};
 
 /// A term binder name.
 pub type Binder = Name;
@@ -698,6 +698,9 @@ impl Subst {
             | Type::DataSource(_)
             | Type::Txn
             | Type::Hole
+            // A witness reference is a type-level binder occurrence, never a term
+            // binder the substitution acts on.
+            | Type::Witness
             | Type::Infer(_) => {}
 
             // a nominal channel domain names its defer
@@ -759,6 +762,18 @@ impl Subst {
             Type::Variant(tags) => tags
                 .iter_mut()
                 .for_each(|(_, t)| self.rewrite_type_go(t, memo)),
+
+            // A value-witness binder is a term binder; but a term substitution
+            // never maps it (it is a fresh Σ-binder, out of the substitution's
+            // domain), so it passes through untouched. Rewrite predicates in the
+            // witness's type children and the body.
+            Type::Sigma(s) => {
+                s.witness
+                    .types_mut()
+                    .iter_mut()
+                    .for_each(|t| self.rewrite_type_go(t, memo));
+                self.rewrite_type_go(&mut s.body, memo);
+            }
         }
     }
 
@@ -867,6 +882,7 @@ impl Subst {
             | Type::DataSource(_)
             | Type::Txn
             | Type::Hole
+            | Type::Witness
             | Type::Infer(_) => ty.clone(),
 
             // rename the named defer binder, mirroring the
@@ -924,6 +940,14 @@ impl Subst {
                 domain: Box::new(self.apply_type(domain)),
                 kind: *kind,
             },
+
+            // A value-witness binder is a fresh Σ-binder, out of a term
+            // substitution's domain, so it passes through. Rewrite predicates in
+            // the witness's type children and the body.
+            Type::Sigma(s) => Type::Sigma(Box::new(SigmaType {
+                witness: s.witness.map_types(|t| self.apply_type(t)),
+                body: Box::new(self.apply_type(&s.body)),
+            })),
         }
     }
 
@@ -977,6 +1001,7 @@ pub fn type_contains_infer(ty: &Type) -> bool {
         | Type::DataSource(_)
         | Type::ChanDom(..)
         | Type::Txn
+        | Type::Witness
         | Type::Hole => false,
         Type::Infer(_) => true,
         Type::Fun {
@@ -989,6 +1014,9 @@ pub fn type_contains_infer(ty: &Type) -> bool {
         Type::Record(fs) => fs.iter().any(|(_, t)| type_contains_infer(t)),
         Type::Variant(tags) => tags.iter().any(|(_, t)| type_contains_infer(t)),
         Type::Refinement(base, _) => type_contains_infer(base),
+        Type::Sigma(s) => {
+            s.witness.types().iter().any(type_contains_infer) || type_contains_infer(&s.body)
+        }
     }
 }
 
@@ -1025,6 +1053,8 @@ fn collect_type_fv(
         | Type::ChanDom(..)
         | Type::Txn
         | Type::Hole
+        // A witness reference is type-level, never a free term variable.
+        | Type::Witness
         | Type::Infer(_) => {}
         Type::Fun {
             name,
@@ -1062,6 +1092,23 @@ fn collect_type_fv(
         Type::History { value, domain, .. } => {
             collect_type_fv(value, bound, visited, out);
             collect_type_fv(domain, bound, visited, out);
+        }
+        // The witness's type children carry free term vars with the binder
+        // *not* in scope (a value-witness's type annotation cannot mention its
+        // own binder). A value-witness's binder, however, is a term binder bound
+        // over the body, so it is subtracted there; a type-witness is anonymous.
+        Type::Sigma(s) => {
+            for t in s.witness.types() {
+                collect_type_fv(t, bound, visited, out);
+            }
+            match &s.witness {
+                Witness::Value { binder, .. } => {
+                    with_binders(bound, [binder.clone()], |bnd| {
+                        collect_type_fv(&s.body, bnd, visited, out)
+                    });
+                }
+                Witness::Type(_) => collect_type_fv(&s.body, bound, visited, out),
+            }
         }
     }
 }

--- a/src/ccl/symbolic.rs
+++ b/src/ccl/symbolic.rs
@@ -736,7 +736,7 @@ mod tests {
     #[case(
         Expr::lambda(
             "x",
-            Type::Fun { name: None, domain: Box::new(Type::Base(BaseType::Int)), codomain: Box::new(Type::Base(BaseType::Bool)) },
+            Type::Fun { name: None, kind: crate::ccl::ty::FunKind::Compute, domain: Box::new(Type::Base(BaseType::Int)), codomain: Box::new(Type::Base(BaseType::Bool)) },
             Expr::var("x"),
         ),
         "λ x : (Int ⇒ Bool) → x"

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -76,8 +76,8 @@ impl fmt::Display for FieldKey {
 ///   lossy simplification.
 /// - [`FunKind::Data`] — `α ⤇ β`: the domain is an *extent*, a collection's
 ///   index set. The domain *is* the data map, so a lossy domain is lost data;
-///   joins of data functions must be lossless — they form a coproduct
-///   ([`Type::extent_coproduct`]) over the extents, never a meet.
+///   joins of data functions must be lossless — they form a conditional-collection
+///   Sigma ([`Type::conditional_collection`]) over the extents, never a meet.
 ///
 /// Set at introduction (list literals, comprehensions, `++`, registered
 /// sources, and every `History` erasure are `Data`; `lambda`/`def` are
@@ -420,18 +420,139 @@ pub enum Type {
         /// off-path positions carry forward.
         kind: HistoryKind,
     },
+    /// A **dependent sum** `Σ (witness). body`: a value pairing a witness with a
+    /// body whose type may depend on it. A **conditional collection** (the
+    /// lossless join of data functions at a control-flow merge) is the finite
+    /// instance — the witness is a type ranging over the branches' candidate
+    /// domains ([`Witness::Type`] with [`Kind::Enumerated`]) and the body is
+    /// `Witness ⤇ V`. `List`/`Map` will be the value-witness instances
+    /// ([`Witness::Value`]) and `Collection[T]` the universe-ranging type-witness
+    /// ([`Kind::Any`]), added with the collections work.
+    ///
+    /// Consuming a Sigma is **elimination** (the consumer distributed over the
+    /// witness, `Σ 𝑤. 𝑔(body)`, collapsing when the result is
+    /// witness-independent) — never a `Σ <: Fun` coercion. Transient in the
+    /// same sense as [`Type::Witness`]: value-`Case` compilation eliminates it.
+    /// See `src/ccl/design/type-inference.md` §4.6.
+    Sigma(Box<SigmaType>),
+    /// A **type-level reference to the enclosing Sigma's type-witness** — the
+    /// witness in *domain* position, e.g. the body `Witness ⤇ V` of a
+    /// conditional collection. Anonymous and nullary (like [`Type::Txn`]): a
+    /// type-witness is always the nearest-enclosing Sigma's and is referenced
+    /// only in that Sigma's immediate body domain, so it needs no identity.
+    /// Transient — discharged to a concrete domain when its Sigma is eliminated,
+    /// so none survives to op-conversion. (A *value*-witness is referenced in a
+    /// refinement predicate as a term `Var` bound by [`Witness::Value`], via the
+    /// §4.5 binder mechanism — not through this leaf.)
+    Witness,
     // Planned:
     // Pi { param: String, param_ty: Box<Type>, body_ty: Box<Type> }
-    // Refinement { base: Box<Type>, predicate: Box<Expr> }
-    //
-    // NOTE: a **conditional collection** (the lossless join of data functions
-    // with distinct extents at a control-flow merge) is not a variant here — it
-    // is a plain coproduct, an `Index`-tagged [`Type::Variant`] of data
-    // functions built by [`Type::extent_coproduct`]. A finite, static set of
-    // branches needs no dependent sum (a finite Σ degenerates to a coproduct);
-    // see `src/ccl/design/type-inference.md`. A genuine dependent `Σ` (over a
-    // runtime/opaque witness — `List` length, `Map` key extent) will be added
-    // with the collections work, where the witness is real.
+}
+
+/// The payload of a [`Type::Sigma`] — a dependent sum `Σ (witness). body`.
+/// Boxed inside `Type` to keep the enum small.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SigmaType {
+    /// What the Sigma is summed over — a type-witness (classified by a [`Kind`])
+    /// or a value-witness (classified by its type). Also selects the eliminator.
+    pub witness: Witness,
+    /// `B(witness)`: a data function whose *domain* is determined by the witness.
+    /// For a [`Witness::Type`] it is `Witness ⤇ V` (the witness in domain
+    /// position); for a [`Witness::Value`] it is `{x | pred(x, binder)} ⤇ V`.
+    pub body: Box<Type>,
+}
+
+impl SigmaType {
+    /// The sum's shared codomain — the element type `V` of the body data function
+    /// `<witness-domain> ⤇ V`. Kind-agnostic: every Sigma body is a data
+    /// function, so this is always well-defined.
+    pub fn codomain(&self) -> &Type {
+        match &*self.body {
+            Type::Fun { codomain, .. } => codomain,
+            _ => unreachable!("Sigma body is always a data function `<domain> ⤇ V`"),
+        }
+    }
+
+    /// The body data function's element (Pi) binder, if any. Kind-agnostic.
+    pub fn binder(&self) -> Option<&crate::ccl::Name> {
+        match &*self.body {
+            Type::Fun { name, .. } => name.as_ref(),
+            _ => unreachable!("Sigma body is always a data function `<domain> ⤇ V`"),
+        }
+    }
+}
+
+/// A [`SigmaType`]'s witness, following the classification hierarchy
+/// **values : types : kinds** — a value-witness is classified by its type, a
+/// type-witness by its [`Kind`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Witness {
+    /// The witness **is a type** (a domain) of the given [`Kind`], referenced
+    /// anonymously in the body's domain position via the nullary
+    /// [`Type::Witness`].
+    Type(Kind),
+    /// The witness **is a value** of `ty` (`Nat` for a `List` length, `Set[K]`
+    /// for a `Map` key-set); `binder` is its fresh Σ-binder, referenced as a
+    /// term `Var(binder)` in the body's domain refinement (via the §4.5 binder
+    /// mechanism). Reserved for the collections work.
+    Value {
+        ty: Box<Type>,
+        binder: crate::ccl::Name,
+    },
+}
+
+/// The **kind** of a type-witness — which domains it ranges over (a kind
+/// classifies types, so it classifies which type the witness may be).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Kind {
+    /// A finite, explicitly **enumerated** set of candidate domains, in
+    /// branch/contribution order (a tested contract). Statically enumerable →
+    /// the value-`Case` fan-out. The conditional-collection case, the only one
+    /// wired today.
+    Enumerated(Vec<Type>),
+    /// **Any** domain — the universe `*` (`Collection[T]`; not enumerable →
+    /// large elimination, opaque). Type reserved; machinery lands with the
+    /// collections work.
+    Any,
+}
+
+impl Witness {
+    /// The type children this witness carries: the candidate domains of a
+    /// [`Kind::Enumerated`] type-witness, or the value type of a
+    /// [`Witness::Value`]. Empty for [`Kind::Any`] (the universe carries no
+    /// enumerated types). A value-witness's *binder* is a name, not a type, so
+    /// it is not included.
+    pub fn types(&self) -> &[Type] {
+        match self {
+            Witness::Type(Kind::Enumerated(choices)) => choices,
+            Witness::Type(Kind::Any) => &[],
+            Witness::Value { ty, .. } => std::slice::from_ref(ty),
+        }
+    }
+
+    /// Mutable analog of [`types`](Self::types).
+    pub fn types_mut(&mut self) -> &mut [Type] {
+        match self {
+            Witness::Type(Kind::Enumerated(choices)) => choices,
+            Witness::Type(Kind::Any) => &mut [],
+            Witness::Value { ty, .. } => std::slice::from_mut(ty),
+        }
+    }
+
+    /// Rebuild this witness with `f` applied to each type child (see
+    /// [`types`](Self::types)), preserving the kind and any value-witness binder.
+    pub fn map_types(&self, mut f: impl FnMut(&Type) -> Type) -> Witness {
+        match self {
+            Witness::Type(Kind::Enumerated(choices)) => {
+                Witness::Type(Kind::Enumerated(choices.iter().map(&mut f).collect()))
+            }
+            Witness::Type(Kind::Any) => Witness::Type(Kind::Any),
+            Witness::Value { ty, binder } => Witness::Value {
+                ty: Box::new(f(ty)),
+                binder: binder.clone(),
+            },
+        }
+    }
 }
 
 /// Which flavour of [`Type::History`] a handle is — a mutable variable (`:=`) or a
@@ -563,6 +684,26 @@ impl fmt::Display for Type {
                     write!(f, "feed({domain} ⇒ {value})")
                 }
             }
+            Type::Sigma(s) => {
+                // The body is `<witness-domain> ⤇ V`; render the anonymous-witness
+                // shorthand `Σ{…} ⤇ V` for a type-witness (no live binder), and the
+                // live-binder form `(Σ b : ty. body)` for a value-witness.
+                let codomain = match &*s.body {
+                    Type::Fun { codomain, .. } => codomain.to_string(),
+                    other => other.to_string(),
+                };
+                match &s.witness {
+                    Witness::Type(Kind::Enumerated(choices)) => {
+                        let cs: Vec<_> = choices.iter().map(|t| t.to_string()).collect();
+                        write!(f, "Σ{{{}}} ⤇ {codomain}", cs.join(", "))
+                    }
+                    Witness::Type(Kind::Any) => write!(f, "Σ* ⤇ {codomain}"),
+                    Witness::Value { ty, binder } => {
+                        write!(f, "(Σ {binder} : {ty}. {})", s.body)
+                    }
+                }
+            }
+            Type::Witness => write!(f, "σ"),
         }
     }
 }
@@ -635,43 +776,35 @@ impl Type {
         }
     }
 
-    /// The type of a **conditional collection**: a coproduct (untagged,
-    /// `Index`-tagged [`Type::Variant`]) of data functions, one per candidate
-    /// extent, all sharing the joined codomain. Formed at a control-flow join
-    /// of data collections with distinct extents (`xs if c else ys`): the value
-    /// is *one* of the arms, tagged by contribution order, and the branch tags
-    /// are exactly the value-`Case` gates the runtime carries.
+    /// The type of a **conditional collection**: a dependent sum
+    /// `Σ{choices} ⤇ codomain` — a type-witness of [`Kind::Enumerated`] over the
+    /// candidate domains (branch/contribution order — a tested contract), whose
+    /// body is `Witness ⤇ codomain` (the anonymous witness in domain position).
+    /// Formed at a control-flow join of data collections with distinct domains
+    /// (`xs if c else ys`); consumed by elimination (the value-`Case` fan-out).
     ///
-    /// This is a plain sum type, **not** a dependent sum — a finite, static set
-    /// of branches needs no witness (a finite `Σ` degenerates to a coproduct);
-    /// see [type-inference.md](../ccl/design/type-inference.md). Callers guarantee
-    /// `choices.len() >= 2` (a single extent is a plain data function); the
-    /// arms share `pi_name` (the element binder) and `codomain`.
-    pub fn extent_coproduct(
+    /// Callers guarantee `choices.len() >= 2` (a single domain is a plain data
+    /// function, not a Sigma). `pi_name` is the body arrow's element binder;
+    /// `codomain` the shared element type.
+    pub fn conditional_collection(
         choices: Vec<Type>,
         pi_name: Option<crate::ccl::Name>,
         codomain: Type,
     ) -> Self {
         debug_assert!(
             choices.len() >= 2,
-            "extent_coproduct: a single extent is a plain data function, not a coproduct"
+            "conditional_collection: a single domain is a plain data function, not a Sigma"
         );
-        let arms = choices
-            .into_iter()
-            .enumerate()
-            .map(|(i, dom)| {
-                (
-                    FieldKey::Index(i),
-                    Type::Fun {
-                        name: pi_name.clone(),
-                        kind: FunKind::Data,
-                        domain: Box::new(dom),
-                        codomain: Box::new(codomain.clone()),
-                    },
-                )
-            })
-            .collect();
-        Type::Variant(arms)
+        let body = Type::Fun {
+            name: pi_name,
+            kind: FunKind::Data,
+            domain: Box::new(Type::Witness),
+            codomain: Box::new(codomain),
+        };
+        Type::Sigma(Box::new(SigmaType {
+            witness: Witness::Type(Kind::Enumerated(choices)),
+            body: Box::new(body),
+        }))
     }
 
     /// If this is a function type, return the domain type, otherwise None.
@@ -728,6 +861,18 @@ impl Type {
             // Erased by `channelize` (before planning); a survivor here
             // is a compiler bug, same as `History`.
             Type::ChanDom(..) => unreachable!("Type::ChanDom survived channelize"),
+            // A dependent sum and its witness placeholder are transient (a
+            // conditional collection is eliminated by value-`Case` compilation
+            // before planning); enumerability is per its candidate domains.
+            Type::Sigma(s) => match &s.witness {
+                Witness::Type(Kind::Enumerated(choices)) => {
+                    choices.iter().all(Type::has_enumerable_extent)
+                }
+                // The universe (`Collection`) and value-witnesses are not
+                // statically enumerable.
+                Witness::Type(Kind::Any) | Witness::Value { .. } => false,
+            },
+            Type::Witness => false,
             // Concrete or type-resolvable domains: enumerable from the type alone.
             Type::Base(_)
             | Type::UIntRange(_)
@@ -751,7 +896,7 @@ impl Type {
     /// collection (`⤇`) becomes a point-free form built from compute combinators
     /// (`zip`, `apply`, `const`), so the reconstructed arrow reads `Compute`
     /// though it denotes the same collection. The kind did its work at inference
-    /// (lossless coproduct joins at coalesce); post-elimination it is not preserved, so
+    /// (lossless conditional-collection joins at coalesce); post-elimination it is not preserved, so
     /// the structural-equality asserts (and the feed-operand agreement check)
     /// compare modulo it. (Kind-aware subtyping therefore acts in
     /// *Emit*-mode inference, not the post-elimination Check-mode pass.)
@@ -800,12 +945,17 @@ impl Type {
                 domain: Box::new(domain.without_pi_names()),
                 kind: *kind,
             },
+            Type::Sigma(s) => Type::Sigma(Box::new(SigmaType {
+                witness: s.witness.map_types(|t| t.without_pi_names()),
+                body: Box::new(s.body.without_pi_names()),
+            })),
             Type::Base(_)
             | Type::UIntRange(_)
             | Type::Hole
             | Type::Infer(_)
             | Type::DataSource(_)
             | Type::ChanDom(..)
+            | Type::Witness
             | Type::Txn => self.clone(),
         }
     }
@@ -840,6 +990,7 @@ impl Type {
             | Type::Infer(_)
             | Type::DataSource(_)
             | Type::ChanDom(..)
+            | Type::Witness
             | Type::Txn => {}
             Type::Fun {
                 domain, codomain, ..
@@ -866,6 +1017,13 @@ impl Type {
                 for (_, t) in tags {
                     f(t);
                 }
+            }
+            // The witness's type children and the body are the Sigma's children.
+            Type::Sigma(s) => {
+                for t in s.witness.types() {
+                    f(t);
+                }
+                f(&s.body);
             }
         }
     }
@@ -881,6 +1039,7 @@ impl Type {
             | Type::Infer(_)
             | Type::DataSource(_)
             | Type::ChanDom(..)
+            | Type::Witness
             | Type::Txn => {}
             Type::Fun {
                 domain, codomain, ..
@@ -907,6 +1066,12 @@ impl Type {
                 for (_, t) in tags {
                     f(t);
                 }
+            }
+            Type::Sigma(s) => {
+                for t in s.witness.types_mut() {
+                    f(t);
+                }
+                f(&mut s.body);
             }
         }
     }

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -456,30 +456,13 @@ pub struct SigmaType {
     /// What the Sigma is summed over — a type-witness (classified by a [`Kind`])
     /// or a value-witness (classified by its type). Also selects the eliminator.
     pub witness: Witness,
-    /// `B(witness)`: a data function whose *domain* is determined by the witness.
-    /// For a [`Witness::Type`] it is `Witness ⤇ V` (the witness in domain
-    /// position); for a [`Witness::Value`] it is `{x | pred(x, binder)} ⤇ V`.
+    /// The body `B(witness)` — an arbitrary type that may depend on the witness.
+    /// The **conditional-collection** instance's body is the data function
+    /// `Witness ⤇ V` (built by [`Type::conditional_collection`]); other Σ
+    /// instances may have non-function bodies, so this stays a general `Type`.
+    /// Code that reads a function body's parts (codomain, element binder) does so
+    /// only where it already knows the instance is a conditional collection.
     pub body: Box<Type>,
-}
-
-impl SigmaType {
-    /// The sum's shared codomain — the element type `V` of the body data function
-    /// `<witness-domain> ⤇ V`. Kind-agnostic: every Sigma body is a data
-    /// function, so this is always well-defined.
-    pub fn codomain(&self) -> &Type {
-        match &*self.body {
-            Type::Fun { codomain, .. } => codomain,
-            _ => unreachable!("Sigma body is always a data function `<domain> ⤇ V`"),
-        }
-    }
-
-    /// The body data function's element (Pi) binder, if any. Kind-agnostic.
-    pub fn binder(&self) -> Option<&crate::ccl::Name> {
-        match &*self.body {
-            Type::Fun { name, .. } => name.as_ref(),
-            _ => unreachable!("Sigma body is always a data function `<domain> ⤇ V`"),
-        }
-    }
 }
 
 /// A [`SigmaType`]'s witness, following the classification hierarchy

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -98,8 +98,8 @@ pub enum FunKind {
     Data,
     /// An unresolved kind, pinned down by the solver at coalesce. Identity is by
     /// the variable's `uid`, so `FunKind` (and `Type`) keep deriving
-    /// `PartialEq`/`Eq`/`Hash` — the [`KindVar`] impls compare by `uid` only.
-    Var(Rc<KindVar>),
+    /// `PartialEq`/`Eq`/`Hash` — the [`FunKindVar`] impls compare by `uid` only.
+    Var(Rc<FunKindVar>),
 }
 
 impl FunKind {
@@ -113,29 +113,29 @@ impl FunKind {
         }
     }
 
-    /// A fresh inferred kind (a new [`KindVar`] with empty bounds).
+    /// A fresh inferred kind (a new [`FunKindVar`] with empty bounds).
     pub fn fresh_var() -> FunKind {
-        FunKind::Var(KindVar::fresh())
+        FunKind::Var(FunKindVar::fresh())
     }
 }
 
-/// Stable identity of a [`KindVar`].
+/// Stable identity of a [`FunKindVar`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct KindVarId(pub(crate) u32);
+pub struct FunKindVarId(pub(crate) u32);
 
-static KIND_VAR_COUNTER: AtomicU32 = AtomicU32::new(0);
+static FUN_KIND_VAR_COUNTER: AtomicU32 = AtomicU32::new(0);
 
-/// Bounds on a [`KindVar`], over the two-point kind lattice `Data ⊑ Compute`.
+/// Bounds on a [`FunKindVar`], over the two-point kind lattice `Data ⊑ Compute`.
 ///
 /// The lattice has only two points, so "bounds" collapse to two flags rather
 /// than the polar bound *lists* an [`crate::ccl::InferVar`] carries — and no
-/// [`Type`] sits inside, so a `KindVar` never forms a cycle. Resolution is a
+/// [`Type`] sits inside, so a `FunKindVar` never forms a cycle. Resolution is a
 /// flag read: `forced_compute ∧ forced_data` is the conflict (`Compute ⊑ κ ⊑
 /// Data`, impossible — the `Compute <: Data` rejection); `forced_compute` alone
 /// → `Compute`; `forced_data` alone → `Data`; neither → the caller's
 /// domain-derived default.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct KindBounds {
+pub struct FunKindBounds {
     /// A `Compute` value flows *into* this kind (`κ ⊒ Compute ⟹ κ = Compute`).
     pub forced_compute: bool,
     /// This kind is *demanded* as `Data` (`κ ⊑ Data ⟹ κ = Data`).
@@ -143,28 +143,28 @@ pub struct KindBounds {
 }
 
 /// A kind-inference variable — an unknown [`FunKind`] the solver pins down by
-/// accumulating [`KindBounds`]. Identity (`uid`) is immutable and lives outside
+/// accumulating [`FunKindBounds`]. Identity (`uid`) is immutable and lives outside
 /// the `RefCell`, so equality/hashing is borrow-free and never inspects the
 /// bounds (mirroring [`crate::ccl::InferVar`]).
-pub struct KindVar {
+pub struct FunKindVar {
     /// Stable, globally-unique identity.
-    pub uid: KindVarId,
+    pub uid: FunKindVarId,
     /// Mutable kind bounds.
-    pub bounds: RefCell<KindBounds>,
+    pub bounds: RefCell<FunKindBounds>,
     /// Vars `u` such that `self <: u` (this kind is below them). A `Compute`
     /// force propagates *up* to them (`self = Compute ⟹ u = Compute`).
-    uppers: RefCell<Vec<Rc<KindVar>>>,
+    uppers: RefCell<Vec<Rc<FunKindVar>>>,
     /// Vars `l` such that `l <: self` (this kind is above them). A `Data` force
     /// propagates *down* to them (`self = Data ⟹ l = Data`).
-    lowers: RefCell<Vec<Rc<KindVar>>>,
+    lowers: RefCell<Vec<Rc<FunKindVar>>>,
 }
 
-impl KindVar {
+impl FunKindVar {
     /// Allocate a fresh kind variable with empty bounds and no links.
-    pub fn fresh() -> Rc<KindVar> {
-        Rc::new(KindVar {
-            uid: KindVarId(KIND_VAR_COUNTER.fetch_add(1, Ordering::Relaxed)),
-            bounds: RefCell::new(KindBounds::default()),
+    pub fn fresh() -> Rc<FunKindVar> {
+        Rc::new(FunKindVar {
+            uid: FunKindVarId(FUN_KIND_VAR_COUNTER.fetch_add(1, Ordering::Relaxed)),
+            bounds: RefCell::new(FunKindBounds::default()),
             uppers: RefCell::new(Vec::new()),
             lowers: RefCell::new(Vec::new()),
         })
@@ -188,7 +188,7 @@ impl KindVar {
     }
 
     /// Force this kind to `Data` and propagate transitively down the `<:` links.
-    /// The dual of [`KindVar::force_compute`]; same fixpoint/termination argument.
+    /// The dual of [`FunKindVar::force_compute`]; same fixpoint/termination argument.
     pub fn force_data(self: &Rc<Self>) {
         if self.bounds.borrow().forced_data {
             return;
@@ -203,14 +203,14 @@ impl KindVar {
     /// it to mirror def-site links onto the per-instantiation copies — the flags
     /// alone are not enough, since a force arriving *after* instantiation must
     /// still traverse the link to the sibling instantiation.
-    pub fn links(&self) -> (Vec<Rc<KindVar>>, Vec<Rc<KindVar>>) {
+    pub fn links(&self) -> (Vec<Rc<FunKindVar>>, Vec<Rc<FunKindVar>>) {
         (self.uppers.borrow().clone(), self.lowers.borrow().clone())
     }
 
     /// Record the edge `lower <: upper` and reconcile the flags already present
     /// on either end. Later forces on either var propagate through the stored
-    /// link via [`KindVar::force_compute`]/[`KindVar::force_data`].
-    pub fn link(lower: &Rc<KindVar>, upper: &Rc<KindVar>) {
+    /// link via [`FunKindVar::force_compute`]/[`FunKindVar::force_data`].
+    pub fn link(lower: &Rc<FunKindVar>, upper: &Rc<FunKindVar>) {
         if Rc::ptr_eq(lower, upper) {
             return;
         }
@@ -227,18 +227,18 @@ impl KindVar {
 
 // Identity-based (by `uid`), mirroring `InferVar`: borrow-free, never touches
 // `bounds`, so it is safe even while a variable's bounds are borrowed.
-impl PartialEq for KindVar {
+impl PartialEq for FunKindVar {
     fn eq(&self, other: &Self) -> bool {
         self.uid == other.uid
     }
 }
-impl Eq for KindVar {}
-impl std::hash::Hash for KindVar {
+impl Eq for FunKindVar {}
+impl std::hash::Hash for FunKindVar {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.uid.hash(state);
     }
 }
-impl fmt::Debug for KindVar {
+impl fmt::Debug for FunKindVar {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "κ{}", self.uid.0)
     }
@@ -247,7 +247,7 @@ impl fmt::Debug for KindVar {
 /// Reset the kind-variable counter to zero (test-only, for predictable output).
 #[cfg(any(test, feature = "test-helpers"))]
 pub fn reset_kind_var_counter() {
-    KIND_VAR_COUNTER.store(0, Ordering::Relaxed);
+    FUN_KIND_VAR_COUNTER.store(0, Ordering::Relaxed);
 }
 
 /// A CCL type annotation.

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -429,7 +429,7 @@ pub enum Type {
     // is a plain coproduct, an `Index`-tagged [`Type::Variant`] of data
     // functions built by [`Type::extent_coproduct`]. A finite, static set of
     // branches needs no dependent sum (a finite Σ degenerates to a coproduct);
-    // see `src/ccl/design/collections.md`. A genuine dependent `Σ` (over a
+    // see `src/ccl/design/type-inference.md`. A genuine dependent `Σ` (over a
     // runtime/opaque witness — `List` length, `Map` key extent) will be added
     // with the collections work, where the witness is real.
 }
@@ -644,7 +644,7 @@ impl Type {
     ///
     /// This is a plain sum type, **not** a dependent sum — a finite, static set
     /// of branches needs no witness (a finite `Σ` degenerates to a coproduct);
-    /// see [collections.md](../ccl/design/collections.md). Callers guarantee
+    /// see [type-inference.md](../ccl/design/type-inference.md). Callers guarantee
     /// `choices.len() >= 2` (a single extent is a plain data function); the
     /// arms share `pi_name` (the element binder) and `codomain`.
     pub fn extent_coproduct(

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -1,8 +1,10 @@
 //! The CCL [`Type`] lattice, its [`Refinement`] subset-type carrier, and the
 //! type-blind structural equality / hashing on refinement predicate terms.
 
+use std::cell::RefCell;
 use std::fmt;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use smol_str::SmolStr;
 
@@ -65,6 +67,189 @@ impl fmt::Display for FieldKey {
     }
 }
 
+/// Whether a [`Type::Fun`]'s domain is a **capability** or an **extent** — the
+/// compute-function vs data-function distinction.
+///
+/// - [`FunKind::Compute`] — `α ⇒ β`: the domain is a *capability*, the inputs
+///   the function accepts. No data sits behind it, so shrinking the domain only
+///   under-promises; the contravariant meet at a control-flow join is a sound,
+///   lossy simplification.
+/// - [`FunKind::Data`] — `α ⤇ β`: the domain is an *extent*, a collection's
+///   index set. The domain *is* the data map, so a lossy domain is lost data;
+///   joins of data functions must be lossless — they form a coproduct
+///   ([`Type::extent_coproduct`]) over the extents, never a meet.
+///
+/// Set at introduction (list literals, comprehensions, `++`, registered
+/// sources, and every `History` erasure are `Data`; `lambda`/`def` are
+/// `Compute`). The audit rule for a rebuilt or erased arrow: it is `Data` iff
+/// `extent_of` will drive iteration off its domain. See
+/// `design/type-inference.md` §4.6.
+///
+/// Kind is **inferred** (see `design/type-inference.md` §4.6):
+/// where the structure fixes it (a list literal is `Data`, a scalar op is
+/// `Compute`) a concrete kind is stamped; where it depends on use or on an
+/// unresolved source (a map/comprehension) a [`FunKind::Var`] is minted and the
+/// solver resolves it, like a type variable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FunKind {
+    /// Capability domain (`⇒`): lossy meet at a join is fine.
+    Compute,
+    /// Extent domain (`⤇`): the domain is data; joins must be lossless.
+    Data,
+    /// An unresolved kind, pinned down by the solver at coalesce. Identity is by
+    /// the variable's `uid`, so `FunKind` (and `Type`) keep deriving
+    /// `PartialEq`/`Eq`/`Hash` — the [`KindVar`] impls compare by `uid` only.
+    Var(Rc<KindVar>),
+}
+
+impl FunKind {
+    /// The display arrow for this kind: `⇒` for compute, `⤇` for data. An
+    /// unresolved variable renders `⇒` (its resolved kind is written back before
+    /// display matters downstream).
+    pub fn arrow(&self) -> &'static str {
+        match self {
+            FunKind::Compute | FunKind::Var(_) => "⇒",
+            FunKind::Data => "⤇",
+        }
+    }
+
+    /// A fresh inferred kind (a new [`KindVar`] with empty bounds).
+    pub fn fresh_var() -> FunKind {
+        FunKind::Var(KindVar::fresh())
+    }
+}
+
+/// Stable identity of a [`KindVar`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KindVarId(pub(crate) u32);
+
+static KIND_VAR_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// Bounds on a [`KindVar`], over the two-point kind lattice `Data ⊑ Compute`.
+///
+/// The lattice has only two points, so "bounds" collapse to two flags rather
+/// than the polar bound *lists* an [`crate::ccl::InferVar`] carries — and no
+/// [`Type`] sits inside, so a `KindVar` never forms a cycle. Resolution is a
+/// flag read: `forced_compute ∧ forced_data` is the conflict (`Compute ⊑ κ ⊑
+/// Data`, impossible — the `Compute <: Data` rejection); `forced_compute` alone
+/// → `Compute`; `forced_data` alone → `Data`; neither → the caller's
+/// domain-derived default.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct KindBounds {
+    /// A `Compute` value flows *into* this kind (`κ ⊒ Compute ⟹ κ = Compute`).
+    pub forced_compute: bool,
+    /// This kind is *demanded* as `Data` (`κ ⊑ Data ⟹ κ = Data`).
+    pub forced_data: bool,
+}
+
+/// A kind-inference variable — an unknown [`FunKind`] the solver pins down by
+/// accumulating [`KindBounds`]. Identity (`uid`) is immutable and lives outside
+/// the `RefCell`, so equality/hashing is borrow-free and never inspects the
+/// bounds (mirroring [`crate::ccl::InferVar`]).
+pub struct KindVar {
+    /// Stable, globally-unique identity.
+    pub uid: KindVarId,
+    /// Mutable kind bounds.
+    pub bounds: RefCell<KindBounds>,
+    /// Vars `u` such that `self <: u` (this kind is below them). A `Compute`
+    /// force propagates *up* to them (`self = Compute ⟹ u = Compute`).
+    uppers: RefCell<Vec<Rc<KindVar>>>,
+    /// Vars `l` such that `l <: self` (this kind is above them). A `Data` force
+    /// propagates *down* to them (`self = Data ⟹ l = Data`).
+    lowers: RefCell<Vec<Rc<KindVar>>>,
+}
+
+impl KindVar {
+    /// Allocate a fresh kind variable with empty bounds and no links.
+    pub fn fresh() -> Rc<KindVar> {
+        Rc::new(KindVar {
+            uid: KindVarId(KIND_VAR_COUNTER.fetch_add(1, Ordering::Relaxed)),
+            bounds: RefCell::new(KindBounds::default()),
+            uppers: RefCell::new(Vec::new()),
+            lowers: RefCell::new(Vec::new()),
+        })
+    }
+
+    /// Force this kind to `Compute` and propagate transitively up the `<:` links.
+    ///
+    /// Propagation keeps the flags at a fixpoint *incrementally*, so — unlike a
+    /// one-shot copy of the flags present when a link is first drawn — a force
+    /// that arrives strictly after its link still reaches every var it must. The
+    /// monotone flag (false → true) both terminates the walk and makes it
+    /// cycle-safe: a var already `Compute` short-circuits before recursing.
+    pub fn force_compute(self: &Rc<Self>) {
+        if self.bounds.borrow().forced_compute {
+            return;
+        }
+        self.bounds.borrow_mut().forced_compute = true;
+        for u in self.uppers.borrow().iter() {
+            u.force_compute();
+        }
+    }
+
+    /// Force this kind to `Data` and propagate transitively down the `<:` links.
+    /// The dual of [`KindVar::force_compute`]; same fixpoint/termination argument.
+    pub fn force_data(self: &Rc<Self>) {
+        if self.bounds.borrow().forced_data {
+            return;
+        }
+        self.bounds.borrow_mut().forced_data = true;
+        for l in self.lowers.borrow().iter() {
+            l.force_data();
+        }
+    }
+
+    /// A snapshot `(uppers, lowers)` of this var's `<:` links. Freshening uses
+    /// it to mirror def-site links onto the per-instantiation copies — the flags
+    /// alone are not enough, since a force arriving *after* instantiation must
+    /// still traverse the link to the sibling instantiation.
+    pub fn links(&self) -> (Vec<Rc<KindVar>>, Vec<Rc<KindVar>>) {
+        (self.uppers.borrow().clone(), self.lowers.borrow().clone())
+    }
+
+    /// Record the edge `lower <: upper` and reconcile the flags already present
+    /// on either end. Later forces on either var propagate through the stored
+    /// link via [`KindVar::force_compute`]/[`KindVar::force_data`].
+    pub fn link(lower: &Rc<KindVar>, upper: &Rc<KindVar>) {
+        if Rc::ptr_eq(lower, upper) {
+            return;
+        }
+        lower.uppers.borrow_mut().push(Rc::clone(upper));
+        upper.lowers.borrow_mut().push(Rc::clone(lower));
+        if lower.bounds.borrow().forced_compute {
+            upper.force_compute();
+        }
+        if upper.bounds.borrow().forced_data {
+            lower.force_data();
+        }
+    }
+}
+
+// Identity-based (by `uid`), mirroring `InferVar`: borrow-free, never touches
+// `bounds`, so it is safe even while a variable's bounds are borrowed.
+impl PartialEq for KindVar {
+    fn eq(&self, other: &Self) -> bool {
+        self.uid == other.uid
+    }
+}
+impl Eq for KindVar {}
+impl std::hash::Hash for KindVar {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.uid.hash(state);
+    }
+}
+impl fmt::Debug for KindVar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "κ{}", self.uid.0)
+    }
+}
+
+/// Reset the kind-variable counter to zero (test-only, for predictable output).
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn reset_kind_var_counter() {
+    KIND_VAR_COUNTER.store(0, Ordering::Relaxed);
+}
+
 /// A CCL type annotation.
 ///
 /// Appears on [`TypedExpr`] nodes and as the output of type inference.
@@ -109,6 +294,11 @@ pub enum Type {
         /// renaming their Pi binder reconcile there (see the substitution
         /// machinery).
         name: Option<crate::ccl::Name>,
+        /// Whether the domain is a capability (`Compute`) or an extent
+        /// (`Data`). See [`FunKind`]. The derived [`PartialEq`] compares it: a
+        /// data function and a compute function over the same domain/codomain
+        /// are genuinely different types (one carries data, one a capability).
+        kind: FunKind,
         /// The parameter (argument) type. Contravariant position.
         domain: Box<Type>,
         /// The result type. Covariant position; may reference `name`.
@@ -233,6 +423,15 @@ pub enum Type {
     // Planned:
     // Pi { param: String, param_ty: Box<Type>, body_ty: Box<Type> }
     // Refinement { base: Box<Type>, predicate: Box<Expr> }
+    //
+    // NOTE: a **conditional collection** (the lossless join of data functions
+    // with distinct extents at a control-flow merge) is not a variant here — it
+    // is a plain coproduct, an `Index`-tagged [`Type::Variant`] of data
+    // functions built by [`Type::extent_coproduct`]. A finite, static set of
+    // branches needs no dependent sum (a finite Σ degenerates to a coproduct);
+    // see `src/ccl/design/collections.md`. A genuine dependent `Σ` (over a
+    // runtime/opaque witness — `List` length, `Map` key extent) will be added
+    // with the collections work, where the witness is real.
 }
 
 /// Which flavour of [`Type::History`] a handle is — a mutable variable (`:=`) or a
@@ -295,16 +494,23 @@ impl fmt::Display for Type {
             // it as `∅` instead of computing `n - 1` and underflowing.
             Type::UIntRange(0) => write!(f, "∅"),
             Type::UIntRange(n) => write!(f, "[0, {}]", n - 1),
+            // The arrow reflects the resolved `kind`: `⇒` for a compute
+            // capability (and an unresolved kind var), `⤇` for a data extent
+            // (see `FunKind::arrow`). Once kind inference resolves every arrow
+            // once resolved, a data collection renders `⤇`, making the extent/capability
+            // distinction legible in every type string.
             Type::Fun {
                 name: Some(x),
+                kind,
                 domain,
                 codomain,
-            } => write!(f, "(({x}: {domain}) ⇒ {codomain})"),
+            } => write!(f, "(({x}: {domain}) {} {codomain})", kind.arrow()),
             Type::Fun {
                 name: None,
+                kind,
                 domain,
                 codomain,
-            } => write!(f, "({domain} ⇒ {codomain})"),
+            } => write!(f, "({domain} {} {codomain})", kind.arrow()),
             Type::Tuple(ts) => {
                 let parts: Vec<_> = ts.iter().map(|t| t.to_string()).collect();
                 write!(f, "({})", parts.join(", "))
@@ -362,22 +568,110 @@ impl fmt::Display for Type {
 }
 
 impl Type {
-    /// Helper for creating a non-dependent function type (`name: None`).
+    /// Helper for creating a non-dependent **compute** function type
+    /// (`name: None`, `kind: Compute`).
     pub fn fun(domain: Self, codomain: Self) -> Self {
         Type::Fun {
             name: None,
+            kind: FunKind::Compute,
             domain: Box::new(domain),
             codomain: Box::new(codomain),
         }
     }
 
-    /// Helper for creating a dependent (Pi) function type `(name: domain) ⇒ codomain`.
+    /// Helper for creating a dependent (Pi) **compute** function type
+    /// `(name: domain) ⇒ codomain`.
     pub fn pi(name: impl Into<crate::ccl::Name>, domain: Self, codomain: Self) -> Self {
         Type::Fun {
             name: Some(name.into()),
+            kind: FunKind::Compute,
             domain: Box::new(domain),
             codomain: Box::new(codomain),
         }
+    }
+
+    /// Helper for creating a dependent (Pi) function type whose **kind is
+    /// inferred** — a fresh [`FunKind::Var`]. Used by `emit_lambda`: a user
+    /// lambda is a capability *or* a collection map depending on its domain and
+    /// use, neither known at emit, so the kind is left to the solver.
+    pub fn pi_inferred_kind(
+        name: impl Into<crate::ccl::Name>,
+        domain: Self,
+        codomain: Self,
+    ) -> Self {
+        Type::Fun {
+            name: Some(name.into()),
+            kind: FunKind::fresh_var(),
+            domain: Box::new(domain),
+            codomain: Box::new(codomain),
+        }
+    }
+
+    /// Helper for creating a non-dependent **data** function type
+    /// (`name: None`, `kind: Data`) — a collection `domain ⤇ codomain`.
+    pub fn data_fun(domain: Self, codomain: Self) -> Self {
+        Type::Fun {
+            name: None,
+            kind: FunKind::Data,
+            domain: Box::new(domain),
+            codomain: Box::new(codomain),
+        }
+    }
+
+    /// Rebuild a function type copying `name` and `kind` from an `exemplar`
+    /// `Fun`, so a downstream rebuild (lambda elimination, inlining, planning)
+    /// can never silently flip a data arrow to compute or drop its Pi binder. A
+    /// non-`Fun` exemplar yields a plain `Compute` arrow with no binder — the
+    /// safe default at a site with no arrow to copy from.
+    pub fn fun_like(exemplar: &Type, domain: Self, codomain: Self) -> Self {
+        match exemplar {
+            Type::Fun { name, kind, .. } => Type::Fun {
+                name: name.clone(),
+                kind: kind.clone(),
+                domain: Box::new(domain),
+                codomain: Box::new(codomain),
+            },
+            _ => Type::fun(domain, codomain),
+        }
+    }
+
+    /// The type of a **conditional collection**: a coproduct (untagged,
+    /// `Index`-tagged [`Type::Variant`]) of data functions, one per candidate
+    /// extent, all sharing the joined codomain. Formed at a control-flow join
+    /// of data collections with distinct extents (`xs if c else ys`): the value
+    /// is *one* of the arms, tagged by contribution order, and the branch tags
+    /// are exactly the value-`Case` gates the runtime carries.
+    ///
+    /// This is a plain sum type, **not** a dependent sum — a finite, static set
+    /// of branches needs no witness (a finite `Σ` degenerates to a coproduct);
+    /// see [collections.md](../ccl/design/collections.md). Callers guarantee
+    /// `choices.len() >= 2` (a single extent is a plain data function); the
+    /// arms share `pi_name` (the element binder) and `codomain`.
+    pub fn extent_coproduct(
+        choices: Vec<Type>,
+        pi_name: Option<crate::ccl::Name>,
+        codomain: Type,
+    ) -> Self {
+        debug_assert!(
+            choices.len() >= 2,
+            "extent_coproduct: a single extent is a plain data function, not a coproduct"
+        );
+        let arms = choices
+            .into_iter()
+            .enumerate()
+            .map(|(i, dom)| {
+                (
+                    FieldKey::Index(i),
+                    Type::Fun {
+                        name: pi_name.clone(),
+                        kind: FunKind::Data,
+                        domain: Box::new(dom),
+                        codomain: Box::new(codomain.clone()),
+                    },
+                )
+            })
+            .collect();
+        Type::Variant(arms)
     }
 
     /// If this is a function type, return the domain type, otherwise None.
@@ -443,13 +737,24 @@ impl Type {
         }
     }
 
-    /// A structural copy with every Pi binder name erased (`Fun.name → None`).
+    /// A structural copy with every Pi binder name erased (`Fun.name → None`)
+    /// and every function **kind** canonicalized to `Compute`.
     ///
     /// The binder is load-bearing only inside the type solver (it carries
     /// dependent-refinement correspondences); downstream passes treat function
     /// types structurally and a `Some`/`None` binder is the same arrow to them.
     /// Use this when comparing types for structural equality across a pass that
     /// does not preserve the cosmetic binder.
+    ///
+    /// Kind is normalized for the same reason: **lambda elimination preserves a
+    /// function's denotation but not its kind representation** — a data
+    /// collection (`⤇`) becomes a point-free form built from compute combinators
+    /// (`zip`, `apply`, `const`), so the reconstructed arrow reads `Compute`
+    /// though it denotes the same collection. The kind did its work at inference
+    /// (lossless coproduct joins at coalesce); post-elimination it is not preserved, so
+    /// the structural-equality asserts (and the feed-operand agreement check)
+    /// compare modulo it. (Kind-aware subtyping therefore acts in
+    /// *Emit*-mode inference, not the post-elimination Check-mode pass.)
     ///
     /// Under the Barendregt convention the blindness needed at the remaining
     /// call sites (lambda elimination's type-preservation asserts) is exactly
@@ -465,6 +770,10 @@ impl Type {
                 domain, codomain, ..
             } => Type::Fun {
                 name: None,
+                // Canonicalize kind — elimination does not preserve it (see the
+                // doc above); comparing modulo it is what these structural asserts
+                // want.
+                kind: FunKind::Compute,
                 domain: Box::new(domain.without_pi_names()),
                 codomain: Box::new(codomain.without_pi_names()),
             },

--- a/tests/compilation_pipeline/joins_aggregates_groupby.rs
+++ b/tests/compilation_pipeline/joins_aggregates_groupby.rs
@@ -164,32 +164,32 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[1,2,3]",
-    "iterate ≫ [1, 2, 3]:([0, 2] ⇒ Int)",
+    "iterate ≫ [1, 2, 3]:([0, 2] ⤇ Int)",
     make_int_list(&[1,2,3])
 )]
 #[case(
     "x = [1,2,3]; x",
-    "let x : ([0, 2] ⇒ Int) = iterate ≫ [1, 2, 3]\nin x:([0, 2] ⇒ Int)",
+    "let x : ([0, 2] ⤇ Int) = iterate ≫ [1, 2, 3]\nin x:([0, 2] ⤇ Int)",
     make_int_list(&[1,2,3])
 )]
 #[case(
     "x = [1,2,3]; [y + 10 for y in x]",
-    "let x : ([0, 2] ⇒ Int) = iterate ≫ [1, 2, 3]\nin x ≫ (id, 10 ▷ const) ▷ zip ≫ add:([0, 2] ⇒ Int)",
+    "let x : ([0, 2] ⤇ Int) = iterate ≫ [1, 2, 3]\nin x ≫ (id, 10 ▷ const) ▷ zip ≫ add:([0, 2] ⇒ Int)",
     make_int_list(&[11,12,13])
 )]
 #[case(
     "[x + 10 + x for x in [1,2,3]]",
-    "iterate ≫ [1, 2, 3] ≫ ((id, 10 ▷ const) ▷ zip ≫ add, id) ▷ zip ≫ add:([0, 2] ⇒ Int)",
+    "iterate ≫ [1, 2, 3] ≫ ((id, 10 ▷ const) ▷ zip ≫ add, id) ▷ zip ≫ add:([0, 2] ⤇ Int)",
     make_int_list(&[12,14,16])
 )]
 #[case(
     "y = 10; [x + y for x in [1,2,3]]",
-    "let y : Int = 10\nin iterate ≫ [1, 2, 3] ≫ (id, y ▷ const) ▷ zip ≫ add:([0, 2] ⇒ Int)",
+    "let y : Int = 10\nin iterate ≫ [1, 2, 3] ≫ (id, y ▷ const) ▷ zip ≫ add:([0, 2] ⤇ Int)",
     make_int_list(&[11,12,13])
 )]
 #[case(
     "[x for x in [False,True] if x]",
-    "iterate ▷ ([false, true] ▷ restrict) ≫ cast([false, true]):({[0, 1] | __elem ▷ [false, true]} ⇒ Bool)",
+    "iterate ▷ ([false, true] ▷ restrict) ≫ cast([false, true]):({[0, 1] | __elem ▷ [false, true]} ⤇ Bool)",
     Tile::SealedFunction {
         domain: ColumnValue::UInts(vec![1]),
         codomain: Box::new(Tile::Scalar(ColumnValue::Bools(BitVec::from_elem(1, true)))),
@@ -199,7 +199,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + 10 for x in [1,2,3] if x == 2]",
-    "iterate ▷ (([1, 2, 3] ≫ (id, 2 ▷ const) ▷ zip ≫ eq) ▷ restrict) ≫ cast([1, 2, 3] ≫ (id, 10 ▷ const) ▷ zip ≫ add):({[0, 2] | __elem ▷ ([1, 2, 3] ≫ (id, 2 ▷ const) ▷ zip ≫ eq)} ⇒ Int)",
+    "iterate ▷ (([1, 2, 3] ≫ (id, 2 ▷ const) ▷ zip ≫ eq) ▷ restrict) ≫ cast([1, 2, 3] ≫ (id, 10 ▷ const) ▷ zip ≫ add):({[0, 2] | __elem ▷ ([1, 2, 3] ≫ (id, 2 ▷ const) ▷ zip ≫ eq)} ⤇ Int)",
     Tile::SealedFunction {
         domain: ColumnValue::UInts(vec![1]),
         codomain: Box::new(Tile::Scalar(ColumnValue::Ints(vec![12]))),
@@ -209,7 +209,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + y for x in [1,2,3] for y in [10,20]]",
-    "iterate ≫ (.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip ≫ add:(([0, 2], [0, 1]) ⇒ Int)",
+    "iterate ≫ (.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip ≫ add:(([0, 2], [0, 1]) ⤇ Int)",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![0, 0, 1, 1, 2, 2])),
@@ -225,7 +225,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[(x, y) for x in [1,2,3] for y in [10,20]]",
-    "iterate ≫ (.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip:(([0, 2], [0, 1]) ⇒ (Int, Int))",
+    "iterate ≫ (.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip:(([0, 2], [0, 1]) ⤇ (Int, Int))",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![0, 0, 1, 1, 2, 2])),
@@ -244,7 +244,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x for x in [1,2,3] for y in [10,20]]",
-    "iterate ≫ .0 ≫ [1, 2, 3]:(([0, 2], [0, 1]) ⇒ Int)",
+    "iterate ≫ .0 ≫ [1, 2, 3]:(([0, 2], [0, 1]) ⤇ Int)",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![0, 0, 1, 1, 2, 2])),
@@ -260,7 +260,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + y for x in [1,2,3] if x == 2 for y in [10,20] if y == 10]",
-    "iterate ▷ ((((.0 ≫ [1, 2, 3], 2 ▷ const) ▷ zip ≫ eq, (.1 ≫ [10, 20], 10 ▷ const) ▷ zip ≫ eq) ▷ zip ≫ and) ▷ restrict) ≫ cast((.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip ≫ add):({([0, 2], [0, 1]) | __elem ▷ (((.0 ≫ [1, 2, 3], 2 ▷ const) ▷ zip ≫ eq, (.1 ≫ [10, 20], 10 ▷ const) ▷ zip ≫ eq) ▷ zip ≫ and)} ⇒ Int)",
+    "iterate ▷ ((((.0 ≫ [1, 2, 3], 2 ▷ const) ▷ zip ≫ eq, (.1 ≫ [10, 20], 10 ▷ const) ▷ zip ≫ eq) ▷ zip ≫ and) ▷ restrict) ≫ cast((.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip ≫ add):({([0, 2], [0, 1]) | __elem ▷ (((.0 ≫ [1, 2, 3], 2 ▷ const) ▷ zip ≫ eq, (.1 ≫ [10, 20], 10 ▷ const) ▷ zip ≫ eq) ▷ zip ≫ and)} ⤇ Int)",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![1])),
@@ -275,18 +275,25 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
     }
 )]
 #[case(
+    // An identity comprehension collapses to `iterate ≫ [1, 2, 3]`; because
+    // `wrap_with_iterate` stamps its result `Data` (an iterated collection is,
+    // by construction, an extent the runtime sweeps), it displays `⤇` in parity
+    // with the bare list literal `[1, 2, 3]` (case above) it denotes. (The one
+    // residual `⇒` is a comprehension whose *source is a let-bound var* —
+    // `x = [1,2,3]; [y+10 for y in x]` — whose compose domain is reconstructed
+    // post-coalesce, so the kind var resolves before its extent is known.)
     "[x for x in [x for x in [x for x in [1,2,3]]]]",
-    "iterate ≫ [1, 2, 3]:([0, 2] ⇒ Int)",
+    "iterate ≫ [1, 2, 3]:([0, 2] ⤇ Int)",
     make_int_list(&[1,2,3])
 )]
 #[case(
     "[x for x in [y for y in [1,2,3] if y < 3] if x < 2]",
-    "iterate ▷ (([1, 2, 3] ≫ (id, 3 ▷ const) ▷ zip ≫ lt) ▷ restrict) ▷ ((cast([1, 2, 3]) ≫ (id, 2 ▷ const) ▷ zip ≫ lt) ▷ restrict) ≫ cast(cast([1, 2, 3])):({{[0, 2] | __elem ▷ ([1, 2, 3] ≫ (id, 3 ▷ const) ▷ zip ≫ lt)} | __elem ▷ (cast([1, 2, 3]) ≫ (id, 2 ▷ const) ▷ zip ≫ lt)} ⇒ Int)",
+    "iterate ▷ (([1, 2, 3] ≫ (id, 3 ▷ const) ▷ zip ≫ lt) ▷ restrict) ▷ ((cast([1, 2, 3]) ≫ (id, 2 ▷ const) ▷ zip ≫ lt) ▷ restrict) ≫ cast(cast([1, 2, 3])):({{[0, 2] | __elem ▷ ([1, 2, 3] ≫ (id, 3 ▷ const) ▷ zip ≫ lt)} | __elem ▷ (cast([1, 2, 3]) ≫ (id, 2 ▷ const) ▷ zip ≫ lt)} ⤇ Int)",
     make_int_list(&[1])
 )]
 #[case(
     "[(x, x) for x in [(x, x) for x in [1,2,3]]]",
-    "iterate ≫ [1, 2, 3] ≫ (id, id) ▷ zip ≫ (id, id) ▷ zip:([0, 2] ⇒ ((Int, Int), (Int, Int)))",
+    "iterate ≫ [1, 2, 3] ≫ (id, id) ▷ zip ≫ (id, id) ▷ zip:([0, 2] ⤇ ((Int, Int), (Int, Int)))",
     Tile::SealedFunction {
         domain: ColumnValue::UInts(vec![0, 1, 2]),
         codomain: Box::new(Tile::Record(HashMap::from([
@@ -305,7 +312,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + y for x in ['a', 'b'] for y in ['c', 'd', 'e']]",
-    "iterate ≫ (.0 ≫ [\"a\", \"b\"], .1 ≫ [\"c\", \"d\", \"e\"]) ▷ zip ≫ concat:(([0, 1], [0, 2]) ⇒ String)",
+    "iterate ≫ (.0 ≫ [\"a\", \"b\"], .1 ≫ [\"c\", \"d\", \"e\"]) ▷ zip ≫ concat:(([0, 1], [0, 2]) ⤇ String)",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![0, 0, 0, 1, 1, 1])),
@@ -321,7 +328,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + 10 for x in testsource1() if x < 15]",
-    "iterate ▷ ((source(testsource1) ≫ (id, 15 ▷ const) ▷ zip ≫ lt) ▷ restrict) ≫ cast(source(testsource1) ≫ (id, 10 ▷ const) ▷ zip ≫ add):({source(testsource1) | __elem ▷ (source(testsource1) ≫ (id, 15 ▷ const) ▷ zip ≫ lt)} ⇒ Int)",
+    "iterate ▷ ((source(testsource1) ≫ (id, 15 ▷ const) ▷ zip ≫ lt) ▷ restrict) ≫ cast(source(testsource1) ≫ (id, 10 ▷ const) ▷ zip ≫ add):({source(testsource1) | __elem ▷ (source(testsource1) ≫ (id, 15 ▷ const) ▷ zip ≫ lt)} ⤇ Int)",
     make_int_list(&[10, 20])
 )]
 #[case("sum([1,2,3])", "(iterate ≫ [1, 2, 3]) ▷ sum:Int", Tile::Scalar(ColumnValue::Ints(vec![6])))]
@@ -477,7 +484,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + y + z for x in [1] for y in [1, 2] for z in [1, 2, 3] if x == z and y == z and x + y == z + 1]",
-    "iterate ▷ (((((.0 ≫ [1], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq, (.1 ≫ [1, 2], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq) ▷ zip ≫ and, ((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, (.2 ≫ [1, 2, 3], 1 ▷ const) ▷ zip ≫ add) ▷ zip ≫ eq) ▷ zip ≫ and) ▷ restrict) ≫ cast(((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, .2 ≫ [1, 2, 3]) ▷ zip ≫ add):({([0, 0], [0, 1], [0, 2]) | __elem ▷ ((((.0 ≫ [1], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq, (.1 ≫ [1, 2], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq) ▷ zip ≫ and, ((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, (.2 ≫ [1, 2, 3], 1 ▷ const) ▷ zip ≫ add) ▷ zip ≫ eq) ▷ zip ≫ and)} ⇒ Int)",
+    "iterate ▷ (((((.0 ≫ [1], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq, (.1 ≫ [1, 2], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq) ▷ zip ≫ and, ((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, (.2 ≫ [1, 2, 3], 1 ▷ const) ▷ zip ≫ add) ▷ zip ≫ eq) ▷ zip ≫ and) ▷ restrict) ≫ cast(((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, .2 ≫ [1, 2, 3]) ▷ zip ≫ add):({([0, 0], [0, 1], [0, 2]) | __elem ▷ ((((.0 ≫ [1], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq, (.1 ≫ [1, 2], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq) ▷ zip ≫ and, ((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, (.2 ≫ [1, 2, 3], 1 ▷ const) ▷ zip ≫ add) ▷ zip ≫ eq) ▷ zip ≫ and)} ⤇ Int)",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![0])),

--- a/tests/compilation_pipeline/scalars_collections.rs
+++ b/tests/compilation_pipeline/scalars_collections.rs
@@ -209,3 +209,35 @@ fn test_let_nonscalar(#[case] code: &str, #[case] expected: Tile) {
 fn test_tuples(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
+
+// ---------------------------------------------------------------------------
+// Conditional-collection coproduct: the safety chokepoint
+// ---------------------------------------------------------------------------
+
+/// A control-flow join of two differently-sized collections types as a
+/// **coproduct** over both extents (an `Index`-tagged `Variant` of data
+/// functions — `Type::extent_coproduct`; see collections.md). This lays only
+/// the *type-level* coproduct (formation + the `Variant <: Fun` consume rule,
+/// so it can be consumed at the type level); *compiling* it — the value-`Case`
+/// fan-out that eliminates it into a union of restricts — lands with
+/// value-`Case` compilation. Until then a coproduct-consuming program must be
+/// rejected **cleanly** (a returned compile error, never a panic and never a
+/// silent miscompile). The value-`Case` is caught at lambda elimination — the
+/// natural not-yet-implemented boundary value-`Case` compilation graduates.
+/// This pins the contract end-to-end: it type-checks, then fails to compile
+/// without crashing.
+#[test]
+fn conditional_collection_rejected_cleanly() {
+    use cambra::ccl::context::{GlobalContext, compile_program};
+    use cambra::interpreter::Consumer;
+    let mut ctx = GlobalContext::default();
+    let consumer: Box<dyn Consumer> = Box::new(|| {});
+    let errs = compile_program(&mut ctx, "sum([1, 2] if True else [1, 2, 3])", consumer)
+        .err()
+        .expect("a coproduct-consuming program must fail to compile, not miscompile or panic");
+    let rendered = format!("{errs:?}");
+    assert!(
+        rendered.contains("lambda elimination") && rendered.contains("Case"),
+        "expected a clean value-Case not-yet-compilable rejection, got:\n{rendered}"
+    );
+}

--- a/tests/compilation_pipeline/scalars_collections.rs
+++ b/tests/compilation_pipeline/scalars_collections.rs
@@ -216,7 +216,7 @@ fn test_tuples(#[case] code: &str, #[case] expected: Value) {
 
 /// A control-flow join of two differently-sized collections types as a
 /// **coproduct** over both extents (an `Index`-tagged `Variant` of data
-/// functions — `Type::extent_coproduct`; see collections.md). This lays only
+/// functions — `Type::extent_coproduct`; see type-inference.md Â§4.6). This lays only
 /// the *type-level* coproduct (formation + the `Variant <: Fun` consume rule,
 /// so it can be consumed at the type level); *compiling* it — the value-`Case`
 /// fan-out that eliminates it into a union of restricts — lands with

--- a/tests/compilation_pipeline/scalars_collections.rs
+++ b/tests/compilation_pipeline/scalars_collections.rs
@@ -211,16 +211,16 @@ fn test_tuples(#[case] code: &str, #[case] expected: Value) {
 }
 
 // ---------------------------------------------------------------------------
-// Conditional-collection coproduct: the safety chokepoint
+// Conditional-collection Sigma: the safety chokepoint
 // ---------------------------------------------------------------------------
 
-/// A control-flow join of two differently-sized collections types as a
-/// **coproduct** over both extents (an `Index`-tagged `Variant` of data
-/// functions — `Type::extent_coproduct`; see type-inference.md Â§4.6). This lays only
-/// the *type-level* coproduct (formation + the `Variant <: Fun` consume rule,
-/// so it can be consumed at the type level); *compiling* it — the value-`Case`
+/// A control-flow join of two differently-sized collections types as the
+/// dependent-sum **conditional collection** over both extents
+/// (`Type::conditional_collection`; see type-inference.md §4.6). This lays only
+/// the *type-level* Sigma (formation + the `Σ <: Fun` elimination rule, so it
+/// can be consumed at the type level); *compiling* it — the value-`Case`
 /// fan-out that eliminates it into a union of restricts — lands with
-/// value-`Case` compilation. Until then a coproduct-consuming program must be
+/// value-`Case` compilation. Until then a Sigma-consuming program must be
 /// rejected **cleanly** (a returned compile error, never a panic and never a
 /// silent miscompile). The value-`Case` is caught at lambda elimination — the
 /// natural not-yet-implemented boundary value-`Case` compilation graduates.
@@ -234,7 +234,7 @@ fn conditional_collection_rejected_cleanly() {
     let consumer: Box<dyn Consumer> = Box::new(|| {});
     let errs = compile_program(&mut ctx, "sum([1, 2] if True else [1, 2, 3])", consumer)
         .err()
-        .expect("a coproduct-consuming program must fail to compile, not miscompile or panic");
+        .expect("a Sigma-consuming program must fail to compile, not miscompile or panic");
     let rendered = format!("{errs:?}");
     assert!(
         rendered.contains("lambda elimination") && rendered.contains("Case"),

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -53,6 +53,7 @@ fn infer_program_with_sources(code: &str, sources: &[(&str, Type)]) -> Type {
             name,
             Type::Fun {
                 name: None,
+                kind: cambra::ccl::FunKind::Compute,
                 domain: Box::new(Type::DataSource(name.to_string())),
                 codomain: Box::new(elem_ty.clone()),
             },
@@ -95,6 +96,7 @@ fn infer_program_with_sources_err(code: &str, sources: &[(&str, Type)]) -> Vec<I
             name,
             Type::Fun {
                 name: None,
+                kind: cambra::ccl::FunKind::Compute,
                 domain: Box::new(Type::DataSource(name.to_string())),
                 codomain: Box::new(elem_ty.clone()),
             },
@@ -184,13 +186,68 @@ fn test_unary_op(#[case] code: &str, #[case] expected: BaseType) {
 
 #[test]
 fn test_list_literal() {
+    // A list literal is a **data** function (extent domain).
     assert_eq!(
         infer_program("[1, 2, 3]"),
-        Type::Fun {
-            name: None,
-            domain: Box::new(Type::UIntRange(3)),
-            codomain: Box::new(int())
-        }
+        Type::data_fun(Type::UIntRange(3), int())
+    );
+}
+
+#[test]
+fn test_conditional_collection_forms_coproduct() {
+    // A control-flow join of two collections with different extents is
+    // lossless: it forms a **coproduct** over both extents (never a lossy
+    // meet-domain function). `[1, 2]` is `[0, 1] ⤇ Int`, `[1, 2, 3]` is
+    // `[0, 2] ⤇ Int`, so the join is the `Index`-tagged sum
+    // `([0, 1] ⤇ Int) | ([0, 2] ⤇ Int)` — a plain sum, not a dependent sum
+    // (a finite branch set needs no witness; see collections.md).
+    assert_eq!(
+        infer_program("[1, 2] if True else [1, 2, 3]"),
+        Type::extent_coproduct(vec![Type::UIntRange(2), Type::UIntRange(3)], None, int())
+    );
+}
+
+#[test]
+fn test_conditional_collection_same_extent_collapses() {
+    // Idempotence: when both arms share an extent, the coproduct collapses back
+    // to a plain data function — no spurious 2-arm coproduct (`union_extents`
+    // dedups the shared extent).
+    assert_eq!(
+        infer_program("[1, 2] if True else [3, 4]"),
+        Type::data_fun(Type::UIntRange(2), int())
+    );
+}
+
+#[test]
+fn test_conditional_record_arms_join_by_field_intersection() {
+    // `emit_case` types arms with `require_sub` (a lattice join), not the old
+    // strict `require_eq` — so two record arms with differing fields no longer
+    // fail; they join to the common-field intersection at positive polarity.
+    // `{a, b} if c else {a, c}` → `{a: Int}`. Pins the widening so a future
+    // change to record-arm polarity can't silently alter which conditionals
+    // type-check. (design/type-inference.md, Case-arm lattice joins)
+    assert_eq!(
+        infer_program("{a: 1, b: 2} if True else {a: 1, c: 3}").to_string(),
+        "{a: Int}"
+    );
+}
+
+#[test]
+fn test_aggregate_over_scalar_lambda_is_rejected() {
+    // Summing a plain `Int ⇒ Int` lambda demands its kind var be `Data` (an
+    // iterable extent) while its domain is provably scalar — the `Compute <:
+    // Data` violation. The rejection must surface at coalesce for a *var*-kinded
+    // user lambda (not only the concrete-`Compute` case), and it must be a clean
+    // error rather than a debug panic / silent miskind. Regression for the
+    // kind-inference rejection being inert on `FunKind::Var`.
+    let errs = infer_program_err("f = lambda i: i + 1\nsum(f)");
+    assert!(
+        errs.iter().any(|e| matches!(
+            e,
+            InferError::Unsupported(m)
+                if m.contains("compute function") && m.contains("data collection")
+        )),
+        "expected a compute-where-data-required rejection, got {errs:?}"
     );
 }
 
@@ -201,6 +258,7 @@ fn test_list_comp_identity() {
         infer_program("[x for x in [1, 2]]"),
         Type::Fun {
             name: None,
+            kind: cambra::ccl::FunKind::Data,
             domain: Box::new(Type::UIntRange(2)),
             codomain: Box::new(int())
         }
@@ -214,6 +272,7 @@ fn test_list_comp_arithmetic_body() {
         infer_program("[x + 1 for x in [1, 2]]"),
         Type::Fun {
             name: None,
+            kind: cambra::ccl::FunKind::Data,
             domain: Box::new(Type::UIntRange(2)),
             codomain: Box::new(int())
         }
@@ -228,6 +287,7 @@ fn test_list_comp_two_gens() {
         ty,
         Type::Fun {
             name: None,
+            kind: cambra::ccl::FunKind::Data,
             domain: Box::new(Type::Tuple(vec![Type::UIntRange(2), Type::UIntRange(2)])),
             codomain: Box::new(int())
         },
@@ -579,7 +639,11 @@ fn test_ternary(#[case] code: &str, #[case] expected: BaseType) {
 
 #[test]
 fn test_if_else_arm_type_mismatch() {
-    // Arms return different types — inference must report a type mismatch.
+    // Arms return different scalar types. Under the lattice-join `Case` rule
+    // the arms are constrained into one result variable; two incompatible
+    // atoms at that positive position are an `IncompatibleBounds` error (the
+    // sound union relaxation for heterogeneous scalars is deferred — see
+    // design/type-inference.md §4.6). Still a type error, as it must be.
     let err = infer_program_err(
         r#"
 if True:
@@ -590,9 +654,11 @@ else:
         .trim(),
     );
     assert!(
-        err.iter()
-            .any(|e| matches!(e, InferError::TypeMismatch { .. })),
-        "expected TypeMismatch, got {err:?}"
+        err.iter().any(|e| matches!(
+            e,
+            InferError::IncompatibleBounds { .. } | InferError::TypeMismatch { .. }
+        )),
+        "expected an arm-mismatch error, got {err:?}"
     );
 }
 
@@ -621,14 +687,14 @@ fn test_self_application_types() {
 f = lambda x: x > 1
 f
 ",
-    Type::Fun { name: None, domain: Box::new(int()), codomain: Box::new(bool_ty()) }
+    Type::Fun { name: None, kind: cambra::ccl::FunKind::Compute, domain: Box::new(int()), codomain: Box::new(bool_ty()) }
 )]
 #[case::arithmetic(
     r"
 f = lambda x: x + 1
 f
 ",
-    Type::Fun { name: None, domain: Box::new(int()), codomain: Box::new(int()) }
+    Type::Fun { name: None, kind: cambra::ccl::FunKind::Compute, domain: Box::new(int()), codomain: Box::new(int()) }
 )]
 fn test_lambda_unapplied(#[case] code: &str, #[case] expected: Type) {
     assert_eq!(infer_program(code), expected);
@@ -922,7 +988,12 @@ mod letrec_typing {
     /// `ι = [0,3]`, `ν = Int`.
     #[test]
     fn guarded_single_binding_letrec_typechecks() {
-        let cnt_ty = Type::fun(Type::UIntRange(3), int());
+        // The recurrence carrier is a *data collection* (`⤇`): `cnt` is indexed
+        // by the iteration extent `[0, 2]` and read back through `get_prev_seq`,
+        // whose history argument demands `Data`. Declaring it `Compute`
+        // (`Type::fun`) is the miskind the `Compute <: Data` rejection now
+        // catches at the recurrence's introduction.
+        let cnt_ty = Type::data_fun(Type::UIntRange(3), int());
         let def = Expr::lambda(
             "r",
             Type::UIntRange(3),

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -200,7 +200,7 @@ fn test_conditional_collection_forms_coproduct() {
     // meet-domain function). `[1, 2]` is `[0, 1] ⤇ Int`, `[1, 2, 3]` is
     // `[0, 2] ⤇ Int`, so the join is the `Index`-tagged sum
     // `([0, 1] ⤇ Int) | ([0, 2] ⤇ Int)` — a plain sum, not a dependent sum
-    // (a finite branch set needs no witness; see collections.md).
+    // (a finite branch set needs no witness; see type-inference.md Â§4.6).
     assert_eq!(
         infer_program("[1, 2] if True else [1, 2, 3]"),
         Type::extent_coproduct(vec![Type::UIntRange(2), Type::UIntRange(3)], None, int())

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -194,23 +194,23 @@ fn test_list_literal() {
 }
 
 #[test]
-fn test_conditional_collection_forms_coproduct() {
+fn test_conditional_collection_forms_sigma() {
     // A control-flow join of two collections with different extents is
-    // lossless: it forms a **coproduct** over both extents (never a lossy
-    // meet-domain function). `[1, 2]` is `[0, 1] ⤇ Int`, `[1, 2, 3]` is
-    // `[0, 2] ⤇ Int`, so the join is the `Index`-tagged sum
-    // `([0, 1] ⤇ Int) | ([0, 2] ⤇ Int)` — a plain sum, not a dependent sum
-    // (a finite branch set needs no witness; see type-inference.md Â§4.6).
+    // lossless: it forms the dependent-sum **conditional collection** over both
+    // extents (never a lossy meet-domain function). `[1, 2]` is `[0, 1] ⤇ Int`,
+    // `[1, 2, 3]` is `[0, 2] ⤇ Int`, so the join is `Σ (w ∈ {[0, 1], [0, 2]}).
+    // w ⤇ Int` — the witness is the runtime branch discriminant (see
+    // type-inference.md §4.6).
     assert_eq!(
         infer_program("[1, 2] if True else [1, 2, 3]"),
-        Type::extent_coproduct(vec![Type::UIntRange(2), Type::UIntRange(3)], None, int())
+        Type::conditional_collection(vec![Type::UIntRange(2), Type::UIntRange(3)], None, int())
     );
 }
 
 #[test]
 fn test_conditional_collection_same_extent_collapses() {
-    // Idempotence: when both arms share an extent, the coproduct collapses back
-    // to a plain data function — no spurious 2-arm coproduct (`union_extents`
+    // Idempotence: when both arms share an extent, the Sigma collapses back
+    // to a plain data function — no spurious 2-choice Sigma (`union_extents`
     // dedups the shared extent).
     assert_eq!(
         infer_program("[1, 2] if True else [3, 4]"),


### PR DESCRIPTION
## Data/compute function kinds, conditional collections as dependent sums, Case-arm joins, and kind inference

PR 1/7 of the mutability-conditionals stack. Lays the **type-system foundation** for
conditional return values, conditional mutation, and conditional feeds, and makes the
data/compute function kind an inferred solver variable. Nothing user-visible compiles
differently yet; this PR makes the type system able to *describe* a control-flow join of
collections without silently losing data.

### Type-system foundation

- **`FunKind` on `Type::Fun`** — every function type records whether it is a *compute*
  function (`⇒`, a capability; lossy meet is fine) or a *data* function (`⤇`, an extent;
  joins must be lossless). `Fun{Data} <: Fun{Compute}` is the safe upcast; `Compute <: Data`
  is the rejection.
- **Conditional collections are real dependent sums (`Type::Sigma`).** A control-flow join
  of data functions with distinct extents forms the dependent sum `Σ{Dᵢ} ⤇ V`
  (`Type::conditional_collection`) — one shared body over a witness, whose candidate domains
  are the branch extents (contribution order, a tested contract), sharing the joined
  codomain. The witness is genuinely load-bearing: it *is* the runtime branch discriminant,
  referenced anonymously in the body's domain position (nullary `Type::Witness`) and
  **projected at elimination** (the value-`Case` fan-out). The witness taxonomy follows the
  classification hierarchy **values : types : kinds** and is built to cover every collection
  form up front (no future refactor), with machinery only for the conditional case:
  `SigmaType { witness: Witness, body }`, `Witness::Type(Kind)` (type-witness, anonymous) |
  `Witness::Value { ty, binder }` (value-witness `List`/`Map`, named — reserved), and
  `Kind::Enumerated(Vec<Type>)` (conditional, wired today) | `Kind::Any` (`Collection[T]`'s
  universe — reserved). Constrain rules: two are genuine subtyping — `Fun{Data} <: Σ`
  **injection** (a branch is-a sum; matches a candidate domain by value) and `Σ <: Σ`
  **width** (a smaller sum is-a bigger sum, by value) — and one is **elimination**, not
  subsumption: `Σ <: Fun` (a Σ value is one branch, not a function total on the union;
  consuming it distributes the consumer over the witness — the discriminated union of
  candidate extents, a fresh consumer domain absorbing it, a concrete narrower extent
  rejected, so a conditional collection never silently narrows). It rides the `<:` solver
  because that is the plumbing for consumption, but the docs and comments keep it distinct
  from the two real subtyping rules. Coalesce forms the Sigma from ≥2 surviving data-domain
  alternatives (`union_extents`), collapsing to a plain data fun at one survivor
  (idempotence).
- **Case-arm lattice joins** — `emit_case` types arms with a fresh var + `require_sub` (was
  strict `require_eq`), so `[1,2] if c else [1,2,3]` types as `Σ (w ∈ {[0,1],[0,2]}). w ⤇ Int`
  and `{a,b} if c else {a,c}` joins to the common-field intersection `{a: Int}` instead of
  failing.

### Kind inference (`FunKind` as a solver-resolved variable)

- **`FunKind::Var`** — a third kind, a solver cell resolved at coalesce. Construction sites
  mint a fresh kind var instead of hand-marking; an unconstrained var resolves from its
  domain (a map/finite-extent domain → `Data`, else `Compute`), so the map-carries-Data rule
  replaces the ~30-site introduce-time obligation.
- **`Compute <: Data` rejection** — surfaced at coalesce: a var left `forced_data` over a
  provably-scalar domain (or `forced_compute ∧ forced_data`) is the same violation as the
  concrete case, reported as `ComputeWhereDataRequired` (e.g. `sum(f)` for a plain
  `Int ⇒ Int` lambda `f`). `freshen_kind` mirrors a kind var's `<:` links onto each
  instantiation, so a use-site force still reaches a linked sibling.
- **Live `⤇` display** — a data collection renders `⤇`, a capability (and an unresolved
  kind var) `⇒`. One residual quirk: a comprehension body over a let-bound source can render
  `⇒` though it denotes a collection (its extent domain is reconstructed only post-coalesce).

### Consumption rejected cleanly
The `Σ <: Fun` elimination rule types a conditional collection *at the type level*, so it
flows down the pipeline, where the value-`Case` (not eliminable until 2/7) is rejected at
**lambda elimination** — a returned compile error, never a panic and never a silent
miscompile.

### Docs
`src/ccl/design/type-inference.md` §4.6 (conditional collections as dependent sums);
`CLAUDE.md` symbolic vocabulary + kind rendering. Green under `./ci.sh`.


Continues cambra-dev/cambra-old#301 (review history there).
