### PR TITLE
Compound (tuple/record) mutable registers (induction + transactions)

### DIFF
--- a/src/ccl/lower/comprehension.rs
+++ b/src/ccl/lower/comprehension.rs
@@ -275,9 +275,9 @@ fn float_comp_source_case(source: Expr, iter_var: &str, body: &Expr) -> Expr {
     // chain Phase 5 builds. The compose form is equivalent (a map applies the
     // body to each element) but `emit_compose` stamps it with the *source's*
     // data kind (a map over a collection is itself a collection). That data kind
-    // is what lets two such arms of a conditional source `sigma_join` into the Σ
-    // (compiled by the gate fan-out) rather than colliding as compute-kinded
-    // lambdas whose distinct index extents would meet.
+    // is what lets two such arms of a conditional source join into the
+    // coproduct (`union_extents`, compiled by the gate fan-out) rather than
+    // colliding as compute-kinded lambdas whose distinct index extents would meet.
     Expr::compose(vec![
         source,
         Expr::lambda(iter_var, Type::Hole, body.clone()),

--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -898,6 +898,22 @@ pub(super) fn lower_type_annotation(annotation: &Spanned<ChlExpr>) -> Result<Typ
             )),
         },
         ChlExpr::Lit(ChlLit::None) => Ok(Type::Base(BaseType::Unit)),
