### PR TITLE
mutability-conditionals 2/7: value-Case compilation via literal union-of-restricts

### DIFF
--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -4,7 +4,8 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::ccl::{
-    BaseType, Builtin, Expr, Lit, Name, PredicateId, Refinement, Type, TypedExprNode,
+    BaseType, BinOpKind, Branch, Builtin, Expr, Lit, LogicKind, Name, PredicateId, Refinement,
+    Type, TypedExprNode, UnaryOpKind,
 };
 
 /// Returns `true` if `expr` directly references the given built-in primitive.
@@ -27,6 +28,63 @@ pub fn apply_function(expr: Expr, function: Expr, output_ty: Type) -> Expr {
         function.with_ty(Type::fun(expr_ty, output_ty.clone())),
     )
     .with_ty(output_ty)
+}
+
+/// Build arm `i`'s effective **first-match** predicate `gᵢ ∧ ¬g₀ ∧ … ∧ ¬gᵢ₋₁`,
+/// encoding a `Case`'s "first matching guard wins" semantics: arm `i` fires only
+/// where its own guard holds and no earlier arm's did. `prior` holds `g₀ … gᵢ₋₁`
+/// in order; `guard` is `gᵢ`. Every guard is a `Bool`-typed expression over the
+/// same element, so the synthesized conjunction is `Bool` too — typed here
+/// because the callers (post-inference desugar, lambda elimination, the
+/// transaction path walk) must be type-preserving.
+///
+/// Shared by [`crate::ccl::channelize`] (feed fan-out), [`crate::ccl::lambda_elim`]
+/// (value-`Case` compilation), and the transaction path walk — every conditional
+/// fan-out in the pipeline partitions its domain with the same encoding.
+pub fn synthesize_arm_predicate(guard: &Expr, prior: &[Expr]) -> Expr {
+    let bool_ty = Type::Base(BaseType::Bool);
+    let mut pred = guard.clone();
+    for g in prior {
+        let mut neg = Expr::unary(UnaryOpKind::Not, g.clone());
+        neg.ty = bool_ty.clone();
+        let mut conj = Expr::binop(pred, BinOpKind::BoolLogic(LogicKind::And), neg);
+        conj.ty = bool_ty.clone();
+        pred = conj;
+    }
+    pred
+}
+
+/// Returns `true` if `b` is a trailing `true → Case{…}` arm whose body is itself
+/// a guard-only value `Case` — the shape an `elif` chain lowers to
+/// (`a if p else b if q else c`; the `else` binds the nested conditional).
+fn is_trailing_nested_case(b: &Branch) -> bool {
+    b.pattern.is_none()
+        && matches!(&b.guard.node, TypedExprNode::Lit(Lit::Bool(true)))
+        && matches!(
+            &b.body.node,
+            TypedExprNode::Case { scrutinee: None, branches }
+                if branches.iter().all(|ib| ib.pattern.is_none())
+        )
+}
+
+/// Flatten `elif` chains: a trailing `true → Case{…}` arm splices its inner
+/// branches into the outer list, so a value-`Case` fan-out sees one flat
+/// partition `[g₀ → e₀; g₁ → e₁; …; true → eₙ]` rather than a nest of `Case`s.
+/// The first-match encoding ([`synthesize_arm_predicate`]) composes the guards
+/// correctly across the flattened arms. Shared by the value-`Case` compilation
+/// ([`crate::ccl::lambda_elim`]) and the comprehension element fan-out
+/// ([`crate::ccl::lower`]).
+pub fn flatten_trailing_value_case(mut branches: Vec<Branch>) -> Vec<Branch> {
+    while branches.last().is_some_and(is_trailing_nested_case) {
+        let last = branches.pop().expect("checked non-empty via last()");
+        if let TypedExprNode::Case {
+            branches: inner, ..
+        } = last.body.node
+        {
+            branches.extend(inner);
+        }
+    }
+    branches
 }
 
 /// Builds a composition of expressions, setting the types based on the input
