### PR TITLE
CI tripwire against pre-rewrite history; lowercase repository URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Full-history fetch of all refs so the pre-rewrite tripwire below
+          # sees every commit reachable from the repo, not just the PR head.
+          fetch-depth: 0
+
+      # This repo was recreated from filter-rewritten history; cbf7ce76 is the
+      # tip of the retired pre-rewrite history (kept in cambra-dev/cambra-old).
+      # If that commit is present, someone pushed a ref based on the old
+      # history, which would republish the content the rewrite removed. Fail
+      # before anything else runs.
+      - name: Refuse pre-rewrite history
+        run: |
+          if git cat-file -e cbf7ce7624005647b6c019e1651dca9806b9738e 2>/dev/null; then
+            echo "::error::Pre-rewrite history detected: commit cbf7ce76 is reachable from a ref in this repo (possibly this PR). Rebase the offending branch onto the rewritten main and delete any ref that carries the old history."
+            exit 1
+          fi
 
       # Validate intra-repo doc references (Markdown links/anchors + code->doc
       # citations). Deliberately runs on EVERY PR — including docs-only ones,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "A programming language with a dependently-typed functional core and streaming-dataflow execution"
-repository = "https://github.com/cambra-dev/Cambra"
+repository = "https://github.com/cambra-dev/cambra"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Two pieces of post-cutover housekeeping:

**History tripwire.** This repo was recreated from filter-rewritten history on 2026-07-22; the pre-rewrite history lives on in cambra-dev/cambra-old. If anyone pushes a branch based on the old history, the content the rewrite removed gets republished. The new CI step fails any run where the pre-rewrite tip commit (cbf7ce76) is reachable from a fetched ref, with an error message that says how to fix it.

*Why repo-wide rather than per-PR:* the checkout fetches all refs (`fetch-depth: 0`), so a single poisoned ref fails every CI run until it's deleted. That's deliberate. The harm is exposure, not a bad merge — the moment an old-based branch is pushed, the removed content is visible on GitHub regardless of what CI says — so the design optimizes time-to-detection: a repo-wide check alarms on the next run of any PR, while a per-PR check only fires if the poisoned branch itself opens a PR, leaving a quietly pushed branch exposed indefinitely. Stopping the line until the ref is excised is the intended response, and recovery is immediate: fetch only transfers objects reachable from advertised refs, so runs go green as soon as the offending ref is deleted. If cross-PR failures ever prove too disruptive, the fallback is a per-PR scoped check plus a scheduled all-refs sweep that alerts Slack.

*Fetch cost:* the full-history all-refs fetch replaces the previous depth-1 fetch. Today that's ~380 commits of a source-only repo — a few MB and well under a second, noise next to the Rust build. Cost grows with history, but a text-source repo needs tens of thousands of commits before a full fetch takes even seconds; if checkout time ever becomes noticeable, switch to the scoped-fetch fallback rather than dropping the guard.

*When to remove:* the only sources of pre-rewrite history are team machines with pre-cutover clones and cambra-dev/cambra-old — the old repo was never public, so external contributors cannot carry the poison. Remove the tripwire (and the `fetch-depth: 0` that serves it) once every pre-cutover local clone is retired; realistically, revisit a month or two after launch once all active work demonstrably lives on rewritten history.

**Repository URL case.** Cargo.toml pointed at `cambra-dev/Cambra`; the repo is now spelled lowercase. GitHub resolves both, so this is cosmetic consistency.