+        // A tuple type annotation `(A, B, …)` — e.g. a compound register value
+        // type `Mut[(int, int), Txn]`. Each element lowered recursively.
+        ChlExpr::Tuple(parts) => Ok(Type::Tuple(
+            parts
+                .iter()
+                .map(lower_type_annotation)
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+        // A record type annotation `{x: A, y: B}` — e.g. `Mut[{x: int}, Txn]`.
+        // Bare-identifier keys (a `Record`, not an expression-keyed `Dict`).
+        ChlExpr::Record(fields) => Ok(Type::Record(
+            fields
+                .iter()
+                .map(|f| Ok((f.name.to_string(), lower_type_annotation(&f.value)?)))
+                .collect::<Result<Vec<_>, LoweringError>>()?,
+        )),
         // Subscripted type constructors, e.g. `List[T]`. The wildcard is
         // accepted anywhere, so `List[_]` recurses to an element `Hole`.
         ChlExpr::Subscript { target, index } => {

--- a/src/interpreter/commit_operator.rs
+++ b/src/interpreter/commit_operator.rs
@@ -315,15 +315,22 @@ enum InitDrainFailure {
 /// produced but stayed empty) from a [`InitDrainFailure::Diverged`] one (no
 /// scalar tile settled within the bound).
 fn read_initial_scalar(producer: &mut dyn TileProducer) -> Result<Value, InitDrainFailure> {
+    use crate::interpreter::tile_operators::scalar_tile_to_column_value;
     let guard = producer.tiling().universal_guard();
     let mut saw_empty_scalar = false;
     for _ in 0..MAX_INIT_PULLS {
-        if let Tile::Scalar(cv) = producer.get(guard.clone()) {
-            if !cv.is_empty() {
-                return Ok(cv.index_at(0));
-            }
-            saw_empty_scalar = true;
+        // A compound (tuple/record) accumulator's init is struct-of-arrays
+        // (`Tile::Record`); box it into a single scalar record value so it seeds
+        // like any scalar. A plain scalar init passes straight through.
+        let cv = match producer.get(guard.clone()) {
+            Tile::Scalar(cv) => cv,
+            tile @ Tile::Record(_) => scalar_tile_to_column_value(tile),
+            _ => continue,
+        };
+        if !cv.is_empty() {
+            return Ok(cv.index_at(0));
         }
+        saw_empty_scalar = true;
     }
     // A scalar that stayed empty across the bound is a genuinely empty init; a
     // producer that never even yielded a scalar never settled.

--- a/src/interpreter/design-operators.md
+++ b/src/interpreter/design-operators.md
@@ -370,6 +370,22 @@ folds a conditional write to one carry-complete writer (`writes = Case[ĝ → w;
 snapshot]`), so there is no multi-writer group and no dense-`Recurse` fallback — the former
 second realization is fully retired.
 
+**Compound (tuple/record) accumulators.** A register holds one `Value`, so a tuple/record
+accumulator is stored *boxed* — a `Scalar(Record)` codomain (one column of record values) —
+while a tuple/record *literal* compiles to a struct-of-arrays `Record` tiling (a column per
+field). The two representations meet at the register boundaries and are reconciled there with
+the existing `scalar_tile_to_column_value` (box: `Tile::Record` → `ColumnValue::Records`) and
+its inverse `column_value_to_tile` (unbox to a declared tiling shape): the `InductionStore`
+init seed (`read_initial_scalar`), the conditional-write decision merge (`flat_merge`), and
+the scalar-final read (`ExtractLast`, which matches on *extent* not tiling shape). So a
+compound accumulator folds, reads-its-own-writes, carries, and conditionally writes like a
+scalar one. The **commit store** shares this: a `Mut[(int, int), Txn]` / `Mut[{x: int}, Txn]`
+transactional register threads through the same `read_initial_scalar` seed and value-Case
+decision merge, so unconditional, conditional (deny), `if`/`else`, record, and mixed
+scalar+compound multi-key stores all commit correctly. (Enabling the transactional form needed
+only the tuple/record *type annotation* syntax in `lower_type_annotation` — the store
+machinery was already compound-ready.)
+
 The finite/async split — the one place in the substrate that distinguished a finite source
 from a streaming one — is **gone**. Everywhere else the tiling protocol treats a finite
 source as a stream that happens to terminate (comprehensions, joins, aggregates all run over

--- a/src/interpreter/tile_operators/extract_last.rs
+++ b/src/interpreter/tile_operators/extract_last.rs
@@ -43,10 +43,16 @@ impl ExtractLast {
             Tiling::SealedFunction { codomain, .. } => *codomain.clone(),
             other => panic!("ExtractLast source must have SealedFunction tiling, got {other}"),
         };
+        // The default and the source codomain need only describe the same
+        // value-space (extent); their *structural* tilings may differ. A
+        // record/tuple value is `Scalar(Record)` from a register history but
+        // `Record({_0: Scalar, …})` (struct-of-arrays) from a literal. `get_impl`
+        // normalizes both through `scalar_tile_to_column_value`, so the real
+        // invariant is that the extents agree, not the tiling shapes.
         debug_assert_eq!(
-            default.tiling(),
-            &tiling,
-            "ExtractLast default tiling must match source codomain tiling",
+            default.tiling().extent(),
+            tiling.extent(),
+            "ExtractLast default extent must match source codomain extent",
         );
         Self {
             source,

--- a/src/interpreter/tile_operators/helpers.rs
+++ b/src/interpreter/tile_operators/helpers.rs
@@ -91,7 +91,7 @@ pub(crate) fn apply_function_tile(
 ///
 /// - `Tiling::Scalar` → `Tile::Scalar(cv)`
 /// - `Tiling::Record` → `Tile::Record(fields)` where each field is rebuilt recursively
-fn column_value_to_tile(cv: ColumnValue, tiling: &Tiling) -> Tile {
+pub(crate) fn column_value_to_tile(cv: ColumnValue, tiling: &Tiling) -> Tile {
     match tiling {
         Tiling::Scalar(_) => Tile::Scalar(cv),
         Tiling::Record(fields) => {

--- a/src/interpreter/tile_operators/union.rs
+++ b/src/interpreter/tile_operators/union.rs
@@ -109,10 +109,12 @@ impl UnionOperator {
 /// key. Each arm is a filtered slice of the *same* fed element stream (a
 /// writer-body value-`Case` fan-out `⧺ᵢ filter_values(π̂ᵢ) ≫ eᵢ`), so the arms'
 /// (`UInt`) positions are disjoint and reassemble the full column — which then
-/// co-iterates with the decision record's sibling `commit` field. Scalar codomain
-/// only (the value a decision field produces); the shared fed predicate is taken
-/// from the first arm (all arms carry it).
-fn flat_merge(tiles: Vec<Tile>, value_extent: &Extent) -> Tile {
+/// co-iterates with the decision record's sibling `commit` field. The codomain is
+/// a scalar decision-field value, or a boxed-compound `Tile::Record` for a
+/// tuple/record accumulator; the shared fed predicate is taken from the first arm
+/// (all arms carry it).
+fn flat_merge(tiles: Vec<Tile>, codomain_tiling: &Tiling) -> Tile {
+    let value_extent = codomain_tiling.extent();
     let mut pairs: Vec<(usize, Value)> = Vec::new();
     let mut domain_predicate = Predicate::False;
     for (i, tile) in tiles.into_iter().enumerate() {
@@ -128,11 +130,18 @@ fn flat_merge(tiles: Vec<Tile>, value_extent: &Extent) -> Tile {
         if i == 0 {
             domain_predicate = dp;
         }
-        let Tile::Scalar(values) = *codomain else {
-            panic!(
-                "flat_merge: writer-body value-Case arm has a Scalar codomain, got {codomain:?}"
-            );
-        };
+        // The decision field's value is usually a scalar, but a compound
+        // (tuple/record) accumulator carries a struct-of-arrays `Tile::Record`
+        // codomain; box it to a single record-valued column so each row extracts
+        // as one `Value`. `scalar_tile_to_column_value` is identity on a scalar.
+        // A function-valued codomain (a collection-valued register) is out of
+        // scope and would panic generically inside the helper — name the boundary.
+        debug_assert!(
+            matches!(codomain.as_ref(), Tile::Scalar(_) | Tile::Record(_)),
+            "flat_merge: a writer-body value-Case arm must have a scalar or \
+             boxed-compound codomain, got {codomain:?}"
+        );
+        let values = scalar_tile_to_column_value(*codomain);
         for row in 0..domain.len() {
             if deleted.contains(row) {
                 continue;
@@ -148,9 +157,13 @@ fn flat_merge(tiles: Vec<Tile>, value_extent: &Extent) -> Tile {
     pairs.sort_by_key(|(pos, _)| *pos);
     let positions: Vec<usize> = pairs.iter().map(|(pos, _)| *pos).collect();
     let values: Vec<Value> = pairs.into_iter().map(|(_, v)| v).collect();
+    // Build the codomain to match the operator's *declared* tiling shape: a
+    // scalar field stays `Tile::Scalar`, a compound (tuple/record) field unboxes
+    // the record-valued column back into a struct-of-arrays `Tile::Record`.
+    let cv = ColumnValue::from_values(values, &value_extent);
     Tile::SealedFunction {
         domain: ColumnValue::from_uints(positions),
-        codomain: Box::new(Tile::Scalar(ColumnValue::from_values(values, value_extent))),
+        codomain: Box::new(column_value_to_tile(cv, codomain_tiling)),
         domain_predicate,
         deleted: BitSet::new(),
     }
@@ -234,11 +247,11 @@ impl TileProducer for UnionProducer {
             .collect();
 
         if self.flat {
-            let value_extent = match self.tiling() {
-                Tiling::SealedFunction { codomain, .. } => codomain.extent(),
+            let codomain_tiling = match self.tiling() {
+                Tiling::SealedFunction { codomain, .. } => (**codomain).clone(),
                 other => panic!("flat union tiling is a SealedFunction, got {other}"),
             };
-            return flat_merge(tiles, &value_extent);
+            return flat_merge(tiles, &codomain_tiling);
         }
 
         let mut domains: Vec<ColumnValue> = Vec::new();

--- a/tests/compilation_pipeline/mutability.rs
+++ b/tests/compilation_pipeline/mutability.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use bit_set::BitSet;
 use cambra::ccl::context::{CompileResultExt, GlobalContext, compile_program, render_errors};
-use cambra::interpreter::{ColumnValue, Consumer, Predicate, Tile};
+use cambra::interpreter::{ColumnValue, Consumer, Predicate, Tile, Value};
 use rstest_log::rstest;
 
 use crate::helpers::*;
@@ -808,5 +808,58 @@ fn trailing_hidden_writer_loop_compiles() {
             .err()
             .map(|e| render_errors(&e, "<test>", code))
             .unwrap_or_default()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Compound (tuple / record) mutable registers
+//
+// A register holds one `Value`, so a tuple/record accumulator is a boxed
+// `Scalar(Record)` in the changelog, while a tuple/record *literal* compiles to
+// a struct-of-arrays `Record` tiling. The two representations are reconciled at
+// the register boundaries (`read_initial_scalar` seeding, `flat_merge` decision
+// values, `ExtractLast` extent-match) via `scalar_tile_to_column_value` /
+// `column_value_to_tile`. These pin that a compound induction accumulator folds,
+// reads-its-own-writes, and carries correctly.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// Unconditional: the whole tuple is overwritten each step → last write (3, 3).
+#[case("acc := (0, 0)\nfor i in [1, 2, 3]:\n    acc := (i, i)\nacc", make_tuple(&[Value::Int(3), Value::Int(3)]))]
+// Read-your-writes across both fields: acc.0 = 0+1+2+3 = 6, acc.1 = 10+1+2+3 = 16.
+#[case("acc := (0, 10)\nfor i in [1, 2, 3]:\n    acc := (acc[0] + i, acc[1] + i)\nacc", make_tuple(&[Value::Int(6), Value::Int(16)]))]
+// Single-arm conditional write to a tuple: fires at i>1 → last (3, 3).
+#[case("acc := (0, 0)\nfor i in [1, 2, 3]:\n    if i > 1:\n        acc := (i, i)\nacc", make_tuple(&[Value::Int(3), Value::Int(3)]))]
+// if/else both arms write different tuples: i=3 → i>2 arm → (3, 30).
+#[case("acc := (0, 0)\nfor i in [1, 2, 3]:\n    if i > 2:\n        acc := (i, i * 10)\n    else:\n        acc := (i, i)\nacc", make_tuple(&[Value::Int(3), Value::Int(30)]))]
+// Trailing carries: writes at i<3 (1,2), carries at 3,4,5 → final (2, 2).
+#[case("acc := (0, 0)\nfor i in [1, 2, 3, 4, 5]:\n    if i < 3:\n        acc := (i, i)\nacc", make_tuple(&[Value::Int(2), Value::Int(2)]))]
+// Heterogeneous tuple (Int, String).
+#[case("acc := (0, \"a\")\nfor i in [1, 2]:\n    acc := (i, \"b\")\nacc", make_tuple(&[Value::Int(2), Value::String("b".into())]))]
+// Three-tuple.
+#[case("acc := (0, 0, 0)\nfor i in [1, 2, 3]:\n    acc := (i, i * 2, i * 3)\nacc", make_tuple(&[Value::Int(3), Value::Int(6), Value::Int(9)]))]
+// Named record register.
+#[case("acc := {x: 0, y: 0}\nfor i in [1, 2, 3]:\n    acc := {x: i, y: i + i}\nacc", make_record(&[("x", Value::Int(3)), ("y", Value::Int(6))]))]
+fn test_compound_register(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+/// Projecting a field off the final tuple accumulator: `acc[0]` after the loop.
+#[test]
+fn test_compound_register_field_read() {
+    check_scalar(
+        "acc := (0, 0)\nfor i in [1, 2, 3]:\n    acc := (acc[0] + i, acc[1])\nacc[0]",
+        Value::Int(6),
+    );
+}
+
+/// A nested tuple `((i, i), i)` — `scalar_tile_to_column_value` /
+/// `column_value_to_tile` recurse through the nested record.
+#[test]
+fn test_compound_register_nested() {
+    check_scalar(
+        "acc := ((0, 0), 0)\nfor i in [1, 2]:\n    acc := ((i, i), i)\nacc",
+        make_tuple(&[make_tuple(&[Value::Int(2), Value::Int(2)]), Value::Int(2)]),
     );
 }

--- a/tests/compilation_pipeline/transactions.rs
+++ b/tests/compilation_pipeline/transactions.rs
@@ -461,6 +461,111 @@ fn commit_stream(ticks: &[usize], values: &[i64]) -> Tile {
     }
 }
 
+/// Drive a program whose result is a single trailing-commit read and return the
+/// committed `Value` at position 0. A compound (tuple/record) register reads back
+/// boxed (`Scalar(Record)`) or struct-of-arrays depending on the read path; both
+/// fold to the same `Value` through `scalar_tile_to_column_value`, so this asserts
+/// on the *value* rather than the (path-dependent) tile shape.
+fn trailing_commit_value(code: &str) -> Value {
+    use cambra::interpreter::tile_operators::scalar_tile_to_column_value;
+    let Tile::SealedFunction {
+        domain, codomain, ..
+    } = run_pipeline(code)
+    else {
+        panic!("expected a commit stream");
+    };
+    assert_eq!(domain.len(), 1, "expected exactly one trailing commit");
+    scalar_tile_to_column_value(*codomain).index_at(0)
+}
+
+// ---------------------------------------------------------------------------
+// Compound (tuple / record) transactional registers
+//
+// A `Mut[(int, int), Txn]` / `Mut[{x: int}, Txn]` register holds one compound
+// `Value`; the commit-store path already threads it (it shares the induction
+// path's `read_initial_scalar` seeding and boxes/unboxes at the value-Case
+// decision merge). Enabling it needed only the tuple/record *type annotation*
+// forms in `lower_type_annotation`.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// Unconditional tuple register: (100,0) −10/+10 → (90,10) −20/+20 → (70,30).
+#[case(indoc! {r#"
+    out = defer()
+    p: Mut[(int, int), Txn] := (100, 0)
+    for r in [10, 20]:
+        with begin():
+            p := (p[0] - r, p[1] + r)
+    with begin():
+        out << p
+    out
+"#}, make_tuple(&[Value::Int(70), Value::Int(30)]))]
+// Conditional tuple write with a deny: r=60 commits (100≥60 → (40,60)); r=60 again
+// denies (40≥60 false) → stays (40,60).
+#[case(indoc! {r#"
+    out = defer()
+    p: Mut[(int, int), Txn] := (100, 0)
+    for r in [60, 60]:
+        with begin():
+            if p[0] >= r:
+                p := (p[0] - r, p[1] + r)
+    with begin():
+        out << p
+    out
+"#}, make_tuple(&[Value::Int(40), Value::Int(60)]))]
+// if/else both arms write a tuple: r=3 → r>2 arm → (3, 30).
+#[case(indoc! {r#"
+    out = defer()
+    p: Mut[(int, int), Txn] := (0, 0)
+    for r in [1, 2, 3]:
+        with begin():
+            if r > 2:
+                p := (r, r * 10)
+            else:
+                p := (r, r)
+    with begin():
+        out << p
+    out
+"#}, make_tuple(&[Value::Int(3), Value::Int(30)]))]
+// Named record register.
+#[case("out = defer()\np: Mut[{x: int, y: int}, Txn] := {x: 100, y: 0}\nfor r in [10, 20]:\n    with begin():\n        p := {x: p.x - r, y: p.y + r}\nwith begin():\n    out << p\nout", make_record(&[("x", Value::Int(70)), ("y", Value::Int(30))]))]
+// Mixed multi-key store: a scalar key `s` and a tuple key `p`, atomic per commit.
+// s = 10+20 = 30; p = (70, 30); trailing read `(s, p)`.
+#[case(indoc! {r#"
+    out = defer()
+    s: Mut[int, Txn] := 0
+    p: Mut[(int, int), Txn] := (100, 0)
+    for r in [10, 20]:
+        with begin():
+            s := s + r
+            p := (p[0] - r, p[1] + r)
+    with begin():
+        out << (s, p)
+    out
+"#}, make_tuple(&[Value::Int(30), make_tuple(&[Value::Int(70), Value::Int(30)])]))]
+fn test_compound_txn_register(#[case] code: &str, #[case] expected: Value) {
+    assert_eq!(trailing_commit_value(code), expected);
+}
+
+/// A field projected off a tuple transactional register in the trailing read.
+#[test]
+fn test_compound_txn_register_field() {
+    assert_eq!(
+        trailing_commit_value(indoc! {r#"
+                out = defer()
+                p: Mut[(int, int), Txn] := (100, 0)
+                for r in [10, 20]:
+                    with begin():
+                        p := (p[0] - r, p[1] + r)
+                with begin():
+                    out << p[0]
+                out
+            "#}),
+        Value::Int(70),
+    );
+}
+
 /// `out << pool` *inside* the block reports each transaction's committed
 /// (read-your-writes) value: `pool - r` after the write — 90, 70, 40 over commit
 /// ticks 1, 2, 3. The feed rides the writer decision as a `to_out` tap,


### PR DESCRIPTION
## Compound (tuple / record) mutable registers

A follow-up on top of the mutability-conditionals stack (based on 7/7, #308). Makes
**tuple- and record-valued mutable registers** work end-to-end, on both the induction
(`for` loop) and transactional (`with begin():`) paths. Found while reviewing the stack:
a compound accumulator previously **panicked** at op-conversion.

```python
acc := (0, 0)
for i in [1, 2, 3]:
    acc := (acc[0] + i, acc[1] + i)
acc                       # was: panic  →  now: (6, 16)

p: Mut[(int, int), Txn] := (100, 0)
for r in [10, 20]:
    with begin():
        p := (p[0] - r, p[1] + r)
# ... trailing read           →  (70, 30)
```

### Root cause

A mutable register holds one `Value`, so a compound accumulator is stored **boxed** — a
`Scalar(Record)` codomain (one column of record values) — while a tuple/record *literal*
compiles to a **struct-of-arrays** `Record` tiling (a column per field). The two
representations met *unreconciled* at the register boundaries, so the runtime tripped an
assert (a `debug_assert` in `ExtractLast`; hard asserts elsewhere).

The interpreter already has both converters — `scalar_tile_to_column_value`
(`Tile::Record` → boxed `ColumnValue::Records`) and its inverse `column_value_to_tile`
(unbox to a declared tiling shape). They just weren't applied at these seams.

### The fix

Four representation seams (each a small application of the existing helpers):

- **`ExtractLast::new`** — the assert compared tiling *structure*, but `get_impl` already
  boxes both source codomain and default via `scalar_tile_to_column_value`; the real
  invariant is equal *extent*, so match on that.
- **`read_initial_scalar`** (the changelog / commit-store init seed) — only matched
  `Tile::Scalar`; box a `Tile::Record` init into one record `Value`. Shared by the
  induction and commit stores.
- **`flat_merge`** (the conditional-write decision-value merge) — box each arm's codomain
  in, then rebuild the merged codomain to the operator's **declared** tiling shape via
  `column_value_to_tile` (a scalar field stays `Scalar`; a compound field unboxes to
  struct-of-arrays). This also fixes `if`/`else`-both-write, which otherwise emitted a
  boxed codomain against a struct-of-arrays declared tiling.

Plus two **type-annotation** forms in `lower_type_annotation`, the only thing blocking the
transactional variant (`Mut[(int, int), Txn]` / `Mut[{x: int}, Txn]`) — the store
machinery was already compound-ready:

- `ChlExpr::Tuple` → `Type::Tuple`
- `ChlExpr::Record` → `Type::Record`

### What works now (all tested)

Induction *and* transactions, over: unconditional writes, single-arm / `if`-`else` /
`elif` conditional writes (incl. deny), read-your-writes across fields, field projection
off the final value, heterogeneous tuples `(int, str)`, N-tuples, **nested** tuples
`((i, i), i)`, trailing-carry conditionals, named records, 3-field records, and mixed
scalar + compound multi-key stores (atomic per commit).

18 tests: 12 induction cases in `mutability.rs`, 6 transactional cases in `transactions.rs`.

### Still not supported (graceful, not a panic)

`for i in []` (empty-loop) yields a `Incompatible lower bounds` type error — but this is
**identical for a scalar register**, so it's an orthogonal empty-list inference issue, not
compound-related.

Green under `./ci.sh` (both clippy passes + doc + full suite).



Continues cambra-dev/cambra-old#309 (review history there).