@@ -397,7 +455,7 @@ pub fn sync_cast_targets(expr: &mut Expr) {
 /// element by the point-free function `predicate : base ⇒ Bool` (stored as
 /// `__elem ▷ predicate`, see [`bare_predicate_of_fn`]). Returns `base` unchanged
 /// when the predicate is trivially true.
-fn refine_with(base: Type, predicate: &Expr) -> Type {
+pub(crate) fn refine_with(base: Type, predicate: &Expr) -> Type {
     if is_trivially_true_predicate(predicate) {
         return base;
     }

--- a/src/ccl/channelize.rs
+++ b/src/ccl/channelize.rs
@@ -110,9 +110,9 @@ use std::fmt;
 use std::rc::Rc;
 
 use crate::ccl::{
-    BaseType, BinOpKind, Branch, Expr, HistoryKind, Lit, LogicKind, Name, Pattern, Refinement,
-    Type, TypedBinding, TypedExpr, TypedExprNode, UnaryOpKind,
-    ccl_utils::{count_free, typed_compose},
+    BaseType, Branch, Expr, HistoryKind, Lit, Name, Pattern, Refinement, Type, TypedBinding,
+    TypedExpr, TypedExprNode,
+    ccl_utils::{count_free, synthesize_arm_predicate, typed_compose},
     letrec::check_letrec_causal,
 };
 
@@ -213,19 +213,21 @@ impl fmt::Display for DeferError {
 /// Recognize a guard-only `Case` that feeds `defer_name` in one or more arms —
 /// the desugar-stage counterpart of `lambda_elim`'s `is_filter_case_body`.
 ///
-/// Shape (as lowered from `if g₀: d << v₀ elif g₁: d << v₁ …` in a for-loop
-/// body): `Case { None, [g₀ → body₀; …; gₙ₋₁ → bodyₙ₋₁; true → unit] }`, where
-/// each non-trailing `bodyᵢ` is either `Feed(defer_name, vᵢ)` (a feeding arm)
-/// or `Unit` (a non-feeding arm), and the trailing arm is the implicit
-/// `true → unit` fallthrough.
+/// Shape (as lowered from `if g₀: d << v₀ elif g₁: d << v₁ … [else: d << vₑ]` in
+/// a for-loop body): `Case { None, [g₀ → body₀; …; true → bodyₜ] }`, where each
+/// `bodyᵢ` is either `Feed(defer_name, vᵢ)` (a feeding arm) or `Unit` (a
+/// non-feeding arm). The trailing `true`-guarded arm is the `else` body when
+/// present (a feed) or the implicit fallthrough (`Unit`) when absent — both are
+/// ordinary arms here, so an `else` that feeds fans out just like a guard arm
+/// (its first-match predicate is `¬⋁ⱼ gⱼ`).
 ///
-/// Returns each non-trailing arm's `(guard, feed_value?)` in source order —
-/// `feed_value` is `None` for a non-feeding arm, whose guard still participates
-/// in later arms' predicate synthesis ([`synthesize_arm_predicate`]). Returns
-/// `None` (not fannable) if there is a scrutinee, no `true → unit` fallthrough,
-/// an arm binds a pattern, or an arm body is neither this defer's feed nor
-/// `Unit` — so a `Case` mixing this defer's feeds with other effects falls
-/// through to the generic handling rather than being silently collapsed.
+/// Returns each arm's `(guard, feed_value?)` in source order — `feed_value` is
+/// `None` for a non-feeding arm, whose guard still participates in later arms'
+/// predicate synthesis ([`synthesize_arm_predicate`]). Returns `None` (not
+/// fannable) if there is a scrutinee, the trailing guard is not `true`, an arm
+/// binds a pattern, or an arm body is neither this defer's feed nor `Unit` — so a
+/// `Case` mixing this defer's feeds with other effects falls through to the
+/// generic handling rather than being silently collapsed.
 fn try_extract_fanout_feed(body: &Expr, defer_name: &Name) -> Option<Vec<(Expr, Option<Expr>)>> {
     let TypedExprNode::Case {
         scrutinee: None,
@@ -237,16 +239,16 @@ fn try_extract_fanout_feed(body: &Expr, defer_name: &Name) -> Option<Vec<(Expr, 
     if branches.len() < 2 {
         return None;
     }
-    let (last, rest) = branches.split_last().expect("len >= 2");
-    // The trailing arm must be the implicit `true → unit` fallthrough.
-    if !matches!(&last.guard.node, TypedExprNode::Lit(Lit::Bool(true)))
-        || !matches!(&last.body.node, TypedExprNode::Lit(Lit::Unit))
-    {
+    // The trailing arm is the fallthrough / `else` — its guard must be `true`.
+    if !matches!(
+        &branches.last().expect("len >= 2").guard.node,
+        TypedExprNode::Lit(Lit::Bool(true))
+    ) {
         return None;
     }
-    let mut arms = Vec::with_capacity(rest.len());
+    let mut arms = Vec::with_capacity(branches.len());
     let mut any_feed = false;
-    for b in rest {
+    for b in branches {
         // A guard-only arm never binds a pattern.
         if b.pattern.is_some() {
             return None;
@@ -261,25 +263,6 @@ fn try_extract_fanout_feed(body: &Expr, defer_name: &Name) -> Option<Vec<(Expr, 
         }
     }
     any_feed.then_some(arms)
-}
-
-/// Build arm `i`'s effective predicate `gᵢ ∧ ¬g₀ ∧ … ∧ ¬gᵢ₋₁`, encoding a
-/// `Case`'s "first matching guard wins" semantics: arm `i` fires only where its
-/// own guard holds and no earlier arm's did. `prior` holds `g₀ … gᵢ₋₁` in
-/// order; `guard` is `gᵢ`. Every guard is a `Bool`-typed expression over the
-/// same loop element, so the synthesized conjunction is `Bool` too — typed here
-/// (desugar runs post-inference and must be type-preserving).
-fn synthesize_arm_predicate(guard: &Expr, prior: &[Expr]) -> Expr {
-    let bool_ty = Type::Base(BaseType::Bool);
-    let mut pred = guard.clone();
-    for g in prior {
-        let mut neg = Expr::unary(UnaryOpKind::Not, g.clone());
-        neg.ty = bool_ty.clone();
-        let mut conj = Expr::binop(pred, BinOpKind::BoolLogic(LogicKind::And), neg);
-        conj.ty = bool_ty.clone();
-        pred = conj;
-    }
-    pred
 }
 
 /// Attempt to apply the defer-returning lift to a `Let` binding.
@@ -2514,16 +2497,54 @@ fn extract_for_defer(
                 // that the fan-out sites above intercept, so there is no
                 // iteration source to restrict per arm. The loop-sourced
                 // multi-arm fan-out (`if g: d << v` and `if/elif` in a for-loop
-                // body) is handled at those sites via `try_extract_fanout_feed`,
-                // one refined-source channel per arm `i` predicated on
-                // `gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`. A *source-less* conditional feed has no
-                // refinement to hang the guard on, so reject it rather than
-                // mishandle. (The former Record-based fan-out is retired — it
-                // published an ill-typed `Unit` empty-channel for no-feed arms,
-                // a silent miscompile.)
-                return Err(DeferError::PartialFeedCaseUnsupported(
-                    defer_name.to_string(),
-                ));
+                // body) is handled at those sites via `try_extract_fanout_feed`.
+                //
+                // A *source-less* conditional feed (`if c: d << 1 else: d << 2`,
+                // outside any loop) has no iteration source, so each feeding arm
+                // becomes a **gated one-shot lift** over the `Unit` driver:
+                // `λ __unused : {Unit | π̂ᵢ} → vᵢ`, first-match `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`
+                // (a source-less feed; see `design/mutability.md`). Lambda elimination const-lifts
+                // each to the value-`Case` C-form arm, planning materializes the
+                // gate, and the channel union publishes exactly the selected arm's
+                // value — empty (a naturally-partial feed) when no arm fires. A
+                // *scrutinee / pattern* feed cannot be gated by a boolean
+                // predicate, so it stays rejected.
+                let guard_only =
+                    scrutinee.is_none() && per_branch.iter().all(|(p, ..)| p.is_none());
+                if !guard_only {
+                    return Err(DeferError::PartialFeedCaseUnsupported(
+                        defer_name.to_string(),
+                    ));
+                }
+                let unit_ty = Type::Base(BaseType::Unit);
+                let mut prior_guards: Vec<Expr> = Vec::new();
+                for (_, guard, branch_feeds, _) in &per_branch {
+                    let pred = synthesize_arm_predicate(guard, &prior_guards);
+                    prior_guards.push(guard.clone());
+                    // `{Unit | π̂ᵢ}` — the gate is constant in the driver element.
+                    // Store `π̂ᵢ` *directly* as the refinement's bare predicate (it
+                    // does not mention `__elem`): planning's `fn_of_bare_predicate`
+                    // slow-paths that through lambda elimination, desugaring the
+                    // `and`/`not` into point-free form — the same path the
+                    // loop-sourced fan-out relies on. A degenerate literal-`true`
+                    // gate leaves the driver unrefined (an unconditional feed).
+                    let refined = if matches!(&pred.node, TypedExprNode::Lit(Lit::Bool(true))) {
+                        unit_ty.clone()
+                    } else {
+                        Type::Refinement(
+                            Box::new(unit_ty.clone()),
+                            Refinement {
+                                predicate: Rc::new(pred),
+                            },
+                        )
+                    };
+                    for v in branch_feeds {
+                        feeds.push(Expr::lambda("__unused", refined.clone(), v.clone()));
+                    }
+                }
+                // Fall through: the residual value in every arm is now feed-free
+                // (`Unit` for a bare `d << v` arm), so the `Case` below denotes the
+                // statement's (discarded) value.
             }
             TypedExprNode::Case {
                 scrutinee,
@@ -2785,6 +2806,33 @@ mod tests {
         assert!(
             run(with_d, false).is_ok(),
             "a multi-arm Case feeding the defer must fan out, not be rejected"
+        );
+    }
+
+    /// A *source-less scrutinee* feed stays rejected. The guard-only source-less
+    /// feed (`if c: d << v`) channelizes to gated `Unit` lifts, but a
+    /// scrutinee/pattern `Case` cannot be gated by a boolean first-match
+    /// predicate, so `guard_only` is false and the narrowed
+    /// `PartialFeedCaseUnsupported` fires. (No surface syntax lowers to a
+    /// scrutinee feed yet, so this defensive path is only reachable at the IR
+    /// level — pinned here.)
+    #[test]
+    fn run_source_less_scrutinee_feed_rejected() {
+        let feeding_arm = Branch {
+            pattern: None,
+            guard: Expr::lit(Lit::Bool(true)),
+            body: Expr::feed("d", lit(1)),
+        };
+        let case_expr = Expr::new(TypedExprNode::Case {
+            scrutinee: Some(Box::new(lit(0))),
+            branches: vec![feeding_arm],
+        });
+        let with_d = Expr::let_bind("d", Expr::new(TypedExprNode::Defer), case_expr);
+        let err = run(with_d, false)
+            .expect_err("a source-less scrutinee feed must stay rejected, not channelize");
+        assert!(
+            matches!(err, DeferError::PartialFeedCaseUnsupported(_)),
+            "expected PartialFeedCaseUnsupported, got {err:?}"
         );
     }
 

--- a/src/ccl/design/lowering.md
+++ b/src/ccl/design/lowering.md
@@ -71,15 +71,16 @@ implementation lives in `src/ccl/mut_elim.rs` (the `For`/`MutWrite` → `LetRec`
 → `Transact` via loop planning) and `src/ccl/channelize.rs` (feed routing).
 
 **Conditionals in loop bodies (designed, not yet implemented).** Today a mutation
-nested inside an `if` is rejected at lowering (`lower_middle_stmt`). The in-flight
-conditionals stack adds a `ChlStmt::If` arm to the direct-mirror loop-body
-lowering: each branch body
-lowers through the same recursive statement-chain helper and is emitted as a
+nested inside an `if` in a loop body is detected (`find_nested_mutation_var`) and
+**rejected** at lowering. The in-flight conditionals stack *will* add a
+`ChlStmt::If` arm to the direct-mirror loop-body lowering: each branch body will
+lower through the same recursive statement-chain helper and be emitted as a
 statement-position `Case` — a faithful mirror, no path computation at lowering
 (mutability is a type-level fact lowering does not have). `find_mutation_loop_vars`
-recurses into the branches so `for x in src: if p: total += x` classifies as a
-mutation loop; the path fan-out happens in `mut_elim`. A `for` or a
-`with begin():` nested inside an `if` inside a loop body stays rejected.
+will then recurse into the branches so `for x in src: if p: total += x` classifies
+as a mutation loop rather than being rejected; the branch merge is compiled
+downstream in `mut_elim`. A `for` or a `with begin():` nested inside an `if` inside
+a loop body stays rejected.
 
 **Let-bindings in generator bodies** (`y = f(x); yield y`) lower to nested `Let` nodes inside the Lambda body, evaluated once per iteration of the enclosing loop.
 

--- a/src/ccl/design/lowering.md
+++ b/src/ccl/design/lowering.md
@@ -70,6 +70,17 @@ The design of record for the recurrence construction and feed routing is
 implementation lives in `src/ccl/mut_elim.rs` (the `For`/`MutWrite` → `LetRec`
 → `Transact` via loop planning) and `src/ccl/channelize.rs` (feed routing).
 
+**Conditionals in loop bodies (designed, not yet implemented).** Today a mutation
+nested inside an `if` is rejected at lowering (`lower_middle_stmt`). The in-flight
+conditionals stack adds a `ChlStmt::If` arm to the direct-mirror loop-body
+lowering: each branch body
+lowers through the same recursive statement-chain helper and is emitted as a
+statement-position `Case` — a faithful mirror, no path computation at lowering
+(mutability is a type-level fact lowering does not have). `find_mutation_loop_vars`
+recurses into the branches so `for x in src: if p: total += x` classifies as a
+mutation loop; the path fan-out happens in `mut_elim`. A `for` or a
+`with begin():` nested inside an `if` inside a loop body stays rejected.
+
 **Let-bindings in generator bodies** (`y = f(x); yield y`) lower to nested `Let` nodes inside the Lambda body, evaluated once per iteration of the enclosing loop.
 
 **Pre-loop lets** (assignments before the outer `for` in a function body) are handled by `lower_stmts` — they wrap the generator expression in `Let` nodes. The `for` lowering itself (`lower_generator_for`) only handles the loop and its body.

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -835,8 +835,8 @@ today rather than silently mishandled.
 > yet implemented.**
 >
 > **Implemented** (value selection compiles via the literal union-of-restricts): scalar / compute
-> ternaries (the C-form), data-collection selection (the gate fan-out, reconciled to the Σ via the
-> gated-partition bridge rules), source-less conditional feeds, a **conditional element** in a
+> ternaries (the C-form), data-collection selection (the gate fan-out, reconciled to the Σ by
+> Σ-introduction), source-less conditional feeds, a **conditional element** in a
 > comprehension (`[a if g(x) else b for x in xs]`, fanned out over the source by the
 > element-dependent gate), and a comprehension **over a conditional collection** (`[f(x) for x in
 > (xs if c else ys)]`, the source `Case` floats out of the map). **Not yet implemented**:
@@ -893,8 +893,9 @@ The value-`Case` positions ride the same union-of-restricts:
   (`lambda_elim::build_value_case_fanout`): each arm's whole collection restricted by a
   constant-in-element gate, unioned; the union carries the Σ the type system gave the `Case` (see
   `design/type-inference.md` §4.6), and the strict wall reconciles its structural `Variant`-domain
-  type via the gated-partition bridge rules (bridge 1 `<: Σ` for distinct extents; bridge 2
-  `<: plain data fun` for the same-extent collapse). `elif` chains flatten to one N-choice
+  type against the Σ by **Σ-introduction** (the compiled gated partition realizes the whole sum —
+  the finite-Σ = gated-coproduct iso, legs' base extents set-equal to the candidates), or against
+  the same-extent collapse's plain data fun. `elif` chains flatten to one N-choice
   partition first. A conditional collection is *consumed* (aggregate, program result) via the
   `Σ <: Fun` subtyping rule, and *through a comprehension* by floating the source `Case` out of the
   map (see the comprehension bullet below).

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -829,6 +829,93 @@ request-indexed, but not commit-ordered. To gate or commit-order a reply, put it
 These features belong to the model above but are not yet built. Each is rejected at compile time
 today rather than silently mishandled.
 
+### Value-selecting `Case` and conditional induction writes (partially implemented)
+
+> **Status: value-selecting `Case`s compile; conditional induction writes are designed but not
+> yet implemented.**
+>
+> **Implemented** (value selection compiles via the literal union-of-restricts): scalar / compute
+> ternaries (the C-form), data-collection selection (the gate fan-out, reconciled to the Σ via the
+> gated-partition bridge rules), source-less conditional feeds, a **conditional element** in a
+> comprehension (`[a if g(x) else b for x in xs]`, fanned out over the source by the
+> element-dependent gate), and a comprehension **over a conditional collection** (`[f(x) for x in
+> (xs if c else ys)]`, the source `Case` floats out of the map). **Not yet implemented**:
+> conditional *induction writes* (`if 𝑝: total += x`, the per-leg writer sites + `DispatchRecurse`
+> below — still rejected at lowering); a conditional *between* standalone comprehensions
+> (`([…]) if c else ([…])` — a comprehension used as a value is compute-kinded, so its arms meet
+> rather than join; the deferred kind-inference work); and a per-element conditional at a site with
+> no visible iteration source (a UDF body, or a comprehension `if`-filter beside the element `Case`).
+
+The *filter* `Case` (`[𝑔 → action; true → unit]` → `Restrict`) and now the value-selecting `Case`
+compile; a conditional induction write (`if 𝑝: total += x`) is still rejected at lowering. The
+compilation is a **literal union of restricts** — the CCL algebra stays restricts + unions — and an
+**off-path arm is never evaluated**, so a guard-protected partial expression (`x // y if y != 0 else
+0`) never faults on the path its guard excludes. A **data-collection** fan-out is lazy structurally:
+an arm whose gate is false restricts to an empty extent, and an empty extent is never iterated. The
+**scalar** value-`Case` C-form gates a `Units(1)` driver and swaps in each arm's constant via
+`MapResultToConst`; when a false gate empties the driver (all rows deleted), `MapResultToConst` returns
+a terminal-empty tile *without* pulling the arm's constant — so the off-path value (a `//`, `%`, or
+index that the gate guards) is never computed. Every fan-out shares one first-match encoding,
+`πᵢ = 𝑔ᵢ ∧ ¬⋁ⱼ˂ᵢ 𝑔ⱼ` (`synthesize_arm_predicate` in `ccl_utils`, shared between channelize, the
+value fan-outs, and the transaction path walk):
+
+```
+target = ⧺ᵢ (source | 𝑝ᵢ ≫ (λ 𝑟 → 𝑣ᵢ))                                  -- channel: partial off-path
+total  = ⧺ᵢ (source | 𝑝ᵢ ≫ (λ 𝑟 → 𝑣ᵢ)) ⧺ (source | ¬⋁ᵢ𝑝ᵢ ≫ (λ 𝑟 → get_prev_seq(total, 𝑟, init)))
+```
+
+The presence or absence of the complement arm *is* the `Overwrite`/`Feed` distinction, and the union
+is **between letrec bindings, not inside one decision body**: a conditional mutable write emits one
+writer-site *leg per path* — the write leg over `{𝑟 : 𝐷 | π̂}` and the **carry-forward leg** over
+the complement `{𝑟 : 𝐷 | ¬̂π}` whose body passes the snapshot through — each guarded by
+`get_prev_seq` over the ⧺-union of all legs' per-key views (a shape the guardedness check already
+admits). Per-leg bindings let decision records differ per path, and a conditional feed on a path
+is **naturally partial**: `Feed(d, __legⱼ ≫ .to_k)` over the leg's restricted domain — no flag
+field. The phase walks the loop body as a *path enumeration* (a statement-position `Case` forks
+per branch plus the implicit complement; the rest of the chain clones into each path; guards
+resolve in the fork point's read-your-writes env), recognition generalizes the single-writer
+induction group to one `Transact` with one writer per leg, and op-conversion realizes the union by
+**ordered dispatch** (`DispatchRecurse`, see `../../interpreter/design-operators.md`): one
+iteration of the base extent, each position fed to exactly the leg whose predicate holds —
+faithful to the ⧺ because the leg predicates partition the domain, and position-aligned by
+construction.
+
+The value-`Case` positions ride the same union-of-restricts:
+
+- **Scalar / compute-typed selection** (a ternary, a per-key merge inside a decision body)
+  — *implemented* (`lambda_elim::build_value_case_cform`): restricts of gated one-shot lifts over
+  the `UIntRange(1)` driver, extracted by the rewrite itself —
+  `((unit | π̂₀ ≫ const 𝑒₀) ⧺ … ⧺ (unit | π̂ₙ ≫ const 𝑒ₙ), 𝑒ₙ) ▷ final_or_default` — exhaustive by
+  the trailing `true` arm, so the union has exactly one element and the outer type is unchanged.
+  The gate is constant in the driver element; the existing `Restrict` masks the extent by the
+  constant boolean directly (no new runtime capability).
+- **Data-typed selection** (`zs = xs if c else ys`) — *implemented*
+  (`lambda_elim::build_value_case_fanout`): each arm's whole collection restricted by a
+  constant-in-element gate, unioned; the union carries the Σ the type system gave the `Case` (see
+  `design/type-inference.md` §4.6), and the strict wall reconciles its structural `Variant`-domain
+  type via the gated-partition bridge rules (bridge 1 `<: Σ` for distinct extents; bridge 2
+  `<: plain data fun` for the same-extent collapse). `elif` chains flatten to one N-choice
+  partition first. A conditional collection is *consumed* (aggregate, program result) via the
+  `Σ <: Fun` subtyping rule, and *through a comprehension* by floating the source `Case` out of the
+  map (see the comprehension bullet below).
+- **Source-less conditional feeds** (`if c: o << 1 else: o << 2` outside any loop) — *implemented*
+  (`channelize`): each feeding arm becomes a gated one-shot lift `λ __unused : {Unit | π̂ᵢ} → 𝑣ᵢ`,
+  one channel per arm — replacing `PartialFeedCaseUnsupported` for guard-only `Case`s. A
+  scrutinee / pattern feed stays rejected; a no-else partial feed is still blocked earlier at
+  lowering (bare `if` as a value expression).
+- **Comprehension over / with a conditional** — *implemented* (`lower::comprehension`). Two shapes,
+  both fanning out the source (a value `Case` has no fixed driver, so it must gate the *iteration
+  source*, not a `Units(1)` one): a conditional **element** (`[a if g(x) else b for x in xs]`) fans
+  the source out by each arm's *element-dependent* gate — `⧺ᵢ [eᵢ for x in xs if π̂ᵢ]`, a union of
+  filtered maps (`fan_out_element_case`); a conditional **source** (`[e for x in (xs if c else ys)]`)
+  floats the source `Case` out of the map — `Case{gᵢ → [e for x in srcᵢ]}`, each arm a data-kinded
+  `Compose` so the arms `sigma_join` (`float_comp_source_case`). Both reduce to constructs already
+  compiled (the filter refinement, the gate fan-out); neither duplicates the loop, only the map.
+- **Bound-then-used values in a loop feed** (`x = 𝑒₁ if 𝑝 else 𝑒₂; o << f(x)`) — *deferred*
+  (case-float in the loop-body / feed path, distinct from the comprehension forms above):
+  `𝐶[Case{[𝑔ᵢ → 𝑒ᵢ]}] → Case{[𝑔ᵢ → 𝐶[𝑒ᵢ]]}` (sound by purity) then the channel fan-out generalized
+  from feed-arms to value-arms — only the fed context duplicates, never the loop.
+
 ### General in-transaction conditionals (and conditional writes)
 
 A `with begin():` block admits a single bare `if 𝑝:` **deny guard** — the transaction commits iff
@@ -842,23 +929,13 @@ of every mutable write and feed** (an empty taken path — including a missing `
 **each write key is a `Case` merged over the branch structure** (read-your-writes; a branch that does
 not write a key keeps its snapshot value). This is keyword-free, subsumes the current deny
 (`if 𝑝: x := 𝑒` → one write at path `𝑝` → `commit = 𝑝`), and admits value-selection, cross-key
-routing, `elif`, nesting (conjunction), and sequencing.
-
-The same path-condition fan-out is what a **conditional induction write** needs. A conditional feed
-(`if 𝑝: o << x`) is absent off-path; a conditional mutable write (`if 𝑝: total += x`) instead carries
-the previous value forward off-path — one extra **carry-forward** arm over the complement domain:
-
-```
-target = ⧺ᵢ (source | 𝑝ᵢ ≫ (λ 𝑟 → 𝑣ᵢ))                                  -- channel: partial off-path
-total  = ⧺ᵢ (source | 𝑝ᵢ ≫ (λ 𝑟 → 𝑣ᵢ)) ⧺ (source | ¬⋁ᵢ𝑝ᵢ ≫ (λ 𝑟 → get_prev_seq(total, 𝑟, init)))
-```
-
-The presence or absence of that carry-forward arm *is* the `Overwrite`/`Feed` distinction. **Blocker:**
-both need a *value-selecting* `Case` (`x = if 𝑝: 𝑒₁ else: 𝑒₂`) as a compiled construct, but only the
-*filter* `Case` (`[𝑔 → action; true → unit]` → `Restrict`) compiles today — a value `Case` errors at
-`lambda_elim`. The planned fix (refinement-based fan-out, lowering a value `Case` to a union of
-restricts `⧺ᵢ (source | pathᵢ ≫ 𝑒ᵢ)`) unblocks both the transaction conditionals and the same-shaped
-N-arm Case-with-feeds gap.
+routing, `elif`, nesting (conjunction), and sequencing. The per-key merges are value-selecting
+`Case`s over the snapshot, compiled by the scalar form above; the path walk itself is the next PR
+of the conditionals stack. One shape is settled by analysis: the block stays **one decision record
+per transaction** —
+per-path writer sites are unsound (a path predicate reads the snapshot, which exists only at the
+commit tick; one `begin()` is one serialization point; multi-key read-your-writes needs one
+snapshot and one write-set).
 
 ### `with t = begin():` transaction handle
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -416,11 +416,11 @@ The pipeline passes downstream of inference treat function types structurally an
 ## 4.6 Data vs compute functions and conditional-collection extent joins
 
 > **Status: implemented.** The `FunKind` marker, lossless conditional-collection
-> formation at control-flow joins, *and* kind-aware subtyping (the
-> `Compute<:Data` rejection) are all live. One guard is deferred with rationale
-> (Data-domain invariance — see the callout below), and the value-`Case`
-> elimination *compilation* lands in the value-`Case` compilation PR (the
-> type-level elimination rule is live here).
+> formation at control-flow joins, kind-aware subtyping (the `Compute<:Data`
+> rejection), *and* the value-`Case` elimination (Σ-introduction via a gated
+> partition, Σ-elimination when consumed) are all live. Deferred with rationale:
+> Data-domain invariance (see the kind-aware callout below) and the
+> heterogeneous-scalar union.
 >
 > **A real dependent sum.** A conditional collection is the dependent sum
 > `Σ (𝑤 ∈ {𝐷ᵢ}). 𝑤 ⤇ V` ([`Type::Sigma`], built by
@@ -573,13 +573,39 @@ collection materializes). The other two witnesses each rule dispatches on — th
 skeletons, present so the general shape is visible and unreachable until those
 witnesses are constructed.
 
-> **Deferred — value-`Case` elimination compilation.** The type-level
-> elimination rule (`Σ <: Fun`) is live here, so a conditional-collection `Case`
-> type-checks and propagates. *Compiling* that elimination — the value-`Case`
-> fan-out that lowers it to a union of restricts — lands with the value-`Case`
-> compilation in a follow-up, where it is exercised end-to-end. Today a
-> conditional-collection `Case` types fine but is rejected at `lambda_elim`
-> (value-`Case`s are not yet compilable).
+> **Landed — value-`Case` elimination.** `lambda_elim` compiles a value-selecting
+> `Case` to a union of gated restricts, and the subtyping solver reconciles that
+> union against the Σ (or its same-extent collapse) — no separate "bridge"
+> concept, just the Σ rules above applied to the compiled form:
+>
+>   * **Σ-introduction** — the compiled gated partition `Fun{Data,
+>     Variant([{𝐷ᵢ | π̂ᵢ}]), 𝑐}` realizes the *whole* Σ. This is the finite-Σ =
+>     gated-coproduct isomorphism: the exclusive+exhaustive gates zero out
+>     all-but-one leg, collapsing the disjoint-union domain (a *product* of
+>     fibers) to the coproduct. Sound iff the legs' base extents, as a *set*,
+>     equal the Σ candidates (every fiber realized, nothing extra — not the
+>     positional bijection an earlier draft used, which rejected a valid `Case`
+>     whose branches share an extent); each leg edge `{𝐷ᵢ | π̂ᵢ} <: 𝐷ᵢ` is
+>     covariant (an introduction). Carried by the `Fun(Data) <: Σ` injection arm.
+>   * **same-extent collapse** — when every arm shares one extent 𝐷 the Σ
+>     collapses to the plain data function `𝐷 ⤇ 𝑐`, and the gated partition
+>     subtypes *that* directly (`is_index_partition_of`), guarded so a genuine
+>     heterogeneous `++` into a fresh-var domain still takes the ordinary
+>     contravariant arm.
+>   * **Σ-elimination** — a conditional collection consumed as a plain collection
+>     (an aggregate, a program result) is the `Σ <: Fun` rule above.
+>
+> The gates' exclusivity+exhaustiveness — the precondition the isomorphism rests
+> on — is a `lambda_elim` construction invariant (asserted at the fan-out
+> boundary: a non-exhaustive value-`Case` would realize an empty collection on
+> the uncovered path, a silent miscompile), *not* re-proven in the solver.
+>
+> Consuming a conditional collection through a *comprehension* (`[f(x) for x in
+> (xs if c else ys)]`) compiles: `lower::comprehension` floats the source `Case`
+> out of the map so it never becomes a Σ *applied to an index* (which would
+> collide); each arm is built as a data-kinded `Compose`, and the arms then join
+> into one Σ (`union_extents`). A conditional *between* two standalone
+> comprehensions is still kind-limited (see the kind-inference follow-up below).
 
 **`Case` arms join by the lattice.** `emit_case` constrains every value/
 collection arm into a fresh result variable (`require_sub`) instead of

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -686,6 +686,59 @@ fn compact_go(
                 ..Default::default()
             }
         }
+        // A **conditional-collection coproduct** (`Type::extent_coproduct`)
+        // re-entering the solver (e.g. a let-bound conditional collection used
+        // again, or a nested conditional whose inner coproduct is an arm of the
+        // outer): its `Index`-tagged arms are data functions over the candidate
+        // extents, so it compacts to a `Data` `CompactFun` whose domains are
+        // those extents — the same shape a fresh join accumulates via
+        // `union_extents` — rather than to variant tags. This is what lets a
+        // nested conditional collection flatten its inner extents into the outer
+        // join's alternatives. The discriminator (arms are data *functions*)
+        // excludes a `++`/gated-partition domain-`Variant`, whose payloads are
+        // bare extents, and a user tagged-union (`Name` tags).
+        Type::Variant(tags)
+            if !tags.is_empty()
+                && tags.iter().enumerate().all(|(i, (k, t))| {
+                    *k == FieldKey::Index(i)
+                        && matches!(
+                            t,
+                            Type::Fun {
+                                kind: crate::ccl::ty::FunKind::Data,
+                                ..
+                            }
+                        )
+                }) =>
+        {
+            let domains = tags
+                .iter()
+                .map(|(_, t)| {
+                    let Type::Fun { domain, .. } = t else {
+                        unreachable!("guard checked all arms are Fun")
+                    };
+                    compact_go(domain, !pol, subst_acc, &BTreeSet::new(), st)
+                })
+                .collect();
+            // Arms share the joined codomain (and element binder); take arm 0's.
+            let Type::Fun {
+                name: pi_name,
+                codomain: cod_ty,
+                ..
+            } = &tags[0].1
+            else {
+                unreachable!("guard checked all arms are Fun")
+            };
+            let cod = compact_go(cod_ty, pol, subst_acc, &BTreeSet::new(), st);
+            CompactType {
+                fun: Some(CompactFun {
+                    name: pi_name.clone(),
+                    kind: KindMerge::Data,
+                    domains,
+                    codomain: Box::new(cod),
+                }),
+                ..Default::default()
+            }
+        }
         Type::Variant(tags) => {
             // Variant payloads are covariant — recurse at the same
             // polarity (no flip, unlike Fun's domain). The merge rule

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -686,59 +686,6 @@ fn compact_go(
                 ..Default::default()
             }
         }
-        // A **conditional-collection coproduct** (`Type::extent_coproduct`)
-        // re-entering the solver (e.g. a let-bound conditional collection used
-        // again, or a nested conditional whose inner coproduct is an arm of the
-        // outer): its `Index`-tagged arms are data functions over the candidate
-        // extents, so it compacts to a `Data` `CompactFun` whose domains are
-        // those extents — the same shape a fresh join accumulates via
-        // `union_extents` — rather than to variant tags. This is what lets a
-        // nested conditional collection flatten its inner extents into the outer
-        // join's alternatives. The discriminator (arms are data *functions*)
-        // excludes a `++`/gated-partition domain-`Variant`, whose payloads are
-        // bare extents, and a user tagged-union (`Name` tags).
-        Type::Variant(tags)
-            if !tags.is_empty()
-                && tags.iter().enumerate().all(|(i, (k, t))| {
-                    *k == FieldKey::Index(i)
-                        && matches!(
-                            t,
-                            Type::Fun {
-                                kind: crate::ccl::ty::FunKind::Data,
-                                ..
-                            }
-                        )
-                }) =>
-        {
-            let domains = tags
-                .iter()
-                .map(|(_, t)| {
-                    let Type::Fun { domain, .. } = t else {
-                        unreachable!("guard checked all arms are Fun")
-                    };
-                    compact_go(domain, !pol, subst_acc, &BTreeSet::new(), st)
-                })
-                .collect();
-            // Arms share the joined codomain (and element binder); take arm 0's.
-            let Type::Fun {
-                name: pi_name,
-                codomain: cod_ty,
-                ..
-            } = &tags[0].1
-            else {
-                unreachable!("guard checked all arms are Fun")
-            };
-            let cod = compact_go(cod_ty, pol, subst_acc, &BTreeSet::new(), st);
-            CompactType {
-                fun: Some(CompactFun {
-                    name: pi_name.clone(),
-                    kind: KindMerge::Data,
-                    domains,
-                    codomain: Box::new(cod),
-                }),
-                ..Default::default()
-            }
-        }
         Type::Variant(tags) => {
             // Variant payloads are covariant — recurse at the same
             // polarity (no flip, unlike Fun's domain). The merge rule

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -25,6 +25,7 @@ use crate::ccl::{Bound, HistoryKind, InferVar, InferVarId, Level, Refinement, Ty
 
 use super::type_level;
 use crate::ccl::FieldKey;
+use crate::ccl::ccl_utils::strip_refinements;
 
 // ---------------------------------------------------------------------------
 // Constraint solver
@@ -328,6 +329,28 @@ fn bridge_holder_gap(lo: &Subst, hi: &Subst) -> (Subst, Subst) {
 /// the only inversions anywhere are of renames (lossless).
 /// This is what lets a non-invertible discharge survive crossing a consumer
 /// edge that was recorded before the producer's content arrived.
+/// Whether `union_dom` is a gated **partition** of the single extent `target`:
+/// a `Variant` with contiguous `Index(0..n)` tags (n ≥ 1) whose every payload,
+/// with its gate refinement stripped, is structurally `target` (also stripped).
+/// This is the shape lambda_elim's value-`Case` fan-out gives *same-extent* arms
+/// — the signature bridge rule 2 realizes as the plain data function
+/// `target ⤇ W`. Requiring the stripped payloads to equal `target` keeps a
+/// genuine heterogeneous `++` flowing into a fresh-var domain out of this rule
+/// (its legs differ, or the target is an unresolved var, so the ordinary
+/// contravariant arm applies).
+fn is_index_partition_of(union_dom: &Type, target: &Type) -> bool {
+    let Type::Variant(tags) = union_dom else {
+        return false;
+    };
+    if tags.is_empty() {
+        return false;
+    }
+    let base = strip_refinements(target);
+    tags.iter()
+        .enumerate()
+        .all(|(i, (k, payload))| *k == FieldKey::Index(i) && strip_refinements(payload) == base)
+}
+
 fn constrain_go(
     lhs: &Type,
     rhs: &Type,
@@ -377,6 +400,39 @@ fn constrain_go(
         // `Txn` is a nullary leaf: reflexively equal to itself, incomparable
         // to every other type (the catch-all `Mismatch` below).
         (Type::Txn, Type::Txn) => Ok(()),
+
+        // Bridge rule 2 (gated-partition `⧺` <: plain data function): the
+        // `Variant`-domain union `⧺ᵢ ({D | π̂ᵢ} ⤇ W)` that lambda_elim's
+        // value-`Case` fan-out produces for **same-extent** arms *is* the plain
+        // data function `D ⤇ W` — an exhaustive + disjoint partition of `D`
+        // (exhaustiveness guaranteed by the stamping phase, not proven here; see
+        // lambda_elim's `build_value_case_fanout` and `design/type-inference.md`
+        // §4.6). Each leg `{D | π̂ᵢ} <: D` by refinement width (covariant, not the
+        // function-domain contravariance below), codomain covariant. Fires only
+        // when every leg refines the *same concrete* target extent `D`, so a
+        // genuine heterogeneous `++` flowing into a fresh-var domain still takes
+        // the ordinary contravariant arm below (its domain var resolves to the
+        // `Variant`, iterating every leg).
+        (
+            Type::Fun {
+                kind: FunKind::Data,
+                domain: union_dom,
+                codomain: c0,
+                ..
+            },
+            Type::Fun {
+                domain: d1,
+                codomain: c1,
+                ..
+            },
+        ) if is_index_partition_of(union_dom, d1) => {
+            if let Type::Variant(tags) = union_dom.as_ref() {
+                for (_, payload) in tags {
+                    constrain_go(payload, d1, sl, sr, cache)?;
+                }
+            }
+            constrain_go(c0, c1, sl, sr, cache)
+        }
 
         // Function: contravariant on domain, covariant on codomain. The
         // codomain edge *derives* the binder correspondence — aligning the two
@@ -439,15 +495,15 @@ fn constrain_go(
         // are general rules on the sum, *realized per witness* (dispatch is on the
         // `Witness`, and for a type-witness further on its `Kind`): the solver
         // knows dependent sums, not any surface concept. Two are genuine subtyping
-        // — the injection `Fun(Data) <: Σ` (a branch is-a sum) and the width
-        // `Σ <: Σ` (a smaller sum is-a bigger sum). The third, `Σ <: Fun`, is
-        // **not** subsumption but Σ-*elimination* discharged through this solver:
-        // a Σ value is one branch, not a function total on the union, so it cannot
-        // be subsumed to one — consuming it distributes the consumer over the
-        // witness. Only the `Kind::Enumerated` witness (what a conditional
-        // collection materializes) is wired today; the `Kind::Any` (`Collection`)
-        // and value-witness (`List`/`Map`) realizations are `todo!()` skeletons.
-        // See type-inference.md §4.6.)
+        // — the injection `Fun(Data) <: Σ` (a branch, or the compiled fan-out,
+        // is-a sum) and the width `Σ <: Σ` (a smaller sum is-a bigger sum). The
+        // third, `Σ <: Fun`, is **not** subsumption but Σ-*elimination* discharged
+        // through this solver: a Σ value is one branch, not a function total on the
+        // union, so it cannot be subsumed to one — consuming it distributes the
+        // consumer over the witness. Only the `Kind::Enumerated` witness (what a
+        // conditional collection materializes) is wired today; the `Kind::Any`
+        // (`Collection`) and value-witness (`List`/`Map`) realizations are
+        // `todo!()` skeletons. See type-inference.md §4.6.)
 
         // Tuple: positional width-subtyping. A longer/equal tuple is a
         // subtype, so every position rhs requires must exist in lhs.
@@ -483,13 +539,26 @@ fn constrain_go(
         }
 
         // **Σ-injection** `Fun(Data) <: Σ`: a data function is a subtype of the
-        // sum iff its domain is a body-instantiation for some witness the sum
-        // ranges over, and its codomain then flows into the sum's shared codomain.
-        // This is how the `emit_case` join lands — each arm is constrained `<:
-        // result`, and `result` coalesces to the Σ, so at the consistency wall
-        // each arm re-injects into it. The membership test is realized per
-        // witness; the codomain then flows covariantly the same way for every
-        // witness.
+        // sum iff it realizes the sum's fibers. Two shapes:
+        //
+        //   * **Single-arm injection** — a data function over *one* candidate
+        //     domain is that fiber (the `emit_case` arm-into-result edge: each arm
+        //     is constrained `<: result`, and `result` coalesces to the Σ, so at
+        //     the wall each arm re-injects). Extent matched by *value*.
+        //   * **Gated-partition introduction** — the compiled value-`Case`
+        //     fan-out, a data function whose domain is a gated partition
+        //     `Variant([{Dᵢ|π̂ᵢ}])`, realizes the *whole* Σ. This is the finite-Σ =
+        //     gated-coproduct isomorphism (`../design/type-inference.md` §4.6): the
+        //     gates zero out all-but-one leg, collapsing the disjoint-union domain
+        //     (a product of fibers) to the coproduct. Sound iff the legs' base
+        //     extents, as a *set*, equal the candidates (every fiber realized,
+        //     nothing extra) — the gates' exclusivity+exhaustiveness is a
+        //     `lambda_elim` construction invariant (asserted there), not re-proven.
+        //     Each leg edge `{Dᵢ|π̂ᵢ} <: Dᵢ` is *covariant* (an introduction —
+        //     refinement width, not the function-domain contravariance).
+        //
+        // Realized per witness; the codomain flows covariantly the same way for
+        // every witness.
         (
             Type::Fun {
                 name: pn,
@@ -499,10 +568,15 @@ fn constrain_go(
             },
             Type::Sigma(s),
         ) => match &s.witness {
-            // A conditional collection: inject iff `domain` is one of its
-            // candidate extents, then flow the codomain. Its body is the data
-            // function `Witness ⤇ V` (built by `conditional_collection`), so its
-            // parts are read here, where that shape is guaranteed.
+            // A conditional collection. Its body is the data function `Witness ⤇
+            // V` (built by `conditional_collection`), so its parts are read here,
+            // where that shape is guaranteed. Two injecting shapes:
+            //   * the compiled value-`Case` fan-out — a gated partition
+            //     `Variant([{Dᵢ|π̂ᵢ}])` — is **Σ-introduction**, sound iff the
+            //     legs' base extents, as a *set*, equal the candidates (finite-Σ =
+            //     gated-coproduct iso; each leg edge `{Dᵢ|π̂ᵢ} <: Dᵢ` covariant);
+            //   * a single arm whose extent matches one candidate (the
+            //     `emit_case` arm-into-result edge).
             Witness::Type(Kind::Enumerated(candidates)) => {
                 let Type::Fun {
                     name: binder,
@@ -512,17 +586,46 @@ fn constrain_go(
                 else {
                     unreachable!("a conditional collection's body is a data function")
                 };
-                if candidates.iter().any(|d| d == domain.as_ref()) {
-                    let cod_sl = match (pn, binder.as_ref()) {
-                        (Some(k), Some(x)) => sl.extended_rename(k, x),
-                        _ => sl.clone(),
-                    };
-                    constrain_go(c0, cod, &cod_sl, sr, cache)
-                } else {
-                    Err(ConstrainError::Mismatch {
-                        lhs: lhs.clone(),
-                        rhs: rhs.clone(),
-                    })
+                let cod_sl = match (pn, binder.as_ref()) {
+                    (Some(k), Some(x)) => sl.extended_rename(k, x),
+                    _ => sl.clone(),
+                };
+                match domain.as_ref() {
+                    Type::Variant(legs) => {
+                        let cand_bases: Vec<Type> =
+                            candidates.iter().map(strip_refinements).collect();
+                        let leg_bases: Vec<Type> =
+                            legs.iter().map(|(_, leg)| strip_refinements(leg)).collect();
+                        let every_fiber_realized =
+                            cand_bases.iter().all(|c| leg_bases.contains(c));
+                        let no_extraneous_leg = leg_bases.iter().all(|l| cand_bases.contains(l));
+                        if every_fiber_realized && no_extraneous_leg {
+                            for (_, leg) in legs {
+                                let leg_base = strip_refinements(leg);
+                                let cand = candidates
+                                    .iter()
+                                    .find(|&c| strip_refinements(c) == leg_base)
+                                    .expect("no_extraneous_leg guarantees a matching candidate");
+                                constrain_go(leg, cand, sl, sr, cache)?;
+                            }
+                            constrain_go(c0, cod, &cod_sl, sr, cache)
+                        } else {
+                            Err(ConstrainError::Mismatch {
+                                lhs: lhs.clone(),
+                                rhs: rhs.clone(),
+                            })
+                        }
+                    }
+                    _ => {
+                        if candidates.iter().any(|d| d == domain.as_ref()) {
+                            constrain_go(c0, cod, &cod_sl, sr, cache)
+                        } else {
+                            Err(ConstrainError::Mismatch {
+                                lhs: lhs.clone(),
+                                rhs: rhs.clone(),
+                            })
+                        }
+                    }
                 }
             }
             // The universe ranges over every domain (any data function injects).

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -596,8 +596,7 @@ fn constrain_go(
                             candidates.iter().map(strip_refinements).collect();
                         let leg_bases: Vec<Type> =
                             legs.iter().map(|(_, leg)| strip_refinements(leg)).collect();
-                        let every_fiber_realized =
-                            cand_bases.iter().all(|c| leg_bases.contains(c));
+                        let every_fiber_realized = cand_bases.iter().all(|c| leg_bases.contains(c));
                         let no_extraneous_leg = leg_bases.iter().all(|l| cand_bases.contains(l));
                         if every_fiber_realized && no_extraneous_leg {
                             for (_, leg) in legs {

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -42,10 +42,13 @@
 
 use std::rc::Rc;
 
-use crate::ccl::ccl_utils::{cast_target_refinement, is_free, is_free_in_value, typed_compose};
+use crate::ccl::ccl_utils::{
+    apply_primitive, cast_target_refinement, flatten_trailing_value_case, is_free,
+    is_free_in_value, refine_with, strip_refinements, synthesize_arm_predicate, typed_compose,
+};
 use crate::ccl::infer::{dbg_typecheck_mv, debug_typecheck};
 use crate::ccl::simplify::simplify;
-use crate::ccl::{Builtin, Lit, Name, Refinement};
+use crate::ccl::{BaseType, Branch, Builtin, FieldKey, Lit, Name, Refinement};
 use crate::ccl::{Expr, Type, TypedExpr, TypedExprNode, symbolic::symbolic};
 
 // ---------------------------------------------------------------------------
@@ -296,6 +299,234 @@ fn extract_filter_case(body: Expr) -> (Expr, Expr) {
     } else {
         panic!("extract_filter_case: expected a filter-pattern Case body")
     }
+}
+
+// ---------------------------------------------------------------------------
+// Value-selecting Case compilation (the scalar C-form)
+// ---------------------------------------------------------------------------
+
+/// Whether `arms` is a **conditional-collection coproduct** — a non-empty,
+/// `Index`-tagged `Variant` whose every payload is a data function
+/// (`Type::extent_coproduct`). Distinguishes it from a user tagged-union.
+fn is_extent_coproduct(arms: &[(FieldKey, Type)]) -> bool {
+    !arms.is_empty()
+        && arms.iter().all(|(_, t)| {
+            matches!(
+                t,
+                Type::Fun {
+                    kind: crate::ccl::ty::FunKind::Data,
+                    ..
+                }
+            )
+        })
+}
+
+/// Returns `true` if `ty` (peeling outer refinements) is a *collection* — a
+/// data/compute function or a conditional-collection coproduct. A
+/// value-selecting `Case` whose arms are collections takes the data-typed gate
+/// fan-out; a `Case` returning a scalar / compute value takes the C-form below.
+fn is_collection_result(ty: &Type) -> bool {
+    match strip_refinements(ty) {
+        Type::Fun { .. } => true,
+        Type::Variant(arms) => is_extent_coproduct(&arms),
+        _ => false,
+    }
+}
+
+/// Compile a guard-based **value-selecting** `Case` (a ternary or `if`/`elif`/
+/// `else` that returns a scalar / compute value) to the **C-form**: a union of
+/// gated one-shot lifts over the `UIntRange(1)` driver, extracted by
+/// `final_or_default`.
+///
+/// ```text
+/// Case{scrutinee: None, [g₀ → e₀; …; gₙ → eₙ]}   (gₙ is the exhaustive trailing `true`)
+///   ⟹  (⧺ᵢ const(eᵢ) : {UIntRange(1) | π̂ᵢ} ⤇ V,  eₙ) ▷ final_or_default
+/// ```
+///
+/// where `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ` ([`synthesize_arm_predicate`]). Each arm is a
+/// constant lift of its value over a one-position driver whose domain is
+/// *refined by the arm's first-match gate*. The gate is **constant in the
+/// driver element** (see `../../interpreter/design-operators.md`): it does not
+/// vary with the driver position, so the whole one-element extent survives (gate
+/// holds) or is emptied (gate fails). The partition is exhaustive (the trailing
+/// `true` guard), so exactly one arm survives and the union has one element;
+/// `final_or_default`'s default `eₙ` is a type anchor for the empty case that
+/// cannot occur. The outer type is the `Case`'s own value type `V`, unchanged,
+/// so lambda_elim's type-preservation assertion holds.
+fn build_value_case_cform(
+    ctx: &mut ElimContext,
+    branches: Vec<Branch>,
+    result_ty: Type,
+) -> Result<Expr, LambdaElimError> {
+    // Exhaustiveness invariant: a value-selecting `Case` must be total (a
+    // trailing `true` guard). `default_body` below becomes `final_or_default`'s
+    // default, and the whole first-match/`final_or_default` argument is sound only
+    // if the last arm is that unconditional fallback — a non-exhaustive `Case`
+    // reaching here would silently return the last arm's value with its gate
+    // false (an empty union → the wrong default). Lowering always appends the
+    // `true` complement (a ternary's `else`); assert it at this boundary.
+    debug_assert!(
+        branches
+            .last()
+            .is_some_and(|b| matches!(&b.guard.node, TypedExprNode::Lit(Lit::Bool(true)))),
+        "value-selecting Case must be exhaustive (trailing `true` guard)"
+    );
+    let bool_ty = Type::Base(BaseType::Bool);
+    let driver_dom = Type::UIntRange(1);
+
+    let mut prior_guards: Vec<Expr> = Vec::new();
+    let mut arms: Vec<Expr> = Vec::new();
+    let mut arm_domains: Vec<Type> = Vec::new();
+    let mut default_body: Option<Expr> = None;
+
+    for b in branches {
+        let guard = elim_lambdas(ctx, b.guard)?;
+        let body = elim_lambdas(ctx, b.body)?;
+        // First-match gate π̂ᵢ, lifted to a constant-in-element predicate
+        // `const(π̂ᵢ) : UIntRange(1) ⇒ Bool` over the driver. `synthesize_arm_predicate`
+        // combines the (already point-free) guards with raw `and`/`not` nodes, so
+        // eliminate once more to desugar those into applied-combinator form.
+        let gate_value = elim_lambdas(ctx, synthesize_arm_predicate(&guard, &prior_guards))?;
+        prior_guards.push(guard);
+        let gate_fn = apply_primitive(
+            gate_value,
+            Builtin::Const,
+            Type::fun(driver_dom.clone(), bool_ty.clone()),
+        );
+        // {UIntRange(1) | π̂ᵢ} — the gated one-shot driver domain. A trivially-true
+        // gate (a leading `if True`) leaves the driver unrefined (always fires).
+        let refined_dom = refine_with(driver_dom.clone(), &gate_fn);
+        arm_domains.push(refined_dom.clone());
+        // const(eᵢ) : {UIntRange(1) | π̂ᵢ} ⤇ V — lift the value over the gated driver.
+        let arm = apply_primitive(
+            body.clone(),
+            Builtin::Const,
+            Type::data_fun(refined_dom, result_ty.clone()),
+        );
+        arms.push(arm);
+        default_body = Some(body);
+    }
+
+    // A one-branch value `Case` denotes just that branch's value.
+    let default_body = default_body.expect("value-selecting Case has at least one branch");
+    if arms.len() == 1 {
+        return Ok(default_body);
+    }
+
+    // Union domain = Variant({Index(i): {UIntRange(1)|π̂ᵢ}}) — the same tagged
+    // union `emit_collection_union` produces, so op-conversion's `UnionOperator`
+    // dispatches to the surviving arm.
+    let union_dom = Type::Variant(
+        arm_domains
+            .into_iter()
+            .enumerate()
+            .map(|(i, d)| (FieldKey::Index(i), d))
+            .collect(),
+    );
+    let union_ty = Type::data_fun(union_dom, result_ty.clone());
+    let union = Expr::collection_union(arms).with_ty(union_ty.clone());
+
+    // (union, eₙ) ▷ final_or_default : V
+    let tuple_ty = Type::Tuple(vec![union_ty, result_ty.clone()]);
+    let arg = Expr::tuple(vec![union, default_body]).with_ty(tuple_ty);
+    Ok(apply_primitive(arg, Builtin::FinalOrDefault, result_ty))
+}
+
+/// The element (codomain) type a collection-valued `Case` produces: the
+/// codomain of a plain data function, or the coproduct's shared codomain when
+/// the arms had distinct extents (the type system gave the `Case` a
+/// conditional-collection coproduct — the arms share the joined codomain, so
+/// the first arm's codomain is it). Peels outer refinements first.
+fn collection_value_ty(ty: &Type) -> Type {
+    match strip_refinements(ty) {
+        Type::Fun { codomain, .. } => *codomain,
+        Type::Variant(arms) if is_extent_coproduct(&arms) => match arms.into_iter().next() {
+            Some((_, Type::Fun { codomain, .. })) => *codomain,
+            _ => unreachable!("is_extent_coproduct guarantees a data-function arm"),
+        },
+        other => other,
+    }
+}
+
+/// Compile a guard-based **value-selecting** `Case` whose arms are *collections*
+/// (data-typed) to the **gate fan-out**: each arm's whole collection,
+/// restricted by its constant first-match gate, unioned.
+///
+/// ```text
+/// Case{scrutinee: None, [g₀ → xs₀; …; gₙ → xsₙ]}   ⟹   ⧺ᵢ (xsᵢ | π̂ᵢ)
+/// ```
+///
+/// where `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ` ([`synthesize_arm_predicate`]). Each gate is
+/// **constant in the element** (see the C-form above), so an arm's collection
+/// survives whole (gate holds) or is emptied (gate fails); the partition is
+/// exhaustive, so exactly one arm is non-empty and the union is that arm's
+/// collection. The union's type is the tagged `Variant`-domain data function —
+/// the same shape `emit_collection_union` gives a `++`, which the strict wall
+/// accepts where the `Case`'s Σ type is demanded via the gated-partition bridge
+/// rule (`../design/type-inference.md` §4.6). The fan-out is type-preserving by
+/// construction: the union's positional tags line up with the Σ's choices.
+fn build_value_case_fanout(
+    ctx: &mut ElimContext,
+    branches: Vec<Branch>,
+    result_ty: Type,
+) -> Result<Expr, LambdaElimError> {
+    // Exhaustiveness invariant (as in [`build_value_case_cform`]): a total value
+    // selection has a trailing `true` guard, so exactly one arm survives the
+    // first-match partition and the union is that arm's whole collection. A
+    // non-exhaustive `Case` here would leave the union empty on the uncovered
+    // path (e.g. `sum` = 0) — a silent miscompile, not a rejection.
+    debug_assert!(
+        branches
+            .last()
+            .is_some_and(|b| matches!(&b.guard.node, TypedExprNode::Lit(Lit::Bool(true)))),
+        "value-selecting Case (fan-out) must be exhaustive (trailing `true` guard)"
+    );
+    let bool_ty = Type::Base(BaseType::Bool);
+    let value_ty = collection_value_ty(&result_ty);
+
+    let mut prior_guards: Vec<Expr> = Vec::new();
+    let mut arms: Vec<Expr> = Vec::new();
+
+    for b in branches {
+        let guard = elim_lambdas(ctx, b.guard)?;
+        let coll = elim_lambdas(ctx, b.body)?;
+        let arm_dom = coll.ty.domain().ok_or_else(|| {
+            LambdaElimError::Unsupported(format!(
+                "value-selecting Case arm is not a plain collection (nested conditional \
+                 collections are not yet supported): {}",
+                coll.ty
+            ))
+        })?;
+        // First-match gate, lifted to a constant-in-element predicate over the
+        // arm's own domain, then attached as a domain refinement (planning
+        // materializes it as the arm's `restrict`).
+        let gate_value = elim_lambdas(ctx, synthesize_arm_predicate(&guard, &prior_guards))?;
+        prior_guards.push(guard);
+        let gate_fn = apply_primitive(
+            gate_value,
+            Builtin::Const,
+            Type::fun(arm_dom.clone(), bool_ty.clone()),
+        );
+        let refined_dom = refine_with(arm_dom, &gate_fn);
+        arms.push(coll.with_ty(Type::data_fun(refined_dom, value_ty.clone())));
+    }
+
+    // A one-branch collection `Case` denotes just that arm's collection, and its
+    // Σ collapses to that arm's plain data function — no union or bridge needed.
+    if arms.len() == 1 {
+        return Ok(arms.pop().unwrap());
+    }
+
+    // The tagged union of gated arms *is* the Σ the type system gave the `Case`
+    // (`../design/type-inference.md` §4.6), so the node carries the Σ directly —
+    // lambda_elim stays type-preserving (Σ in, Σ out). The union's positional
+    // `Index(i)` tags line up with the Σ's choices (bridge rule 1's ordering
+    // contract). The strict `typecheck` reconciles the union's structural
+    // `Variant`-domain type against this stamped Σ via the gated-partition bridge
+    // rule (`union <: Σ`); op-conversion compiles the union straight to a
+    // `UnionOperator` from its operands (whose domains are concrete extents),
+    // never consulting the Σ, so the Σ chokepoint is never reached.
+    Ok(Expr::collection_union(arms).with_ty(result_ty))
 }
 
 // ---------------------------------------------------------------------------
@@ -696,6 +927,28 @@ fn elim_lambda_impl(
             unreachable!("lambda_elim: Transact is born by recognition, after this pass")
         }
 
+        // A value-selecting `Case` inside a bare lambda body (`λ x → Case{[gᵢ → eᵢ]}`),
+        // where the gate `gᵢ(x)` varies with the element. A *comprehension*
+        // element conditional (`[a if g(x) else b for x in xs]`) is fanned out at
+        // comprehension lowering (`lower::comprehension::fan_out_element_case`) into
+        // `⧺ᵢ src|π̂ᵢ ≫ eᵢ`, so it never reaches here. This arm catches the residual
+        // shapes — a per-element conditional in a lambda whose *iteration source is
+        // not visible at lowering* (a UDF body, a comprehension with an extra
+        // `if`-filter alongside the element `Case`) — which need the same source
+        // fan-out but at a site without a source in hand. Deferred (a documented
+        // follow-up; see `design/mutability.md` §"Value-selecting `Case`…").
+        TypedExprNode::Case {
+            scrutinee: None,
+            branches,
+        } if branches.iter().all(|b| b.pattern.is_none()) => {
+            Err(LambdaElimError::Unsupported(format!(
+                "per-element conditional (a value-selecting `Case` inside `λ {param} → …`) is \
+                 not compilable at a site with no visible iteration source. A comprehension \
+                 element conditional (`[a if g({param}) else b for {param} in xs]`), a top-level \
+                 ternary, a conditional collection, and a conditional feed all compile today."
+            )))
+        }
+
         // Unsupported constructs.
         body => Err(LambdaElimError::Unsupported(format!(
             "unsupported body kind in lambda elimination for param '{param}' in body {body:?}"
@@ -862,6 +1115,27 @@ fn elim_lambdas_impl(ctx: &mut ElimContext, expr: Expr) -> Result<Expr, LambdaEl
         }
 
         TypedExprNode::Error => crate::unexpected_error_node!(),
+
+        // Value-selecting guard `Case`: the literal union-of-restricts. A
+        // scalar / compute result takes the C-form (gated one-shot lifts +
+        // `final_or_default`); a data-collection result takes the gate fan-out
+        // (each whole arm restricted then unioned). A pattern-matching
+        // `Case` (`scrutinee: Some`) is not handled here yet.
+        TypedExprNode::Case {
+            scrutinee: None,
+            branches,
+        } if branches.iter().all(|b| b.pattern.is_none()) => {
+            // Flatten `elif` chains to one partition first, so a nested
+            // conditional collection collapses into a single N-choice fan-out.
+            let branches = flatten_trailing_value_case(branches);
+            let result = if is_collection_result(&ty) {
+                build_value_case_fanout(ctx, branches, ty)?
+            } else {
+                build_value_case_cform(ctx, branches, ty)?
+            };
+            debug_typecheck(&result);
+            Ok(result)
+        }
 
         // Control-flow constructs not yet supported.
         node @ TypedExprNode::Case { .. } => Err(LambdaElimError::Unsupported(format!(

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -305,32 +305,12 @@ fn extract_filter_case(body: Expr) -> (Expr, Expr) {
 // Value-selecting Case compilation (the scalar C-form)
 // ---------------------------------------------------------------------------
 
-/// Whether `arms` is a **conditional-collection coproduct** — a non-empty,
-/// `Index`-tagged `Variant` whose every payload is a data function
-/// (`Type::extent_coproduct`). Distinguishes it from a user tagged-union.
-fn is_extent_coproduct(arms: &[(FieldKey, Type)]) -> bool {
-    !arms.is_empty()
-        && arms.iter().all(|(_, t)| {
-            matches!(
-                t,
-                Type::Fun {
-                    kind: crate::ccl::ty::FunKind::Data,
-                    ..
-                }
-            )
-        })
-}
-
 /// Returns `true` if `ty` (peeling outer refinements) is a *collection* — a
-/// data/compute function or a conditional-collection coproduct. A
-/// value-selecting `Case` whose arms are collections takes the data-typed gate
-/// fan-out; a `Case` returning a scalar / compute value takes the C-form below.
+/// data/compute function or a conditional-collection Σ. A value-selecting `Case`
+/// whose arms are collections takes the data-typed gate fan-out; a `Case`
+/// returning a scalar / compute value takes the C-form below.
 fn is_collection_result(ty: &Type) -> bool {
-    match strip_refinements(ty) {
-        Type::Fun { .. } => true,
-        Type::Variant(arms) => is_extent_coproduct(&arms),
-        _ => false,
-    }
+    matches!(strip_refinements(ty), Type::Fun { .. } | Type::Sigma(_))
 }
 
 /// Compile a guard-based **value-selecting** `Case` (a ternary or `if`/`elif`/
@@ -433,16 +413,18 @@ fn build_value_case_cform(
 }
 
 /// The element (codomain) type a collection-valued `Case` produces: the
-/// codomain of a plain data function, or the coproduct's shared codomain when
-/// the arms had distinct extents (the type system gave the `Case` a
-/// conditional-collection coproduct — the arms share the joined codomain, so
-/// the first arm's codomain is it). Peels outer refinements first.
+/// codomain of a plain data function, or the shared codomain of a
+/// conditional-collection Σ when the arms had distinct extents (all fibers
+/// share the joined codomain). Peels outer refinements first.
 fn collection_value_ty(ty: &Type) -> Type {
     match strip_refinements(ty) {
         Type::Fun { codomain, .. } => *codomain,
-        Type::Variant(arms) if is_extent_coproduct(&arms) => match arms.into_iter().next() {
-            Some((_, Type::Fun { codomain, .. })) => *codomain,
-            _ => unreachable!("is_extent_coproduct guarantees a data-function arm"),
+        // A conditional-collection Σ shares one codomain across its fibers; its
+        // body is the data function `Witness ⤇ V`, read here (this is only
+        // reached for a collection-typed `Case`, so the shape is guaranteed).
+        Type::Sigma(s) => match &*s.body {
+            Type::Fun { codomain, .. } => codomain.as_ref().clone(),
+            _ => unreachable!("a conditional collection's body is a data function"),
         },
         other => other,
     }

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -936,7 +936,8 @@ fn elim_lambda_impl(
         // not visible at lowering* (a UDF body, a comprehension with an extra
         // `if`-filter alongside the element `Case`) — which need the same source
         // fan-out but at a site without a source in hand. Deferred (a documented
-        // follow-up; see `design/mutability.md` §"Value-selecting `Case`…").
+        // follow-up; see `design/mutability.md`
+        // "Value-selecting `Case` and conditional induction writes (partially implemented)").
         TypedExprNode::Case {
             scrutinee: None,
             branches,

--- a/src/ccl/lower/comprehension.rs
+++ b/src/ccl/lower/comprehension.rs
@@ -4,8 +4,10 @@
 use super::*;
 use crate::{
     ccl::{
-        BinOpKind, Expr, LogicKind, Name, Type,
-        ccl_utils::{make_cast, refined_fn_type},
+        BinOpKind, Branch, Expr, LogicKind, Name, Type, TypedExprNode,
+        ccl_utils::{
+            flatten_trailing_value_case, make_cast, refined_fn_type, synthesize_arm_predicate,
+        },
         uniquify,
     },
     chl_parser::ast::{AssignTarget, CompClause, Comprehension, Expr as ChlExpr, Spanned},
@@ -138,6 +140,60 @@ pub(super) fn lower_list_comp(
         }
     };
 
+    // ---- Phase 4.5: Float a value-`Case` source out of the comprehension --------
+    // `[e for x in (xs if c else ys)]` — a comprehension over a *conditional
+    // collection* — lowers with a value-`Case` source. Iterating it directly
+    // would bind the index variable to *both* choice extents (as the read index
+    // and the result domain), which inference rejects as an untagged-sum
+    // collision. Because the guards do not reference the comprehension variable,
+    // the `Case` floats out soundly: `[e for x in Case{gᵢ→srcᵢ}]` ⟹
+    // `Case{gᵢ → [e for x in srcᵢ]}` — each arm an ordinary map over a concrete
+    // collection, the enclosing `Case` a value-`Case` over collections (typed as
+    // the Σ, compiled by the gate fan-out). Single generator, no comprehension
+    // filter; a nested conditional source floats per arm by recursion. (A
+    // multi-generator or filtered comprehension over a conditional source is a
+    // follow-up — it falls through to the direct path.)
+    if single_gen
+        && pred_op.is_none()
+        && matches!(
+            &gen_sources[0].node,
+            TypedExprNode::Case { scrutinee: None, branches }
+                if branches.iter().all(|b| b.pattern.is_none())
+        )
+    {
+        let source = gen_sources.pop().expect("single generator has one source");
+        return Ok(float_comp_source_case(source, &gen_iter_vars[0], &body));
+    }
+
+    // ---- Phase 4.6: Fan out a value-`Case` *element* into filtered maps ----------
+    // `[a if g(x) else b for x in xs]` — a comprehension whose *element* is a
+    // per-element conditional — lowers with a value-`Case` body. The `Case`
+    // cannot float out (its guards reference the comprehension variable `x`), so
+    // instead fan out the source by each arm's first-match gate:
+    // `[eᵢ if gᵢ … for x in xs]` ⟹ `⧺ᵢ [eᵢ for x in xs if π̂ᵢ]`,
+    // `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`. Each arm restricts the source by its
+    // (element-dependent) gate — the ordinary filter refinement — and maps by
+    // that arm's value; the gates partition the source, so the union recombines
+    // the arms by position into the fully-mapped collection. A `CollectionUnion`
+    // (not a `Case`), so the compute-kinded per-arm maps do not need to join.
+    // Single generator, no comprehension filter; the value arms may reference `x`.
+    if single_gen
+        && pred_op.is_none()
+        && matches!(
+            &body.node,
+            TypedExprNode::Case { scrutinee: None, branches }
+                if branches.iter().all(|b| b.pattern.is_none())
+        )
+    {
+        let source = gen_sources.pop().expect("single generator has one source");
+        return Ok(fan_out_element_case(
+            source,
+            &gen_iter_vars[0],
+            outer_var,
+            body,
+        ));
+    }
+
     // ---- Phase 5: Build the body as a nested Apply/Lambda chain ------------------
     // Working innermost-first (reverse order) we wrap the accumulated expression:
     //   body = Apply(Lambda(iter_var_i, body), Apply(source_i, idx_arg_i))
@@ -183,6 +239,96 @@ pub(super) fn lower_list_comp(
         Ok(make_cast(unrefined_lambda, target_ty))
     } else {
         Ok(Expr::lambda(outer_var, Type::Hole, body_expr))
+    }
+}
+
+/// Float a value-`Case` *source* out of a single-generator comprehension:
+/// `[e for x in Case{gᵢ→srcᵢ}]` ⟹ `Case{gᵢ → [e for x in srcᵢ]}`. Sound because
+/// the guards do not reference the comprehension variable `x`. Recurses so a
+/// nested conditional source flattens per arm; a concrete (non-`Case`) source
+/// builds the ordinary map chain `λ __idx → __idx ▷ src ▷ (λ x → body)`.
+fn float_comp_source_case(source: Expr, iter_var: &str, body: &Expr) -> Expr {
+    let is_value_case = matches!(
+        &source.node,
+        TypedExprNode::Case { scrutinee: None, branches }
+            if branches.iter().all(|b| b.pattern.is_none())
+    );
+    if is_value_case {
+        let TypedExprNode::Case { branches, .. } = source.node else {
+            unreachable!("guarded by is_value_case")
+        };
+        let floated = branches
+            .into_iter()
+            .map(|b| Branch {
+                pattern: b.pattern,
+                guard: b.guard,
+                // The arm body *is* this arm's source collection; float into it.
+                body: float_comp_source_case(b.body, iter_var, body),
+            })
+            .collect();
+        return Expr::new(TypedExprNode::Case {
+            scrutinee: None,
+            branches: floated,
+        });
+    }
+    // Concrete source: `source ≫ (λ x → body)` — a `Compose`, *not* the apply
+    // chain Phase 5 builds. The compose form is equivalent (a map applies the
+    // body to each element) but `emit_compose` stamps it with the *source's*
+    // data kind (a map over a collection is itself a collection). That data kind
+    // is what lets two such arms of a conditional source `sigma_join` into the Σ
+    // (compiled by the gate fan-out) rather than colliding as compute-kinded
+    // lambdas whose distinct index extents would meet.
+    Expr::compose(vec![
+        source,
+        Expr::lambda(iter_var, Type::Hole, body.clone()),
+    ])
+}
+
+/// Fan out a single-generator comprehension whose *element* is a value-`Case`
+/// into a union of filtered maps: `[eᵢ if gᵢ … for x in src]` ⟹
+/// `⧺ᵢ [eᵢ for x in src if π̂ᵢ]`, first-match `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`. Each arm is a
+/// filtered map — the source restricted on its domain by the arm's
+/// (element-dependent) gate (a `cast` carrying the refinement, exactly the shape
+/// Phase 6 builds for a comprehension `if`-filter), composed with the arm's value
+/// map. The gates partition the source, so the `++`-union recombines the arms by
+/// position into the fully-mapped collection.
+fn fan_out_element_case(source: Expr, iter_var: &str, outer_var: &str, body: Expr) -> Expr {
+    let TypedExprNode::Case { branches, .. } = body.node else {
+        unreachable!("fan_out_element_case requires a Case body")
+    };
+    // Flatten a nested `elif` element (`a if p else b if q else c`, a trailing
+    // `true → Case{…}`) into one flat partition, so each arm is a plain value.
+    let branches = flatten_trailing_value_case(branches);
+    let mut prior_guards: Vec<Expr> = Vec::new();
+    let arms: Vec<Expr> = branches
+        .into_iter()
+        .map(|b| {
+            let gate = synthesize_arm_predicate(&b.guard, &prior_guards);
+            prior_guards.push(b.guard);
+            // Element map: `λ __idx → __idx ▷ src ▷ (λ x → eᵢ)`.
+            let elem_map = Expr::lambda(
+                outer_var,
+                Type::Hole,
+                Expr::apply(
+                    Expr::apply(Expr::var(Name::raw(outer_var)), source.clone()),
+                    Expr::lambda(iter_var, Type::Hole, b.body),
+                ),
+            );
+            // Gate over the source domain: `__elem ▷ src ▷ (λ x → π̂ᵢ)` — the bare
+            // refinement predicate, matching Phase 6's loop-join filter shape.
+            let gate_on_source = Expr::apply(
+                Expr::apply(Expr::var(Name::elem()), source.clone()),
+                Expr::lambda(iter_var, Type::Hole, gate),
+            );
+            let target = refined_fn_type(Type::Hole, gate_on_source, Type::Hole);
+            make_cast(elem_map, target)
+        })
+        .collect();
+    // A one-arm value `Case` (degenerate) is just the single filtered map.
+    if arms.len() == 1 {
+        arms.into_iter().next().expect("checked len == 1")
+    } else {
+        Expr::collection_union(arms)
     }
 }
 

--- a/src/ccl/lower/loops.rs
+++ b/src/ccl/lower/loops.rs
@@ -381,19 +381,13 @@ fn lower_for_body_terminal(
             branches,
             else_body,
         } => {
-            if else_body.is_some() {
-                return Err(LoweringError::unsupported(
-                    stmt.span,
-                    "if/else inside generator for-loop body is not supported; \
-                     use a plain if-guard (no else branch)",
-                ));
-            }
-            // `if` / `elif` (no `else`): one `Case` branch per guard, in source
-            // order, then a trailing `true → Unit` fallthrough. A feeding
-            // multi-arm `Case` is fanned out by `channelize` into one
-            // refined-source channel per feeding arm (predicate
-            // `gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`, encoding "first matching guard wins"), so `elif`
-            // is no longer gated here.
+            // `if` / `elif` [/ `else`]: one `Case` branch per guard, in source
+            // order. A feeding multi-arm `Case` is fanned out by `channelize` into
+            // one refined-source channel per feeding arm (predicate
+            // `gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`, first-matching-guard-wins), so `elif` and `else` are
+            // both ordinary arms. The trailing arm is the `else` body when present
+            // (guard `true`, so its first-match predicate is `¬⋁ⱼ gⱼ`), else a
+            // `true → Unit` fallthrough (positions no guard admits do nothing).
             let mut out_branches = Vec::with_capacity(branches.len() + 1);
             for branch in branches {
                 let cond = lower_expr(&branch.cond, ctx)?;
@@ -412,10 +406,20 @@ fn lower_for_body_terminal(
                     body: arm,
                 });
             }
+            let fallthrough = match else_body {
+                Some(else_body) => lower_for_body_stmts(
+                    else_body,
+                    defer_name,
+                    mutation_scope,
+                    frame_introduced.clone(),
+                    ctx,
+                )?,
+                None => Expr::lit(Lit::Unit),
+            };
             out_branches.push(Branch {
                 pattern: None,
                 guard: Expr::lit(Lit::Bool(true)),
-                body: Expr::lit(Lit::Unit),
+                body: fallthrough,
             });
             Ok(Expr::new(TypedExprNode::Case {
                 scrutinee: None,
@@ -1147,9 +1151,11 @@ x";
         );
     }
 
-    /// `if/else` inside a generator for-loop body is rejected.
+    /// `if/else` inside a generator for-loop body lowers: the `else` becomes the
+    /// trailing `true`-guarded `Case` arm (its first-match predicate `¬(x > 0)`),
+    /// which `channelize` fans out as its own feeding channel.
     #[test]
-    fn test_generator_if_else_in_body_rejected() {
+    fn test_generator_if_else_in_body_lowers() {
         let code = "\
 def bad(xs):
     for x in xs:
@@ -1159,15 +1165,9 @@ def bad(xs):
             yield 0
 bad";
         let stmts = parse_module(code);
-        let err = expect_one_lowering_error(&stmts);
-        match &err {
-            LoweringError::Unsupported { message: msg, .. } => {
-                assert!(
-                    msg.contains("if/else inside generator"),
-                    "error should mention if/else in generator: {msg}"
-                );
-            }
-        }
+        lower_stmts(&stmts, &mut LoweringContext::default())
+            .into_result()
+            .expect("if/else in a generator for-loop body should lower");
     }
 
     /// A for/yield loop preceded by assignments is supported: the preceding

--- a/src/interpreter/design-operators.md
+++ b/src/interpreter/design-operators.md
@@ -268,6 +268,17 @@ non-`Iterate` arm reaching op-conversion with `input=None` fails an assertion �
 a planner bug, not a user error.  Similarly, `Restrict` reaching op-conversion
 with `input=None` is a planner bug.
 
+**Constant-in-element predicates.** The scalar value-`Case` C-form
+(`(unit | π̂ ≫ const 𝑒) ⧺ …`) and the data-collection gate fan-out
+(`zs = xs if c else ys`) restrict a domain by a predicate that is *constant in
+the element* — the gate is the arm's first-match path condition, not a function
+of the position.  These compile through the ordinary `Restrict` path with no new
+operator: a `const(c)` gate with a non-literal `c` is *not* matched by
+`is_trivially_true_predicate` (which recognises only a literal `true`), so it
+yields a real `Restrict` that gates the whole extent — empty when the gate is
+false, identity when true — over both `Units(1)` one-shot drivers and full
+extents.
+
 ### Let-bindings and `BindingKind`
 
 `Let { binding, bound_expr, body }` fans the parent's input out to both children
@@ -337,6 +348,32 @@ In all three cases planning has ensured every iteration site has an explicit
 what to emit based only on its own AST shape and the input flowing in.
 
 ---
+
+## Designed, not yet implemented
+
+Operator work specified by the in-flight conditionals stack; listed here so the
+specs live next to their peers. Each graduates into the sections above when its PR
+lands.
+
+### `DispatchRecurse` — multi-leg induction (conditional store writes)
+
+A conditional induction write compiles to one writer-site *leg per path* — each leg a
+decision body over a predicate-restricted slice of one shared base extent, including a
+carry-forward leg over the complement (see `../ccl/design/mutability.md` §"Value-selecting
+`Case` and conditional induction writes"). `build_induction_store` today hard-wires exactly one
+writer (`let [w] = writers`); `DispatchRecurse` extends `Recurse` to N legs:
+
+- One `IterateExtent(D)` over the shared base extent, in base order — the legs' ⧺-union
+  is realized by **ordered dispatch**, never by materializing a tagged union (which would
+  re-tag positions and desync the body-input buffers).
+- Per position: evaluate the leg predicates (disjoint and exhaustive by construction —
+  the phase synthesized first-match predicates plus the complement; a runtime
+  debug-assert checks exactly one matches) and feed the position to only the matching
+  leg's body buffer, `(snapshot…, item)` tuple convention unchanged.
+- The interleaved decision stream is the store's body stream; the recurrence cycle on
+  `.writes` and the release semantics are `Recurse`'s, per leg. Leg predicates compile
+  against the same body-input shape, so a guard reading the accumulator
+  (`if total < 10: total += x`) works.
 
 ## Open Challenges
 

--- a/src/interpreter/tile_operators/map.rs
+++ b/src/interpreter/tile_operators/map.rs
@@ -487,23 +487,62 @@ impl TileProducer for MapResultToConstProducer {
             _ => i_tiling.universal_guard(),
         };
         let input_tile = self.input.get(input_guard);
-        let constant_tile = self.constant.get(c_tiling.universal_guard());
-
-        // The broadcast value must be fully known before we can replicate it
-        // across the input's domain: `repeat` fabricates nothing, it copies a
-        // single present value. A constant that is still absent (e.g. a scalar
-        // read from a sibling induction loop that has not yet converged) yields
-        // an empty (non-terminal) output — the consumer re-pulls once it lands,
-        // rather than us inventing a value for the unknown positions.
-        //
-        // This is one half of a single invariant — "never fabricate a position
-        // from a not-yet-converged sibling read." The other half is the
-        // co-presence truncate in `binop::zip_arithmetic`/`zip_concat`: a binop
-        // over a lagging operand combines only the common prefix instead of
-        // returning the longer side's tail. Keep the two in step.
-        if !constant_tile.is_terminal() {
-            return self.tiling().empty_tile();
+        // **Laziness — do not evaluate an off-path arm.** In the scalar value-`Case`
+        // C-form a false first-match gate empties this arm's `Units(1)` driver — the
+        // `Restrict` marks the driver row *deleted* rather than dropping it. When
+        // every driver row is deleted, the arm contributes no live rows, so the
+        // constant's value is never observed. Crucially we must not *pull* it: the
+        // arm's value may be a partial expression (`//`, `%`, an index) the gate
+        // exists to guard, and pulling it would evaluate e.g. `x // 0` and panic.
+        // Return a terminal-empty tile carrying the input's decidedness, so the
+        // union / `final_or_default` sees this arm resolve to nothing rather than
+        // waiting forever. The data-collection fan-out is lazy the same way (an
+        // emptied restrict is never iterated); this brings the scalar form in line.
+        if let Tile::SealedFunction {
+            domain,
+            deleted,
+            domain_predicate,
+            ..
+        } = &input_tile
+            && (0..domain.len()).all(|i| deleted.contains(i))
+        {
+            let mut out = self.tiling().empty_tile();
+            if let Tile::SealedFunction {
+                domain_predicate: out_pred,
+                ..
+            } = &mut out
+            {
+                // Carry the input's decidedness so a decided (false-gate) arm reads
+                // terminal-empty — the union / `final_or_default` sees it resolve to
+                // nothing rather than waiting forever.
+                *out_pred = domain_predicate.clone();
+            } else {
+                // MapResultToConst's output is always a function tiling; a
+                // non-`SealedFunction` here would silently drop the decidedness
+                // carry-over and leave a decided arm reading non-terminal forever.
+                unreachable!("MapResultToConst output tiling is always SealedFunction");
+            }
+            return out;
         }
+        let constant_tile = {
+            // The broadcast value must be fully known before we can replicate it
+            // across the input's domain: `repeat` fabricates nothing, it copies a
+            // single present value. A constant that is still absent (e.g. a scalar
+            // read from a sibling induction loop that has not yet converged) yields
+            // an empty (non-terminal) output — the consumer re-pulls once it lands,
+            // rather than us inventing a value for the unknown positions.
+            //
+            // This is one half of a single invariant — "never fabricate a position
+            // from a not-yet-converged sibling read." The other half is the
+            // co-presence truncate in `binop::zip_arithmetic`/`zip_concat`: a binop
+            // over a lagging operand combines only the common prefix instead of
+            // returning the longer side's tail. Keep the two in step.
+            let ct = self.constant.get(c_tiling.universal_guard());
+            if !ct.is_terminal() {
+                return self.tiling().empty_tile();
+            }
+            ct
+        };
 
         let mode = self.mode;
         process_tile_result(self.tiling(), input_tile, move |codomain| {

--- a/tests/compilation_pipeline.rs
+++ b/tests/compilation_pipeline.rs
@@ -26,6 +26,8 @@ mod helpers;
 
 #[path = "compilation_pipeline/comprehensions.rs"]
 mod comprehensions;
+#[path = "compilation_pipeline/conditionals.rs"]
+mod conditionals;
 #[path = "compilation_pipeline/feeds_cases.rs"]
 mod feeds_cases;
 #[path = "compilation_pipeline/generators_udf_poly.rs"]

--- a/tests/compilation_pipeline/conditionals.rs
+++ b/tests/compilation_pipeline/conditionals.rs
@@ -111,9 +111,9 @@ fn test_value_ternary_skips_partial_off_path_arm(#[case] code: &str, #[case] exp
 // type system gave the `Case`; exactly one gated arm is non-empty, so consuming
 // the union (here via `sum`) sees just that arm's elements.
 //
-// The union's tagged-`Variant` domain reconciles against the Σ via the
-// gated-partition bridge rules (distinct extents → bridge 1 / `<: Σ`;
-// same-extent collapse → bridge 2 / `<: plain data fun`).
+// The union's tagged-`Variant` domain reconciles against the Σ by
+// Σ-introduction (distinct extents → the compiled partition realizes the whole
+// Σ; same-extent collapse → it subtypes the collapsed plain data fun).
 // ---------------------------------------------------------------------------
 
 #[rstest]
@@ -121,7 +121,7 @@ fn test_value_ternary_skips_partial_off_path_arm(#[case] code: &str, #[case] exp
 // Distinct-extent arms — the `Case` types as a Σ; `sum` consumes it via `Σ <: Fun`.
 #[case("c: bool = True\nsum([1, 2] if c else [1, 2, 3])", Value::Int(3))]
 #[case("c: bool = False\nsum([1, 2] if c else [1, 2, 3])", Value::Int(6))]
-// Same-extent arms — the Σ collapses to a plain data function (bridge rule 2).
+// Same-extent arms — the Σ collapses to a plain data function.
 #[case("c: bool = True\nsum([1, 2] if c else [3, 4])", Value::Int(3))]
 #[case("c: bool = False\nsum([1, 2] if c else [3, 4])", Value::Int(7))]
 // Guard is a computed comparison.
@@ -137,6 +137,23 @@ fn test_value_ternary_skips_partial_off_path_arm(#[case] code: &str, #[case] exp
 #[case(
     "n: int = 3\nsum([1] if n == 1 else [2, 2] if n == 2 else [3, 3, 3])",
     Value::Int(9)
+)]
+// **Repeated extent across branches.** `[1]` and `[2]` share extent `[0,1)`, so
+// the Σ has *two* candidates (`{[0,1), [0,2)}`) but the fan-out has *three*
+// legs. This is the case a positional leg↔candidate bijection would reject; the
+// set-equality (coverage) Σ-introduction rule accepts it (two legs realize the
+// shared `[0,1)` fiber, their gates partitioning "branch a or b was taken").
+#[case(
+    "n: int = 1\nsum([1] if n == 1 else [2] if n == 2 else [3, 3])",
+    Value::Int(1)
+)]
+#[case(
+    "n: int = 2\nsum([1] if n == 1 else [2] if n == 2 else [3, 3])",
+    Value::Int(2)
+)]
+#[case(
+    "n: int = 9\nsum([1] if n == 1 else [2] if n == 2 else [3, 3])",
+    Value::Int(6)
 )]
 fn test_value_case_collection_sum(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
@@ -156,9 +173,9 @@ fn test_value_case_collection_result() {
 }
 
 // Same-extent arms as a program result: the Σ collapses to a plain data
-// function (bridge rule 2), not a Σ, but the runtime still selects the right
-// arm. This pins the tile shape of the collapse, which the `sum` cases above
-// only exercise through an aggregate.
+// function, not a Σ, but the runtime still selects the right arm. This pins the
+// tile shape of the collapse, which the `sum` cases above only exercise through
+// an aggregate.
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_value_case_same_extent_collection_result() {

--- a/tests/compilation_pipeline/conditionals.rs
+++ b/tests/compilation_pipeline/conditionals.rs
@@ -1,0 +1,348 @@
+//! Conditionals: value-selecting `Case` compilation via the literal
+//! union-of-restricts forms (the C-form and the data-typed gate fan-out).
+//!
+//! See `src/ccl/design/mutability.md` §"Value-selecting `Case` and conditional
+//! induction writes".
+
+use std::time::Duration;
+
+use cambra::interpreter::{ColumnValue, Tile, Value};
+use rstest_log::rstest;
+
+use crate::helpers::*;
+
+/// Extract the codomain integers of a (possibly `Union`-domain) collection
+/// result tile, sorted. A conditional-collection result is a tagged union whose
+/// single non-empty variant carries the selected arm's elements.
+fn codomain_ints(tile: &Tile) -> Vec<i64> {
+    let Tile::SealedFunction { codomain, .. } = tile else {
+        panic!("expected a SealedFunction tile, got {tile:?}");
+    };
+    let Tile::Scalar(ColumnValue::Ints(v)) = codomain.as_ref() else {
+        panic!("expected an Ints scalar codomain, got {codomain:?}");
+    };
+    let mut v = v.clone();
+    v.sort_unstable();
+    v
+}
+
+// ---------------------------------------------------------------------------
+// Scalar / compute value selection — the C-form
+//
+// `x = e₁ if p else e₂` compiles to a union of gated one-shot lifts over the
+// `UIntRange(1)` driver, extracted by `final_or_default`. The gates partition
+// the driver by first-match (`πᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`), so exactly one arm's
+// element survives.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// Basic ternary, both branches.
+#[case("c: bool = True\n1 if c else 2", Value::Int(1))]
+#[case("c: bool = False\n1 if c else 2", Value::Int(2))]
+// Guard is a computed comparison, not a bare variable.
+#[case("a: int = 1\nb: int = 2\n10 if a < b else 20", Value::Int(10))]
+#[case("a: int = 5\nb: int = 2\n10 if a < b else 20", Value::Int(20))]
+// The selected value is itself a computed expression over outer bindings.
+#[case("a: int = 5\nc: bool = True\na * 2 if c else a - 1", Value::Int(10))]
+#[case("a: int = 5\nc: bool = False\na * 2 if c else a - 1", Value::Int(4))]
+// `elif` chain — first matching guard wins.
+#[case(
+    "n: int = 1\n100 if n == 1 else 200 if n == 2 else 300",
+    Value::Int(100)
+)]
+#[case(
+    "n: int = 2\n100 if n == 1 else 200 if n == 2 else 300",
+    Value::Int(200)
+)]
+#[case(
+    "n: int = 9\n100 if n == 1 else 200 if n == 2 else 300",
+    Value::Int(300)
+)]
+// Ternary in an arithmetic context — the whole `Case` is a scalar `V`.
+#[case("c: bool = True\n(1 if c else 2) + 10", Value::Int(11))]
+// Nested ternary in an arm.
+#[case(
+    "a: int = 1\nb: int = 1\n(100 if b == 1 else 101) if a == 1 else 200",
+    Value::Int(100)
+)]
+#[case(
+    "a: int = 1\nb: int = 9\n(100 if b == 1 else 101) if a == 1 else 200",
+    Value::Int(101)
+)]
+#[case(
+    "a: int = 9\nb: int = 1\n(100 if b == 1 else 101) if a == 1 else 200",
+    Value::Int(200)
+)]
+// Degenerate constant guard folds to the first arm.
+#[case("7 if True else 8", Value::Int(7))]
+// String and bool arms — the C-form is value-agnostic.
+#[case("c: bool = False\n\"yes\" if c else \"no\"", Value::String("no".into()))]
+#[case("c: bool = True\nFalse if c else True", Value::Bool(false))]
+fn test_value_ternary_scalar(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// The off-path arm is **not evaluated**: a guard-protected partial expression
+// (`//` by a value the guard proves non-zero) must not fault on the path its
+// guard excludes. The scalar C-form lifts each arm over a gated `Units(1)`
+// driver, and `MapResultToConst` skips a false-gate arm's value entirely — so
+// `10 // b` is never computed when `b == 0`. (Before the laziness fix this
+// panicked with "attempt to divide by zero".)
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// Off-path partial arm: guard false → the `10 // b` arm is skipped, not faulted.
+#[case("b: int = 0\n0 if b == 0 else 10 // b", Value::Int(0))]
+// On-path partial arm still evaluates normally.
+#[case("b: int = 2\n10 // b if b != 0 else 0", Value::Int(5))]
+// Guard true selects the safe arm; the partial `else` is skipped.
+#[case("b: int = 0\n99 if b == 0 else 10 // b", Value::Int(99))]
+// The partial arm is the (excluded) `else` of an explicit guard.
+#[case("b: int = 0\n10 // b if b != 0 else 42", Value::Int(42))]
+fn test_value_ternary_skips_partial_off_path_arm(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Data-collection value selection — the gate fan-out
+//
+// `zs = xs if c else ys` compiles to `⧺ᵢ (xsᵢ | π̂ᵢ)`: each arm's whole
+// collection restricted by its constant gate, unioned. The result is the Σ the
+// type system gave the `Case`; exactly one gated arm is non-empty, so consuming
+// the union (here via `sum`) sees just that arm's elements.
+//
+// The union's tagged-`Variant` domain reconciles against the Σ via the
+// gated-partition bridge rules (distinct extents → bridge 1 / `<: Σ`;
+// same-extent collapse → bridge 2 / `<: plain data fun`).
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// Distinct-extent arms — the `Case` types as a Σ; `sum` consumes it via `Σ <: Fun`.
+#[case("c: bool = True\nsum([1, 2] if c else [1, 2, 3])", Value::Int(3))]
+#[case("c: bool = False\nsum([1, 2] if c else [1, 2, 3])", Value::Int(6))]
+// Same-extent arms — the Σ collapses to a plain data function (bridge rule 2).
+#[case("c: bool = True\nsum([1, 2] if c else [3, 4])", Value::Int(3))]
+#[case("c: bool = False\nsum([1, 2] if c else [3, 4])", Value::Int(7))]
+// Guard is a computed comparison.
+#[case(
+    "n: int = 2\nsum([10, 20] if n == 1 else [1, 2, 3, 4])",
+    Value::Int(10)
+)]
+// `elif` over collections — first matching arm's collection wins.
+#[case(
+    "n: int = 2\nsum([1] if n == 1 else [2, 2] if n == 2 else [3, 3, 3])",
+    Value::Int(4)
+)]
+#[case(
+    "n: int = 3\nsum([1] if n == 1 else [2, 2] if n == 2 else [3, 3, 3])",
+    Value::Int(9)
+)]
+fn test_value_case_collection_sum(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// A conditional collection used directly as the program result: the tagged
+// union tile carries exactly the selected arm (the other variant is empty).
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn test_value_case_collection_result() {
+    // `True` arm: the surviving variant holds `[1, 2]`.
+    let result = run_pipeline("c: bool = True\n[1, 2] if c else [1, 2, 3]");
+    assert_eq!(codomain_ints(&result), vec![1, 2]);
+    // `False` arm: the surviving variant holds `[1, 2, 3]`.
+    let result = run_pipeline("c: bool = False\n[1, 2] if c else [1, 2, 3]");
+    assert_eq!(codomain_ints(&result), vec![1, 2, 3]);
+}
+
+// Same-extent arms as a program result: the Σ collapses to a plain data
+// function (bridge rule 2), not a Σ, but the runtime still selects the right
+// arm. This pins the tile shape of the collapse, which the `sum` cases above
+// only exercise through an aggregate.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn test_value_case_same_extent_collection_result() {
+    let result = run_pipeline("c: bool = True\n[1, 2] if c else [3, 4]");
+    assert_eq!(codomain_ints(&result), vec![1, 2]);
+    let result = run_pipeline("c: bool = False\n[1, 2] if c else [3, 4]");
+    assert_eq!(codomain_ints(&result), vec![3, 4]);
+}
+
+// Consuming a conditional collection through a comprehension
+// (`[f(x) for x in (xs if c else ys)]`) is exercised below by
+// `test_comprehension_over_conditional`.
+
+// ---------------------------------------------------------------------------
+// Source-less conditional feeds
+//
+// `if c: d << v1 else: d << v2` (outside any loop) has no iteration source, so
+// each feeding arm becomes a gated one-shot lift `λ __unused : {Unit | π̂ᵢ} → vᵢ`
+// over the `Unit` driver. The channel union publishes exactly the selected arm's
+// value (empty when no arm fires — a naturally-partial feed). A `defer()` read
+// surfaces the channel.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// if/else — the selected arm's value is fed.
+#[case("c: bool = True\nx = defer()\nif c:\n    x << 1\nelse:\n    x << 2\nx", vec![1])]
+#[case("c: bool = False\nx = defer()\nif c:\n    x << 1\nelse:\n    x << 2\nx", vec![2])]
+// elif — first matching arm's value.
+#[case(
+    "n: int = 1\nx = defer()\nif n == 1:\n    x << 10\nelif n == 2:\n    x << 20\nelse:\n    x << 30\nx",
+    vec![10]
+)]
+#[case(
+    "n: int = 2\nx = defer()\nif n == 1:\n    x << 10\nelif n == 2:\n    x << 20\nelse:\n    x << 30\nx",
+    vec![20]
+)]
+#[case(
+    "n: int = 9\nx = defer()\nif n == 1:\n    x << 10\nelif n == 2:\n    x << 20\nelse:\n    x << 30\nx",
+    vec![30]
+)]
+fn test_conditional_feed(#[case] code: &str, #[case] expected: Vec<i64>) {
+    assert_eq!(codomain_ints(&run_pipeline(code)), expected);
+}
+
+// Off-path laziness for the source-less feed: each arm is a gated one-shot lift
+// over the `Unit` driver, so only the fired arm's value is pulled — a
+// guard-protected partial op in the *unfired* arm is never evaluated. `100 // n`
+// must not fault at n = 0. (A non-lazy fan-out would divide by zero here.)
+//
+// Note: this laziness holds for the source-less feed (and the scalar C-form)
+// because each arm is a distinct gated one-shot lift. It does NOT extend to a
+// partial op inside a *filtered comprehension* body (`[100 // x for x in xs if
+// x != 0]`), where the filter is a logical delete and the map still evaluates
+// the deleted positions — a pre-existing limitation independent of conditionals.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// n=0 → else fires (42); the `100 // n` arm is not pulled.
+#[case("n: int = 0\nx = defer()\nif n != 0:\n    x << 100 // n\nelse:\n    x << 42\nx", vec![42])]
+// n=5 → the partial arm fires and evaluates normally (100 // 5 = 20).
+#[case("n: int = 5\nx = defer()\nif n != 0:\n    x << 100 // n\nelse:\n    x << 42\nx", vec![20])]
+fn test_conditional_feed_skips_partial_off_path_arm(
+    #[case] code: &str,
+    #[case] expected: Vec<i64>,
+) {
+    assert_eq!(codomain_ints(&run_pipeline(code)), expected);
+}
+
+// NOTE: a *source-less no-else* conditional feed (`if c: d << v`, a naturally
+// partial feed) is blocked earlier, at lowering — a bare `if` with no `else` is
+// rejected as a value-returning expression before channelize sees it. The source-less-feed path handles
+// the feed extraction once lowering admits the shape; the if/else and elif forms
+// above exercise it. A *scrutinee / pattern* feed stays rejected
+// (`PartialFeedCaseUnsupported`): a pattern match cannot be gated by a boolean.
+
+// ---------------------------------------------------------------------------
+// Comprehension over a conditional collection
+//
+// `[f(x) for x in (xs if c else ys)]` floats the source `Case` out of the map
+// (`lower::comprehension`) — `Case{gᵢ → [f(x) for x in srcᵢ]}` — with each arm
+// built as a `Compose` (`src ≫ λx→body`) so it carries the source's *data* kind.
+// The arms then `sigma_join` into the Σ and compile via the gate fan-out,
+// rather than colliding as compute-kinded lambdas over distinct index extents.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// Identity comprehension over a conditional collection.
+#[case(
+    "c: bool = True\nsum([x for x in ([1, 2] if c else [1, 2, 3])])",
+    Value::Int(3)
+)]
+#[case(
+    "c: bool = False\nsum([x for x in ([1, 2] if c else [1, 2, 3])])",
+    Value::Int(6)
+)]
+// Mapping comprehension over a conditional collection.
+#[case(
+    "c: bool = True\nsum([x * 10 for x in ([1, 2] if c else [1, 2, 3])])",
+    Value::Int(30)
+)]
+#[case(
+    "c: bool = False\nsum([x * 10 for x in ([1, 2] if c else [1, 2, 3])])",
+    Value::Int(60)
+)]
+// Nested conditional source (an `elif` in the iterable) floats per arm.
+#[case(
+    "n: int = 2\nsum([x for x in ([1] if n == 1 else [2, 2] if n == 2 else [3, 3, 3])])",
+    Value::Int(4)
+)]
+#[case(
+    "n: int = 3\nsum([x for x in ([1] if n == 1 else [2, 2] if n == 2 else [3, 3, 3])])",
+    Value::Int(9)
+)]
+fn test_comprehension_over_conditional(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// A conditional *between* two standalone comprehensions
+// (`([x for x in xs]) if c else ([y for y in ys])`). This is the case
+// kind inference unblocks: a comprehension used as a
+// value is a lambda whose kind var resolves to `Data` from its extent domain, so
+// the two `Case` arms `sigma_join` into the Σ instead of colliding as
+// compute meets. (`sum` consumes the Σ via `Σ <: Fun`.)
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case(
+    "c: bool = True\nsum(([x for x in [1, 2]]) if c else ([y for y in [1, 2, 3]]))",
+    Value::Int(3)
+)]
+#[case(
+    "c: bool = False\nsum(([x for x in [1, 2]]) if c else ([y for y in [1, 2, 3]]))",
+    Value::Int(6)
+)]
+#[case(
+    "c: bool = True\nsum(([x * 10 for x in [1, 2]]) if c else ([y for y in [1, 2, 3]]))",
+    Value::Int(30)
+)]
+fn test_conditional_between_comprehensions(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Conditional element in a comprehension
+//
+// `[a if g(x) else b for x in xs]` — a per-element conditional — fans the source
+// out by each arm's *element-dependent* first-match gate
+// (`lower::comprehension::fan_out_element_case`): `⧺ᵢ [eᵢ for x in xs if π̂ᵢ]`.
+// Each arm is a filtered map (source restricted by the gate, mapped by the arm
+// value); the gates partition the source, so the `++`-union recombines the arms
+// by position into the fully-mapped collection. A `CollectionUnion`, so the
+// compute-kinded per-arm maps do not need to join.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// [1,2,3,4] with `x*10 if x>2 else 0` → [0,0,30,40].
+#[case(
+    "sum([(x * 10 if x > 2 else 0) for x in [1, 2, 3, 4]])",
+    Value::Int(70)
+)]
+// Both arms reference the element.
+#[case(
+    "sum([(x * 2 if x > 2 else x + 100) for x in [1, 2, 3, 4]])",
+    Value::Int(217)
+)]
+// Nested `elif` element flattens to a flat partition.
+#[case(
+    "sum([(100 if x == 1 else 200 if x == 2 else 300) for x in [1, 2, 3]])",
+    Value::Int(600)
+)]
+// Degenerate gates: always-true / never-true.
+#[case("sum([(x if x > 0 else 0) for x in [1, 2, 3]])", Value::Int(6))]
+#[case("sum([(99 if x > 100 else x) for x in [1, 2, 3]])", Value::Int(6))]
+fn test_conditional_element_comprehension(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// The conditional-element comprehension result is a tagged union — one variant
+// per arm, each carrying the elements the arm mapped.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn test_conditional_element_result() {
+    // x>2 → x*10 (positions 2,3 → 30,40); else 0 (positions 0,1 → 0,0).
+    let result = run_pipeline("[(x * 10 if x > 2 else 0) for x in [1, 2, 3, 4]]");
+    assert_eq!(codomain_ints(&result), vec![0, 0, 30, 40]);
+}

--- a/tests/compilation_pipeline/feeds_cases.rs
+++ b/tests/compilation_pipeline/feeds_cases.rs
@@ -346,6 +346,39 @@ d"#;
     );
 }
 
+/// An `if/else` where **both arms feed** a pure-feed loop (no accumulator). The
+/// `else` is an ordinary trailing arm (guard `true`, first-match predicate
+/// `¬(i < 2)`), so it fans out as its own refined-source channel — `channelize`
+/// refines the *source* domain per arm (a shared `Int` codomain), rather than
+/// leaving the guard on a `Unit` gated lift. As a function: 0 ↦ 0, 1 ↦ 1,
+/// 2 ↦ 100, 3 ↦ 100.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn if_else_both_feed_fan_out() {
+    let code = r#"o = defer()
+for i in [0, 1, 2, 3]:
+    if i < 2:
+        o << i
+    else:
+        o << 100
+o"#;
+    check_tile(
+        code,
+        Tile::SealedFunction {
+            domain: ColumnValue::Union {
+                tags: vec![0, 0, 1, 1],
+                variants: vec![
+                    ColumnValue::UInts(vec![0, 1]),
+                    ColumnValue::UInts(vec![2, 3]),
+                ],
+            },
+            codomain: Box::new(Tile::Scalar(ColumnValue::Ints(vec![0, 1, 100, 100]))),
+            domain_predicate: Predicate::Union(vec![Predicate::True, Predicate::True]),
+            deleted: BitSet::new(),
+        },
+    );
+}
+
 /// `<<=` sets a channel's whole stream, so its RHS must be a collection
 /// (a `Fun`). A scalar RHS is rejected by typing — the discipline that keeps
 /// every feed history a genuine `domain ⇒ value` stream (scalar values belong

--- a/tests/compilation_pipeline/scalars_collections.rs
+++ b/tests/compilation_pipeline/scalars_collections.rs
@@ -210,34 +210,7 @@ fn test_tuples(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
 
-// ---------------------------------------------------------------------------
-// Conditional-collection Sigma: the safety chokepoint
-// ---------------------------------------------------------------------------
-
-/// A control-flow join of two differently-sized collections types as the
-/// dependent-sum **conditional collection** over both extents
-/// (`Type::conditional_collection`; see type-inference.md §4.6). This lays only
-/// the *type-level* Sigma (formation + the `Σ <: Fun` elimination rule, so it
-/// can be consumed at the type level); *compiling* it — the value-`Case`
-/// fan-out that eliminates it into a union of restricts — lands with
-/// value-`Case` compilation. Until then a Sigma-consuming program must be
-/// rejected **cleanly** (a returned compile error, never a panic and never a
-/// silent miscompile). The value-`Case` is caught at lambda elimination — the
-/// natural not-yet-implemented boundary value-`Case` compilation graduates.
-/// This pins the contract end-to-end: it type-checks, then fails to compile
-/// without crashing.
-#[test]
-fn conditional_collection_rejected_cleanly() {
-    use cambra::ccl::context::{GlobalContext, compile_program};
-    use cambra::interpreter::Consumer;
-    let mut ctx = GlobalContext::default();
-    let consumer: Box<dyn Consumer> = Box::new(|| {});
-    let errs = compile_program(&mut ctx, "sum([1, 2] if True else [1, 2, 3])", consumer)
-        .err()
-        .expect("a Sigma-consuming program must fail to compile, not miscompile or panic");
-    let rendered = format!("{errs:?}");
-    assert!(
-        rendered.contains("lambda elimination") && rendered.contains("Case"),
-        "expected a clean value-Case not-yet-compilable rejection, got:\n{rendered}"
-    );
-}
+// A conditional collection consumed by `sum` (`sum([1,2] if c else [1,2,3])`)
+// type-checks as a Σ (via the `Σ <: Fun` elimination rule) and *compiles* via
+// value-`Case` elimination — see `conditionals.rs` for the end-to-end
+// compile-and-run coverage.


### PR DESCRIPTION
## Value-Case compilation via literal union-of-restricts

PR 2/7 of the mutability-conditionals stack. With the type system able to describe a
conditional collection as a real dependent sum (the Σ from 1/7), this PR **compiles**
value-selecting conditionals. The unifying idea: a total value selection is a genuine union
of restricted arms `⧺ᵢ (eᵢ ↾ π̂ᵢ)` (first-match predicates `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`), not a
fused select builtin — lazy arm evaluation falls out for free and the union carries its own
extent.

### What changes

- **Scalar value-Case C-form** — a scalar/compute-typed `x = a if p else b` compiles to
  gated scalar lifts over a `Units(1)` driver plus `final_or_default`; the extraction is
  inserted by the rewrite itself. One new operator-level primitive: a constant-predicate
  `Restrict` (dedicated test).
- **Data-typed value-Case gate fan-out** — `xs if c else ys` compiles to the gated union
  `⧺ᵢ (eᵢ ↾ π̂ᵢ)`, whose structural type is a data function over a discriminated-union domain
  `Variant([{Dᵢ | π̂ᵢ}]) ⤇ V`. The fan-out is **Σ-agnostic**: it stamps the union with the
  type inference gave the `Case` (a Σ for distinct extents, or its same-extent collapse to a
  plain data function), so lambda-elim stays type-preserving (Σ in, Σ out).
- **Source-less conditional feeds** — a guard-only source-less feed Case channelizes to gated
  scalar-lift channels rather than dying with `PartialFeedCaseUnsupported`; a scrutinee/pattern
  feed stays rejected.
- **Comprehension conditionals** — comprehension *over* a conditional collection, a conditional
  *element* in a comprehension, and a conditional *between* comprehensions, plus a clear error
  for the deferred per-element case-float case that is not yet wired.
- **if/else (both arms feed) in a pure-feed loop** — the generator lowering emits the `else` as
  the trailing `true`-guarded arm; the loop-source fan-out refines the *source* domain per arm
  into disjoint refined-source channels with a shared codomain.
- **Off-path laziness** — the scalar C-form never evaluates an off-path arm: `MapResultToConst`
  skips *pulling* the constant when all driver rows are deleted, so a partial off-path
  expression (e.g. `total // x` under `x != 0`) never faults. Pinned by a dedicated test.

### How the compiled form types against the Σ

The reconciliation between the compiled fan-out and the Σ is **not** an ad-hoc "bridge rule" —
it is the finite-Σ = gated-coproduct isomorphism, `Σ(w∈{Dᵢ}). w⤇V ≅ ⊕ᵢ (Dᵢ⤇V) ≅
Variant([{Dᵢ|π̂ᵢ}]) ⤇ V`. A function over a disjoint-union domain is normally a *product* of
fibers (total on all), the wrong type; the exclusive+exhaustive gates zero out all-but-one leg
(empty = unit), collapsing the product to the coproduct. So the wall check is **Σ-introduction**
(covariant — an introduction, not the function-domain contravariance): the compiled gated
partition realizes the whole Σ.

- **distinct extents** — the gated partition subtypes the Σ (`Fun(Data) <: Σ`), sound iff the
  legs' base extents, *as a set*, equal the Σ candidates (every fiber realized, nothing extra).
  This corrects a positional leg↔candidate bijection an earlier draft used, which rejected a
  valid `Case` whose branches *share* an extent (e.g. `[1] if a else [2] if b else [3,3]` — two
  length-1 legs, one Σ candidate). A dedicated repeated-extent test locks it.
- **same-extent collapse** — the Σ collapses to a plain data function `D ⤇ V`, and the gated
  partition subtypes that directly (`is_index_partition_of`).
- **consumption** — a conditional collection consumed as a plain collection is the `Σ <: Fun`
  elimination rule from 1/7.

The gates' exclusivity+exhaustiveness — the precondition the isomorphism rests on — is a
`lambda_elim` construction invariant (asserted at the fan-out boundary: a non-exhaustive
value-`Case` would realize an empty collection on the uncovered path, a silent miscompile),
not re-proven in the solver. Op-conversion compiles the union straight to a `UnionOperator`
from its operands (concrete extents), never consulting the Σ, so no Σ reaches a runtime
operator.

### Docs
`src/ccl/design/mutability.md` (value selection graduates out of "Not yet implemented"; `⧺` as
both spec and operational form); `src/interpreter/design-operators.md` (constant-predicate
Restrict); `src/ccl/design/type-inference.md` §4.6 (Σ-introduction).

Green under `./ci.sh`. Conditional *induction writes* (3/7) and path-based `with begin():`
conditionals (4/7) build on this.


Continues cambra-dev/cambra-old#303 (review history there).
