### PR TITLE
mutability-conditionals 1/7: data/compute function kinds and kind inference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,8 @@ Vocabulary, matching `src/ccl/symbolic.rs`:
 
 Types (from `Display for Type` in `src/ccl/mod.rs`):
 
-- **Function**: `(T ⇒ U)`.
+- **Function**: `(T ⇒ U)` for a compute function; `(T ⤇ U)` (plain-text `|=>`) for a data function (the domain is the data map, joins must be lossless). FunKind is inferred by the solver (`FunKind::Var`, resolved at coalesce — see `src/ccl/design/type-inference.md` §4.6) and `Display` renders it live: a data collection shows `⤇`, a capability (and a genuinely unresolved kind var) `⇒`. A comprehension over a **let-bound** collection source resolves to `⤇` just like one over a literal source (`let x = [1,2,3] in [y + 10 for y in x]` is `⤇`) — its domain is a data collection.
+- **Sigma** (in-flight, same stack): `Σ{D0, D1} ⤇ V` — a data function whose domain is exactly one of the listed choices; with a live witness binder, `(Σ n ∈ {D0, D1}. n ⤇ V)`.
 - **Refinement**: `{T | predicate}` — predicate is rendered via `symbolic`.
 - **UIntRange**: `[0, N]`, or `∅` when empty.
 - **Hole**: `_`.
@@ -158,6 +159,7 @@ Use the symbolic forms below in prose and inline pseudo-code (not in fenced code
 
 - **Function type with named binder** (`Type::Fun` with `name: Some(_)`): `(𝑥: 𝐴) ⇒ 𝐵`. `𝑥` is bound in `𝐵`.
 - **Function type with no named binder** (`Type::Fun` with `name: None`): `𝐴 ⇒ 𝐵`.
+- **Data function type** (`FunKind::Data`, kind inferred and rendered live): `𝐴 ⤇ 𝐵`, named-binder form `(𝑥: 𝐴) ⤇ 𝐵` — same associativity as `⇒`; the bar reads "the domain is the data". **Σ type** (formation live; witness binder still dormant): `Σ 𝑛 ∈ {𝐷₀, 𝐷₁}. 𝑛 ⤇ 𝑉` — a dependent sum over candidate domains; anonymous-witness shorthand `Σ{𝐷₀, 𝐷₁} ⤇ 𝑉`.
 - **Refinement type**: `{𝑥: 𝑇 | 𝑝(𝑥)}` — standard subset-type notation.
 - **Lambda** (term): `λ 𝑥 → body`. The `→` after the binder separates the parameter from the body.
 - **Forward apply** (term level): `𝑎 ▷ 𝑓` means `𝑓(𝑎)`.

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -13,6 +13,103 @@ pub(crate) fn is_builtin(expr: &Expr, b: Builtin) -> bool {
     matches!(&expr.node, TypedExprNode::Builtin(x) if *x == b)
 }
 
+/// Whether `e` is a chain-head **iteration-source marker** `iterate(pred)` —
+/// `Apply(pred, Builtin::Iterate)`. Planning inserts these into the *term tree*
+/// ([`crate::ccl::planning::insert_iterate_markers`]) to mark an extent as an
+/// iteration site; `iterate ≫ src` denotes exactly `src` (the marker is
+/// denotation-neutral).
+pub(crate) fn is_iterate_marker(e: &Expr) -> bool {
+    matches!(&e.node, TypedExprNode::Apply { function, .. } if is_builtin(function, Builtin::Iterate))
+}
+
+/// Strip chain-head `iterate` source markers from a term, flattening the
+/// `Compose` chains they head (`iterate ≫ src` ⟹ `src`).
+///
+/// Used when a term value is substituted **into a type** (a refinement
+/// predicate — e.g. the §6.2 move-site discharge of a `let`-bound collection
+/// into a refined domain like a join predicate `{d | __elem ▷ (.0 ≫ a) …}`). A
+/// refinement predicate is a *denotational* term; the `iterate` marker is a
+/// term-tree planning artifact with no meaning there, and leaving it in makes
+/// the predicate churn under `simplify` (nested-`Compose` vs `flatten_compose`)
+/// and diverge from inference's (pre-marker) copy at the post-planning
+/// typecheck. Since `iterate` is denotation-neutral, dropping it recovers the
+/// collection's value unchanged.
+///
+/// A `restrict`/`filter_values` marker is deliberately **not** stripped — it is
+/// a real filter and part of the denotation; a filtered source reaching a
+/// predicate is an unsupported case caught loudly by
+/// [`debug_assert_no_iteration_markers_in_type`] rather than silently mis-stripped.
+pub(crate) fn strip_iterate_markers(e: &Expr) -> Expr {
+    let mut out = e.clone();
+    out.map_children(|c| strip_iterate_markers(&c));
+    if let TypedExprNode::Compose(elts) = &out.node {
+        let mut flat: Vec<Expr> = Vec::new();
+        for elt in elts {
+            if is_iterate_marker(elt) {
+                continue; // drop the neutral source marker
+            }
+            match &elt.node {
+                // Splice a nested compose the substitution created (e.g.
+                // `(a ≫ f)[a ↦ iterate ≫ xs]` = `(iterate ≫ xs) ≫ f`).
+                TypedExprNode::Compose(inner) => flat.extend(inner.iter().cloned()),
+                _ => flat.push(elt.clone()),
+            }
+        }
+        let ty = out.ty.clone();
+        return match flat.len() {
+            0 => out,
+            1 => flat.into_iter().next().expect("len == 1"),
+            _ => Expr::compose(flat).with_ty(ty),
+        };
+    }
+    out
+}
+
+/// Debug-only invariant: no refinement predicate embedded in `ty` contains an
+/// `iterate` or `restrict` planning marker. Predicates are denotational; markers
+/// are term-tree artifacts. Upheld by [`strip_iterate_markers`] at the term→type
+/// substitution boundary. A `restrict` here means a *filtered* source reached a
+/// predicate (e.g. `x in [y for y in ys if p]`) — a real but unsupported case
+/// that should surface loudly, not miscompile.
+#[cfg(debug_assertions)]
+pub(crate) fn debug_assert_no_iteration_markers_in_type(ty: &Type) {
+    fn expr_has_marker(e: &Expr) -> bool {
+        is_iterate_marker(e)
+            || is_builtin_applied(e, Builtin::Restrict)
+            || e.fold_children(false, |acc, c| acc || expr_has_marker(c))
+    }
+    fn go(ty: &Type) {
+        if let Type::Refinement(_, r) = ty {
+            debug_assert!(
+                !expr_has_marker(&r.predicate),
+                "iteration/restrict marker leaked into a refinement predicate: {}",
+                crate::ccl::symbolic::symbolic(&r.predicate)
+            );
+        }
+        ty.walk_children(go);
+    }
+    go(ty);
+}
+
+/// Whether `e` applies `b` as its function (`Apply { function: Builtin(b) }`).
+#[cfg(debug_assertions)]
+fn is_builtin_applied(e: &Expr, b: Builtin) -> bool {
+    matches!(&e.node, TypedExprNode::Apply { function, .. } if is_builtin(function, b))
+}
+
+/// Debug-only invariant walk over a whole expression tree: every node's type
+/// (and a `Cast`'s target) is checked marker-free by
+/// [`debug_assert_no_iteration_markers_in_type`]. Called at the planning→
+/// op-conversion boundary to catch a marker that leaked into a predicate.
+#[cfg(debug_assertions)]
+pub(crate) fn debug_assert_no_iteration_markers(expr: &Expr) {
+    debug_assert_no_iteration_markers_in_type(&expr.ty);
+    if let TypedExprNode::Cast { target, .. } = &expr.node {
+        debug_assert_no_iteration_markers_in_type(target);
+    }
+    expr.walk_children(debug_assert_no_iteration_markers);
+}
+
 /// Builds an application of a primitive combinator, setting the types based on
 /// the input expression's type and the provided output type.
 pub fn apply_primitive(expr: Expr, primitive: Builtin, output_ty: Type) -> Expr {
@@ -297,8 +394,8 @@ pub fn cast_target_refinement(target: &Type) -> Option<Refinement> {
 ///
 /// `base_domain` and `codomain` are typically `Type::Hole` at lowering time;
 /// inference fills them in by unifying against the value being cast.
-pub fn refined_fn_type(base_domain: Type, predicate: Expr, codomain: Type) -> Type {
-    Type::fun(
+pub fn refined_data_fun(base_domain: Type, predicate: Expr, codomain: Type) -> Type {
+    Type::data_fun(
         Type::Refinement(Box::new(base_domain), Refinement::born(Rc::new(predicate))),
         codomain,
     )
@@ -314,14 +411,8 @@ pub(crate) fn strip_refinements(ty: &Type) -> Type {
     match ty {
         Type::Refinement(base, _) => strip_refinements(base),
         Type::Fun {
-            name,
-            domain,
-            codomain,
-        } => Type::Fun {
-            name: name.clone(),
-            domain: Box::new(strip_refinements(domain)),
-            codomain: Box::new(strip_refinements(codomain)),
-        },
+            domain, codomain, ..
+        } => Type::fun_like(ty, strip_refinements(domain), strip_refinements(codomain)),
         Type::Tuple(ts) => Type::Tuple(ts.iter().map(strip_refinements).collect()),
         Type::Record(fs) => Type::Record(
             fs.iter()

--- a/src/ccl/channelize.rs
+++ b/src/ccl/channelize.rs
@@ -719,6 +719,8 @@ fn erase_chan_domains_in_type(ty: &mut Type, map: &HashMap<Name, Type>) {
         let value = std::mem::replace(value.as_mut(), Type::Hole);
         *ty = Type::Fun {
             name: None,
+            // A feed channel is a collection stream: erase History → a data function.
+            kind: crate::ccl::ty::FunKind::Data,
             domain: Box::new(domain),
             codomain: Box::new(value),
         };
@@ -858,16 +860,12 @@ fn assert_no_type_residue(expr: &Expr) {
 fn refine_source_domain(source: &mut Expr, refinement: Refinement, ctx: &DesugarCtx) {
     if ctx.input_typed
         && let Type::Fun {
-            name,
-            domain,
-            codomain,
+            domain, codomain, ..
         } = &source.ty
     {
-        source.ty = Type::Fun {
-            name: name.clone(),
-            domain: Box::new(Type::Refinement(domain.clone(), refinement)),
-            codomain: codomain.clone(),
-        };
+        let refined_domain = Type::Refinement(domain.clone(), refinement);
+        let codomain = (**codomain).clone();
+        source.ty = Type::fun_like(&source.ty, refined_domain, codomain);
         return;
     }
     // A typed-order channel source is always a concrete function type, stamped
@@ -2991,6 +2989,7 @@ mod tests {
         let refinement = Refinement::born(Rc::new(pred));
         let typed = Expr::lit(Lit::Unit).with_ty(Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Refinement(Box::new(Type::Hole), refinement)),
             codomain: Box::new(Type::Hole),
         });

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -11,7 +11,7 @@ use log::debug;
 
 use crate::{
     ccl::{
-        Expr, Type, channelize,
+        Expr, channelize,
         infer::{
             InferError, TypeInferenceContext, check_mut_discipline, check_mut_write_targets,
             check_pre_desugar, infer, typecheck,
@@ -795,14 +795,10 @@ pub fn compile_program(
     for (_name, source) in ctx.lowering_ctx().take_sources() {
         let name = source.borrow().get_id().to_string();
         let output_type = source.borrow().output_type();
-        ctx.inference_ctx().register_source_type(
-            &name,
-            Type::Fun {
-                name: None,
-                domain: Box::new(Type::DataSource(name.clone())),
-                codomain: Box::new(output_type),
-            },
-        );
+        // The source's data-function type is constructed inside
+        // `register_source_type` from the element type — the `Data` kind is
+        // intrinsic, not stamped here.
+        ctx.inference_ctx().register_source_type(&name, output_type);
         ctx.conversion_ctx().register_source(name, source);
     }
 
@@ -1016,6 +1012,13 @@ pub fn compile_program(
     // equality, so the staging shapes now validate without re-blinding the
     // check or peeling cast refinements.
     typecheck(&join_planned).expect("type error after join planning");
+    // Invariant (debug): planning's `iterate`/`restrict` markers live in the
+    // term tree, never inside a type's refinement predicates — the substitution
+    // boundary strips the neutral `iterate` marker (`ccl_utils::strip_iterate_markers`),
+    // and a `restrict` reaching a predicate (a filtered source used in a refined
+    // domain) is unsupported and must surface loudly, not miscompile.
+    #[cfg(debug_assertions)]
+    crate::ccl::ccl_utils::debug_assert_no_iteration_markers(&join_planned);
 
     // Compile to one operator per field of the trailing record.  Pure
     // programs (no sinks) end up at this point with a bare expression at the

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -621,7 +621,7 @@ A consumer reading "as of `𝑡`" must know no further commits will land at `≤
 carries this: function tiles hold a `domain_predicate` marking the complete region of the domain. A
 watermark *is* a `domain_predicate` advancing over `Txn`. Conflict validation — which depends on
 which value combinations were observed — is deliberately engine-level, above the tiling algebra,
-because that is exactly what extent predicates cannot express.
+because that is exactly what domain predicates cannot express.
 
 ## Concurrency and distribution
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -575,16 +575,17 @@ The pipeline passes downstream of inference treat function types structurally an
 
 ## 4.6 Data vs compute functions
 
-> **Status: implemented.** The `FunKind` marker, kind inference, and kind-aware
-> subtyping (the `Compute <: Data` rejection) are all live, as is the rejection of
-> a data join that would narrow a domain. Data-domain invariance holds for the
-> base and is unenforced for a domain *refinement* — see the callout below.
+> **Status: implemented, minus Σ.** The `FunKind` marker, kind inference,
+> kind-aware subtyping (the `Compute <: Data` rejection) and the invariant data
+> domain are all live. What is missing is the type the model says a domain join
+> *produces* — the Σ — so a join over distinct domains is diagnosed rather than
+> typed. See the callout below.
 
 The unresolved domain-join corner of §4.5 (O1/O4 — two collections meeting at one
 join point) is resolved by making a missing distinction explicit. The distinction
 does not by itself make every such join *typeable*; what it does is make the
 untypeable ones an **error** rather than a silently short collection. See
-[The domain-join rejection](#the-domain-join-rejection).
+[The domain join is a Σ](#the-domain-join-is-a-σ).
 
 **The distinction.** A function's domain can mean two things. A **compute
 function** `α ⇒ β` treats it as a *capability* — the inputs accepted; no data
@@ -644,34 +645,47 @@ sets `kind` explicitly.
 > a kind-aware re-check would false-reject. `sum([x for x in xs])`,
 > comprehensions, and `groupby` type fine because they are stamped concrete
 > `Data` at construction (the provenance annotation / `refined_data_fun` cast
-> target). One guard is only half in force — see
+> target). The same arm carries the data-domain invariance guard — see
 > [Data domains are invariant](#data-domains-are-invariant) below.
 
-### The domain-join rejection
+### The domain join is a Σ
 
 A join of two data functions is **not** the contravariant meet of their domains. The
 domain of a collection *is* its data, so meeting `[0,1] ⤇ Int` with `[0,2] ⤇ Int`
 down to `[0,1] ⤇ Int` silently discards the third row — a wrong answer with nothing
-in the type recording that it happened. The join is therefore defined only where
-narrowing is a no-op: where the two arms turn out to hold the **same** domain, the
-join is that collection (`[1,2] if c else [3,4]` is `[0,1] ⤇ Int`, and so is
-`xs if c else xs`). Where the domains differ, the join is **rejected**
-(`CoalesceError::DomainJoinConflict`).
+in the type recording that it happened.
 
-This is the whole payoff of tracking the kind. Without it, both arrows are just
-functions and the compute lattice's meet applies — which is correct for
-capabilities and destroys rows for collections. With it, the two cases are distinct
-and the collection case can refuse.
+Nor is the join undefined. It is the dependent sum `Σ (𝑤 ∈ {𝐷ᵢ}). 𝑤 ⤇ 𝑉` over the
+candidate domains, whose witness `𝑤` is the runtime branch discriminant and which is
+eliminated by distributing the consumer over it. **That Σ is the least upper bound**
+— data functions over distinct domains are incomparable, and their join is a
+different element of the lattice rather than one of them. So the lattice is
+*incomplete* without Σ, and the three rules here are one model:
 
-The lossless answer exists and is not this: it is the dependent sum
-`Σ (𝑤 ∈ {𝐷ᵢ}). 𝑤 ⤇ V` over the arms' candidate domains, whose witness `𝑤` is the
-runtime branch discriminant, eliminated by distributing the consumer over it. That
-is the collections work — a type-level construct with formation, subtyping and
-elimination rules of its own, plus the value-`Case` fan-out that compiles the
-elimination. Until it lands the rejection is the contract, and the reason a
-rejection is an acceptable interim state (rather than a gap that has to be closed
-first) is that it is *loud*: the alternative to a Σ is a diagnosed error, not a
-silent miscompile. Pinned end-to-end by `conditional_collection_rejected_cleanly`.
+- **Subtyping** relates two data functions when their domains are the same domain
+  ([Data domains are invariant](#data-domains-are-invariant)).
+- **Joining** two whose domains differ yields the Σ.
+- Where the Σ collapses — the candidates turn out to be one domain — the join is
+  that plain data function (`[1,2] if c else [3,4]` is `[0,1] ⤇ Int`, and so is
+  `xs if c else xs`).
+
+Σ is not yet representable, so the middle rule currently has no answer to produce
+and **diagnoses** instead. That is an acceptable interim state only because it is
+*loud*: the alternative to a Σ is an error, not a silent miscompile. Pinned
+end-to-end by `conditional_collection_rejected_cleanly`.
+
+Tracking the kind is what makes the three rules statable at all. Without it both
+arrows are just functions, the compute lattice's meet applies, and the join silently
+narrows — correct for capabilities, row-destroying for collections.
+
+**The same fact surfaces at two phases**, because a join can be forced at either.
+When a consumer imposes a concrete demand on the joined value, the domains meet at a
+`Fun`/`Fun` edge and the invariant domain rule reports it there
+(`ConstrainError::DataDomainMismatch`). When nothing forces it — the joined
+collection *is* the program's value, or is only let-bound — the candidates ride to
+coalesce as alternatives and are reported there
+(`CoalesceError::DomainJoinConflict`). Both are "the join is a Σ"; neither path is
+redundant, and Σ has to satisfy both.
 
 **Mechanics.** The decision is split across two phases, and the split is forced. At
 the compact merge, a positive `Data ⊔ Data` accumulates its domain **alternatives**
@@ -744,19 +758,17 @@ the tagged variant is the substitute.
 The `Fun`/`Fun` domain edge is contravariant, which is right for a *compute*
 function: the domain is a parameter, nothing in the language can ask a capability
 which inputs it accepts, and shrinking the accepted set only under-promises. A
-**data** function's domain is invariant instead — and that is not a second
-principle standing beside [the domain-join rejection](#the-domain-join-rejection),
-it is the same rule read at the other site.
+**data** function's domain is invariant instead — the subtyping half of the same
+model [The domain join is a Σ](#the-domain-join-is-a-σ) states.
 
-**One lattice.** A join *is* the least upper bound of the subtype order, so the two
-cannot disagree. Suppose the contravariant edge applied to data functions, making a
-wider collection a subtype of a narrower one — `[0,10] ⤇ 𝑉 <: [0,5] ⤇ 𝑉`, which is
-`[0,5] <: [0,10]` at the domain. Then the least upper bound of the arms of
-`[1,2] if c else [1,2,3]` is `[0,1] ⤇ Int`, and `sum` of it returns `3` even when
-the else-arm ran, with nothing in the type recording that a row was dropped. That is
-precisely the miscompile `DomainJoinConflict` exists to prevent. Contravariant data
-domains and the domain-join rejection are one choice made twice in opposite
-directions; whichever is adopted, the other has to go.
+**One lattice.** Subtyping and joining are the same order, so they cannot disagree.
+Suppose the contravariant edge applied to data functions, making a wider collection
+a subtype of a narrower one — `[0,10] ⤇ 𝑉 <: [0,5] ⤇ 𝑉`, which is `[0,5] <: [0,10]`
+at the domain. Then the least upper bound of the arms of `[1,2] if c else [1,2,3]`
+is `[0,1] ⤇ Int`, and `sum` of it returns `3` even when the else-arm ran, with
+nothing in the type recording that a row was dropped. Under invariance the two
+collections are instead incomparable and their least upper bound is the Σ — which
+loses nothing, and is why the two halves fit together rather than trading off.
 
 **Why the stand-in is not free.** The contravariant reading is tempting because it
 looks like record width subtyping, which *is* sound: `{a: Int, b: Int} <: {a: Int}`
@@ -800,19 +812,38 @@ So the rule is stable under a surface data domain. What the syntax changes is th
 the explicit forms invariance requires become *writable*, which argues for the rule
 rather than against it.
 
-**What is enforced, and the hole.** The *base* half is in force, structurally rather
-than by a kind-aware guard: [`Type::UIntRange`] relates only by equality, so a wider
-or a narrower range domain is rejected under either kind, in both directions. The
-*refinement* half is *not* enforced. Because the domain is contravariant, the
-ordinary drop-only refinement lattice (`{𝐷 | 𝑝} <: 𝐷`) inverts behind the arrow: of
-the two edges over one base, the surviving one is **acquisition** — `𝐷 ⤇ 𝑉 <:
-{𝐷 | 𝑝} ⤇ 𝑉`, an unfiltered collection standing where a filtered domain is declared
-— while *dropping* a domain refinement does not hold at all. Both change which rows
-the consumer reads, so by the rule above neither should hold; the guard that would
-reject acquisition is missing.
-`data_domain_refinement_relates_only_by_acquisition` pins all three facts together —
-both refinement edges and the base equality — so what is absent is a recorded fact
-rather than an assumption.
+**How it is enforced: both edges, unconditionally.** When both kinds are concretely
+`Data`, the `Fun`/`Fun` arm constrains the domains in *both* directions rather than
+contravariantly. That is the only order-independent spelling available: any rule
+conditioned on what a domain looks like *at the moment the edge fires* — is it still
+a variable, does it carry a refinement yet — makes typing depend on constraint
+emission order, so two programs differing only in traversal order could type
+differently. Invariance is a property of two types, not of when they are compared.
+
+Both directions is also all it takes. `[`Type::UIntRange`]` relating only by equality
+already rejects both base directions, and refinement **drop** (`{𝐷 | 𝑝} ⤇ 𝑉 <:
+𝐷 ⤇ 𝑉`) is already rejected one step less obviously, since behind a contravariant
+domain it demands `𝐷 <: {𝐷 | 𝑝}`. What the reverse edge adds is the case that
+inversion left admitted — refinement **acquisition**, `𝐷 ⤇ 𝑉 <: {𝐷 | 𝑝} ⤇ 𝑉`, an
+unfiltered collection standing where a filtered domain is declared. A failure in
+either direction is reported as `ConstrainError::DataDomainMismatch`, naming the two
+domains; `a_data_domain_relates_only_to_itself` pins all four directions plus the
+reflexive case, and the compute counterpart that still relates contravariantly.
+
+**Emitting both directions does not preempt a join.** Two domains meeting at one
+variable is a join like any other, so what a domain variable joining `[0,1]` and
+`[0,2]` *should* become is the same Σ that the arms of a `Case` become — Σ is the
+join wherever it arises, not a `Case`-specific construct, and a domain position is
+not privileged. Until Σ is representable that join has no answer at either site,
+which is why the same program can be diagnosed from the edge or from coalesce
+depending on whether a consumer forces the question early (see
+[The domain join is a Σ](#the-domain-join-is-a-σ)). The consequence for the Σ work is
+that candidate domains must be expected at a domain variable, not only at a `Case`
+result.
+
+Like the `Compute <: Data` rejection, the rule fires only when the cache is
+kind-aware, because elimination preserves denotation but not kind representation and
+the post-inference re-check must not see it.
 
 ### Deliberately incomplete here
 
@@ -824,7 +855,7 @@ Recorded so a reader can tell a deliberate boundary from an oversight.
   (`sum([1,2] if c else [1,2,3])` is unambiguously `3` or `6`). What makes this an
   acceptable interim state is only that it is diagnosed rather than miscompiled; it
   is not a semantic position. The dependent sum described in
-  [The domain-join rejection](#the-domain-join-rejection) is the answer, and it
+  [The domain join is a Σ](#the-domain-join-is-a-σ) is the answer, and it
   arrives with the collections work.
 
 - **`KindMerge::Conflict` is covered only by hand-constructed compact graphs.** Both
@@ -840,13 +871,13 @@ Recorded so a reader can tell a deliberate boundary from an oversight.
   source-level route is found, it belongs in the suite; if one provably does not
   exist, the branch should collapse into the constraint-level check.
 
-- **The refinement half of data-domain invariance is not enforced.** Base domains
-  are invariant structurally — [`Type::UIntRange`] relates only by equality — but the
-  contravariant domain edge still admits *acquisition*: an unfiltered collection
-  standing where a filtered domain is declared. The guard cannot live on that edge —
-  the demanded domain is often an unresolved variable there — so it belongs at
-  coalesce, on the materialized domain alternatives, and it is not written. See
-  [Data domains are invariant](#data-domains-are-invariant) above.
+- **Σ is the missing type, and it is missing at two sites.** Because a domain join
+  can be forced from a `Fun`/`Fun` edge as well as at coalesce, the Σ work has to
+  answer both: candidate domains arrive at a **domain variable**, not only at a
+  `Case` result. `DataDomainMismatch` and `DomainJoinConflict` are the two faces of
+  the same unrepresentable join, and both are live from source
+  (`sum([1,2] if c else [1,2,3])` reaches the first; the same conditional as the
+  program's own value reaches the second).
 
 ---
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -488,12 +488,12 @@ A refinement is **required**, so `constrain_subtype` is strict for *concrete* ba
 
 **Refinements in the post-inference check.** The post-inference structural check (`infer::check`, reimplemented on the same structural rules as emission via the `Typing` trait — see §2, *The post-inference check*) is **strict and refinement-aware throughout** — it does not strip refinements before its width-subtyping checks. It runs `constrain_subtype` in two places, both fully refinement-aware:
 
-* **Adjacency rules** (a `Compose` link's `prev_cod <: next_dom`, an `Apply`'s argument-vs-domain) check *refinement flow*: feeding an unrefined producer into a refinement consumer is rejected (`T ⊀ {T | p}`), exactly as the solver is. There is **no cast escape** — a producer must already carry the refinement its consumer demands. A `… ≫ (id ≫ cast({D | r} ⇒ V))` chain composes because join planning surfaces the iterated / join-satisfying extent on the *producing* morphism's codomain, so the upstream genuinely supplies `{D | r}` (see the reconstructability bullets below). The producer's witness and the cast's contract are typically re-minted as distinct predicate terms, so the adjacency relies on the structural-predicate match above.
+* **Adjacency rules** (a `Compose` link's `prev_cod <: next_dom`, an `Apply`'s argument-vs-domain) check *refinement flow*: feeding an unrefined producer into a refinement consumer is rejected (`T ⊀ {T | p}`), exactly as the solver is. There is **no cast escape** — a producer must already carry the refinement its consumer demands. A `… ≫ (id ≫ cast({D | r} ⇒ V))` chain composes because join planning surfaces the iterated / join-satisfying domain on the *producing* morphism's codomain, so the upstream genuinely supplies `{D | r}` (see the reconstructability bullets below). The producer's witness and the cast's contract are typically re-minted as distinct predicate terms, so the adjacency relies on the structural-predicate match above.
 * **The reconcile** (a node's rule-reconstructed type vs the type inference recorded on it) is the plain strict `rule <: recorded` subtype check, refinements included (the recorded type may be a width-wider supertype — e.g. an annotation). A rule that rebuilds a node's type from its children rebuilds its refinements too, so a recorded refinement the reconstruction lacks is a real disagreement about the node — and in practice it is one specific bug: a **merge point that took one input's refinement** instead of the join of all of them (see the merge law above). Comparing modulo refinements here — stripping both sides, or a refinement-blind relation — is the *only* thing that hides that class, and this is the check best placed to catch it. Keeping it strict is what forced each merge point to join.
 
 For the reconcile to hold, the passes that *introduce* refined types post-inference (lambda-elim, join-planning) must leave each node's recorded type **reconstructable** — consistent with what the bottom-up rules rebuild from its children. These sites were emitting internally-inconsistent or under-refined nodes and are now fixed at the source rather than papered over by relaxing the check:
 
-* **Iterated / join-satisfying extents on producer codomains** (`planning`'s `set_codomain` / `refine_codomain`). An iteration source produces the refined extent it iterates, so its codomain is the site's refined domain `{D | p} ⇒ {D | p}` (mirroring `make_iterate`'s symmetry); a hash join folds its equi-conditions into the key structure with no residual `Restrict`, so the extent it yields would otherwise reach the body's `cast` *bare*. Surfacing `{D | p}` on the codomain — threaded down the combinator's whole function spine so the leaf builtin the Check pass rebuilds from agrees — keeps the `producer ≫ cast` adjacency refined-to-refined. Reconstructable because a combinator node carries its own function type and `emit_apply` returns *that* codomain verbatim. This is the post-inference counterpart of the inference-time `make_iterate`/`make_restrict`/`refine_with` refinements; trivially-true layers (`if True`) are dropped by the latter but reintroduced from the site domain so the body's `{D | true}` cast still matches.
+* **Iterated / join-satisfying domains on producer codomains** (`planning`'s `set_codomain` / `refine_codomain`). An iteration source produces the refined domain it iterates, so its codomain is the site's refined domain `{D | p} ⇒ {D | p}` (mirroring `make_iterate`'s symmetry); a hash join folds its equi-conditions into the key structure with no residual `Restrict`, so the domain it yields would otherwise reach the body's `cast` *bare*. Surfacing `{D | p}` on the codomain — threaded down the combinator's whole function spine so the leaf builtin the Check pass rebuilds from agrees — keeps the `producer ≫ cast` adjacency refined-to-refined. Reconstructable because a combinator node carries its own function type and `emit_apply` returns *that* codomain verbatim. This is the post-inference counterpart of the inference-time `make_iterate`/`make_restrict`/`refine_with` refinements; trivially-true layers (`if True`) are dropped by the latter but reintroduced from the site domain so the body's `{D | true}` cast still matches.
 
 * **Dependent groupby refinement** (`lambda_elim`'s cast-wrapped-lambda arm). `groupby` lowers to `λ k → cast({I | key(i) == k} ⇒ A, λ i → c(i))`. Because the key binder `k` is now a genuine **Pi binder** (the refinement closes over it but the *value* does not mention it), lambda-elim emits the Pi-const form `const(cast(c)) : (k) ⇒ ({I | i ▷ c ▷ key == k} ⇒ A)` — the `k`-dependence rides the refinement and is materialized as a `Restrict` at the iteration boundary (the dependent-application model, §4.5). Planning's pointful recogniser (`recognize_groupby_sites` / `convert_groupby_pointful`) matches that Pi-const source directly — identifying the key binder structurally as the free variable on one side of the predicate's equality — and emits the bucketize chain `converse(c ≫ key) ≫ map(c)`.
 * **`permute_domain` over a refined morphism** (`join_plan::convert_loop_join`). The combinator is polymorphic in the morphism it rearranges; its declared input type is the morphism's *actual* type (which may carry the join-condition refinement), not a bare `actual ⇒ actual`. Otherwise `apply_function` re-stamps the partially-applied combinator's recorded type to `fun(expr.ty, …)` (carrying the refinement) while its inner `PermuteDomain` builtin keeps the bare declaration — an inconsistent node the reconstruction can't rebuild, because the refinement rides the morphism's *invariant* domain⇒codomain position (where subtyping would demand `T <: {T|p}` *and* `{T|p} <: T` at once).
@@ -553,13 +553,13 @@ Some refinement predicates **close over an outer binder**. The motivating case i
 
 **Edges carry substitutions, stored two-sided in their native direction.** Each entry of a variable's bound lists is a `Bound { self_subst, ty, ty_subst }`: an upper entry on `𝑉` reads `𝑉‹self_subst› <: ty‹ty_subst›`, a lower entry `ty‹ty_subst› <: 𝑉‹self_subst›` (both identity for ordinary bounds). `constrain_subtype` delegates to `constrain_go(lhs, rhs, sl, sr, cache)` — each side under its own morphism. The **Fun/Fun arm derives the binder correspondence** `[𝑘 ↦ 𝑥]` onto the lhs side of the codomain edge, and the contravariant domain edge **swaps the two sides** rather than inverting anything. The var arms record edges verbatim — *nothing is inverted at record time*. A **discharge has no inverse**, so edges are recorded in their native direction rather than pre-inverted and re-inverted during closure (which would degrade a discharge to the identity, silently destroying it whenever a consumer edge is recorded before the producer's concrete codomain arrives — the opaque/higher-order application order, O3). Under identity morphisms every arm reduces exactly to the substitution-free solver, so all monomorphic inference is byte-identical.
 
-**Closure chains by bridging holder views, composing forward only.** When a new edge meets a variable's existing opposite edges, the two entries hold `𝑉` under possibly different morphisms (`lo`, `hi`); `bridge_holder_gap` reconciles them by moving whichever side is movable (substitution application is monotone w.r.t. subtyping): equal morphisms need no bridge; an invertible side bridges by `hi ∘ lo⁻¹` (renames only — lossless); two non-invertible composites that share their discharge part and differ only in correspondence renames are factored (`Subst::split_renames`) and bridged on the rename part. Two *distinct* discharges meeting at one variable is the extent-join corner (O1/O4), guarded by `invert_rename`'s panic — the loud tripwire, never a silent drop. The **constraint cache is σ-aware**: it keys each `(lhs, rhs)` pair on the *set of side-morphism pairs* seen, so `g(0)` and `g(1)` flowing into one position record two distinct edges instead of the second being conflated away; termination holds because cyclic (var⇄var) edges carry renames over the episode's finite binder set, whose composites saturate, while discharges ride acyclic content edges.
+**Closure chains by bridging holder views, composing forward only.** When a new edge meets a variable's existing opposite edges, the two entries hold `𝑉` under possibly different morphisms (`lo`, `hi`); `bridge_holder_gap` reconciles them by moving whichever side is movable (substitution application is monotone w.r.t. subtyping): equal morphisms need no bridge; an invertible side bridges by `hi ∘ lo⁻¹` (renames only — lossless); two non-invertible composites that share their discharge part and differ only in correspondence renames are factored (`Subst::split_renames`) and bridged on the rename part. Two *distinct* discharges meeting at one variable is the domain-join corner (O1/O4), guarded by `invert_rename`'s panic — the loud tripwire, never a silent drop. The **constraint cache is σ-aware**: it keys each `(lhs, rhs)` pair on the *set of side-morphism pairs* seen, so `g(0)` and `g(1)` flowing into one position record two distinct edges instead of the second being conflated away; termination holds because cyclic (var⇄var) edges carry renames over the episode's finite binder set, whose composites saturate, while discharges ride acyclic content edges.
 
 **Coalesce forces suspended substitutions.** `compact_go` threads a substitution accumulator: descending a bound edge composes the edge's *rendering morphism* (`edge_render_subst`: `ty_subst`, transported across `self_subst` by rename-inversion, or by the identity for a discharge — exact because the content lives in the post-discharge context and cannot mention the discharged binder, debug-asserted) and the composite is applied — *forced* — at each refinement-predicate leaf. A bound reached transitively through `𝑣 → 𝑤 → …` thus arrives with every edge's morphism composed (the deferred transitive closure recovered by the walk). Identity accumulator ⇒ no-op.
 
 **Dependent application.** `Typing::apply` types `f(arg)`. Emit constrains `fn_ty <: (𝑥: 𝑑) ⇒ result` against an expected Pi (the one-way Apply shape edge of §2) and returns `result` under a suspended discharge `[𝑥 ↦ arg]` on a fresh variable's lower edge, fired on the partition predicate at coalesce. So `groupby(xs, key)(𝑘₀)` types as `{𝑖 | 𝑖 ▷ xs ▷ key == 𝑘₀} ⇒ 𝑉`. The **post-inference check** (`CheckCtx::apply`) re-runs the discharge on the resolved codomain so its reconstruction matches; `force_refinement` rewrites the predicate to the same term in both places, so the two refinements compare equal under structural witness equality (§4).
 
-The expected binder is **always globally fresh** (proposal §5.2 verbatim; the §3.6 freshness discipline). The two-sided edge storage is what makes this sound at every polarity and in every constraint order: the correspondence `[𝑘 ↦ 𝑥]` and the discharge `[𝑥 ↦ arg]` compose forward along the closure regardless of whether `fn_ty` was concrete at the apply site or resolved only later (the opaque/higher-order case — a dependent function received as a *parameter* — now discharges correctly, unblocking O3 at the graph level). A contravariant position is reached by side-*swapping*, not inversion, so the discharge arrives at a `map`/aggregate's parameter domain intact. The remaining deferral is the extent-join corner — two *distinct* discharges meeting at one coalescing position (O1/O4) — guarded loudly by the closure bridge's tripwire.
+The expected binder is **always globally fresh** (proposal §5.2 verbatim; the §3.6 freshness discipline). The two-sided edge storage is what makes this sound at every polarity and in every constraint order: the correspondence `[𝑘 ↦ 𝑥]` and the discharge `[𝑥 ↦ arg]` compose forward along the closure regardless of whether `fn_ty` was concrete at the apply site or resolved only later (the opaque/higher-order case — a dependent function received as a *parameter* — now discharges correctly, unblocking O3 at the graph level). A contravariant position is reached by side-*swapping*, not inversion, so the discharge arrives at a `map`/aggregate's parameter domain intact. The remaining deferral is the domain-join corner — two *distinct* discharges meeting at one coalescing position (O1/O4) — guarded loudly by the closure bridge's tripwire.
 
 **Discharged-argument slot resolution.** A predicate's interior is typed **by construction**, and the invariant that makes that hold is that *substitution never discards a type*. A `Discharge` carries a typed argument term and clones it; a `Rename` materializes as a fresh `Var` node and takes the type of the occurrence it replaces, because α-renaming cannot change a term's type — the type belongs to the position, not to the name. Nothing re-derives a predicate's types afterwards, and nothing may: a predicate's interior is outside the walk that resolves node types (its terms ride a *type*), so a slot left untyped here would survive to the post-inference wall as an unresolved variable with no way to recover it except lexical scope — which is a *name* lookup standing in for a type that was thrown away. (`freshen_above` separately copy-and-freshens a specialization clone's predicate type slots.)
 
@@ -569,9 +569,247 @@ The expected binder is **always globally fresh** (proposal §5.2 verbatim; the �
 
 **Deferred (flagged in code).**
 * **O2 (polymorphic case)** — `freshen_above` copy-and-freshens a refined value's predicate type slots through the shared cache (its `Refinement` arm), so a specialization's predicate is a proper freshen instance rather than a shared `Rc`. Immutable predicate terms are acyclic, so no refinement-cycle guard is needed.
-* **O4** — two *different* discharges of one refinement (`g(0)` vs `g(1)`) are distinguished once forced — `force_refinement` rewrites the predicate term and witness equality is structural (§4) — and the constraint cache is σ-aware, so the two discharges record distinct edges rather than conflating. The residual extent-join corner is two *distinct non-invertible* morphisms meeting at one variable (O1/O4), guarded loudly by `bridge_holder_gap`'s panic tripwire rather than silently dropped.
+* **O4** — two *different* discharges of one refinement (`g(0)` vs `g(1)`) are distinguished once forced — `force_refinement` rewrites the predicate term and witness equality is structural (§4) — and the constraint cache is σ-aware, so the two discharges record distinct edges rather than conflating. The residual domain-join corner is two *distinct non-invertible* morphisms meeting at one variable (O1/O4), guarded loudly by `bridge_holder_gap`'s panic tripwire rather than silently dropped.
 
 The pipeline passes downstream of inference treat function types structurally and compare modulo the Pi binder (`Type::without_pi_names`). **Refinement-predicate compilation is deferred out of lambda-elim** (proposal §6.3): predicates ride through inference and lambda-elim in their bare pointful form (a bare boolean over the implicit `REFINEMENT_BINDER`), and **planning** compiles them. Order matters: the group-by / hash-join recognizers run *first*, on the bare form — compiling first would destroy the pointful shapes they match (see the pointful-join-recognizers plan) — and `planning::compile_refinement_predicates` then runs the lambda-elim → simplify sub-pipeline on each remaining predicate (keyed by predicate `Rc` identity) before the generic `iterate`/`restrict` lowering consumes it. This is what lets a refined collection — including a group-by over a *filtered* source (`[sum(x) for x in groupby([y+10 for y in xs if y<6], key)]`) — compile to a runtime `Restrict`/`Filter` rather than reaching op-conversion as an un-compiled predicate. Single-key dependent lookups (`sum(groupby(xs, key)(k))`) and the nested filtered-source group-by both run end-to-end with correct values.
+
+## 4.6 Data vs compute functions
+
+> **Status: implemented.** The `FunKind` marker, kind inference, and kind-aware
+> subtyping (the `Compute <: Data` rejection) are all live, as is the rejection of
+> a data join that would narrow a domain. One guard is deferred with rationale
+> (data-domain invariance — see the callout below).
+
+The unresolved domain-join corner of §4.5 (O1/O4 — two collections meeting at one
+join point) is resolved by making a missing distinction explicit. The distinction
+does not by itself make every such join *typeable*; what it does is make the
+untypeable ones an **error** rather than a silently short collection. See
+[The domain-join rejection](#the-domain-join-rejection).
+
+**The distinction.** A function's domain can mean two things. A **compute
+function** `α ⇒ β` treats it as a *capability* — the inputs accepted; no data
+behind it; shrinking under-promises, so the lossy contravariant meet at a
+join is fine. A **data function** `α ⤇ β` treats it as a *collection* — the
+domain *is* the data map, so a lossy domain is lost data. `Type::Fun` carries
+a `kind: FunKind` (`Compute | Data | Var`). **FunKind is a *provenance* property,
+not a function of the domain** — the *same* domain can back a data collection or
+a capability (`Map(Color, V)` vs `Color ⇒ V`), so it is decided by *what the
+value is*, stamped concretely at introduction. `Data`: list literals, `++`,
+registered sources, comprehensions and `groupby` (a comprehension over a
+collection, a keyed collection — stamped via the `data_fun` provenance annotation
+that `emit_node` reads as a concrete-kind stamp; a *filtered* comprehension's
+`refined_data_fun` cast target carries the same `Data`), induction recurrence
+carriers (a `letrec` binder declared `Data` — an accumulator indexed by the
+iteration domain — whose declared type stamps the accumulator lambda's kind,
+same `stamp_kind_from` mechanism), aggregate consumers, and every `History`
+erasure. `Compute`: scalar/combinator builtins and ordinary user lambdas
+(capabilities) — a bare `λ` is built **concrete `Compute`** (`emit_lambda`),
+because a lambda that denotes a collection is not born bare, it is one of the
+stamped `Data` forms above. A `FunKind::Var` is minted only where the kind is
+genuinely *inferred* — a function parameter or a freshened polymorphic scheme —
+resolved by uses (below); an **unconstrained var defaults to `Compute`** (the
+capability default). No arm inspects the domain shape. The audit rule for the
+*concrete* stamps: *an arrow is data iff it denotes a collection*, which the
+construction site knows.
+Constructor `data_fun` mints a data arrow directly; `fun_like(exemplar, d, c)`
+rebuilds an arrow copying the exemplar's `name` and `kind`, so a domain/codomain-
+only rewrite (`subst`, `strip_refinements`, source-domain refinement) can never
+silently flip a data arrow to compute or drop its Pi binder. A rebuild that
+*intends* a new binder or mixes two arrows' kinds (the compose-chain rebuild in
+`coalesce_node`, the Pi-adding rebuild in `lambda_elim`) constructs directly and
+sets `kind` explicitly.
+
+> **FunKind-aware subtyping (landed).** Concrete kinds (the common case — data
+> collections and capabilities are stamped at construction, above) pass through;
+> only a kind-*polymorphic* function carries a `FunKind::Var`, resolved from its
+> bounds, defaulting to `Compute` when unconstrained (no domain-shape guess). The
+> Fun-vs-Fun arm adds a kind edge over `Data ⊑ Compute`: `data <: compute`
+> upcasts, a concrete `compute <: data` is rejected
+> (`ConstrainError::ComputeWhereDataRequired`), and a var picks up
+> `forced_compute`/`forced_data` flags. A **capability demanded as data** —
+> e.g. `sum(λ x → x + 1)`, summing a plain `Int ⇒ Int` lambda — is caught right
+> here at the edge: the lambda is *concrete* `Compute`, so `sum`'s `Data` demand
+> is the concrete `compute <: data` reject, no domain inspection needed. (This is
+> why the domain-shape guess is gone: a capability is `Compute` by construction,
+> a collection `Data` by construction, so a scalar/keyed domain never decides a
+> kind.) For a genuinely *var*-kinded function (a parameter, a freshened scheme)
+> the violation is invisible at the edge — the flags are merely recorded — so a
+> var that ends with `forced_compute ∧ forced_data` is the same `Compute <: Data`
+> error, surfaced at coalesce as `CoalesceError::ComputeWhereDataRequired`; a var
+> with only `forced_data` resolves to `Data` (a parameter used only as a collection).
+> The rejection is **emission-only**: the
+> post-inference check runs a *kind-blind* `ConstrainCache` (`new_kind_blind`),
+> because elimination canonicalizes a map's reconstructed kind to `Compute`
+> (`without_pi_names`) — denotation is preserved, kind representation is not, so
+> a kind-aware re-check would false-reject. `sum([x for x in xs])`,
+> comprehensions, and `groupby` type fine because they are stamped concrete
+> `Data` at construction (the provenance annotation / `refined_data_fun` cast
+> target). One guard is deferred — see
+> [Deferred: data-domain invariance](#deferred-data-domain-invariance) below.
+
+### The domain-join rejection
+
+A join of two data functions is **not** the contravariant meet of their domains. The
+domain of a collection *is* its data, so meeting `[0,1] ⤇ Int` with `[0,2] ⤇ Int`
+down to `[0,1] ⤇ Int` silently discards the third row — a wrong answer with nothing
+in the type recording that it happened. The join is therefore defined only where
+narrowing is a no-op: where the two arms turn out to hold the **same** domain, the
+join is that collection (`[1,2] if c else [3,4]` is `[0,1] ⤇ Int`, and so is
+`xs if c else xs`). Where the domains differ, the join is **rejected**
+(`CoalesceError::DomainJoinConflict`).
+
+This is the whole payoff of tracking the kind. Without it, both arrows are just
+functions and the compute lattice's meet applies — which is correct for
+capabilities and destroys rows for collections. With it, the two cases are distinct
+and the collection case can refuse.
+
+The lossless answer exists and is not this: it is the dependent sum
+`Σ (𝑤 ∈ {𝐷ᵢ}). 𝑤 ⤇ V` over the arms' candidate domains, whose witness `𝑤` is the
+runtime branch discriminant, eliminated by distributing the consumer over it. That
+is the collections work — a type-level construct with formation, subtyping and
+elimination rules of its own, plus the value-`Case` fan-out that compiles the
+elimination. Until it lands the rejection is the contract, and the reason a
+rejection is an acceptable interim state (rather than a gap that has to be closed
+first) is that it is *loud*: the alternative to a Σ is a diagnosed error, not a
+silent miscompile. Pinned end-to-end by `conditional_collection_rejected_cleanly`.
+
+**Mechanics.** The decision is split across two phases, and the split is forced. At
+the compact merge, a positive `Data ⊔ Data` accumulates its domain **alternatives**
+(`CompactFun::domains`, unioned and deduplicated by `union_domains` — never met).
+It cannot decide there whether the alternatives are really two domains: a compact
+domain still carries inference-variable identity that `simplify_type` may merge
+afterwards, so two structurally identical domains can arrive as two alternatives.
+Coalesce materializes each alternative to a `Type` and deduplicates *again*, and
+that second comparison is the one that decides — one survivor is a plain data
+function, two or more is the rejection. A `Data ⊔ Compute` collision is a third
+outcome, `KindMerge::Conflict`, reported as `DomainJoinConflict` when it would drop
+≥ 2 alternatives and as `ComputeWhereDataRequired` when a single slot is a
+capability demanded as a collection.
+
+Refinements ride *inside* each alternative domain, so differently-filtered arms of
+one source (`[x for x in xs if x > 1]` vs `[x for x in xs if x < 3]`) are two
+distinct domains and reject like any other pair — refinement is not a special case
+here. Meeting them would claim one domain satisfying both filters; picking either
+would claim positions the other branch does not produce.
+
+**`Case` arms join by the lattice.** `emit_case` constrains *every* arm into a
+fresh result variable (`require_sub`) instead of requiring equality. Homogeneous
+arms recover the old behavior; data-collection arms with distinct domains are the
+rejection above. There is no `Mut`/`History` exception: a mutable read derefs into
+the join like any other, so a `Case` over two registers types as their *value*, and
+the second-class discipline still rejects a selected register reaching a write
+position because rule 1 reads the argument *node* rather than its type (see the
+merge-law bullets under
+[Refinements as witness sets](#refinements-as-witness-sets)).
+
+> **Deferred — heterogeneous-scalar union (follow-up).** The design goal is for
+> heterogeneous scalar arms (`1 if c else "x"`) to coalesce to a union.
+> A global positive-atom union at coalesce is **unsound** — it is
+> indistinguishable there from a binop-operand join (`1 + true`), which must
+> stay a hard error. So heterogeneous scalar arms currently remain an
+> `IncompatibleBounds` error; the sound union needs strict scalar consumers
+> (binops, …) to impose concrete bounds, tracked as a follow-up.
+
+**The codomain is joined, not preserved — and that asymmetry is principled.** Where
+two data arms *do* join (a shared domain), the codomain is the ordinary covariant
+lattice join `τ₀ ⊔ τ₁` (`CompactFun::merge` merges the codomain at `pol`, the
+domains at `!pol`), forgetting which arm contributed which element type. Loss is
+forbidden exactly where it is *silent and destroys data* — the domain, where
+dropping an index drops a row with no trace. It is permitted exactly where it is
+*visible and only coarsens type* — the codomain: `Int | String` sits in the type,
+and a consumer that needs `Int` (say `sum`) fails at *its own* constraint site.
+Where the LUB is representable this is a structured coarsening that does not error
+(record codomains intersect to their common fields, refinements drop to the shared
+base); where it is a **scalar** union it is the deferred piece above and errors at
+coalesce, the same `IncompatibleBounds` rejection as `1 + true`.
+
+Two further consequences of joining the codomain, on the record. The correlation is
+**recoverable by construction**: the correlated form is a tagged variant with each
+arm's own codomain, and a program that needs a branch-aware consumer introduces the
+choice *explicitly* (`.Ints(xs) if flag else .Strs(ys)`) and `match`es it — the
+case-split tax is paid by the code that benefits from it. And the default keeps
+consumer complexity **linear**: if the implicit join preserved correlation, every
+conditional would default to a variant every downstream consumer must destructure,
+and nested conditionals would multiply the arms through the whole consumer graph.
+This direction *depends on* tagged-variant **surface syntax** (`.Foo(x)`
+constructors + `match`, the open part of [[type-checker-tagged-variants]]): until
+that ships the codomain join is a *forced* loss with no recovery path, not a chosen
+one. We are also deliberately declining **flow-sensitive typing** — an
+occurrence-typing language could keep the arms correlated through the path
+condition `flag` itself, with no tag; Cambra does not narrow on opaque `Bool`s, and
+the tagged variant is the substitute.
+
+### Deferred: data-domain invariance
+
+The `Fun`/`Fun` domain edge is contravariant for **both** kinds. For a *compute*
+function that is right — the domain is a parameter. For a *data* function it is not:
+the domain **is** the data, so a `[0,10] ⤇ 𝑉` standing where a `[0,5] ⤇ 𝑉` is declared
+is silent row addition, and the reverse is silent row loss. Neither should typecheck.
+
+The guard is nonetheless **not** enabled. The **base** half of it is settled — strip
+refinements, require the *base* domains equal — and is already in force in practice,
+because [`Type::UIntRange`] relates only by equality. What the **refinement** half should
+be is open, and stating it needs the two candidate edges named.
+
+**What the arm does today, precisely.** For two data functions over one base differing
+only in a domain refinement, exactly one of the two edges holds
+(`a_refined_data_domain_relates_only_by_acquisition_today`):
+
+| edge | holds today | what it means when the domain *is* the data |
+| --- | --- | --- |
+| `𝐷 ⤇ 𝑉 <: {𝐷 \| 𝑝} ⤇ 𝑉` — *acquire* | **yes** | row **addition**: an unfiltered collection standing where a filtered one is declared |
+| `{𝐷 \| 𝑝} ⤇ 𝑉 <: 𝐷 ⤇ 𝑉` — *drop* | no | row **loss** |
+
+The direction is the opposite of the one a reader expects, and the reason is that the
+domain is **contravariant**. At a bare domain position the ordinary lattice is drop-only
+(`{𝐷 | 𝑝} <: 𝐷`); behind the arrow that inverts, so the relation that survives is the one
+whose *supertype* is the more refined.
+
+So the edge that is live is the row-addition one, and a *drop* pattern is not something a
+strict guard would break, because it does not hold in the first place.
+
+**The open question is which of those two edges to keep.** Under the "domain is the data"
+reading the answer looks like *neither* — both change the row set — which is full
+invariance: `strip`-equal bases **and** equal refinements. The cost is not a
+filtered-flows-where-unfiltered pattern (there isn't one) but whatever relies on
+acquisition. Establishing what that is, and what replaces it, is the work.
+
+It is deferred rather than wrong-by-omission because of what the domains actually are
+today: ranges, which are already invariant, and fresh join variables, which carry no
+refinement to acquire. The acquisition edge becomes reachable — and the omission
+load-bearing — as soon as *refined* domains are pervasive.
+
+### Deliberately incomplete here
+
+Recorded so a reader can tell a deliberate boundary from an oversight.
+
+- **The rejection is a placeholder for the lossless join, not the intended end
+  state.** Every program whose branches produce collections of different sizes is
+  rejected — including ones with an obvious meaning
+  (`sum([1,2] if c else [1,2,3])` is unambiguously `3` or `6`). What makes this an
+  acceptable interim state is only that it is diagnosed rather than miscompiled; it
+  is not a semantic position. The dependent sum described in
+  [The domain-join rejection](#the-domain-join-rejection) is the answer, and it
+  arrives with the collections work.
+
+- **`KindMerge::Conflict` is covered only by hand-constructed compact graphs.** Both
+  of its coalesce outcomes are exercised (`coalesce_domain_join_conflict_errs`,
+  `coalesce_single_domain_conflict_is_compute_where_data_required`), but no *source
+  program* in the suite reaches either. The `Data ⊔ Compute` collision needs a slot
+  that is simultaneously fed a capability and demanded as a collection, and the
+  single-slot case needs a `FunKind::Var` ending with both `forced_compute` and
+  `forced_data` — a kind-polymorphic function whose two uses disagree. The
+  constraint-level face of the same rejection *is* reachable from source
+  (`ConstrainError::ComputeWhereDataRequired`, e.g. `sum(λ x → x + 1)`), which is
+  why the coalesce-time face is a backstop rather than the primary check. If a
+  source-level route is found, it belongs in the suite; if one provably does not
+  exist, the branch should collapse into the constraint-level check.
+
+- **Data-domain invariance is not enforced**, so the contravariant `Fun`/`Fun`
+  domain edge still admits a data function standing where a differently-domained one
+  is declared. See
+  [Deferred: data-domain invariance](#deferred-data-domain-invariance) above for why
+  the obvious formulation is wrong and what the correct rule is.
 
 ---
 
@@ -604,6 +842,8 @@ The pipeline passes downstream of inference treat function types structurally an
 ### `Case` inference
 
 For each `Branch { guard, body }`: the guard flows one-way into `Type::Base(BaseType::Bool)` (a refined boolean is still a boolean); every body flows one-way into one shared variable. The overall `Case` type is that variable — the arms' **join**. Two arms of incompatible base types therefore collide as `IncompatibleBounds` at coalesce, where a heterogeneous list literal or `CollectionUnion` reports it, rather than as an eager mismatch here. A 0-branch `Case` is a malformed AST (lowering never produces one) and returns `InferError::EmptyCase`.
+
+The in-flight conditionals stack replaces the arm unification with a genuine lattice join (fresh result variable + per-arm `require_sub`) — see [Data vs compute functions](#46-data-vs-compute-functions); the strict-equality behavior above is current until that lands.
 
 ### Record literals and field access
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -577,8 +577,8 @@ The pipeline passes downstream of inference treat function types structurally an
 
 > **Status: implemented.** The `FunKind` marker, kind inference, and kind-aware
 > subtyping (the `Compute <: Data` rejection) are all live, as is the rejection of
-> a data join that would narrow a domain. One guard is deferred with rationale
-> (data-domain invariance — see the callout below).
+> a data join that would narrow a domain. Data-domain invariance holds for the
+> base and is unenforced for a domain *refinement* — see the callout below.
 
 The unresolved domain-join corner of §4.5 (O1/O4 — two collections meeting at one
 join point) is resolved by making a missing distinction explicit. The distinction
@@ -644,8 +644,8 @@ sets `kind` explicitly.
 > a kind-aware re-check would false-reject. `sum([x for x in xs])`,
 > comprehensions, and `groupby` type fine because they are stamped concrete
 > `Data` at construction (the provenance annotation / `refined_data_fun` cast
-> target). One guard is deferred — see
-> [Deferred: data-domain invariance](#deferred-data-domain-invariance) below.
+> target). One guard is only half in force — see
+> [Data domains are invariant](#data-domains-are-invariant) below.
 
 ### The domain-join rejection
 
@@ -739,45 +739,80 @@ occurrence-typing language could keep the arms correlated through the path
 condition `flag` itself, with no tag; Cambra does not narrow on opaque `Bool`s, and
 the tagged variant is the substitute.
 
-### Deferred: data-domain invariance
+### Data domains are invariant
 
-The `Fun`/`Fun` domain edge is contravariant for **both** kinds. For a *compute*
-function that is right — the domain is a parameter. For a *data* function it is not:
-the domain **is** the data, so a `[0,10] ⤇ 𝑉` standing where a `[0,5] ⤇ 𝑉` is declared
-is silent row addition, and the reverse is silent row loss. Neither should typecheck.
+The `Fun`/`Fun` domain edge is contravariant, which is right for a *compute*
+function: the domain is a parameter, nothing in the language can ask a capability
+which inputs it accepts, and shrinking the accepted set only under-promises. A
+**data** function's domain is invariant instead — and that is not a second
+principle standing beside [the domain-join rejection](#the-domain-join-rejection),
+it is the same rule read at the other site.
 
-The guard is nonetheless **not** enabled. The **base** half of it is settled — strip
-refinements, require the *base* domains equal — and is already in force in practice,
-because [`Type::UIntRange`] relates only by equality. What the **refinement** half should
-be is open, and stating it needs the two candidate edges named.
+**One lattice.** A join *is* the least upper bound of the subtype order, so the two
+cannot disagree. Suppose the contravariant edge applied to data functions, making a
+wider collection a subtype of a narrower one — `[0,10] ⤇ 𝑉 <: [0,5] ⤇ 𝑉`, which is
+`[0,5] <: [0,10]` at the domain. Then the least upper bound of the arms of
+`[1,2] if c else [1,2,3]` is `[0,1] ⤇ Int`, and `sum` of it returns `3` even when
+the else-arm ran, with nothing in the type recording that a row was dropped. That is
+precisely the miscompile `DomainJoinConflict` exists to prevent. Contravariant data
+domains and the domain-join rejection are one choice made twice in opposite
+directions; whichever is adopted, the other has to go.
 
-**What the arm does today, precisely.** For two data functions over one base differing
-only in a domain refinement, exactly one of the two edges holds
-(`a_refined_data_domain_relates_only_by_acquisition_today`):
+**Why the stand-in is not free.** The contravariant reading is tempting because it
+looks like record width subtyping, which *is* sound: `{a: Int, b: Int} <: {a: Int}`
+because a consumer of `{a: Int}` can only apply a key it declared, so the extra
+field is unobservable. A data function has eliminators that **reflect** its domain
+rather than index into it, and they make the difference observable twice over.
 
-| edge | holds today | what it means when the domain *is* the data |
-| --- | --- | --- |
-| `𝐷 ⤇ 𝑉 <: {𝐷 \| 𝑝} ⤇ 𝑉` — *acquire* | **yes** | row **addition**: an unfiltered collection standing where a filtered one is declared |
-| `{𝐷 \| 𝑝} ⤇ 𝑉 <: 𝐷 ⤇ 𝑉` — *drop* | no | row **loss** |
+- The declared domain **is the loop bound the program runs**. Op-conversion's
+  `Builtin::Iterate` arm builds its iteration source as
+  `IterateExtent::new(extent_of(𝐷))` from the *static* domain of the iterate
+  marker's predicate. So handing an 11-row collection to a slot declared
+  `[0,5] ⤇ 𝑉` does not forget rows the way the record forgets `b`; it emits a
+  program that reads six of them and reports the result as the collection's.
+- The domain is **reproduced in eliminator results**. A comprehension has the shape
+  `𝐷 ⤇ 𝐴 ⇒ 𝐷 ⤇ 𝐵`, so `𝐷` occurs covariantly — in an output — as well as
+  contravariantly at application, and a variable occurring in both positions is
+  invariant. That is the ordinary variance calculus, not a Cambra-specific rule, and
+  it is the whole content of the `Data`/`Compute` split: a compute domain occurs
+  contravariantly only, because nothing enumerates it.
 
-The direction is the opposite of the one a reader expects, and the reason is that the
-domain is **contravariant**. At a bare domain position the ordinary lattice is drop-only
-(`{𝐷 | 𝑝} <: 𝐷`); behind the arrow that inverts, so the relation that survives is the one
-whose *supertype* is the more refined.
+There is a coherent language in which the wider collection *should* stand in: one
+where a declared domain is a **view**, and narrowing it means "give me this much of
+it". Cambra is not that language — and the reason is *not* that a data domain is
+currently unwritable. It will not stay unwritable:
+[`Array(𝑛, 𝑇)`](../../../docs/chl-spec.md#63-direction-collections-as-functions-tentative),
+a data function over `Fin(𝑛)`, is a planned surface type. The reason is that both
+things the view reading would buy are better bought elsewhere, and the surface
+syntax is what makes them cheap:
 
-So the edge that is live is the row-addition one, and a *drop* pattern is not something a
-strict guard would break, because it does not hold in the first place.
+- **"Works for any length" is quantification, not subsumption.** The function that
+  accepts every extent is `∀𝑛. Array(𝑛, 𝑇) ⇒ …`, an ordinary scheme the solver
+  already freshens per use. Contravariant widening is a poor stand-in for
+  polymorphism: it relates one pair of extents at one site, and charges the row-set
+  guarantee everywhere for it.
+- **A deliberate prefix is a term, not a coercion.** A program that wants the first
+  five rows takes them, and the truncation is then visible where it happens, at an
+  extent chosen by the use site. A subsumption edge hides the same truncation in a
+  declaration, and only ever at the width that declaration happens to name.
 
-**The open question is which of those two edges to keep.** Under the "domain is the data"
-reading the answer looks like *neither* — both change the row set — which is full
-invariance: `strip`-equal bases **and** equal refinements. The cost is not a
-filtered-flows-where-unfiltered pattern (there isn't one) but whatever relies on
-acquisition. Establishing what that is, and what replaces it, is the work.
+So the rule is stable under a surface data domain. What the syntax changes is that
+the explicit forms invariance requires become *writable*, which argues for the rule
+rather than against it.
 
-It is deferred rather than wrong-by-omission because of what the domains actually are
-today: ranges, which are already invariant, and fresh join variables, which carry no
-refinement to acquire. The acquisition edge becomes reachable — and the omission
-load-bearing — as soon as *refined* domains are pervasive.
+**What is enforced, and the hole.** The *base* half is in force, structurally rather
+than by a kind-aware guard: [`Type::UIntRange`] relates only by equality, so a wider
+or a narrower range domain is rejected under either kind, in both directions. The
+*refinement* half is *not* enforced. Because the domain is contravariant, the
+ordinary drop-only refinement lattice (`{𝐷 | 𝑝} <: 𝐷`) inverts behind the arrow: of
+the two edges over one base, the surviving one is **acquisition** — `𝐷 ⤇ 𝑉 <:
+{𝐷 | 𝑝} ⤇ 𝑉`, an unfiltered collection standing where a filtered domain is declared
+— while *dropping* a domain refinement does not hold at all. Both change which rows
+the consumer reads, so by the rule above neither should hold; the guard that would
+reject acquisition is missing.
+`data_domain_refinement_relates_only_by_acquisition` pins all three facts together —
+both refinement edges and the base equality — so what is absent is a recorded fact
+rather than an assumption.
 
 ### Deliberately incomplete here
 
@@ -805,11 +840,13 @@ Recorded so a reader can tell a deliberate boundary from an oversight.
   source-level route is found, it belongs in the suite; if one provably does not
   exist, the branch should collapse into the constraint-level check.
 
-- **Data-domain invariance is not enforced**, so the contravariant `Fun`/`Fun`
-  domain edge still admits a data function standing where a differently-domained one
-  is declared. See
-  [Deferred: data-domain invariance](#deferred-data-domain-invariance) above for why
-  the obvious formulation is wrong and what the correct rule is.
+- **The refinement half of data-domain invariance is not enforced.** Base domains
+  are invariant structurally — [`Type::UIntRange`] relates only by equality — but the
+  contravariant domain edge still admits *acquisition*: an unfiltered collection
+  standing where a filtered domain is declared. The guard cannot live on that edge —
+  the demanded domain is often an unresolved variable there — so it belongs at
+  coalesce, on the materialized domain alternatives, and it is not written. See
+  [Data domains are invariant](#data-domains-are-invariant) above.
 
 ---
 

--- a/src/ccl/infer/api.rs
+++ b/src/ccl/infer/api.rs
@@ -191,11 +191,33 @@ impl TypeInferenceContext {
         TypeInferenceContextGuard { ctx: self }
     }
 
-    /// Register the CCL type for an externally-managed data source.
+    /// Register an externally-managed data source by its **element type**.
     ///
-    /// Typically called by [`crate::ccl::context::GlobalContext`] when a source
-    /// is registered; the type is a `Fun(DataSource(name), output_type)`.
-    pub fn register_source_type(&mut self, name: &str, ty: Type) {
+    /// The source's CCL type is constructed here — a data function
+    /// `DataSource(name) ⤇ elem_ty` — rather than accepted from the caller. A
+    /// registered source is *definitionally* a data collection, so its
+    /// [`FunKind::Data`](crate::ccl::ty::FunKind) is intrinsic provenance
+    /// (`DataSource` is minted only for sources), not free information a caller
+    /// could stamp wrong: taking only the element type makes a miscategorized
+    /// source unrepresentable. Typically called by
+    /// [`crate::ccl::context::GlobalContext`] when a source is registered.
+    pub fn register_source_type(&mut self, name: &str, elem_ty: Type) {
+        // `elem_ty` is the source's *element* type, not the whole source arrow.
+        // A `Fun` over a `DataSource` domain is the source type itself, so seeing
+        // one here means a caller passed the constructed source type by mistake
+        // (the pre-Option-A signature took the full `Type::Fun`); catch that
+        // regression rather than silently nesting `DataSource ⤇ (DataSource ⤇ …)`.
+        debug_assert!(
+            !matches!(&elem_ty, Type::Fun { domain, .. } if matches!(**domain, Type::DataSource(_))),
+            "register_source_type: elem_ty is itself a source data function \
+             (`{elem_ty}`) — pass the element type, not the whole source arrow"
+        );
+        let ty = Type::Fun {
+            name: None,
+            kind: crate::ccl::ty::FunKind::Data,
+            domain: Box::new(Type::DataSource(name.to_string())),
+            codomain: Box::new(elem_ty),
+        };
         self.source_types.insert(name.to_string(), ty);
     }
 
@@ -242,9 +264,15 @@ pub enum InferError {
     /// A variable was referenced but not bound in the current scope.
     UnboundVariable(String),
     /// A type mismatch was detected between two solved types.
+    ///
+    /// The two `Type`s are boxed to keep `InferError` under the
+    /// `result_large_err` budget: this is the widest variant (two `Type`s plus
+    /// a `ctx` string), and `Type` grew when [`crate::ccl::ty::FunKind`] gained
+    /// an inference variable. Boxing here keeps every
+    /// `Result<_, InferError>` cheap on the common `Ok` path.
     TypeMismatch {
-        type_a: Type,
-        type_b: Type,
+        type_a: Box<Type>,
+        type_b: Box<Type>,
         ctx: String,
     },
     /// A [`Type::Fun`] was required — e.g. in a function-application or
@@ -756,8 +784,19 @@ fn collect_type_errors(
             }
         }
         Type::Fun {
-            domain, codomain, ..
+            domain,
+            codomain,
+            kind,
+            ..
         } => {
+            // Coalesce resolves every kind var to a concrete `Data`/`Compute`
+            // (`KindMerge::of`); a surviving `FunKind::Var` is a missed resolution
+            // that would silently display `⇒` and behave as `Compute`. Catch it
+            // loudly rather than letting the wrong default ride downstream.
+            debug_assert!(
+                !matches!(kind, crate::ccl::ty::FunKind::Var(_)),
+                "unresolved FunKind::Var survived coalesce at `{context_sym}`"
+            );
             collect_type_errors(domain, context_sym, strictness, errors, seen_refinements);
             collect_type_errors(codomain, context_sym, strictness, errors, seen_refinements);
         }
@@ -1419,6 +1458,7 @@ mod tests {
             ty,
             Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Compute,
                 domain: Box::new(Type::Base(BaseType::Int)),
                 codomain: Box::new(Type::Base(BaseType::Int))
             }
@@ -1452,13 +1492,10 @@ mod tests {
         // [10, 20]  =>  Fun(UIntRange(2), Int)
         let mut expr = Expr::list(vec![Expr::lit(Lit::Int(10)), Expr::lit(Lit::Int(20))]);
         let ty = infer(&mut expr, &mut ctx).unwrap();
+        // A list literal is a **data** function (domain).
         assert_eq!(
             ty,
-            Type::Fun {
-                name: None,
-                domain: Box::new(Type::UIntRange(2)),
-                codomain: Box::new(Type::Base(BaseType::Int))
-            }
+            Type::data_fun(Type::UIntRange(2), Type::Base(BaseType::Int))
         );
     }
 
@@ -1469,7 +1506,7 @@ mod tests {
         let ty = infer(&mut expr, &mut ctx).unwrap();
         assert_eq!(
             ty,
-            Type::fun(Type::UIntRange(0), Type::Base(BaseType::Unit))
+            Type::data_fun(Type::UIntRange(0), Type::Base(BaseType::Unit))
         );
     }
 
@@ -1649,6 +1686,7 @@ mod tests {
             ty,
             Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Compute,
                 domain: Box::new(Type::Base(BaseType::Int)),
                 codomain: Box::new(Type::Base(BaseType::Int))
             }
@@ -1836,11 +1874,11 @@ mod tests {
         assert!(
             errs.iter().any(|e| matches!(
                 e,
-                InferError::TypeMismatch {
-                    type_a: Type::Base(BaseType::Int),
-                    type_b: Type::Base(BaseType::String),
-                    ..
-                }
+                InferError::TypeMismatch { type_a, type_b, .. }
+                    if matches!(
+                        (type_a.as_ref(), type_b.as_ref()),
+                        (Type::Base(BaseType::Int), Type::Base(BaseType::String))
+                    )
             )),
             "expected TypeMismatch Int/String, got {errs:?}"
         );
@@ -1976,7 +2014,7 @@ mod tests {
         let value = Expr::lambda("x", int(), Expr::var("x").with_ty(int()))
             .with_ty(Type::fun(int(), int()));
         let predicate = Expr::lit(Lit::Bool(true));
-        let target = crate::ccl::ccl_utils::refined_fn_type(int(), predicate, int());
+        let target = crate::ccl::ccl_utils::refined_data_fun(int(), predicate, int());
         let mut expr = crate::ccl::ccl_utils::make_cast(value, target);
         let ty = infer(&mut expr, &mut ctx).unwrap();
         match ty {
@@ -2093,8 +2131,10 @@ mod tests {
 
     /// `Sum` wrapping a list-comprehension lambda: `sum([x for x in [1, 2]])`.
     ///
-    /// The unannotated lambda is fully annotated by inference; its type is
-    /// `Fun(UIntRange(2), Int)` and the aggregate returns `Int`.
+    /// The unannotated lambda's domain/codomain are inferred; its kind is stamped
+    /// `Data` by the `data_fun` provenance annotation lowering puts on every
+    /// comprehension (a comprehension *is* a data collection). Its type is then
+    /// `[0, 1] ⤇ Int`, which `Sum` accepts, returning `Int`.
     #[test]
     fn test_infer_aggregate_sum_over_list_comp() {
         let mut ctx = TypeInferenceContext::new();
@@ -2103,7 +2143,8 @@ mod tests {
             Expr::list(vec![Expr::lit(Lit::Int(1)), Expr::lit(Lit::Int(2))]),
             "x",
             Expr::var("x"),
-        );
+        )
+        .with_user_annotation(Type::data_fun(Type::Hole, Type::Hole));
         let mut expr = Expr::aggregate(comp, AggregateKind::Sum);
         assert_eq!(infer(&mut expr, &mut ctx), Ok(Type::Base(BaseType::Int)));
     }
@@ -2331,6 +2372,7 @@ mod tests {
             ty,
             Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Compute,
                 domain: Box::new(Type::Base(BaseType::Int)),
                 codomain: Box::new(Type::Base(BaseType::Unit))
             }
@@ -2348,12 +2390,14 @@ mod tests {
     #[test]
     fn test_infer_source_returns_registered_type() {
         let mut ctx = TypeInferenceContext::new();
+        ctx.register_source_type("mystream", Type::Base(BaseType::String));
+        // Registration constructs the source's data function from the element type.
         let source_ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Data,
             domain: Box::new(Type::DataSource("mystream".into())),
             codomain: Box::new(Type::Base(BaseType::String)),
         };
-        ctx.register_source_type("mystream", source_ty.clone());
         let mut expr = Expr::new(TypedExprNode::Source("mystream".into()));
         assert_eq!(infer(&mut expr, &mut ctx), Ok(source_ty));
     }
@@ -2374,18 +2418,20 @@ mod tests {
     #[test]
     fn test_infer_multiple_sources_resolve_independently() {
         let mut ctx = TypeInferenceContext::new();
+        ctx.register_source_type("ints", Type::Base(BaseType::Int));
+        ctx.register_source_type("strs", Type::Base(BaseType::String));
         let int_ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Data,
             domain: Box::new(Type::DataSource("ints".into())),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
         let str_ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Data,
             domain: Box::new(Type::DataSource("strs".into())),
             codomain: Box::new(Type::Base(BaseType::String)),
         };
-        ctx.register_source_type("ints", int_ty.clone());
-        ctx.register_source_type("strs", str_ty.clone());
 
         let mut e1 = Expr::new(TypedExprNode::Source("ints".into()));
         let mut e2 = Expr::new(TypedExprNode::Source("strs".into()));
@@ -2424,11 +2470,11 @@ mod tests {
         assert!(
             errs.iter().any(|e| matches!(
                 e,
-                InferError::TypeMismatch {
-                    type_a: Type::Base(BaseType::Bool),
-                    type_b: Type::Base(BaseType::Int),
-                    ..
-                }
+                InferError::TypeMismatch { type_a, type_b, .. }
+                    if matches!(
+                        (type_a.as_ref(), type_b.as_ref()),
+                        (Type::Base(BaseType::Bool), Type::Base(BaseType::Int))
+                    )
             )),
             "expected TypeMismatch Bool/Int, got {errs:?}"
         );
@@ -2564,6 +2610,7 @@ mod tests {
         })
         .with_ty(Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         });
@@ -2606,6 +2653,7 @@ mod tests {
         })
         .with_ty(Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         });
@@ -2658,6 +2706,7 @@ mod tests {
         })
         .with_ty(Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         });
@@ -2676,6 +2725,7 @@ mod tests {
         // The node type is Fun(Hole, Int) — the Hole is inside the compound type.
         let expr = Expr::lit(Lit::Int(1)).with_ty(Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Hole),
             codomain: Box::new(Type::Base(BaseType::Int)),
         });
@@ -2911,6 +2961,7 @@ mod tests {
         let str_elem = Expr::lit(Lit::String("hello".into())).with_ty(Type::Base(BaseType::String));
         let list_ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::UIntRange(2)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
@@ -2944,6 +2995,7 @@ mod tests {
         })
         .with_ty(Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::String)),
             codomain: Box::new(Type::Base(BaseType::String)),
         });

--- a/src/ccl/infer/check.rs
+++ b/src/ccl/infer/check.rs
@@ -42,7 +42,7 @@ use super::{lit_base, map_constrain_err};
 ///
 /// There is no cast escape in the adjacency rule: a producer must already
 /// carry the refinement its consumer demands. Join planning makes this hold by
-/// surfacing each iterated/join-satisfying extent on the *producing* morphism's
+/// surfacing each iterated/join-satisfying domain on the *producing* morphism's
 /// codomain (`planning`'s `refine_codomain` / iteration-source `set_codomain`),
 /// so a `… ≫ (id ≫ cast({D | r} ⇒ V))` chain composes because the upstream
 /// genuinely supplies `{D | r}`. Because planning re-mints a fresh refinement
@@ -123,7 +123,7 @@ impl Typing for CheckCtx {
         // truth for width/variance and (since refinements ride the lattice as
         // restriction witnesses) witness subsetting. A failure is recorded (not
         // propagated) so the walk continues and reports every error.
-        if let Err(e) = constrain_subtype(sub, sup, &mut ConstrainCache::new()) {
+        if let Err(e) = constrain_subtype(sub, sup, &mut ConstrainCache::new_kind_blind()) {
             let located = self.raise(map_constrain_err(e, &at()));
             self.errors.push(located);
         }

--- a/src/ccl/infer/context.rs
+++ b/src/ccl/infer/context.rs
@@ -161,10 +161,12 @@ impl InferCtx {
             // normalize any nested holes/refinements.
             Type::Fun {
                 name,
+                kind,
                 domain: d,
                 codomain: c,
             } => Type::Fun {
                 name: name.clone(),
+                kind: kind.clone(),
                 domain: Box::new(self.normalize_annotation(d)),
                 codomain: Box::new(self.normalize_annotation(c)),
             },

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -55,7 +55,7 @@ pub(super) fn emit_node(expr: &mut Expr, ctx: &mut InferCtx) -> Result<Type, Loc
 fn emit_node_inner(expr: &mut Expr, ctx: &mut InferCtx) -> Result<Type, LocatedInferError> {
     // Compute the label before the mutable borrow so Case can pass it to emit_case.
     let label = symbolic(expr);
-    let ty = match &mut expr.node {
+    let mut ty = match &mut expr.node {
         TypedExprNode::Lit(lit) => ctx.lit_singleton(lit),
 
         // Resolve a variable through its bound scheme. A monomorphic binder
@@ -249,6 +249,12 @@ fn emit_node_inner(expr: &mut Expr, ctx: &mut InferCtx) -> Result<Type, LocatedI
             .user_annotation
             .clone()
             .expect("user_annotation is present");
+        // A **concrete** function kind on the annotation is a *provenance stamp*:
+        // lowering marks a data collection (a comprehension / `groupby`) with a
+        // `data_fun(_, _)` annotation, and here we set that kind concretely on the
+        // node's own type (see `stamp_kind_from`). `bind_annotation` below still
+        // reconciles the domain/codomain.
+        stamp_kind_from(&mut ty, &annotation);
         ctx.bind_annotation(&ty, &annotation)?;
     }
 
@@ -259,6 +265,29 @@ fn emit_node_inner(expr: &mut Expr, ctx: &mut InferCtx) -> Result<Type, LocatedI
     expr.ty = ty.clone();
 
     Ok(ty)
+}
+
+/// Stamp a concrete function **kind** from a *provenance-declaring* reference
+/// type onto a `target` function type. FunKind is a provenance property, not a
+/// function of the domain (see `KindMerge::of`, `src/ccl/infer/solver/compact.rs`),
+/// and a bare lambda is built `Compute` by construction (`emit_lambda`). The two
+/// sites that *declare* a lambda to be a data collection instead — a `data_fun`
+/// annotation on a comprehension / `groupby`, and a declared `Data` recurrence
+/// carrier on a `letrec` binder — carry a concrete (non-`Var`) function kind;
+/// this copies that kind onto the target so it is data by construction over *any*
+/// domain, rather than routed through `bind_annotation`/`require_sub` (which only
+/// draws a kind *edge* — and `Compute <: Data` is a hard reject, not a coercion).
+/// A concrete `Data` kind here is always lowering-internal or a declared carrier
+/// type — user function annotations are `Compute`/unkinded — so this never
+/// silently relabels a user's kind.
+fn stamp_kind_from(target: &mut Type, reference: &Type) {
+    use crate::ccl::ty::FunKind;
+    if let Type::Fun { kind: ref_kind, .. } = peel_refinements_outer(reference)
+        && !matches!(ref_kind, FunKind::Var(_))
+        && let Type::Fun { kind, .. } = target
+    {
+        *kind = ref_kind.clone();
+    }
 }
 
 /// Emit constraints for every refinement predicate embedded in an
@@ -459,6 +488,16 @@ pub(super) fn emit_lambda<C: Typing>(
     // ordinary functions — coalesce strips it when the codomain does not
     // reference it (see `coalesce_compact_go`) — so monomorphic output is
     // unchanged.
+    //
+    // The lambda's **kind is `Compute` by construction**: kind is a provenance
+    // property (see `KindMerge::of`, `src/ccl/infer/solver/compact.rs`), and a
+    // bare `λ` *is* a capability. A data collection is not born here — it is a
+    // comprehension / `groupby` / list literal, each concrete-stamped `Data` via
+    // a `data_fun` annotation that `emit_node` reads as a provenance stamp
+    // (overriding this `Compute`). Because a capability is now concrete `Compute`
+    // rather than a kind var, a capability supplied where a collection is demanded
+    // (`sum(λ x → x + 1)`) is the plain `Compute <: Data` rejection in
+    // `constrain_kind` — no domain-shape guess is needed to catch it.
     Ok(Type::pi(&param.name, param_simple, body_ty))
 }
 
@@ -511,15 +550,35 @@ pub(super) fn emit_cast<C: Typing>(
         Some(r) => Type::Refinement(Box::new(d), r),
         None => d,
     };
+    // A cast re-views the value *at* `target`, so the result carries `target`'s
+    // kind: a cast to a filtered-collection target (`refined_data_fun`, `Data`)
+    // yields a `Data` collection even though the underlying value is a `Compute`
+    // element projection (`λ u → u.score`, record ⇒ scalar). Preserving only the
+    // domain refinement while dropping `Data` would make every filtered
+    // comprehension / groupby a compute function again, and the aggregate that
+    // consumes it would reject it as compute-where-data.
+    // Peel refinements: a target that is a *refined function* (`{Fun | p}`)
+    // still carries its arrow's kind, which a match on the raw target would drop
+    // to the `Compute` default.
+    let kind = match peel_refinements_outer(target) {
+        Type::Fun { kind, .. } => kind.clone(),
+        _ => crate::ccl::ty::FunKind::Compute,
+    };
     // Preserve the value's Pi binder so the cast result stays a *named* function.
     // A dependent application of the cast then reconciles binders by the identity
     // correspondence (reusing the binder rather than minting a fresh `__arg`),
     // which is what keeps the O8 contravariant-domain discharge from leaving an
     // undischarged binder in the domain's refinement predicate (design §5.2, O8).
-    match peel_refinements_outer(&value_ty) {
-        Type::Fun { name: Some(k), .. } => Ok(Type::pi(k.clone(), domain, v)),
-        _ => Ok(fun(domain, v)),
-    }
+    let name = match peel_refinements_outer(&value_ty) {
+        Type::Fun { name: Some(k), .. } => Some(k.clone()),
+        _ => None,
+    };
+    Ok(Type::Fun {
+        name,
+        kind,
+        domain: Box::new(domain),
+        codomain: Box::new(v),
+    })
 }
 
 pub(super) fn emit_apply<C: Typing>(
@@ -783,7 +842,9 @@ pub(super) fn emit_collection_union<C: Typing>(
         tags.insert(FieldKey::Index(i), dom);
     }
     let dom_variant = variant_type(tags);
-    Ok(fun(dom_variant, cod_var))
+    // `++` produces a collection — a **data** function over the tagged union of
+    // its operands' domains.
+    Ok(Type::data_fun(dom_variant, cod_var))
 }
 
 /// Aggregate (`Sum`, `Max`): the scheme is the full operator type
@@ -986,7 +1047,14 @@ pub(super) fn emit_letrec<C: Typing>(
     }
     scoped_group(ctx, &declared, &mut |ctx| {
         for (i, (b, def)) in bindings.iter_mut().enumerate() {
-            let def_ty = ctx.subexpr(def)?;
+            let mut def_ty = ctx.subexpr(def)?;
+            // The declared binder type is the recurrence carrier's type; when it
+            // is a `Data` collection (an induction store indexed by the iteration
+            // domain), it declares the value lambda's kind by provenance — stamp
+            // it, so a `Compute`-by-construction accumulator body reconciles rather
+            // than tripping the `Compute <: Data` reject in `require_sub`.
+            stamp_kind_from(&mut def_ty, &declared[i].1);
+            stamp_kind_from(&mut def.ty, &declared[i].1);
             let label = b.name.clone();
             ctx.require_sub(&def_ty, &declared[i].1, &|| {
                 format!("LetRec binding `{label}`")
@@ -1086,7 +1154,7 @@ pub(super) fn emit_list<C: Typing>(
     ctx: &mut C,
 ) -> Result<Type, LocatedInferError> {
     if elts.is_empty() {
-        return Ok(fun(Type::UIntRange(0), prim(BaseType::Unit)));
+        return Ok(Type::data_fun(Type::UIntRange(0), prim(BaseType::Unit)));
     }
     // Element type: the **join** of the elements, not a type the first one fixes and
     // the rest must equal. Every element flows one-way into a shared variable, so
@@ -1106,8 +1174,10 @@ pub(super) fn emit_list<C: Typing>(
     let n = elts.len();
     // Deref a bare mutable read to its value, as in `emit_tuple`: the list's
     // element (codomain) type takes the dereferenced element type so no `Mut`
-    // appears in the list type.
-    Ok(fun(Type::UIntRange(n), deref_mut(&first_ty)))
+    // appears in the list type. A list literal is a **data** function — its
+    // domain is the index set, so a join with another collection may not narrow
+    // it — see `src/ccl/design/type-inference.md`, "The domain-join rejection".
+    Ok(Type::data_fun(Type::UIntRange(n), deref_mut(&first_ty)))
 }
 
 /// Emit constraints for a [`TypedExprNode::Case`] — the unified
@@ -1148,20 +1218,30 @@ pub(super) fn emit_case<C: Typing>(
         ctx.require_sub(&scrut_ty, &expected, &|| "Case scrutinee".to_string())?;
     }
 
-    // A `Case` selects one arm at runtime, so its type is what the arms have in
-    // common: the **join**, exactly as a list's element type is the join of its
+    // Every arm joins by the **lattice**: each arm's type is a subtype of one
+    // fresh result variable, so the result is their least upper bound — what the
+    // arms have in common, exactly as a list's element type is the join of its
     // elements. Refinements ride in untouched and the join is what decides which
-    // survive — arms depositing different singletons intersect to none (`if c: 1
+    // survive: arms depositing different singletons intersect to none (`if c: 1
     // else: 2` is an `Int`), while a restriction *every* arm establishes is kept
     // (identical filtered comprehensions stay filtered). Relating each arm to a
-    // *stripped* sibling instead loses that, and for a collection arm — whose extent
-    // rides the contravariant `Fun` domain — it demands `D <: {D | p}`, rejecting two
-    // arms that are the same expression.
+    // *stripped* sibling instead loses that, and for a collection arm — whose
+    // domain rides the contravariant `Fun` domain — it demands `D <: {D | p}`,
+    // rejecting two arms that are the same expression.
+    //
+    // Data-collection arms with distinct domains are rejected at coalesce rather
+    // than met (`CoalesceError::DomainJoinConflict`). (Heterogeneous *scalar* arms
+    // remain a hard `IncompatibleBounds` error — the sound union relaxation for
+    // them is deferred; see `coalesce`.)
+    //
+    // A `Mut` arm needs no special case: it derefs into the join like any other
+    // read, so a `Case` over two registers types as their *value*. The
+    // second-class discipline is unaffected — what it forbids is a selected
+    // register reaching a position that writes through it, and that rule reads
+    // the argument *node*, not its type (mutability.md, "No aliasing: `Mut`
+    // values are second-class (downward-only)").
     let result_ty = ctx.fresh();
     for b in branches.iter_mut() {
-        // A pattern binds its payload (the var just written to `binding.ty`)
-        // over the branch's guard and body. `scoped` restores the scope on
-        // both the happy and error paths.
         let scope_info = b
             .pattern
             .as_ref()
@@ -1222,7 +1302,7 @@ pub(super) fn emit_compose<C: Typing>(
         // Strict refinement-aware adjacency: `prev_cod <: next_dom`, refinement
         // witnesses and all — no cast escape. A producer must already supply the
         // refinement its consumer demands. Join planning surfaces the
-        // join-satisfying / iterated extent on each producing morphism's
+        // join-satisfying / iterated domain on each producing morphism's
         // codomain (`planning`'s `refine_codomain` / iteration-source
         // `set_codomain`), so a `… ≫ (id ≫ cast({D|r} ⇒ V))` chain composes
         // because the upstream genuinely carries `{D | r}` — matched
@@ -1244,8 +1324,22 @@ pub(super) fn emit_compose<C: Typing>(
         Type::Fun { name, .. } => name.clone(),
         _ => None,
     };
+    // The chain's kind is the **first** morphism's: a chain over a data source
+    // (`xs ≫ f`, a comprehension) is a data collection; a chain of compute
+    // morphisms is compute. When the first morphism is still a bare `Infer`
+    // (the common case in Emit — a comprehension composed over a source whose
+    // type has not yet resolved to a `Fun`), the chain's kind is genuinely
+    // use-dependent: mint a fresh kind var so a `Data`-demanding consumer (an
+    // aggregate) forces it `Data` via `constrain_kind`, and it otherwise
+    // resolves from its (now-concrete) domain at coalesce. Hardcoding `Compute`
+    // here would reject every composed comprehension flowing into an aggregate.
+    let kind = match peel_refinements_outer(&tys[0]) {
+        Type::Fun { kind, .. } => kind.clone(),
+        _ => crate::ccl::ty::FunKind::fresh_var(),
+    };
     Ok(Type::Fun {
         name: last_name,
+        kind,
         domain: Box::new(first_dom),
         codomain: Box::new(prev_cod),
     })

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -1176,7 +1176,7 @@ pub(super) fn emit_list<C: Typing>(
     // element (codomain) type takes the dereferenced element type so no `Mut`
     // appears in the list type. A list literal is a **data** function — its
     // domain is the index set, so a join with another collection may not narrow
-    // it — see `src/ccl/design/type-inference.md`, "The domain-join rejection".
+    // it — see `src/ccl/design/type-inference.md`, "The domain join is a Σ".
     Ok(Type::data_fun(Type::UIntRange(n), deref_mut(&first_ty)))
 }
 

--- a/src/ccl/infer/mod.rs
+++ b/src/ccl/infer/mod.rs
@@ -185,6 +185,16 @@ pub(super) fn map_constrain_err(err: ConstrainError, ctx_label: &str) -> InferEr
             type_a: Box::new(coalesce_for_error(&lhs)),
             type_b: Box::new(coalesce_for_error(&rhs)),
         },
+        ConstrainError::DataDomainMismatch { lhs, rhs } => InferError::TypeMismatch {
+            ctx: format!(
+                "collection domain conflict at {ctx_label} (a collection's domain is \
+                 its data, so a join may not narrow it — two collections over distinct \
+                 domains have no common data-function type, and their lossless join is \
+                 a dependent sum over the candidate domains)"
+            ),
+            type_a: Box::new(coalesce_for_error(&lhs)),
+            type_b: Box::new(coalesce_for_error(&rhs)),
+        },
     }
 }
 

--- a/src/ccl/infer/mod.rs
+++ b/src/ccl/infer/mod.rs
@@ -156,25 +156,34 @@ pub(super) fn map_constrain_err(err: ConstrainError, ctx_label: &str) -> InferEr
             } else {
                 InferError::TypeMismatch {
                     ctx: ctx_label.to_string(),
-                    type_a: lhs_ty,
-                    type_b: rhs_ty,
+                    type_a: Box::new(lhs_ty),
+                    type_b: Box::new(rhs_ty),
                 }
             }
         }
         ConstrainError::MissingField { key, in_type } => InferError::TypeMismatch {
             ctx: format!("{ctx_label} (missing field {key:?})"),
-            type_a: coalesce_for_error(&in_type),
-            type_b: Type::Hole,
+            type_a: Box::new(coalesce_for_error(&in_type)),
+            type_b: Box::new(Type::Hole),
         },
         ConstrainError::ExtraTag { tag, in_type } => InferError::TypeMismatch {
             ctx: format!("{ctx_label} (variant tag .{tag} not accepted)"),
-            type_a: coalesce_for_error(&in_type),
-            type_b: Type::Hole,
+            type_a: Box::new(coalesce_for_error(&in_type)),
+            type_b: Box::new(Type::Hole),
         },
         ConstrainError::NotAFeed { found, required } => InferError::TypeMismatch {
             ctx: format!("{ctx_label} (a feed handle is required here, but the value is not one)"),
-            type_a: coalesce_for_error(&found),
-            type_b: coalesce_for_error(&required),
+            type_a: Box::new(coalesce_for_error(&found)),
+            type_b: Box::new(coalesce_for_error(&required)),
+        },
+        ConstrainError::ComputeWhereDataRequired { lhs, rhs } => InferError::TypeMismatch {
+            ctx: format!(
+                "{ctx_label} (a compute function ⇒ was supplied where a data \
+                 collection ⤇ is required — using a capability as a collection \
+                 would iterate a declared domain the value does not cover)"
+            ),
+            type_a: Box::new(coalesce_for_error(&lhs)),
+            type_b: Box::new(coalesce_for_error(&rhs)),
         },
     }
 }
@@ -199,6 +208,17 @@ pub(super) fn map_coalesce_err(err: CoalesceError, ctx_label: &str) -> InferErro
         },
         CoalesceError::RecursiveType { details } => InferError::Unsupported(format!(
             "recursive type at {}: {} (residual μ-types are forbidden)",
+            ctx_label, details
+        )),
+        CoalesceError::DomainJoinConflict { details } => InferError::Unsupported(format!(
+            "collection domain conflict at {}: {} \
+             (a collection's domain is its data, so a join may not narrow it)",
+            ctx_label, details
+        )),
+        CoalesceError::ComputeWhereDataRequired { details } => InferError::Unsupported(format!(
+            "a compute function ⇒ was supplied where a data collection ⤇ is required at {}: {} \
+             (using a capability as a collection would iterate a declared domain the value \
+             does not cover)",
             ctx_label, details
         )),
     }

--- a/src/ccl/infer/schemes.rs
+++ b/src/ccl/infer/schemes.rs
@@ -103,37 +103,47 @@ impl OperatorSchemes {
         // Not: Bool → Bool
         let not_op = PolyScheme::mono(fun(prim(BaseType::Bool), prim(BaseType::Bool)));
 
-        // Sum: ∀α. (α → Int) → Int. The full operator type: consumes a
-        // collection (a function whose domain α is unconstrained) and folds
-        // its Int codomain to an Int. Inline-built so α gets its own fresh
-        // var even though it's unconstrained.
+        // Sum: ∀α. (α ⤇ Int) → Int. The full operator type: consumes a
+        // **collection** (a data function whose domain α is unconstrained) and
+        // folds its Int codomain to an Int. Inline-built so α gets its own
+        // fresh var even though it's unconstrained.
         let alpha = fresh_var(BODY_LEVEL);
         let aggregate_sum = PolyScheme::poly(
             SCHEME_LEVEL,
-            fun(fun(alpha.clone(), prim(BaseType::Int)), prim(BaseType::Int)),
+            fun(
+                Type::data_fun(alpha.clone(), prim(BaseType::Int)),
+                prim(BaseType::Int),
+            ),
         );
 
-        // Max: ∀α γ. (α → γ) → γ. Consumes a collection and folds its
+        // Max: ∀α γ. (α ⤇ γ) → γ. Consumes a collection and folds its
         // codomain γ to a result of the same type.
         let alpha = fresh_var(BODY_LEVEL);
         let gamma = fresh_var(BODY_LEVEL);
-        let aggregate_max = PolyScheme::poly(SCHEME_LEVEL, fun(fun(alpha, gamma.clone()), gamma));
+        let aggregate_max = PolyScheme::poly(
+            SCHEME_LEVEL,
+            fun(Type::data_fun(alpha, gamma.clone()), gamma),
+        );
 
-        // FinalOrDefault: ∀α β. ((α → β), β) → β
-        // Inline-built (not via `normalize_annotation`) so the codomain of the
-        // stream and the default share one variable `β`.
+        // FinalOrDefault: ∀α β. ((α ⤇ β), β) → β. The first field is a
+        // collection stream. Inline-built (not via `normalize_annotation`) so
+        // the codomain of the stream and the default share one variable `β`.
         let alpha = fresh_var(BODY_LEVEL);
         let beta = fresh_var(BODY_LEVEL);
         let mut tup: BTreeMap<FieldKey, Type> = BTreeMap::new();
-        tup.insert(FieldKey::Index(0), fun(alpha.clone(), beta.clone()));
+        tup.insert(
+            FieldKey::Index(0),
+            Type::data_fun(alpha.clone(), beta.clone()),
+        );
         tup.insert(FieldKey::Index(1), beta.clone());
         let final_or_default = PolyScheme::poly(SCHEME_LEVEL, fun(product(tup), beta));
 
-        // GetPrevSeq: ∀ι ν. ((ι → ν), ι, ν) → ν — history, position, default.
+        // GetPrevSeq: ∀ι ν. ((ι ⤇ ν), ι, ν) → ν — history (a collection),
+        // position, default.
         let iota = fresh_var(BODY_LEVEL);
         let nu = fresh_var(BODY_LEVEL);
         let mut tup: BTreeMap<FieldKey, Type> = BTreeMap::new();
-        tup.insert(FieldKey::Index(0), fun(iota.clone(), nu.clone()));
+        tup.insert(FieldKey::Index(0), Type::data_fun(iota.clone(), nu.clone()));
         tup.insert(FieldKey::Index(1), iota);
         tup.insert(FieldKey::Index(2), nu.clone());
         let get_prev_seq = PolyScheme::poly(SCHEME_LEVEL, fun(product(tup), nu));
@@ -156,7 +166,8 @@ impl OperatorSchemes {
             ("write".to_string(), nu.clone()),
         ]);
         let mut tup: BTreeMap<FieldKey, Type> = BTreeMap::new();
-        tup.insert(FieldKey::Index(0), fun(iota, commit_record));
+        // The commit stream (field 0) is a collection — a data function.
+        tup.insert(FieldKey::Index(0), Type::data_fun(iota, commit_record));
         tup.insert(FieldKey::Index(1), Type::Txn);
         tup.insert(FieldKey::Index(2), nu.clone());
         let get_prev_txn = PolyScheme::poly(SCHEME_LEVEL, fun(product(tup), nu));
@@ -307,7 +318,11 @@ mod tests {
     /// Tracked by `type-checker-traits-comparability` (P3) in the project vault.
     #[test]
     fn max_over_non_orderable_codomain_is_unsoundly_accepted() {
-        // Aggregate { input: λx → (1, 2), kind: Max }
+        // Aggregate { input: λx → (1, 2), kind: Max }. The input stands in for a
+        // data collection of tuples (what `max` really consumes), so it carries
+        // the `data_fun` provenance stamp lowering puts on a collection — without
+        // it, the bare lambda is a `Compute` capability and `max`'s `Data` demand
+        // rejects it on *kind* before the codomain-orderability gap under test.
         let lam = TypedExpr::new(TypedExprNode::Lambda {
             param: TypedBinding {
                 name: "x".into(),
@@ -318,7 +333,8 @@ mod tests {
                 lit_int(1),
                 lit_int(2),
             ]))),
-        });
+        })
+        .with_user_annotation(Type::data_fun(Type::Hole, Type::Hole));
         let mut e = TypedExpr::aggregate(lam, AggregateKind::Max);
         let ty = run_inference(&mut e).expect("inference succeeds (the bug under test)");
         // Buggy current behavior: the non-orderable tuple codomain is accepted.

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -331,11 +331,13 @@ fn types_agree_modulo_unread(read: &Type, now: &Type, witnesses: bool) -> bool {
                 name: n1,
                 domain: d1,
                 codomain: c1,
+                ..
             },
             Type::Fun {
                 name: n2,
                 domain: d2,
                 codomain: c2,
+                ..
             },
         ) => {
             n1 == n2
@@ -398,6 +400,8 @@ fn types_agree_modulo_unread(read: &Type, now: &Type, witnesses: bool) -> bool {
             crate::ccl::HistoryKind::Append => {
                 let stream = Type::Fun {
                     name: None,
+                    // A feed's read view is a collection stream: a data function.
+                    kind: crate::ccl::ty::FunKind::Data,
                     domain: domain.clone(),
                     codomain: value.clone(),
                 };
@@ -847,7 +851,9 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
             if let (Some(first), Some(last)) = (elts.first(), elts.last())
                 && let (
                     Type::Fun {
-                        domain: first_dom, ..
+                        domain: first_dom,
+                        kind: first_kind,
+                        ..
                     },
                     Type::Fun {
                         name: last_name,
@@ -867,6 +873,9 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
                 // dependence.
                 expr.ty = Type::Fun {
                     name: last_name.clone(),
+                    // FunKind is the first morphism's (mirrors `emit_compose`): a
+                    // chain over a data source is a data collection.
+                    kind: first_kind.clone(),
                     domain: Box::new((**first_dom).clone()),
                     codomain: Box::new((**last_cod).clone()),
                 };
@@ -1495,6 +1504,7 @@ pub(super) fn specialize_lambda_domain(lambda: &mut Expr, input: &Type) {
     }
     let Type::Fun {
         name,
+        kind,
         domain: dom,
         codomain: cod,
     } = cur
@@ -1526,6 +1536,7 @@ pub(super) fn specialize_lambda_domain(lambda: &mut Expr, input: &Type) {
         // *shape*; a dependent codomain still refers to the same binder.
         Type::Fun {
             name,
+            kind,
             domain: Box::new(new_dom),
             codomain: cod,
         },
@@ -1630,6 +1641,7 @@ mod tests {
         let mut lam = TypedExpr::lambda("x", Type::Base(BaseType::Int), body);
         lam.ty = Type::Fun {
             name: Some("x".into()),
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(refined_int(TypedExpr::var("x"))),
         };

--- a/src/ccl/infer/solver/coalesce.rs
+++ b/src/ccl/infer/solver/coalesce.rs
@@ -61,7 +61,7 @@ pub enum CoalesceError {
     /// by a `Data ⊔ Data` join (the common case) or by a multi-alternative slot
     /// meeting a compute function, where collapsing to the ordinary meet would drop
     /// domains. Reported loudly rather than silently losing rows. See
-    /// `src/ccl/design/type-inference.md`, "The domain-join rejection".
+    /// `src/ccl/design/type-inference.md`, "The domain join is a Σ".
     DomainJoinConflict {
         /// Pretty representation of the conflicting function shapes.
         details: String,
@@ -176,7 +176,7 @@ fn coalesce_compact_go(ct: &CompactType, polarity: bool) -> Result<Type, Coalesc
                 // Two or more surviving domains mean a data function's domains
                 // would be dropped by collapsing to a compute meet (a genuine
                 // domain-join collision). See `src/ccl/design/type-inference.md`,
-                // "The domain-join rejection".
+                // "The domain join is a Σ".
                 if doms.len() <= 1 {
                     return Err(CoalesceError::ComputeWhereDataRequired {
                         details: format!("a compute function (capability) over {{{doms_s}}}"),

--- a/src/ccl/infer/solver/coalesce.rs
+++ b/src/ccl/infer/solver/coalesce.rs
@@ -56,6 +56,28 @@ pub enum CoalesceError {
         /// Pretty representation of the cycle entry point.
         details: String,
     },
+    /// A data-function join whose domain alternatives survive materialization as
+    /// distinct domains, so no single domain holds every arm's rows. Raised either
+    /// by a `Data ⊔ Data` join (the common case) or by a multi-alternative slot
+    /// meeting a compute function, where collapsing to the ordinary meet would drop
+    /// domains. Reported loudly rather than silently losing rows. See
+    /// `src/ccl/design/type-inference.md`, "The domain-join rejection".
+    DomainJoinConflict {
+        /// Pretty representation of the conflicting function shapes.
+        details: String,
+    },
+    /// A single function slot whose kind resolved contradictorily: it was
+    /// demanded as a data domain (`forced_data`) while being — or being fed as
+    /// — a compute capability (a provably-scalar domain, or `forced_compute`).
+    /// This is the coalesce-time face of `Compute <: Data`, the counterpart of
+    /// [`super::constrain::ConstrainError::ComputeWhereDataRequired`] for the
+    /// case where the violation only becomes provable once the kind variable's
+    /// bounds and domain are resolved (e.g. summing a plain `Int ⇒ Int`
+    /// lambda). See `src/ccl/design/type-inference.md`, "4.6 Data vs compute functions".
+    ComputeWhereDataRequired {
+        /// Pretty representation of the offending capability.
+        details: String,
+    },
 }
 
 /// Distinguishes a partial tuple (Index keys) from a partial record
@@ -117,21 +139,95 @@ fn coalesce_compact_go(ct: &CompactType, polarity: bool) -> Result<Type, Coalesc
     if let Some(var) = &ct.var {
         shapes.push(materialize_variant(var, polarity)?);
     }
-    if let Some((name, dom, cod)) = &ct.fun {
-        let d = coalesce_compact_go(dom, !polarity)?;
-        let c = coalesce_compact_go(cod, polarity)?;
+    if let Some(cf) = &ct.fun {
+        use super::compact::KindMerge;
+        // Materialize the codomain once (covariant) and each domain alternative
+        // (contravariant), deduplicating at the `Type` level. This is where the
+        // "same domain or not?" question is actually decided: the compact-time
+        // `CompactType ==` dedup in `union_domains` cannot settle it, because a
+        // compact domain still carries variable identity that `simplify_type` may
+        // merge afterwards, so two identical domains can arrive as two alternatives.
+        let c = coalesce_compact_go(&cf.codomain, polarity)?;
+        let mut doms: Vec<Type> = Vec::new();
+        for d in &cf.domains {
+            let dt = coalesce_compact_go(d, !polarity)?;
+            if !doms.contains(&dt) {
+                doms.push(dt);
+            }
+        }
         // Strip the Pi binder unless the codomain's refinement predicates
         // actually reference it (design §3.2 / O10): keeps ordinary functions
-        // `name: None` while a genuinely dependent codomain keeps its binder
-        // bound.
-        let kept_name = name
+        // `name: None` while a genuinely dependent codomain keeps its binder.
+        let kept_name = cf
+            .name
             .clone()
             .filter(|b| crate::ccl::subst::type_free_vars(&c).contains(b));
-        shapes.push(Type::Fun {
-            name: kept_name,
-            domain: Box::new(d),
-            codomain: Box::new(c),
-        });
+        match cf.kind {
+            KindMerge::Conflict => {
+                let doms_s = doms
+                    .iter()
+                    .map(|t| t.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ⊔ ");
+                // A single surviving domain means one function slot whose kind
+                // resolved contradictorily: it was demanded as a data domain
+                // (`forced_data`) while being (or being fed as) a compute
+                // capability — the coalesce-time face of `Compute <: Data`.
+                // Two or more surviving domains mean a data function's domains
+                // would be dropped by collapsing to a compute meet (a genuine
+                // domain-join collision). See `src/ccl/design/type-inference.md`,
+                // "The domain-join rejection".
+                if doms.len() <= 1 {
+                    return Err(CoalesceError::ComputeWhereDataRequired {
+                        details: format!("a compute function (capability) over {{{doms_s}}}"),
+                    });
+                }
+                return Err(CoalesceError::DomainJoinConflict {
+                    details: format!("a data function over {{{doms_s}}}"),
+                });
+            }
+            KindMerge::Compute => {
+                debug_assert_eq!(doms.len(), 1, "compute fun accumulated domain alternatives");
+                shapes.push(Type::Fun {
+                    name: kept_name,
+                    kind: crate::ccl::ty::FunKind::Compute,
+                    domain: Box::new(doms.into_iter().next().expect("compute fun has one domain")),
+                    codomain: Box::new(c),
+                });
+            }
+            KindMerge::Data => {
+                // One surviving alternative: they reconciled, so the join loses
+                // nothing and this is a plain data function. `xs if c else xs` types
+                // as `xs`, and so does any join whose arms turn out to share an
+                // domain once their domains are materialized.
+                let [dom] = <[Type; 1]>::try_from(doms).map_err(|doms: Vec<Type>| {
+                    // Two or more: the arms hold different domains, and a
+                    // collection's domain *is* its data, so no single domain holds
+                    // both arms' rows. The contravariant meet the compute lattice
+                    // would take here drops whichever rows the narrower domain
+                    // lacks; refusing is what the `Data` kind buys. The lossless
+                    // answer — a dependent sum over the candidate domains — is the
+                    // collections work.
+                    let doms_s = doms
+                        .iter()
+                        .map(|t| t.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    CoalesceError::DomainJoinConflict {
+                        details: format!(
+                            "collections over the distinct domains {{{doms_s}}} join at none \
+                             of them without losing rows"
+                        ),
+                    }
+                })?;
+                shapes.push(Type::Fun {
+                    name: kept_name,
+                    kind: crate::ccl::ty::FunKind::Data,
+                    domain: Box::new(dom),
+                    codomain: Box::new(c),
+                });
+            }
+        }
     }
     if let Some((value, domain, kind)) = &ct.history_slot {
         // Both children materialize at the same polarity (invariant — both
@@ -158,6 +254,15 @@ fn coalesce_compact_go(ct: &CompactType, polarity: bool) -> Result<Type, Coalesc
         1 => all.remove(0),
         _ => {
             // Multiple incompatible contributions. Reject.
+            //
+            // NB: a positive-polarity union relaxation for heterogeneous scalar
+            // `Case` arms (`1 if c else "x"` → `Int | String`) is *not* done
+            // here: it is indistinguishable at coalesce from a binop-operand
+            // join (`1 + true`), which must stay a hard error. A sound version
+            // needs strict scalar consumers (binops, …) to impose concrete
+            // bounds so the union is rejected at *their* site; that is deferred
+            // past the conditional-collection foundation. Collection arms still join losslessly — that happens in
+            // the `fun` slot above (`union_domains`), not through atoms.
             let pretty = all
                 .iter()
                 .map(|t| format!("{t}"))
@@ -211,7 +316,13 @@ fn dissolve_read_feeds(mut ct: CompactType, polarity: bool) -> CompactType {
         // `fun`-slot CompactType (exactly what the old single-payload slot held)
         // and merge it into the read view.
         let chan = CompactType {
-            fun: Some((None, domain, value)),
+            fun: Some(super::compact::CompactFun {
+                name: None,
+                // A feed's read view is a collection stream: a data function.
+                kind: super::compact::KindMerge::Data,
+                domains: vec![*domain],
+                codomain: value,
+            }),
             ..Default::default()
         };
         ct = CompactType::merge(polarity, ct, chan);
@@ -339,10 +450,148 @@ mod tests {
             t,
             Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Compute,
                 domain: Box::new(Type::Base(BaseType::Int)),
                 codomain: Box::new(Type::Base(BaseType::Bool))
             }
         );
+    }
+
+    #[test]
+    fn coalesce_two_data_domains_is_a_join_conflict() {
+        use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
+        // A `Data` fun slot whose two alternatives survive materialization as
+        // distinct domains has no lossless single domain, so it is rejected here
+        // rather than narrowed to a meet.
+        let graph = CompactGraph {
+            term: CompactType {
+                fun: Some(CompactFun {
+                    name: None,
+                    kind: KindMerge::Data,
+                    domains: vec![
+                        compact_type(&Type::UIntRange(2)).term,
+                        compact_type(&Type::UIntRange(3)).term,
+                    ],
+                    codomain: Box::new(compact_type(&prim(BaseType::Int)).term),
+                }),
+                ..Default::default()
+            },
+            rec_vars: BTreeMap::new(),
+        };
+        assert!(matches!(
+            coalesce_compact(&graph),
+            Err(CoalesceError::DomainJoinConflict { .. })
+        ));
+    }
+
+    #[test]
+    fn coalesce_single_data_domain_is_plain_data_fun() {
+        use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
+        // One surviving domain collapses to a plain `Data` fun (idempotence:
+        // `xs if c else xs` types as `xs`).
+        let graph = CompactGraph {
+            term: CompactType {
+                fun: Some(CompactFun {
+                    name: None,
+                    kind: KindMerge::Data,
+                    domains: vec![compact_type(&Type::UIntRange(2)).term],
+                    codomain: Box::new(compact_type(&prim(BaseType::Int)).term),
+                }),
+                ..Default::default()
+            },
+            rec_vars: BTreeMap::new(),
+        };
+        assert_eq!(
+            coalesce_compact(&graph).unwrap(),
+            Type::Fun {
+                name: None,
+                kind: crate::ccl::ty::FunKind::Data,
+                domain: Box::new(Type::UIntRange(2)),
+                codomain: Box::new(Type::Base(BaseType::Int)),
+            }
+        );
+    }
+
+    #[test]
+    fn coalesce_duplicate_data_domains_dedup_to_plain_fun() {
+        use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
+        // Two structurally-equal domains dedup to one → a plain `Data` fun, not
+        // a spurious 2-choice conditional collection.
+        let graph = CompactGraph {
+            term: CompactType {
+                fun: Some(CompactFun {
+                    name: None,
+                    kind: KindMerge::Data,
+                    domains: vec![
+                        compact_type(&Type::UIntRange(2)).term,
+                        compact_type(&Type::UIntRange(2)).term,
+                    ],
+                    codomain: Box::new(compact_type(&prim(BaseType::Int)).term),
+                }),
+                ..Default::default()
+            },
+            rec_vars: BTreeMap::new(),
+        };
+        assert_eq!(
+            coalesce_compact(&graph).unwrap(),
+            Type::Fun {
+                name: None,
+                kind: crate::ccl::ty::FunKind::Data,
+                domain: Box::new(Type::UIntRange(2)),
+                codomain: Box::new(Type::Base(BaseType::Int)),
+            }
+        );
+    }
+
+    #[test]
+    fn coalesce_domain_join_conflict_errs() {
+        use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
+        // A `Conflict` kind (a multi-domain data function met a compute function) is
+        // a loud coalesce error, never a silent domain drop.
+        let graph = CompactGraph {
+            term: CompactType {
+                fun: Some(CompactFun {
+                    name: None,
+                    kind: KindMerge::Conflict,
+                    domains: vec![
+                        compact_type(&Type::UIntRange(2)).term,
+                        compact_type(&Type::UIntRange(3)).term,
+                    ],
+                    codomain: Box::new(compact_type(&prim(BaseType::Int)).term),
+                }),
+                ..Default::default()
+            },
+            rec_vars: BTreeMap::new(),
+        };
+        assert!(matches!(
+            coalesce_compact(&graph),
+            Err(CoalesceError::DomainJoinConflict { .. })
+        ));
+    }
+
+    #[test]
+    fn coalesce_single_domain_conflict_is_compute_where_data_required() {
+        use crate::ccl::infer::solver::compact::{CompactFun, KindMerge};
+        // A `Conflict` over a *single* domain is one function slot demanded as a
+        // data domain while being a compute capability — the coalesce-time face
+        // of `Compute <: Data`, reported as `ComputeWhereDataRequired` rather
+        // than the multi-domain `DomainJoinConflict`.
+        let graph = CompactGraph {
+            term: CompactType {
+                fun: Some(CompactFun {
+                    name: None,
+                    kind: KindMerge::Conflict,
+                    domains: vec![compact_type(&prim(BaseType::Int)).term],
+                    codomain: Box::new(compact_type(&prim(BaseType::Int)).term),
+                }),
+                ..Default::default()
+            },
+            rec_vars: BTreeMap::new(),
+        };
+        assert!(matches!(
+            coalesce_compact(&graph),
+            Err(CoalesceError::ComputeWhereDataRequired { .. })
+        ));
     }
 
     #[test]

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -82,7 +82,158 @@ impl AtomKey {
 /// neither directly, so [`coalesce_compact`](super::coalesce::coalesce_compact)
 /// picks a single concrete type from these bag-of-types contributions and
 /// errors on conflict.
-#[derive(Debug, Clone, Default)]
+/// The kind of a merged function slot. Three-state so [`CompactType::merge`]
+/// stays infallible: a `Data ⊔ Compute` collision that would collapse a
+/// data function's domain alternatives becomes `Conflict` and is reported loudly at coalesce
+/// ([`super::coalesce::CoalesceError::DomainJoinConflict`]), never a mid-merge
+/// panic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KindMerge {
+    /// domain — the ordinary contravariant meet.
+    Compute,
+    /// domain — joins are lossless (`union_domains`).
+    Data,
+    /// A data/compute or multi-domain collision; deferred to coalesce.
+    Conflict,
+}
+
+impl KindMerge {
+    /// Resolve a function's kind. FunKind is a **provenance** property, not a
+    /// function of the domain: a concrete [`FunKind`](crate::ccl::ty::FunKind)
+    /// passes through unchanged. Data collections — list literals, comprehensions,
+    /// `groupby` — are concrete-stamped `Data` at construction; a bare lambda is
+    /// concrete `Compute` (a capability, `emit_lambda`). Only an *inferred* kind
+    /// ([`FunKind::Var`](crate::ccl::ty::FunKind::Var) — a function parameter or a
+    /// freshened scheme kind) resolves from its bounds over the two-point lattice
+    /// `Data ⊑ Compute`: a `Compute` lower bound → `Compute`, a `Data` upper bound
+    /// (demand) → `Data`, both → the `Compute <: Data` conflict, neither → the
+    /// `Compute` capability default. No domain inspection is involved: a capability
+    /// supplied where a collection is demanded (e.g. `sum(λ x → x + 1)`) is a concrete
+    /// `Compute` value against a `Data` demand, rejected up front in
+    /// [`constrain_kind`](super::constrain) — it never reaches a var here.
+    fn of(kind: &crate::ccl::ty::FunKind) -> Self {
+        use crate::ccl::ty::FunKind;
+        match kind {
+            FunKind::Compute => KindMerge::Compute,
+            FunKind::Data => KindMerge::Data,
+            FunKind::Var(v) => {
+                let b = v.bounds.borrow();
+                match (b.forced_compute, b.forced_data) {
+                    (true, true) => KindMerge::Conflict,
+                    // A var demanded as data with no compute lower bound is `Data`
+                    // (e.g. a parameter used only as a collection). A capability
+                    // flowing in would carry a concrete `Compute`, forcing the
+                    // `(true, _)` arms or failing at `constrain_kind` first.
+                    (false, true) => KindMerge::Data,
+                    (true, false) => KindMerge::Compute,
+                    // Unconstrained → `Compute` (a capability is the default).
+                    (false, false) => KindMerge::Compute,
+                }
+            }
+        }
+    }
+}
+
+/// A merged function shape. `domains` holds one entry for an ordinary function
+/// (the meet of the merged domains); a positive `Data ⊔ Data` join accumulates
+/// ≥ 2 deduplicated alternatives, which coalesce reconciles (see `union_domains`).
+/// `Compute` slots always carry exactly one.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompactFun {
+    /// The Pi (element) binder, `na.or(nb)` on merge.
+    pub name: Option<Name>,
+    /// The merged kind.
+    pub kind: KindMerge,
+    /// Domain alternatives — `len == 1` unless a `Data ⊔ Data` join accumulated more.
+    pub domains: Vec<CompactType>,
+    /// The codomain (covariant).
+    pub codomain: Box<CompactType>,
+}
+
+/// The join of two data-function domain-alternative lists: the union of the
+/// alternatives, deduplicated by structural [`CompactType`] equality. Never a
+/// meet — a `Data` domain *is* the data, so narrowing it drops rows.
+///
+/// Both alternatives are kept because whether they are really two domains cannot
+/// be decided here: at compact time a domain still carries unresolved variable
+/// identity, so two structurally identical domains can compare unequal. Coalesce
+/// re-runs the comparison on the materialized [`Type`]s and decides there — one
+/// surviving domain is a plain data function, and more than one is a join with no
+/// lossless single-domain answer.
+fn union_domains(mut a: Vec<CompactType>, b: Vec<CompactType>) -> Vec<CompactType> {
+    for d in b {
+        if !a.contains(&d) {
+            a.push(d);
+        }
+    }
+    a
+}
+
+impl CompactFun {
+    /// Merge two function slots. `pol` is the *outer* polarity; domains merge
+    /// contravariantly (at `!pol`), the codomain covariantly (at `pol`).
+    fn merge(pol: bool, a: CompactFun, b: CompactFun) -> CompactFun {
+        use KindMerge::*;
+        let name = a.name.clone().or_else(|| b.name.clone());
+        let codomain = Box::new(CompactType::merge(pol, *a.codomain, *b.codomain));
+        // The contravariant domain meet, defined only when both sides carry a
+        // single domain (a multi-domain collection has no single domain to meet).
+        let meet = |x: Vec<CompactType>, y: Vec<CompactType>| -> Vec<CompactType> {
+            debug_assert!(x.len() == 1 && y.len() == 1, "meet of a multi-domain");
+            vec![CompactType::merge(
+                !pol,
+                x.into_iter().next().unwrap(),
+                y.into_iter().next().unwrap(),
+            )]
+        };
+        // On any prior conflict, stay conflicted (keep the wider domain list
+        // so coalesce can render diagnostics).
+        let widest = |x: Vec<CompactType>, y: Vec<CompactType>| {
+            if x.len() >= y.len() { x } else { y }
+        };
+        let (kind, domains) = if a.kind == Conflict || b.kind == Conflict {
+            (Conflict, widest(a.domains, b.domains))
+        } else if pol {
+            // Positive (join).
+            match (a.kind, b.kind) {
+                (Data, Data) => (Data, union_domains(a.domains, b.domains)),
+                (Compute, Compute) => (Compute, meet(a.domains, b.domains)),
+                // Data ⊔ Compute: an honest upcast to a callable (Compute) iff
+                // the data side is a single domain; collapsing several alternatives
+                // to a meet would drop domains → Conflict.
+                _ => {
+                    if a.domains.len() == 1 && b.domains.len() == 1 {
+                        (Compute, meet(a.domains, b.domains))
+                    } else {
+                        (Conflict, widest(a.domains, b.domains))
+                    }
+                }
+            }
+        } else {
+            // Negative (meet): the stronger contract wins (Data if either is).
+            let k = if a.kind == Data || b.kind == Data {
+                Data
+            } else {
+                Compute
+            };
+            if a.domains.len() == 1 && b.domains.len() == 1 {
+                (k, meet(a.domains, b.domains))
+            } else {
+                // Two multi-domain requirements meeting at a negative position — no current
+                // program produces this; flag it loudly at coalesce.
+                (Conflict, widest(a.domains, b.domains))
+            }
+        };
+        CompactFun {
+            name,
+            kind,
+            domains,
+            codomain,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct CompactType {
     /// Variable contributions from this position. Multiple variables
     /// can co-occur (e.g. when two projection morphisms both flow into
@@ -116,13 +267,11 @@ pub struct CompactType {
     /// the absorbing element (here from intersecting disjoint tag sets at
     /// negative polarity).
     pub var: Option<BTreeMap<FieldKey, CompactType>>,
-    /// Function shape, if any: an optional Pi binder name plus the domain
-    /// and codomain. Recursively merged with polarity flip on the domain.
-    /// The name is preserved so a dependent codomain's refinement predicate
-    /// keeps its binder bound through coalesce; it is stripped at
-    /// materialization when the codomain does not actually reference it
-    /// (keeping ordinary functions `name: None`).
-    pub fun: Option<(Option<Name>, Box<CompactType>, Box<CompactType>)>,
+    /// Function shape, if any: see [`CompactFun`]. Carries the Pi binder, the
+    /// merged [`KindMerge`], the domain alternatives (one, unless a positive
+    /// `Data ⊔ Data` join accumulated alternatives via [`union_domains`]), and the
+    /// codomain. Recursively merged with polarity flip on the domain.
+    pub fun: Option<CompactFun>,
     /// Witness contributions at this position. A set with `==`
     /// membership (deduplicated by [`Refinement`]'s structural `PartialEq`),
     /// stored as a `Vec` in first-insertion order. A refinement-set is
@@ -176,15 +325,7 @@ impl CompactType {
         };
         let fun = match (lhs.fun, rhs.fun) {
             (None, f) | (f, None) => f,
-            (Some((na, la, ra)), Some((nb, lb, rb))) => Some((
-                // Prefer a present binder name; two distinct names at one
-                // position only arise for unrelated functions merging, where
-                // either is as good (the name is stripped at coalesce unless
-                // the codomain references it).
-                na.or(nb),
-                Box::new(Self::merge(!pol, *la, *lb)),
-                Box::new(Self::merge(pol, *ra, *rb)),
-            )),
+            (Some(a), Some(b)) => Some(CompactFun::merge(pol, a, b)),
         };
         let refinements = Self::merge_refinements(pol, lhs.refinements, rhs.refinements);
         // History children merge componentwise at the outer polarity
@@ -430,6 +571,7 @@ fn compact_go(
         Type::Hole => CompactType::empty(),
         Type::Fun {
             name,
+            kind,
             domain: d,
             codomain: c,
         } => {
@@ -446,7 +588,12 @@ fn compact_go(
             };
             let cod = compact_go(c, pol, &cod_acc, &BTreeSet::new(), st);
             CompactType {
-                fun: Some((name.clone(), Box::new(dom), Box::new(cod))),
+                fun: Some(CompactFun {
+                    name: name.clone(),
+                    kind: KindMerge::of(kind),
+                    domains: vec![dom],
+                    codomain: Box::new(cod),
+                }),
                 ..Default::default()
             }
         }

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -90,6 +90,21 @@ pub enum ConstrainError {
         /// The demanded data collection.
         rhs: Type,
     },
+    /// Two collections over domains that are not the same domain met at one
+    /// position. A data domain is invariant (see
+    /// `src/ccl/design/type-inference.md`, "Data domains are invariant"), so
+    /// neither collection stands in for the other; their join is a Σ over the two
+    /// candidate domains, which is not yet representable. The coalesce-time face
+    /// of the same fact — reached when no edge forces the question earlier — is
+    /// [`super::coalesce::CoalesceError::DomainJoinConflict`]. Like
+    /// [`Self::ComputeWhereDataRequired`], raised only when the cache is
+    /// kind-aware.
+    DataDomainMismatch {
+        /// The supplied collection's domain.
+        lhs: Type,
+        /// The domain demanded at the position.
+        rhs: Type,
+    },
 }
 
 /// Cache of in-progress subtyping checks. Breaks cycles introduced through
@@ -415,25 +430,34 @@ fn constrain_go(
                 (Some(k), Some(x)) => sl.extended_rename(k, x),
                 _ => sl.clone(),
             };
-            constrain_go(d1, d0, sr, sl, cache)?;
-            // A `Data` domain should be **invariant**: it is the loop bound
-            // op-conversion emits, so subsuming it in either direction changes
-            // which rows the consumer reads (`src/ccl/design/type-inference.md`,
-            // "Data domains are invariant"). Only the *base* half of that is in
-            // force, and structurally rather than here — `UIntRange` relates only
-            // by equality, so the contravariant edge above already rejects a wider
-            // or a narrower range domain. What the missing guard would add is
-            // rejecting *acquisition*, `D ⤇ V <: {D | p} ⤇ V`: contravariance
-            // inverts the drop-only refinement lattice, so an unfiltered
-            // collection is admitted where a filtered domain is declared
-            // (`data_domain_refinement_relates_only_by_acquisition`).
+            // The domain edge. A *compute* domain is contravariant: it is a
+            // parameter, nothing can enumerate it, and accepting more inputs than
+            // demanded only under-promises. A **data** domain is *invariant* — it is
+            // the loop bound op-conversion emits and it reappears in every
+            // eliminator's result, so narrowing or widening it changes which rows the
+            // consumer reads (`src/ccl/design/type-inference.md`, "Data domains are
+            // invariant"). Invariance is spelled the only order-independent way it
+            // can be, as both edges; anything conditional on *when* the edge fires
+            // would make typing depend on constraint order.
             //
-            // What the guard should be is open. Requiring the two domains to be
-            // *equal* here does not work: when this edge is emitted the demanded
-            // domain is routinely an unresolved variable whose refinement arrives
-            // later through its bounds (a filtered comprehension into an aggregate
-            // emits `{?i | p} ⤇ V <: ?j ⤇ V`), so comparing layers rejects sound
-            // programs.
+            // Emitting both directions does not preempt a domain join. Two domains
+            // meeting at one variable is a join like any other, and the join of two
+            // data functions is a Σ over the candidate domains — at a domain position
+            // exactly as at a `Case` result. Until Σ is representable that join has
+            // no answer, which is the error below; the same fact reaches coalesce as
+            // `CoalesceError::DomainJoinConflict` when no edge forces it earlier.
+            if kind_aware && matches!(k0, FunKind::Data) && matches!(k1, FunKind::Data) {
+                if constrain_go(d1, d0, sr, sl, cache).is_err()
+                    || constrain_go(d0, d1, sl, sr, cache).is_err()
+                {
+                    return Err(ConstrainError::DataDomainMismatch {
+                        lhs: (**d0).clone(),
+                        rhs: (**d1).clone(),
+                    });
+                }
+            } else {
+                constrain_go(d1, d0, sr, sl, cache)?;
+            }
             constrain_go(c0, c1, &cod_sl, sr, cache)
         }
 
@@ -1127,17 +1151,12 @@ mod tests {
     }
 
     #[test]
-    fn data_domain_refinement_relates_only_by_acquisition() {
-        // A data domain should be invariant (`design/type-inference.md`, "Data
-        // domains are invariant"). This pins how much of that holds: the base half
-        // does, because `UIntRange` relates only by equality; the refinement half
-        // does not.
-        //
-        // The domain is contravariant, so the ordinary refinement-width rule
-        // (`{D | p} <: D`, drop-only) *inverts* behind the arrow: the relation that
-        // survives is the one whose **supertype** is the more refined. That is
-        // *acquisition* — an unfiltered collection standing where a filtered one is
-        // declared — and it is the edge the missing guard would reject.
+    fn a_data_domain_relates_only_to_itself() {
+        // A data domain is invariant (`design/type-inference.md`, "Data domains are
+        // invariant"), so a data function relates to another only when the domains
+        // are the same domain — pinned in all four directions, base and refinement.
+        // Two collections that differ are not ordered either way; their join is a Σ,
+        // not one of them.
         use crate::ccl::{Lit, TypedExpr};
         let refined_dom = || {
             Type::Refinement(
@@ -1169,17 +1188,32 @@ mod tests {
             .is_err()
         );
 
-        // The same refinement behind a data arrow: inverted by contravariance.
+        // Behind a data arrow, neither refinement direction relates.
         assert!(
-            constrain_subtype(&bare, &refined, &mut ConstrainCache::new()).is_ok(),
-            "acquisition is the edge that survives — and the one left unguarded"
+            matches!(
+                constrain_subtype(&bare, &refined, &mut ConstrainCache::new()),
+                Err(ConstrainError::DataDomainMismatch { .. })
+            ),
+            "a collection may not acquire a domain filter by subsumption"
         );
         assert!(
             constrain_subtype(&refined, &bare, &mut ConstrainCache::new()).is_err(),
-            "dropping a domain refinement does not hold at the arrow"
+            "nor drop one"
         );
 
-        // The base half of invariance, in force in both directions.
+        // A *compute* arrow over the same domains keeps the contravariant lattice:
+        // invariance is about collections, not about refinements behind any arrow.
+        assert!(
+            constrain_subtype(
+                &fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &fun(refined_dom(), prim(BaseType::Int)),
+                &mut ConstrainCache::new()
+            )
+            .is_ok(),
+            "a capability's domain is not data — acquiring a refinement is sound"
+        );
+
+        // Nor either base direction.
         assert!(
             constrain_subtype(&bare, &wider, &mut ConstrainCache::new()).is_err(),
             "a narrower range domain does not stand in for a wider one"
@@ -1187,6 +1221,17 @@ mod tests {
         assert!(
             constrain_subtype(&wider, &bare, &mut ConstrainCache::new()).is_err(),
             "nor a wider one for a narrower — no contravariant widening of a data domain"
+        );
+
+        // The same domain does relate: invariance is equality, not a blanket
+        // rejection of `Data`/`Data` edges.
+        assert!(
+            constrain_subtype(&bare, &bare, &mut ConstrainCache::new()).is_ok(),
+            "a data function relates to itself"
+        );
+        assert!(
+            constrain_subtype(&refined, &refined, &mut ConstrainCache::new()).is_ok(),
+            "including through a domain refinement"
         );
     }
 

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -416,19 +416,24 @@ fn constrain_go(
                 _ => sl.clone(),
             };
             constrain_go(d1, d0, sr, sl, cache)?;
-            // NB: Data-domain **invariance** (equating both arrows' domains when
-            // both are `Data`, to stop a wider collection standing where a
-            // narrower declared domain is expected — the silent-row-drop guard
-            // of design §5) is deliberately *not* enabled here. A naive
-            // strict-equality reverse edge breaks the sound, common pattern of a
-            // *filtered* collection (`{[0, n] | p} ⤇ V`) flowing where the
-            // unfiltered domain (`[0, n] ⤇ V`) is expected: the reverse edge
-            // demands `[0, n] <: {[0, n] | p}`, i.e. acquiring a refinement by
-            // subsumption, which the lattice strictly forbids. Invariance must
-            // therefore be *modulo refinements* and range-aware; see
-            // `src/ccl/design/type-inference.md`, "Deferred: data-domain invariance".
-            // The contravariant edge above plus the strict refinement lattice
-            // already reject *acquiring* a collection by subsumption.
+            // A `Data` domain should be **invariant**: it is the loop bound
+            // op-conversion emits, so subsuming it in either direction changes
+            // which rows the consumer reads (`src/ccl/design/type-inference.md`,
+            // "Data domains are invariant"). Only the *base* half of that is in
+            // force, and structurally rather than here — `UIntRange` relates only
+            // by equality, so the contravariant edge above already rejects a wider
+            // or a narrower range domain. What the missing guard would add is
+            // rejecting *acquisition*, `D ⤇ V <: {D | p} ⤇ V`: contravariance
+            // inverts the drop-only refinement lattice, so an unfiltered
+            // collection is admitted where a filtered domain is declared
+            // (`data_domain_refinement_relates_only_by_acquisition`).
+            //
+            // What the guard should be is open. Requiring the two domains to be
+            // *equal* here does not work: when this edge is emitted the demanded
+            // domain is routinely an unresolved variable whose refinement arrives
+            // later through its bounds (a filtered comprehension into an aggregate
+            // emits `{?i | p} ⤇ V <: ?j ⤇ V`), so comparing layers rejects sound
+            // programs.
             constrain_go(c0, c1, &cod_sl, sr, cache)
         }
 
@@ -1122,18 +1127,17 @@ mod tests {
     }
 
     #[test]
-    fn a_refined_data_domain_relates_only_by_acquisition_today() {
-        // What the `Fun`/`Fun` arm does to a *data* function whose domain carries a
-        // refinement — pinned because the direction is the opposite of what a reader
-        // expects, and because it is the edge `design/type-inference.md`, "Deferred:
-        // data-domain invariance" is about.
+    fn data_domain_refinement_relates_only_by_acquisition() {
+        // A data domain should be invariant (`design/type-inference.md`, "Data
+        // domains are invariant"). This pins how much of that holds: the base half
+        // does, because `UIntRange` relates only by equality; the refinement half
+        // does not.
         //
         // The domain is contravariant, so the ordinary refinement-width rule
         // (`{D | p} <: D`, drop-only) *inverts* behind the arrow: the relation that
-        // holds is the one whose **supertype** is the more refined. That is row
-        // *addition* — an unfiltered collection standing where a filtered one is
-        // declared — which is the direction a data function must not admit. Base
-        // domains are already invariant: `UIntRange` relates only by equality.
+        // survives is the one whose **supertype** is the more refined. That is
+        // *acquisition* — an unfiltered collection standing where a filtered one is
+        // declared — and it is the edge the missing guard would reject.
         use crate::ccl::{Lit, TypedExpr};
         let refined_dom = || {
             Type::Refinement(
@@ -1168,16 +1172,22 @@ mod tests {
         // The same refinement behind a data arrow: inverted by contravariance.
         assert!(
             constrain_subtype(&bare, &refined, &mut ConstrainCache::new()).is_ok(),
-            "acquisition holds today — the row-addition direction"
+            "acquisition is the edge that survives — and the one left unguarded"
         );
         assert!(
             constrain_subtype(&refined, &bare, &mut ConstrainCache::new()).is_err(),
             "dropping a domain refinement does not hold at the arrow"
         );
 
-        // Bases relate only by equality, in both directions.
-        assert!(constrain_subtype(&bare, &wider, &mut ConstrainCache::new()).is_err());
-        assert!(constrain_subtype(&wider, &bare, &mut ConstrainCache::new()).is_err());
+        // The base half of invariance, in force in both directions.
+        assert!(
+            constrain_subtype(&bare, &wider, &mut ConstrainCache::new()).is_err(),
+            "a narrower range domain does not stand in for a wider one"
+        );
+        assert!(
+            constrain_subtype(&wider, &bare, &mut ConstrainCache::new()).is_err(),
+            "nor a wider one for a narrower — no contravariant widening of a data domain"
+        );
     }
 
     #[test]

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -20,6 +20,7 @@ use std::rc::Rc;
 use smol_str::SmolStr;
 
 use crate::ccl::subst::Subst;
+use crate::ccl::ty::{FunKind, FunKindVar};
 use crate::ccl::{Bound, HistoryKind, InferVar, InferVarId, Level, Refinement, Type};
 
 use super::type_level;
@@ -75,6 +76,20 @@ pub enum ConstrainError {
         /// The feed type demanded.
         required: Type,
     },
+    /// A compute function (a capability, `⇒`) was supplied where a data
+    /// collection (`⤇`) is demanded. `Data <: Compute` is the safe
+    /// upcast — a collection is callable at any index in its domain — but the
+    /// reverse would iterate a *declared* domain the value does not actually
+    /// cover, silently dropping rows. Raised only when the cache is
+    /// kind-aware (constraint emission); the post-inference check is kind-blind
+    /// (see [`ConstrainCache`]), since elimination preserves denotation but not
+    /// kind representation.
+    ComputeWhereDataRequired {
+        /// The supplied compute function.
+        lhs: Type,
+        /// The demanded data collection.
+        rhs: Type,
+    },
 }
 
 /// Cache of in-progress subtyping checks. Breaks cycles introduced through
@@ -94,7 +109,51 @@ pub enum ConstrainError {
 /// (var⇄var) edges are renames over the episode's finite binder set, whose
 /// composites saturate; discharges ride acyclic content edges only (their
 /// composites grow along lexical nesting depth, not around cycles).
-pub type ConstrainCache = HashMap<(Type, Type), Vec<(Subst, Subst)>>;
+///
+/// Carries the `kind_aware` mode flag alongside the edge map. The
+/// `Compute <: Data` kind rejection (a capability supplied where a collection is
+/// demanded — see [`ConstrainError::ComputeWhereDataRequired`]) fires only
+/// during constraint **emission** (inference), where kinds are being inferred
+/// and a mismatch is a real domain-loss bug. The post-inference structural
+/// check is **kind-blind**: lambda elimination is denotation-preserving but not
+/// kind-preserving (`Type::without_pi_names` canonicalizes every reconstructed
+/// arrow to `Compute`), so a point-free map flowing into a `Data` argument is
+/// well-denoted and must not be re-rejected on kind. FunKind is an inference-time
+/// property, so the flag rides the cache that is already threaded through the
+/// whole recursion.
+pub struct ConstrainCache {
+    edges: HashMap<(Type, Type), Vec<(Subst, Subst)>>,
+    kind_aware: bool,
+}
+
+impl ConstrainCache {
+    /// A kind-aware cache (constraint emission / inference): the
+    /// `Compute <: Data` rejection is live.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            edges: HashMap::new(),
+            kind_aware: true,
+        }
+    }
+
+    /// A kind-blind cache (the post-inference structural check): kind
+    /// mismatches are ignored (see the type doc).
+    pub fn new_kind_blind() -> Self {
+        Self {
+            edges: HashMap::new(),
+            kind_aware: false,
+        }
+    }
+
+    /// The composite-substitution bridges recorded for a subtyping edge,
+    /// inserting an empty list on first visit. This is the cycle breaker: a
+    /// re-entry on the same `(lhs, rhs)` pair finds its in-progress entry rather
+    /// than recursing forever.
+    fn edge_bridges(&mut self, lhs: Type, rhs: Type) -> &mut Vec<(Subst, Subst)> {
+        self.edges.entry((lhs, rhs)).or_default()
+    }
+}
 
 /// Cache for [`extrude`], keyed by the polar pair (variable uid, polarity).
 ///
@@ -114,6 +173,48 @@ pub fn constrain_subtype(
     cache: &mut ConstrainCache,
 ) -> Result<(), ConstrainError> {
     constrain_go(lhs, rhs, &Subst::id(), &Subst::id(), cache)
+}
+
+/// Constrain the kind edge `k0 <: k1` over the two-point lattice
+/// `Data ⊑ Compute` (`Data` bottom / most specific, `Compute` top).
+///
+/// Concrete edges: `Data <: κ` and `κ <: Compute` always hold; `Compute <: Data`
+/// is the sole failure — returned as `true` (the caller raises
+/// [`ConstrainError::ComputeWhereDataRequired`], having the full function types
+/// for the diagnostic) **iff** `kind_aware` (emission mode).
+///
+/// Variable edges set `forced_*` flags, resolved at coalesce
+/// ([`super::compact::KindMerge`]): a compute value flowing *into* a var forces
+/// it `Compute`; a var *demanded* as data forces it `Data`; a var-to-var edge
+/// records a `<:` link ([`FunKindVar::link`]). Forces propagate transitively along
+/// links as they arrive, so ordering does not matter (a force after its link
+/// still reaches the far end). A var that ends up with both flags is the
+/// conflict — surfaced loudly at coalesce, never here.
+fn constrain_kind(k0: &FunKind, k1: &FunKind, kind_aware: bool) -> bool {
+    use FunKind::*;
+    match (k0, k1) {
+        // `Data` is bottom, `Compute` is top: these edges always hold.
+        (Data, _) | (_, Compute) => false,
+        // The one rejection — a capability supplied where a collection is demanded.
+        (Compute, Data) => kind_aware,
+        // A compute value flows into this var: it cannot be `Data`. The force
+        // propagates up any `<:` links already drawn to this var.
+        (Compute, Var(v1)) => {
+            v1.force_compute();
+            false
+        }
+        // This var is demanded as data: it cannot be `Compute`. Propagates down.
+        (Var(v0), Data) => {
+            v0.force_data();
+            false
+        }
+        // A var-to-var edge `v0 <: v1`: record the link so a force arriving on
+        // either end *after* this edge still reaches the other. See [`FunKindVar`].
+        (Var(v0), Var(v1)) => {
+            FunKindVar::link(v0, v1);
+            false
+        }
+    }
 }
 
 /// Bridge the holder gap when chaining two edges through one variable.
@@ -136,7 +237,7 @@ pub fn constrain_subtype(
 ///   upper — a discharge lands on a holder side at every contravariant edge
 ///   swap — where `V <: U` and `L <: V‹[x↦0]›` derive `L <: U‹[x↦0]›`);
 /// - two *distinct non-invertible* morphisms meeting at one variable is the
-///   unhandled extent-join corner (O1/O4) — `invert_rename` is its loud
+///   unhandled domain-join corner (O1/O4) — `invert_rename` is its loud
 ///   tripwire.
 fn bridge_holder_gap(lo: &Subst, hi: &Subst) -> (Subst, Subst) {
     if lo == hi {
@@ -195,16 +296,14 @@ fn bridge_holder_gap(lo: &Subst, hi: &Subst) -> (Subst, Subst) {
     }
     // Two *distinct* non-invertible morphisms meeting at one variable: bounds
     // constraining different fibers (of one family — g(0) vs g(1) — or of two
-    // unrelated families), between which no sound transport exists. This is
-    // the extent-join corner (O1/O4); the eventual resolution is the
-    // lossless-Σ extent regime (vault: type-checker-data-vs-compute-functions),
-    // under which both fibers become components of the one Σ-type and the
-    // question dissolves. Until then: no reachable program produces this
-    // shape, so reaching it means a solver bug — refuse loudly rather than
-    // corrupt the edge.
+    // unrelated families), between which no sound transport exists. This is the
+    // domain-join corner (O1/O4): the two fibers are distinct domains of one data
+    // family, which is exactly the join a `Data` kind refuses to narrow. No
+    // reachable program produces this shape, so reaching it means a solver bug —
+    // refuse loudly rather than corrupt the edge.
     panic!(
         "closure bridge: two distinct non-invertible morphisms met at one \
-         variable (extent-join corner, O1/O4): lo={lo:?}, hi={hi:?}"
+         variable (domain-join corner, O1/O4): lo={lo:?}, hi={hi:?}"
     );
 }
 
@@ -249,7 +348,7 @@ fn constrain_go(
     // different constraint (see `ConstrainCache`).
     let either_var = matches!(lhs, Type::Infer(_)) || matches!(rhs, Type::Infer(_));
     if either_var {
-        let seen = cache.entry((lhs.clone(), rhs.clone())).or_default();
+        let seen = cache.edge_bridges(lhs.clone(), rhs.clone());
         // Morphisms compare modulo emit-time type slots — the SAME notion of
         // constraint identity the closure bridge uses (`eq_modulo_ty_slots`).
         // Strict `==` here would admit a near-duplicate edge (two captures of
@@ -288,20 +387,48 @@ fn constrain_go(
         (
             Type::Fun {
                 name: n0,
+                kind: k0,
                 domain: d0,
                 codomain: c0,
             },
             Type::Fun {
                 name: n1,
+                kind: k1,
                 domain: d1,
                 codomain: c1,
             },
         ) => {
-            constrain_go(d1, d0, sr, sl, cache)?;
+            // The kind edge over the lattice `Data ⊑ Compute` (see
+            // `constrain_kind`): `Data <: κ` and `κ <: Compute` always hold; a
+            // concrete `Compute <: Data` is the rejection (a capability where an
+            // domain is demanded → silent row loss), live only when the cache is
+            // kind-aware (emission, not the kind-blind post-inference check).
+            // FunKind vars accumulate `forced_*` flags here and resolve at coalesce.
+            let kind_aware = cache.kind_aware;
+            if constrain_kind(k0, k1, kind_aware) {
+                return Err(ConstrainError::ComputeWhereDataRequired {
+                    lhs: lhs.clone(),
+                    rhs: rhs.clone(),
+                });
+            }
             let cod_sl = match (n0, n1) {
                 (Some(k), Some(x)) => sl.extended_rename(k, x),
                 _ => sl.clone(),
             };
+            constrain_go(d1, d0, sr, sl, cache)?;
+            // NB: Data-domain **invariance** (equating both arrows' domains when
+            // both are `Data`, to stop a wider collection standing where a
+            // narrower declared domain is expected — the silent-row-drop guard
+            // of design §5) is deliberately *not* enabled here. A naive
+            // strict-equality reverse edge breaks the sound, common pattern of a
+            // *filtered* collection (`{[0, n] | p} ⤇ V`) flowing where the
+            // unfiltered domain (`[0, n] ⤇ V`) is expected: the reverse edge
+            // demands `[0, n] <: {[0, n] | p}`, i.e. acquiring a refinement by
+            // subsumption, which the lattice strictly forbids. Invariance must
+            // therefore be *modulo refinements* and range-aware; see
+            // `src/ccl/design/type-inference.md`, "Deferred: data-domain invariance".
+            // The contravariant edge above plus the strict refinement lattice
+            // already reject *acquiring* a collection by subsumption.
             constrain_go(c0, c1, &cod_sl, sr, cache)
         }
 
@@ -499,6 +626,8 @@ fn constrain_go(
         ) => {
             let chan = Type::Fun {
                 name: None,
+                // A feed's read view is a collection stream: a data function.
+                kind: FunKind::Data,
                 domain: domain.clone(),
                 codomain: value.clone(),
             };
@@ -520,6 +649,8 @@ fn constrain_go(
         ) => {
             let chan = Type::Fun {
                 name: None,
+                // A feed's read view is a collection stream: a data function.
+                kind: FunKind::Data,
                 domain: domain.clone(),
                 codomain: value.clone(),
             };
@@ -715,10 +846,12 @@ pub fn extrude(ty: &Type, pol: bool, target_level: Level, cache: &mut ExtrudeCac
         | Type::Hole => ty.clone(),
         Type::Fun {
             name,
+            kind,
             domain: d,
             codomain: c,
         } => Type::Fun {
             name: name.clone(),
+            kind: kind.clone(),
             domain: Box::new(extrude(d, !pol, target_level, cache)),
             codomain: Box::new(extrude(c, pol, target_level, cache)),
         },
@@ -989,6 +1122,65 @@ mod tests {
     }
 
     #[test]
+    fn a_refined_data_domain_relates_only_by_acquisition_today() {
+        // What the `Fun`/`Fun` arm does to a *data* function whose domain carries a
+        // refinement — pinned because the direction is the opposite of what a reader
+        // expects, and because it is the edge `design/type-inference.md`, "Deferred:
+        // data-domain invariance" is about.
+        //
+        // The domain is contravariant, so the ordinary refinement-width rule
+        // (`{D | p} <: D`, drop-only) *inverts* behind the arrow: the relation that
+        // holds is the one whose **supertype** is the more refined. That is row
+        // *addition* — an unfiltered collection standing where a filtered one is
+        // declared — which is the direction a data function must not admit. Base
+        // domains are already invariant: `UIntRange` relates only by equality.
+        use crate::ccl::{Lit, TypedExpr};
+        let refined_dom = || {
+            Type::Refinement(
+                Box::new(Type::UIntRange(3)),
+                Refinement {
+                    predicate: Rc::new(TypedExpr::lit(Lit::Bool(true))),
+                },
+            )
+        };
+        let refined = Type::data_fun(refined_dom(), prim(BaseType::Int));
+        let bare = Type::data_fun(Type::UIntRange(3), prim(BaseType::Int));
+        let wider = Type::data_fun(Type::UIntRange(9), prim(BaseType::Int));
+
+        // Bare domain position: the plain lattice, drop-only.
+        assert!(
+            constrain_subtype(
+                &refined_dom(),
+                &Type::UIntRange(3),
+                &mut ConstrainCache::new()
+            )
+            .is_ok()
+        );
+        assert!(
+            constrain_subtype(
+                &Type::UIntRange(3),
+                &refined_dom(),
+                &mut ConstrainCache::new()
+            )
+            .is_err()
+        );
+
+        // The same refinement behind a data arrow: inverted by contravariance.
+        assert!(
+            constrain_subtype(&bare, &refined, &mut ConstrainCache::new()).is_ok(),
+            "acquisition holds today — the row-addition direction"
+        );
+        assert!(
+            constrain_subtype(&refined, &bare, &mut ConstrainCache::new()).is_err(),
+            "dropping a domain refinement does not hold at the arrow"
+        );
+
+        // Bases relate only by equality, in both directions.
+        assert!(constrain_subtype(&bare, &wider, &mut ConstrainCache::new()).is_err());
+        assert!(constrain_subtype(&wider, &bare, &mut ConstrainCache::new()).is_err());
+    }
+
+    #[test]
     fn structurally_equal_refinements_hash_equal() {
         // The `Hash`/`Eq` contract: structurally-equal refinements in
         // distinct `Rc`s are `==`, so they must also hash equal — otherwise the
@@ -1018,13 +1210,10 @@ mod tests {
         let mut cache = ConstrainCache::new();
         let sid = (Subst::id(), Subst::id());
         cache
-            .entry((a.clone(), prim(BaseType::Int)))
-            .or_default()
+            .edge_bridges(a.clone(), prim(BaseType::Int))
             .push(sid.clone());
         assert!(
-            cache
-                .get(&(b, prim(BaseType::Int)))
-                .is_some_and(|seen| seen.contains(&sid)),
+            cache.edge_bridges(b, prim(BaseType::Int)).contains(&sid),
             "structurally-equal refined key must hit the same cache entry"
         );
 
@@ -1890,5 +2079,117 @@ mod tests {
         };
         assert!(lam().eq_modulo_ty_slots(&lam()));
         drop(arena);
+    }
+
+    // ----- FunKind edge (the `Compute <: Data` rejection) -----------
+
+    fn data_fun(d: Type, c: Type) -> Type {
+        Type::data_fun(d, c)
+    }
+
+    #[test]
+    fn kind_data_upcasts_to_compute() {
+        // `Data <: Compute` is the safe upcast — a collection is callable at any
+        // index in its domain. `[0, 2] ⤇ Int <: [0, 2] ⇒ Int`.
+        let mut cache = ConstrainCache::new();
+        assert!(
+            constrain_subtype(
+                &data_fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &mut cache,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn kind_compute_where_data_is_rejected() {
+        // `Compute ⋢ Data`: a capability supplied where a collection is demanded is
+        // the rejection (the silent-row-loss guard). `[0, 2] ⇒ Int ⊀ [0, 2] ⤇ Int`.
+        let mut cache = ConstrainCache::new();
+        assert!(matches!(
+            constrain_subtype(
+                &fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &data_fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &mut cache,
+            ),
+            Err(ConstrainError::ComputeWhereDataRequired { .. })
+        ));
+    }
+
+    #[test]
+    fn kind_rejection_is_off_in_the_kind_blind_check() {
+        // The post-inference check is kind-blind: the very `Compute <: Data`
+        // edge the emission cache rejects is accepted here (elimination
+        // preserves denotation, not kind representation).
+        let mut cache = ConstrainCache::new_kind_blind();
+        assert!(
+            constrain_subtype(
+                &fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &data_fun(Type::UIntRange(3), prim(BaseType::Int)),
+                &mut cache,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn kind_var_demanded_as_data_is_forced_data() {
+        // A kind var *demanded* as `Data` acquires `forced_data` (no eager
+        // rejection — the var may still legitimately resolve `Data`); it
+        // resolves at coalesce. A compute value flowing into it would set
+        // `forced_compute`, and both flags together is the conflict.
+        let v = FunKindVar::fresh();
+        let var_fun = Type::Fun {
+            name: None,
+            kind: FunKind::Var(Rc::clone(&v)),
+            domain: Box::new(Type::UIntRange(3)),
+            codomain: Box::new(prim(BaseType::Int)),
+        };
+        let mut cache = ConstrainCache::new();
+        constrain_subtype(
+            &var_fun,
+            &data_fun(Type::UIntRange(3), prim(BaseType::Int)),
+            &mut cache,
+        )
+        .expect("var <: Data records forced_data, never an eager rejection");
+        assert!(v.bounds.borrow().forced_data, "demanded as data");
+        assert!(
+            !v.bounds.borrow().forced_compute,
+            "no compute value flowed in"
+        );
+    }
+
+    #[test]
+    fn kind_var_link_then_late_force_propagates() {
+        // Regression: a force that arrives *after* a var-var link must still
+        // reach the far end. Draw `v0 <: v1` first, then force `v0` compute via
+        // a later edge (`Compute <: v0`). Transitive propagation must carry
+        // `forced_compute` up to `v1`; the old one-shot copy dropped it, letting
+        // `v1` fall to its (possibly `Data`) domain default — a silent miskind.
+        let v0 = FunKindVar::fresh();
+        let v1 = FunKindVar::fresh();
+        let fun_of = |v: &Rc<FunKindVar>| Type::Fun {
+            name: None,
+            kind: FunKind::Var(Rc::clone(v)),
+            domain: Box::new(Type::UIntRange(3)),
+            codomain: Box::new(prim(BaseType::Int)),
+        };
+        let mut cache = ConstrainCache::new();
+        // Link first: `v0 <: v1`.
+        constrain_subtype(&fun_of(&v0), &fun_of(&v1), &mut cache).expect("var-var link");
+        assert!(!v1.bounds.borrow().forced_compute, "not forced yet");
+        // Force later: a compute function flows into `v0` (`Compute <: v0`).
+        constrain_subtype(
+            &fun(Type::UIntRange(3), prim(BaseType::Int)),
+            &fun_of(&v0),
+            &mut cache,
+        )
+        .expect("compute <: var records forced_compute");
+        assert!(v0.bounds.borrow().forced_compute, "v0 forced compute");
+        assert!(
+            v1.bounds.borrow().forced_compute,
+            "compute force propagates up the link to v1 after the fact"
+        );
     }
 }

--- a/src/ccl/infer/solver/mod.rs
+++ b/src/ccl/infer/solver/mod.rs
@@ -108,6 +108,7 @@ pub fn prim(b: BaseType) -> Type {
 pub fn fun(d: Type, c: Type) -> Type {
     Type::Fun {
         name: None,
+        kind: crate::ccl::ty::FunKind::Compute,
         domain: Box::new(d),
         codomain: Box::new(c),
     }

--- a/src/ccl/infer/solver/scheme.rs
+++ b/src/ccl/infer/solver/scheme.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::ccl::subst::Subst;
+use crate::ccl::ty::{FunKind, FunKindVar, FunKindVarId};
 use crate::ccl::{Bound, InferVar, InferVarId, Level, Refinement, Type, TypedExpr};
 
 use super::type_level;
@@ -83,6 +84,14 @@ pub struct FreshenCache {
     /// Original quantified channel-domain name → its rename. Seeded by
     /// `specialize_use` with use-site pairings; unpaired names mint fresh.
     pub chan_doms: HashMap<crate::ccl::Name, crate::ccl::Name>,
+    /// Original quantified kind variable → its fresh replacement. A generalized
+    /// function's arrow kind ([`FunKind::Var`]) must be decided *per use*, just
+    /// like the type it quantifies: two instantiations that flow into differently
+    /// -kinded contexts (one demanding `Data`, one `Compute`) must not share a
+    /// `FunKindVar` cell, or forcing one contaminates the other into a spurious
+    /// `DomainJoinConflict`. Freshening mints one `κ'` per original `κ` (bounds
+    /// copied so def-intrinsic forcing survives), consistently within a copy.
+    pub kind_vars: HashMap<FunKindVarId, Rc<FunKindVar>>,
 }
 
 impl FreshenCache {
@@ -113,6 +122,49 @@ pub enum FreshenLevel {
 /// The bounds of each quantified variable are themselves freshened
 /// (recursively), so the fresh copy carries the same constraints as the
 /// original.
+/// Freshen a function's arrow kind at instantiation. A concrete kind
+/// (`Data`/`Compute`) is intrinsic and copies through. An unresolved
+/// [`FunKind::Var`] is *quantified*: mint one fresh `FunKindVar` per original
+/// (cached by `uid` so repeated occurrences of the same `κ` in one copy stay
+/// identified), seeding it with a copy of the original's bounds so any
+/// def-intrinsic forcing is preserved while use-site forcing lands on the fresh
+/// cell — decoupling instantiations (see [`FreshenCache::kind_vars`]).
+fn freshen_kind(kind: &FunKind, cache: &mut FreshenCache) -> FunKind {
+    match kind {
+        FunKind::Compute | FunKind::Data => kind.clone(),
+        FunKind::Var(kv) => FunKind::Var(freshen_kind_var(kv, cache)),
+    }
+}
+
+/// Mint (or retrieve, cached by `uid`) the per-instantiation copy of a
+/// quantified kind var, mirroring its def-site `<:` links onto the fresh copies.
+///
+/// Copying the bounds alone is not enough: a `<:` link is load-bearing when a
+/// force arrives *after* instantiation (a use-site force on one instantiation
+/// must still reach a linked sibling). Each edge `x <: y` is drawn exactly once
+/// — from `x`'s `uppers` — while `lowers` are recursed only to guarantee every
+/// linked var is minted; inserting into the cache before recursing terminates a
+/// link cycle on the cache hit.
+fn freshen_kind_var(kv: &Rc<FunKindVar>, cache: &mut FreshenCache) -> Rc<FunKindVar> {
+    if let Some(f) = cache.kind_vars.get(&kv.uid) {
+        return f.clone();
+    }
+    let f = FunKindVar::fresh();
+    *f.bounds.borrow_mut() = *kv.bounds.borrow();
+    cache.kind_vars.insert(kv.uid, Rc::clone(&f));
+    let (uppers, lowers) = kv.links();
+    for u in &uppers {
+        let fu = freshen_kind_var(u, cache);
+        FunKindVar::link(&f, &fu);
+    }
+    for l in &lowers {
+        // The edge `l <: kv` is drawn from `l`'s side (its `uppers` include
+        // `kv`); recurse only so `l`'s copy exists to carry it.
+        freshen_kind_var(l, cache);
+    }
+    f
+}
+
 pub fn freshen_above(
     lim: Level,
     ty: &Type,
@@ -160,10 +212,12 @@ pub fn freshen_above(
         }
         Type::Fun {
             name,
+            kind,
             domain: d,
             codomain: c,
         } => Type::Fun {
             name: name.clone(),
+            kind: freshen_kind(kind, cache),
             domain: Box::new(freshen_above(lim, d, target, cache)),
             codomain: Box::new(freshen_above(lim, c, target, cache)),
         },
@@ -486,4 +540,108 @@ fn freshen_subst_payloads(
     let mut subst = subst.clone();
     subst.for_each_discharge_term_mut(&mut |t| freshen_expr_type_slots(t, lim, target, cache));
     subst
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccl::ty::{FunKind, FunKindVar};
+    use crate::ccl::{BaseType, InferVar};
+
+    #[test]
+    fn freshening_mints_a_distinct_kind_var_per_instantiation() {
+        // A generalized function's arrow kind must be decided per use. Freshening
+        // a Fun whose kind is an unresolved var must mint a *new* FunKindVar (bounds
+        // copied), not share the original — otherwise forcing one instantiation's
+        // kind contaminates the other into a spurious `DomainJoinConflict`.
+        let kv = FunKindVar::fresh();
+        kv.bounds.borrow_mut().forced_data = true; // a def-intrinsic bound to carry
+        // A quantified domain (level > lim) so the Fun is instantiated, not
+        // early-returned as a captured/monomorphic shape.
+        let f = Type::Fun {
+            name: None,
+            kind: FunKind::Var(Rc::clone(&kv)),
+            domain: Box::new(Type::Infer(InferVar::fresh(5))),
+            codomain: Box::new(Type::Base(BaseType::Int)),
+        };
+        let mut cache = FreshenCache::new();
+        let fresh = freshen_above(0, &f, FreshenLevel::At(1), &mut cache);
+        let Type::Fun {
+            kind: FunKind::Var(kv2),
+            ..
+        } = fresh
+        else {
+            panic!("expected a kind var on the freshened function");
+        };
+        assert_ne!(
+            kv.uid, kv2.uid,
+            "instantiation must mint a distinct kind var"
+        );
+        assert!(
+            kv2.bounds.borrow().forced_data,
+            "def-intrinsic bounds are copied to the fresh var"
+        );
+        // Forcing the fresh instantiation must not reach back to the original.
+        kv2.force_compute();
+        assert!(
+            !kv.bounds.borrow().forced_compute,
+            "the original var stays decoupled from this instantiation"
+        );
+    }
+
+    #[test]
+    fn freshening_mirrors_kind_var_links_onto_instantiation() {
+        // Two `<:`-linked kind vars in one scheme must stay linked after
+        // freshening, so a use-site force on one instantiation still reaches its
+        // sibling. Copying the bounds alone (the flags present at def time) would
+        // drop the link and let a later force miss the far end.
+        let lower = FunKindVar::fresh(); // κ₁
+        let upper = FunKindVar::fresh(); // κ₂, with κ₁ <: κ₂
+        FunKindVar::link(&lower, &upper);
+        // A higher-order type with κ₁ on the (quantified) domain arrow and κ₂ on
+        // the outer arrow; the Infer domain lifts both above `lim` so both are
+        // instantiated rather than early-returned.
+        let inner = Type::Fun {
+            name: None,
+            kind: FunKind::Var(Rc::clone(&lower)),
+            domain: Box::new(Type::Infer(InferVar::fresh(5))),
+            codomain: Box::new(Type::Base(BaseType::Int)),
+        };
+        let outer = Type::Fun {
+            name: None,
+            kind: FunKind::Var(Rc::clone(&upper)),
+            domain: Box::new(inner),
+            codomain: Box::new(Type::Base(BaseType::Int)),
+        };
+        let mut cache = FreshenCache::new();
+        let fresh = freshen_above(0, &outer, FreshenLevel::At(1), &mut cache);
+        let Type::Fun {
+            kind: FunKind::Var(fresh_upper),
+            domain: fresh_domain,
+            ..
+        } = fresh
+        else {
+            panic!("expected a kind var on the freshened outer function");
+        };
+        let Type::Fun {
+            kind: FunKind::Var(fresh_lower),
+            ..
+        } = *fresh_domain
+        else {
+            panic!("expected a kind var on the freshened inner function");
+        };
+        assert_ne!(fresh_lower.uid, lower.uid);
+        assert_ne!(fresh_upper.uid, upper.uid);
+        // A `Compute` force on the fresh lower must propagate up the mirrored
+        // link to the fresh upper — and not touch the originals.
+        fresh_lower.force_compute();
+        assert!(
+            fresh_upper.bounds.borrow().forced_compute,
+            "the def-site link κ₁ <: κ₂ must be mirrored onto the instantiation"
+        );
+        assert!(
+            !upper.bounds.borrow().forced_compute,
+            "the original vars stay decoupled from the instantiation"
+        );
+    }
 }

--- a/src/ccl/infer/solver/simplify_type.rs
+++ b/src/ccl/infer/solver/simplify_type.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::ccl::InferVarId;
 
-use super::compact::{AtomKey, CompactGraph, CompactType};
+use super::compact::{AtomKey, CompactFun, CompactGraph, CompactType};
 
 // ---------------------------------------------------------------------------
 // Type simplification: co-occurrence analysis
@@ -246,17 +246,19 @@ fn simplify_analyze(
             );
         }
     }
-    if let Some((_, dom, cod)) = &ct.fun {
+    if let Some(cf) = &ct.fun {
+        for dom in &cf.domains {
+            simplify_analyze(
+                dom,
+                !pol,
+                input_rec_vars,
+                all_vars,
+                rec_processed,
+                co_occurrences,
+            );
+        }
         simplify_analyze(
-            dom,
-            !pol,
-            input_rec_vars,
-            all_vars,
-            rec_processed,
-            co_occurrences,
-        );
-        simplify_analyze(
-            cod,
+            &cf.codomain,
             pol,
             input_rec_vars,
             all_vars,
@@ -315,12 +317,15 @@ fn simplify_reconstruct(
             .collect()
     });
 
-    let new_fun = ct.fun.map(|(name, dom, cod)| {
-        (
-            name,
-            Box::new(simplify_reconstruct(*dom, var_subst)),
-            Box::new(simplify_reconstruct(*cod, var_subst)),
-        )
+    let new_fun = ct.fun.map(|cf| CompactFun {
+        name: cf.name,
+        kind: cf.kind,
+        domains: cf
+            .domains
+            .into_iter()
+            .map(|d| simplify_reconstruct(d, var_subst))
+            .collect(),
+        codomain: Box::new(simplify_reconstruct(*cf.codomain, var_subst)),
     });
 
     let new_history_slot = ct.history_slot.map(|(value, domain, kind)| {
@@ -344,8 +349,19 @@ fn simplify_reconstruct(
 
 #[cfg(test)]
 mod tests {
+    use super::super::compact::KindMerge;
     use super::*;
     use crate::ccl::{BaseType, InferVar};
+
+    /// A single-domain compute `fun` slot, for the simplify tests below.
+    fn compute_fun(dom: CompactType, cod: CompactType) -> Option<CompactFun> {
+        Some(CompactFun {
+            name: None,
+            kind: KindMerge::Compute,
+            domains: vec![dom],
+            codomain: Box::new(cod),
+        })
+    }
 
     /// Build a fresh [`InferVarId`] for use in hand-constructed CompactTypes.
     fn fresh_uid() -> InferVarId {
@@ -370,14 +386,16 @@ mod tests {
         };
         let graph = CompactGraph {
             term: CompactType {
-                fun: Some((None, Box::new(dom), Box::new(cod))),
+                fun: compute_fun(dom, cod),
                 ..Default::default()
             },
             rec_vars: BTreeMap::new(),
         };
 
         let simplified = simplify_type(graph);
-        let (_, dom_s, cod_s) = simplified.term.fun.unwrap();
+        let cf = simplified.term.fun.unwrap();
+        let dom_s = &cf.domains[0];
+        let cod_s = &cf.codomain;
         assert!(dom_s.vars.contains(&uid_a), "a kept in dom");
         assert!(cod_s.vars.contains(&uid_a), "a kept in cod");
         assert!(!cod_s.vars.contains(&uid_b), "b eliminated from cod");
@@ -397,18 +415,19 @@ mod tests {
         };
         let graph = CompactGraph {
             term: CompactType {
-                fun: Some((
-                    None,
-                    Box::new(make_side([uid_a].into_iter().collect())),
-                    Box::new(make_side([uid_a].into_iter().collect())),
-                )),
+                fun: compute_fun(
+                    make_side([uid_a].into_iter().collect()),
+                    make_side([uid_a].into_iter().collect()),
+                ),
                 ..Default::default()
             },
             rec_vars: BTreeMap::new(),
         };
 
         let simplified = simplify_type(graph);
-        let (_, dom_s, cod_s) = simplified.term.fun.unwrap();
+        let cf = simplified.term.fun.unwrap();
+        let dom_s = &cf.domains[0];
+        let cod_s = &cf.codomain;
         assert!(dom_s.vars.is_empty(), "a absorbed in dom");
         assert!(cod_s.vars.is_empty(), "a absorbed in cod");
         assert!(dom_s.atoms.contains(&int_key), "Int remains in dom");
@@ -425,24 +444,25 @@ mod tests {
 
         let graph = CompactGraph {
             term: CompactType {
-                fun: Some((
-                    None,
-                    Box::new(CompactType {
+                fun: compute_fun(
+                    CompactType {
                         vars: both.clone(),
                         ..Default::default()
-                    }),
-                    Box::new(CompactType {
+                    },
+                    CompactType {
                         vars: both,
                         ..Default::default()
-                    }),
-                )),
+                    },
+                ),
                 ..Default::default()
             },
             rec_vars: BTreeMap::new(),
         };
 
         let simplified = simplify_type(graph);
-        let (_, dom_s, cod_s) = simplified.term.fun.unwrap();
+        let cf = simplified.term.fun.unwrap();
+        let dom_s = &cf.domains[0];
+        let cod_s = &cf.codomain;
         assert_eq!(dom_s.vars.len(), 1, "one var after merge in dom");
         assert_eq!(cod_s.vars.len(), 1, "one var after merge in cod");
         assert_eq!(dom_s.vars, cod_s.vars, "same representative in dom and cod");
@@ -456,24 +476,25 @@ mod tests {
 
         let graph = CompactGraph {
             term: CompactType {
-                fun: Some((
-                    None,
-                    Box::new(CompactType {
+                fun: compute_fun(
+                    CompactType {
                         vars: [uid_a].into_iter().collect(),
                         ..Default::default()
-                    }),
-                    Box::new(CompactType {
+                    },
+                    CompactType {
                         vars: [uid_a].into_iter().collect(),
                         ..Default::default()
-                    }),
-                )),
+                    },
+                ),
                 ..Default::default()
             },
             rec_vars: BTreeMap::new(),
         };
 
         let simplified = simplify_type(graph);
-        let (_, dom_s, cod_s) = simplified.term.fun.unwrap();
+        let cf = simplified.term.fun.unwrap();
+        let dom_s = &cf.domains[0];
+        let cod_s = &cf.codomain;
         assert!(dom_s.vars.contains(&uid_a), "a preserved in dom");
         assert!(cod_s.vars.contains(&uid_a), "a preserved in cod");
     }

--- a/src/ccl/inline.rs
+++ b/src/ccl/inline.rs
@@ -15,7 +15,7 @@
 //! - **List-producing UDFs**: `Fun(Fun(iterable_domain, _), _)`.  Functions
 //!   whose domain is itself a function type — generator functions and
 //!   list-returning `def`s lowered to `λ user_arg → λ __iter_record → body`.
-//!   A `Fun` domain has no iterable extent, so these are covered by the same
+//!   A `Fun` domain has no iterable domain, so these are covered by the same
 //!   non-iterable-domain rule.
 //!
 //! After substituting the bound lambda at each call site, the resulting
@@ -98,10 +98,10 @@ pub fn inline_non_iterable_lambdas(expr: Expr) -> Expr {
 }
 
 // ---------------------------------------------------------------------------
-// Domain extent predicates
+// Domain predicates
 // ---------------------------------------------------------------------------
 
-/// Returns `true` when `ty` has a finite, enumerable extent — i.e., when the
+/// Returns `true` when `ty` has a finite, enumerable domain — i.e., when the
 /// operator graph can natively schedule a function over this domain as
 /// `IterateExtent` without inlining.
 ///
@@ -109,7 +109,7 @@ pub fn inline_non_iterable_lambdas(expr: Expr) -> Expr {
 /// |------|-----------|--------|
 /// | `Base(_)` | no | No finite enumeration of all integers / strings / bools |
 /// | `Tuple(ts)` | yes only if ALL `t` are iterable | A tuple can only be iterated if every component can |
-/// | `Record(fields)` | yes only if ALL fields are iterable | Same logic as tuples: a record with an unbounded field has no finite extent |
+/// | `Record(fields)` | yes only if ALL fields are iterable | Same logic as tuples: a record with an unbounded field has no finite domain |
 /// | `Refinement(inner, _)` | same as `inner` | Refinement doesn't add iterability |
 /// | `UIntRange(_)` | yes | Finite, bounded range |
 /// | `DataSource(_)` | yes | Externally-backed finite collection |
@@ -121,7 +121,7 @@ fn is_iterable_domain(ty: &Type) -> bool {
         // A tuple domain is iterable only if ALL components are iterable; you
         // can't enumerate (UIntRange(3), Int) because Int is unbounded.
         Type::Tuple(ts) => ts.iter().all(is_iterable_domain),
-        // Records are structurally equivalent to tuples for extent purposes.
+        // Records are structurally equivalent to tuples for domain purposes.
         Type::Record(fields) => fields.iter().all(|(_, t)| is_iterable_domain(t)),
         // Refinement inherits the iterability of its base type.
         Type::Refinement(inner, _) => is_iterable_domain(inner),
@@ -130,7 +130,7 @@ fn is_iterable_domain(ty: &Type) -> bool {
         // There are infinitely many possible functions for any given function
         // type, so function-typed domains cannot be enumerated.
         Type::Fun { .. } => false,
-        // A history-typed domain has no enumerable extent — treat it
+        // A history-typed domain has no enumerable domain — treat it
         // non-iterable like a function so a history-param UDF is inlined; the
         // `_ => true` fallthrough would otherwise strand it. Two cases reach
         // here, both pre-erasure (inlining runs before `channelize` and the
@@ -734,9 +734,10 @@ mod tests {
     #[test]
     fn non_iterable_domain_fun() {
         // There are infinitely many possible Int → Int functions, so Fun-as-domain
-        // has no finite, enumerable extent.
+        // has no finite, enumerable domain.
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
@@ -751,6 +752,7 @@ mod tests {
     fn should_inline_scalar_to_scalar() {
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
@@ -764,9 +766,11 @@ mod tests {
         // eliminates the nested lambda before any `curry` combinator is produced.
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Compute,
                 domain: Box::new(Type::Base(BaseType::Int)),
                 codomain: Box::new(Type::Base(BaseType::Int)),
             }),
@@ -784,11 +788,13 @@ mod tests {
         let refinement = Refinement::born(pred);
         let inner_fun = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Base(BaseType::Int)),
             codomain: Box::new(Type::Refinement(Box::new(inner_fun), refinement)),
         };
@@ -800,6 +806,7 @@ mod tests {
         // UIntRange(3) → Int: iterable domain, don't inline.
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::UIntRange(3)),
             codomain: Box::new(Type::Base(BaseType::Int)),
         };
@@ -811,6 +818,7 @@ mod tests {
         // (Int, Int) → Int: both components non-iterable, should inline.
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Tuple(vec![
                 Type::Base(BaseType::Int),
                 Type::Base(BaseType::Int),
@@ -826,6 +834,7 @@ mod tests {
         // non-iterable, so this is inlined.
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(Type::Tuple(vec![
                 Type::UIntRange(3),
                 Type::Base(BaseType::Int),
@@ -1050,6 +1059,7 @@ mod tests {
     fn fn_ty(domain: Type, codomain: Type) -> Type {
         Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(domain),
             codomain: Box::new(codomain),
         }

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -341,9 +341,13 @@ fn elim_lambda_impl(
     let body_ty = body.ty.clone();
     let result_ty = match fun_ty_or_hole(param_ty, &body_ty) {
         Type::Fun {
-            domain, codomain, ..
+            domain,
+            codomain,
+            kind,
+            ..
         } if crate::ccl::subst::type_free_vars(&body_ty).contains(param) => Type::Fun {
             name: Some(param.clone()),
+            kind,
             domain,
             codomain,
         },
@@ -925,6 +929,7 @@ mod tests {
     fn fun_ty(a: Type, b: Type) -> Type {
         Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(a),
             codomain: Box::new(b),
         }

--- a/src/ccl/lower/comprehension.rs
+++ b/src/ccl/lower/comprehension.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::{
     ccl::{
         BinOpKind, Expr, LogicKind, Name, Type,
-        ccl_utils::{make_cast, refined_fn_type},
+        ccl_utils::{make_cast, refined_data_fun},
         uniquify,
     },
     chl_parser::ast::{AssignTarget, CompClause, Comprehension, Expr as ChlExpr, Spanned},
@@ -186,7 +186,7 @@ pub(super) fn lower_list_comp(
                 Expr::lambda(iter_var, Type::Hole, pred_expr),
             );
         }
-        // A refined parameter lowers to a `cast(refined_fn_type, λ outer_var →
+        // A refined parameter lowers to a `cast(refined_data_fun, λ outer_var →
         // body_expr)` — a pure type-level assertion of the predicate-refined
         // domain.  The refinement is carried by the cast's target type; the
         // Cast Apply arm in `infer::emit` constructs the refined result
@@ -201,11 +201,18 @@ pub(super) fn lower_list_comp(
             element_span,
             lc,
         );
-        let target_ty = refined_fn_type(Type::Hole, pred_expr, Type::Hole);
+        let target_ty = refined_data_fun(Type::Hole, pred_expr, Type::Hole);
         Ok(ctx.tag_machinery(make_cast(unrefined_lambda, target_ty), element_span, lc))
     } else {
+        // A comprehension is a **data collection** (a map over its source's
+        // extent): stamp it `Data` by provenance. The `data_fun(_, _)` annotation
+        // is a concrete-kind stamp (`emit_node`), the unfiltered counterpart of
+        // the filtered branch's `refined_data_fun` (also `Data`) cast target — so a
+        // comprehension is data-by-construction, not by a domain guess. (Filtered
+        // comprehensions above already get `Data` from their cast.)
         Ok(ctx.tag_machinery(
-            Expr::lambda(outer_var, Type::Hole, body_expr),
+            Expr::lambda(outer_var, Type::Hole, body_expr)
+                .with_user_annotation(Type::data_fun(Type::Hole, Type::Hole)),
             comp.element.span,
             lc,
         ))

--- a/src/ccl/lower/exprs.rs
+++ b/src/ccl/lower/exprs.rs
@@ -7,7 +7,7 @@ use crate::{
     ccl::{
         AggregateKind, ArithmeticKind, BinOpKind, CompareKind, Expr, LogicKind, Name, Type,
         TypedExprNode, UnaryOpKind,
-        ccl_utils::{make_cast, refined_fn_type},
+        ccl_utils::{make_cast, refined_data_fun},
     },
     chl_parser::ast::{
         AssignTarget, AugOp, BinOp as ChlBinOp, BoolOp, CmpOp, Expr as ChlExpr, Lit as ChlLit,
@@ -93,9 +93,14 @@ pub(super) fn lower_call(
                 func.span,
                 gb,
             );
-            let target_ty = refined_fn_type(Type::Hole, bare_pred, Type::Hole);
+            let target_ty = refined_data_fun(Type::Hole, bare_pred, Type::Hole);
             let cast = ctx.tag_machinery(make_cast(unrefined_inner, target_ty), func.span, gb);
-            Ok(Expr::lambda("__gb_k", Type::Hole, cast))
+            // A group-by is a **data function** (a keyed collection): stamp its
+            // outer arrow `Data` by provenance (the `data_fun` annotation is a
+            // concrete-kind stamp — see `emit_node`), so its kind is data-by-
+            // construction rather than guessed from its (scalar key) domain.
+            Ok(Expr::lambda("__gb_k", Type::Hole, cast)
+                .with_user_annotation(Type::data_fun(Type::Hole, Type::Hole)))
         }
         "sum" | "max" => {
             if args.len() != 1 {
@@ -577,22 +582,22 @@ mod tests {
     // Variable collection and inline key lambda
     #[case(
         "groupby(xs, \\x -> x)",
-        "λ __gb_k → cast(({_ | __elem ▷ xs ▷ (λ x → x) == __gb_k} ⇒ _), λ __gb_i → __gb_i ▷ xs)"
+        "λ __gb_k → cast(({_ | __elem ▷ xs ▷ (λ x → x) == __gb_k} ⤇ _), λ __gb_i → __gb_i ▷ xs)"
     )]
     // List literal collection with a more complex key
     #[case(
         "groupby([1, 2, 3], \\x -> x // 2)",
-        "λ __gb_k → cast(({_ | __elem ▷ [1, 2, 3] ▷ (λ x → x // 2) == __gb_k} ⇒ _), λ __gb_i → __gb_i ▷ [1, 2, 3])"
+        "λ __gb_k → cast(({_ | __elem ▷ [1, 2, 3] ▷ (λ x → x // 2) == __gb_k} ⤇ _), λ __gb_i → __gb_i ▷ [1, 2, 3])"
     )]
     // Key is a variable reference (pre-defined function)
     #[case(
         "groupby(xs, key_fn)",
-        "λ __gb_k → cast(({_ | __elem ▷ xs ▷ key_fn == __gb_k} ⇒ _), λ __gb_i → __gb_i ▷ xs)"
+        "λ __gb_k → cast(({_ | __elem ▷ xs ▷ key_fn == __gb_k} ⤇ _), λ __gb_i → __gb_i ▷ xs)"
     )]
     // Keyed aggregation
     #[case(
         "[sum(x) for x in groupby(xs, key_fn)]",
-        "λ __iter_record → __iter_record ▷ (λ __gb_k → cast(({_ | __elem ▷ xs ▷ key_fn == __gb_k} ⇒ _), λ __gb_i → __gb_i ▷ xs)) ▷ (λ x → Sum(x))"
+        "λ __iter_record → __iter_record ▷ (λ __gb_k → cast(({_ | __elem ▷ xs ▷ key_fn == __gb_k} ⤇ _), λ __gb_i → __gb_i ▷ xs)) ▷ (λ x → Sum(x))"
     )]
     fn test_lower_groupby(#[case] code: &str, #[case] expected: &str) {
         let expr = parse_expr(code);

--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -1030,10 +1030,11 @@ fn lower_type_application(
     args: &[Spanned<ChlExpr>],
 ) -> Result<Type, LoweringError> {
     match head {
-        // A list type is a mapping `index-range ⇒ element`; the length
+        // A list type is a mapping `index-range ⤇ element`; the length
         // (domain) is unknown at annotation time, so it is a `Hole` (inferred,
         // like the value slot of a bare `_`). The element type is the sole
-        // argument lowered recursively.
+        // argument lowered recursively. A `List` annotation is a collection
+        // type: a data function.
         "List" => {
             let [elem] = args else {
                 return Err(LoweringError::unsupported(
@@ -1043,6 +1044,7 @@ fn lower_type_application(
             };
             Ok(Type::Fun {
                 name: None,
+                kind: crate::ccl::ty::FunKind::Data,
                 domain: Box::new(Type::Hole),
                 codomain: Box::new(lower_type_annotation(elem)?),
             })

--- a/src/ccl/mod.rs
+++ b/src/ccl/mod.rs
@@ -60,6 +60,7 @@ pub(crate) use ty::eq_refinement_predicate;
 #[cfg(any(test, feature = "test-helpers"))]
 pub fn reset_all_id_counters() {
     reset_infer_var_counter();
+    reset_kind_var_counter();
 }
 
 /// Convenience for the [`TypedExprNode::Error`] match arm in passes that run

--- a/src/ccl/planning/iterate.rs
+++ b/src/ccl/planning/iterate.rs
@@ -414,6 +414,27 @@ pub(super) fn wrap_with_iterate(expr: &mut Expr) {
     // re-mints (each rebuilt as a fresh `Rc`) compare equal structurally,
     // and nothing downstream depends on which term instance the codomain
     // holds.
+    //
+    // Stamp the site's kind `Data`: a `wrap_with_iterate` result is, by
+    // construction, an *iterated collection* — the runtime sweeps its domain
+    // extent — whatever (possibly `Compute`/var) kind the value-producer body
+    // inferred. This is what gives an identity comprehension `[x for x in xs]`
+    // display parity (`⤇`) with the bare list `xs` it denotes: both are the
+    // same collection, so both render the data arrow.
+    let site_ty = match site_ty {
+        Type::Fun {
+            name,
+            domain,
+            codomain,
+            ..
+        } => Type::Fun {
+            name,
+            kind: crate::ccl::ty::FunKind::Data,
+            domain,
+            codomain,
+        },
+        other => other,
+    };
     *expr = typed_compose(elts).with_ty(site_ty);
 }
 

--- a/src/ccl/planning/mod.rs
+++ b/src/ccl/planning/mod.rs
@@ -274,6 +274,7 @@ pub(crate) mod test_helpers {
     pub(crate) fn fun_ty(domain: Type, codomain: Type) -> Type {
         Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(domain),
             codomain: Box::new(codomain),
         }

--- a/src/ccl/simplify.rs
+++ b/src/ccl/simplify.rs
@@ -191,39 +191,19 @@ fn simplify_once(expr: &mut Expr, memo: &PredMemo) -> (bool, bool) {
 /// and whether any child's subtree contains an `iterate` source (OR-ed up so
 /// the parent need not re-scan its descendants).
 fn recurse_simplify(expr: &mut Expr, memo: &PredMemo) -> (bool, bool) {
-    let (mut changed, has_iteration) = expr.fold_children_mut((false, false), |(c, it), e| {
+    let (changed, has_iteration) = expr.fold_children_mut((false, false), |(c, it), e| {
         let (child_changed, child_has_iteration) = simplify_once(e, memo);
         (c | child_changed, it | child_has_iteration)
     });
-    // After simplifying children, propagate the Let body's type up to the Let
-    // itself. Simplification can change the body's type (e.g., union flattening
-    // rewrites Fun(Union(Union(A,B),C), D) → Fun(Union(A,B,C), D)); the Let
-    // must stay in sync so downstream passes see a consistent representation.
-    // Lifting the body's type out of the binder's scope must discharge
-    // `[v ↦ bound]` into its refinement predicates (design §6.2 move-site
-    // rule), matching inference's let-closing so the recorded type stays
-    // well-formed (closed over `v`) and the post-pass check reconciles.
-    if let TypedExprNode::Let {
-        binding,
-        bound_expr,
-        body,
-    } = &expr.node
-    {
-        // The discharge only changes the type in the dependent case (binder
-        // free in the body type's refinement predicates); skip cloning the
-        // bound expression otherwise. The sync below still runs so a body type
-        // simplify rewrote stays mirrored on the `let`.
-        let body_ty = if crate::ccl::subst::type_free_vars(&body.ty).contains(&binding.name) {
-            crate::ccl::subst::Subst::discharge(&binding.name, (**bound_expr).clone())
-                .apply_type(&body.ty)
-        } else {
-            body.ty.clone()
-        };
-        if expr.ty != body_ty {
-            expr.ty = body_ty;
-            changed = true;
-        }
-    }
+    // NB: simplify is **type-preserving** — no rule mutates a node's type — so a
+    // `Let`'s recorded type (already closed over its binder by inference's
+    // let-closing) stays valid and needs no re-sync here. A former propagation
+    // re-derived `Let.ty` from `body.ty` (for a since-removed union-flatten rule
+    // that changed body types); it also *downgraded* a let-bound-source
+    // comprehension's kind `⤇ → ⇒` and re-discharged marker-bearing sources into
+    // predicates. Both are bugs, so it is gone; the marker-free predicate
+    // invariant is upheld at the substitution boundary instead
+    // (`ccl_utils::strip_iterate_markers`).
     (changed, has_iteration)
 }
 
@@ -1037,6 +1017,7 @@ mod tests {
     fn fun_ty(a: Type, b: Type) -> Type {
         Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: Box::new(a),
             codomain: Box::new(b),
         }
@@ -1058,6 +1039,7 @@ mod tests {
         }
         let ty = Type::Fun {
             name: None,
+            kind: crate::ccl::ty::FunKind::Compute,
             domain: fun_tys.first().unwrap().0.clone(),
             codomain: fun_tys.last().unwrap().1.clone(),
         };

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -54,7 +54,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
-use crate::ccl::ccl_utils::{PredMemo, is_free};
+use crate::ccl::ccl_utils::{PredMemo, is_free, strip_iterate_markers};
 use crate::ccl::provenance::NodeId;
 use crate::ccl::{Branch, Name, PredicateId, Type, TypedExpr, TypedExprNode};
 
@@ -240,7 +240,7 @@ impl Subst {
     /// would also compare equal here; predicates resolve names lexically at
     /// their introduction site, so this requires two distinct dependent
     /// functions with colliding argument spellings meeting at one position —
-    /// the extent-join territory that O1/O4 owns anyway.)
+    /// the domain-join territory that O1/O4 owns anyway.)
     pub fn eq_modulo_ty_slots(&self, other: &Subst) -> bool {
         self.0.len() == other.0.len()
             && self
@@ -813,6 +813,7 @@ impl Subst {
                 name: None,
                 domain,
                 codomain,
+                ..
             } => {
                 self.rewrite_type_go(domain, memo);
                 self.rewrite_type_go(codomain, memo);
@@ -822,6 +823,7 @@ impl Subst {
                 name: Some(b),
                 domain,
                 codomain,
+                ..
             } => {
                 self.rewrite_type_go(domain, memo);
                 let restricted = self.shadow(b);
@@ -850,6 +852,13 @@ impl Subst {
                         return false;
                     }
                     restricted.rewrite_expr_go(pred, memo);
+                    // Keep the predicate marker-free: a substituted collection may
+                    // carry a term-tree `iterate` marker that must not leak into a
+                    // type (see `strip_iterate_markers` and the `force_refinement`
+                    // twin). Only the rewritten path needs it — a marker arrives
+                    // *through* the substitution, so the vacuous path above, which
+                    // rewrites nothing and keeps the origin `Rc`, has none to strip.
+                    *pred = strip_iterate_markers(pred);
                     true
                 });
                 self.rewrite_type_go(base, memo);
@@ -917,7 +926,13 @@ impl Subst {
         if !restricted.0.keys().any(|k| is_free(k, &r.predicate)) {
             return r.clone();
         }
-        let new_pred = restricted.apply_expr(&r.predicate);
+        // A refinement predicate is a *denotational* term, so a substituted
+        // value must not drag a term-tree `iterate` planning marker into it
+        // (the §6.2 move-site discharge of a `let`-bound, iterate-marked
+        // collection into a refined domain). Strip the neutral marker so the
+        // predicate stays marker-free — otherwise it churns under `simplify`
+        // and diverges from inference's pre-marker copy.
+        let new_pred = strip_iterate_markers(&restricted.apply_expr(&r.predicate));
         // Scope-validity (design §6.2): a discharged binder must not survive
         // in the rewritten predicate — once `[x ↦ arg]` fires, no free `x`
         // may remain, or a downstream pass would observe a dangling
@@ -981,14 +996,12 @@ impl Subst {
                 name: None,
                 domain,
                 codomain,
-            } => Type::Fun {
-                name: None,
-                domain: Box::new(self.apply_type(domain)),
-                codomain: Box::new(self.apply_type(codomain)),
-            },
+                ..
+            } => Type::fun_like(ty, self.apply_type(domain), self.apply_type(codomain)),
 
             Type::Fun {
                 name: Some(b),
+                kind,
                 domain,
                 codomain,
             } => {
@@ -996,6 +1009,7 @@ impl Subst {
                 let (b2, inner) = self.under_binder_ty(b, codomain);
                 Type::Fun {
                     name: Some(b2),
+                    kind: kind.clone(),
                     domain,
                     codomain: Box::new(inner),
                 }
@@ -1069,6 +1083,34 @@ pub fn type_free_vars(ty: &Type) -> BTreeSet<Binder> {
     out
 }
 
+/// Whether `ty`'s structural skeleton contains an unresolved [`Type::Infer`]
+/// leaf. This is the per-type dual of `check_fully_typed`'s whole-program scan:
+/// a cheap "is this type ground" predicate for invariant assertions at pass
+/// boundaries. It walks the type skeleton only — a `Refinement`'s predicate is
+/// a term, not a type, and is not descended into (an `Infer` embedded in a
+/// predicate cast is out of scope and would need a term walk).
+pub fn type_contains_infer(ty: &Type) -> bool {
+    match ty {
+        Type::Base(_)
+        | Type::UIntRange(_)
+        | Type::DataSource(_)
+        | Type::ChanDom(..)
+        | Type::Txn
+        | Type::Hole => false,
+        Type::Infer(_) => true,
+        Type::Fun {
+            domain, codomain, ..
+        } => type_contains_infer(domain) || type_contains_infer(codomain),
+        Type::History { value, domain, .. } => {
+            type_contains_infer(value) || type_contains_infer(domain)
+        }
+        Type::Tuple(ts) => ts.iter().any(type_contains_infer),
+        Type::Record(fs) => fs.iter().any(|(_, t)| type_contains_infer(t)),
+        Type::Variant(tags) => tags.iter().any(|(_, t)| type_contains_infer(t)),
+        Type::Refinement(base, _) => type_contains_infer(base),
+    }
+}
+
 /// Insert each of `names` into `bound` for the duration of `f`, restoring the
 /// set afterward. Only names that were *newly* inserted are removed, so a
 /// binder that shadows an already-in-scope name of the same spelling does not
@@ -1107,6 +1149,7 @@ fn collect_type_fv(
             name,
             domain,
             codomain,
+            ..
         } => {
             collect_type_fv(domain, bound, visited, out);
             // A `Some` name is the Pi binder, bound in the codomain.

--- a/src/ccl/symbolic.rs
+++ b/src/ccl/symbolic.rs
@@ -736,7 +736,7 @@ mod tests {
     #[case(
         Expr::lambda(
             "x",
-            Type::Fun { name: None, domain: Box::new(Type::Base(BaseType::Int)), codomain: Box::new(Type::Base(BaseType::Bool)) },
+            Type::Fun { name: None, kind: crate::ccl::ty::FunKind::Compute, domain: Box::new(Type::Base(BaseType::Int)), codomain: Box::new(Type::Base(BaseType::Bool)) },
             Expr::var("x"),
         ),
         "λ x : (Int ⇒ Bool) → x"

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -1,8 +1,10 @@
 //! The CCL [`Type`] lattice, its [`Refinement`] subset-type carrier, and the
 //! type-blind structural equality / hashing on refinement predicate terms.
 
+use std::cell::RefCell;
 use std::fmt;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use smol_str::SmolStr;
 
@@ -65,6 +67,194 @@ impl fmt::Display for FieldKey {
     }
 }
 
+/// Whether a [`Type::Fun`]'s domain is a **capability** or a **collection** — the
+/// compute-function vs data-function distinction.
+///
+/// - [`FunKind::Compute`] — `α ⇒ β`: the domain is a *capability*, the inputs
+///   the function accepts. No data sits behind it, so shrinking the domain only
+///   under-promises; the contravariant meet at a control-flow join is a sound,
+///   lossy simplification.
+/// - [`FunKind::Data`] — `α ⤇ β`: the domain is a *collection*'s index set. The
+///   domain *is* the data map, so a lossy domain is lost data. A join of two data
+///   functions therefore may not take the contravariant meet: where their domains
+///   differ it is rejected (`CoalesceError::DomainJoinConflict`) rather than
+///   silently dropping rows. The lossless join — a dependent sum over the candidate
+///   domains — is the collections work; the kind distinction is what makes its
+///   absence an error instead of a wrong answer.
+///
+/// Set at introduction (list literals, comprehensions, `++`, registered
+/// sources, and every `History` erasure are `Data`; `lambda`/`def` are
+/// `Compute`). The audit rule for a rebuilt or erased arrow: it is `Data` iff
+/// `extent_of` will drive iteration off its domain. See
+/// `design/type-inference.md`, "4.6 Data vs compute functions".
+///
+/// FunKind is **inferred** (see `design/type-inference.md`, "4.6 Data vs compute
+/// functions"):
+/// where the structure fixes it (a list literal is `Data`, a scalar op is
+/// `Compute`) a concrete kind is stamped; where it depends on use or on an
+/// unresolved source (a map/comprehension) a [`FunKind::Var`] is minted and the
+/// solver resolves it, like a type variable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FunKind {
+    /// A compute function / capability (`⇒`): lossy meet at a join is fine.
+    Compute,
+    /// A data function / collection (`⤇`): the domain *is* the data; joins must
+    /// be lossless.
+    Data,
+    /// An unresolved kind, pinned down by the solver at coalesce. Identity is by
+    /// the variable's `uid`, so `FunKind` (and `Type`) keep deriving
+    /// `PartialEq`/`Eq`/`Hash` — the [`FunKindVar`] impls compare by `uid` only.
+    Var(Rc<FunKindVar>),
+}
+
+impl FunKind {
+    /// The display arrow for this kind: `⇒` for compute, `⤇` for data. An
+    /// unresolved variable renders `⇒` (its resolved kind is written back before
+    /// display matters downstream).
+    pub fn arrow(&self) -> &'static str {
+        match self {
+            FunKind::Compute | FunKind::Var(_) => "⇒",
+            FunKind::Data => "⤇",
+        }
+    }
+
+    /// A fresh inferred kind (a new [`FunKindVar`] with empty bounds).
+    pub fn fresh_var() -> FunKind {
+        FunKind::Var(FunKindVar::fresh())
+    }
+}
+
+/// Stable identity of a [`FunKindVar`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FunKindVarId(pub(crate) u32);
+
+static FUN_KIND_VAR_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// Bounds on a [`FunKindVar`], over the two-point kind lattice `Data ⊑ Compute`.
+///
+/// The lattice has only two points, so "bounds" collapse to two flags rather
+/// than the polar bound *lists* an [`crate::ccl::InferVar`] carries — and no
+/// [`Type`] sits inside, so a `FunKindVar` never forms a cycle. Resolution is a
+/// flag read: `forced_compute ∧ forced_data` is the conflict (`Compute ⊑ κ ⊑
+/// Data`, impossible — the `Compute <: Data` rejection); `forced_compute` alone
+/// → `Compute`; `forced_data` alone → `Data`; neither → the caller's
+/// domain-derived default.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FunKindBounds {
+    /// A `Compute` value flows *into* this kind (`κ ⊒ Compute ⟹ κ = Compute`).
+    pub forced_compute: bool,
+    /// This kind is *demanded* as `Data` (`κ ⊑ Data ⟹ κ = Data`).
+    pub forced_data: bool,
+}
+
+/// A kind-inference variable — an unknown [`FunKind`] the solver pins down by
+/// accumulating [`FunKindBounds`]. Identity (`uid`) is immutable and lives outside
+/// the `RefCell`, so equality/hashing is borrow-free and never inspects the
+/// bounds (mirroring [`crate::ccl::InferVar`]).
+pub struct FunKindVar {
+    /// Stable, globally-unique identity.
+    pub uid: FunKindVarId,
+    /// Mutable kind bounds.
+    pub bounds: RefCell<FunKindBounds>,
+    /// Vars `u` such that `self <: u` (this kind is below them). A `Compute`
+    /// force propagates *up* to them (`self = Compute ⟹ u = Compute`).
+    uppers: RefCell<Vec<Rc<FunKindVar>>>,
+    /// Vars `l` such that `l <: self` (this kind is above them). A `Data` force
+    /// propagates *down* to them (`self = Data ⟹ l = Data`).
+    lowers: RefCell<Vec<Rc<FunKindVar>>>,
+}
+
+impl FunKindVar {
+    /// Allocate a fresh kind variable with empty bounds and no links.
+    pub fn fresh() -> Rc<FunKindVar> {
+        Rc::new(FunKindVar {
+            uid: FunKindVarId(FUN_KIND_VAR_COUNTER.fetch_add(1, Ordering::Relaxed)),
+            bounds: RefCell::new(FunKindBounds::default()),
+            uppers: RefCell::new(Vec::new()),
+            lowers: RefCell::new(Vec::new()),
+        })
+    }
+
+    /// Force this kind to `Compute` and propagate transitively up the `<:` links.
+    ///
+    /// Propagation keeps the flags at a fixpoint *incrementally*, so — unlike a
+    /// one-shot copy of the flags present when a link is first drawn — a force
+    /// that arrives strictly after its link still reaches every var it must. The
+    /// monotone flag (false → true) both terminates the walk and makes it
+    /// cycle-safe: a var already `Compute` short-circuits before recursing.
+    pub fn force_compute(self: &Rc<Self>) {
+        if self.bounds.borrow().forced_compute {
+            return;
+        }
+        self.bounds.borrow_mut().forced_compute = true;
+        for u in self.uppers.borrow().iter() {
+            u.force_compute();
+        }
+    }
+
+    /// Force this kind to `Data` and propagate transitively down the `<:` links.
+    /// The dual of [`FunKindVar::force_compute`]; same fixpoint/termination argument.
+    pub fn force_data(self: &Rc<Self>) {
+        if self.bounds.borrow().forced_data {
+            return;
+        }
+        self.bounds.borrow_mut().forced_data = true;
+        for l in self.lowers.borrow().iter() {
+            l.force_data();
+        }
+    }
+
+    /// A snapshot `(uppers, lowers)` of this var's `<:` links. Freshening uses
+    /// it to mirror def-site links onto the per-instantiation copies — the flags
+    /// alone are not enough, since a force arriving *after* instantiation must
+    /// still traverse the link to the sibling instantiation.
+    pub fn links(&self) -> (Vec<Rc<FunKindVar>>, Vec<Rc<FunKindVar>>) {
+        (self.uppers.borrow().clone(), self.lowers.borrow().clone())
+    }
+
+    /// Record the edge `lower <: upper` and reconcile the flags already present
+    /// on either end. Later forces on either var propagate through the stored
+    /// link via [`FunKindVar::force_compute`]/[`FunKindVar::force_data`].
+    pub fn link(lower: &Rc<FunKindVar>, upper: &Rc<FunKindVar>) {
+        if Rc::ptr_eq(lower, upper) {
+            return;
+        }
+        lower.uppers.borrow_mut().push(Rc::clone(upper));
+        upper.lowers.borrow_mut().push(Rc::clone(lower));
+        if lower.bounds.borrow().forced_compute {
+            upper.force_compute();
+        }
+        if upper.bounds.borrow().forced_data {
+            lower.force_data();
+        }
+    }
+}
+
+// Identity-based (by `uid`), mirroring `InferVar`: borrow-free, never touches
+// `bounds`, so it is safe even while a variable's bounds are borrowed.
+impl PartialEq for FunKindVar {
+    fn eq(&self, other: &Self) -> bool {
+        self.uid == other.uid
+    }
+}
+impl Eq for FunKindVar {}
+impl std::hash::Hash for FunKindVar {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.uid.hash(state);
+    }
+}
+impl fmt::Debug for FunKindVar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "κ{}", self.uid.0)
+    }
+}
+
+/// Reset the kind-variable counter to zero (test-only, for predictable output).
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn reset_kind_var_counter() {
+    FUN_KIND_VAR_COUNTER.store(0, Ordering::Relaxed);
+}
+
 /// A CCL type annotation.
 ///
 /// Appears on [`TypedExpr`] nodes and as the output of type inference.
@@ -77,7 +267,7 @@ impl fmt::Display for FieldKey {
 /// | `Infer(id)` | Type checker only | "Inference variable N from the coalesce pass" | End of inference for any type reachable from the program's root output (flagged as `UnresolvedInfer` by `collect_type_errors`); an induction accumulator's *domain* is necessarily `Infer` until the unified phase resolves it (see `Strictness::PreDesugar`) |
 /// | `History` (`kind: Overwrite`) | Type checker only | "Mutable variable: a `value` cell tracked over a `domain` (loop index or transaction time)" | the unified phase (`transact_phase` / `mut_elim`, which runs *before* `channelize`; a survivor downstream is a compiler bug) |
 /// | `History` (`kind: Feed`) | Type checker only | "Feed channel `domain ⇒ value`: the defer binding's post-desugar stream type" | `channelize` (which runs after inference; a survivor downstream is a compiler bug) |
-/// | `ChanDom(d, _)` | Type checker only | "Rigid nominal domain of feed channel `d` — its extent resolves at channel assembly" | `channelize` (substituted to the concrete channel domain; a survivor downstream is a compiler bug) |
+/// | `ChanDom(d, _)` | Type checker only | "Rigid nominal domain of feed channel `d` — its domain resolves at channel assembly" | `channelize` (substituted to the concrete channel domain; a survivor downstream is a compiler bug) |
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Type {
     /// A primitive base type.
@@ -109,6 +299,11 @@ pub enum Type {
         /// renaming their Pi binder reconcile there (see the substitution
         /// machinery).
         name: Option<crate::ccl::Name>,
+        /// Whether this function is a capability (`Compute`) or a data
+        /// collection (`Data`). See [`FunKind`]. The derived [`PartialEq`] compares it: a
+        /// data function and a compute function over the same domain/codomain
+        /// are genuinely different types (one carries data, one a capability).
+        kind: FunKind,
         /// The parameter (argument) type. Contravariant position.
         domain: Box<Type>,
         /// The result type. Covariant position; may reference `name`.
@@ -174,7 +369,7 @@ pub enum Type {
     /// channel-domain residue forms. `channelize` erases it with a whole-tree
     /// substitution `ChanDom(d) ↦ <concrete channel domain>` once the channel
     /// is assembled. Like [`Type::DataSource`], it is a nominal leaf whose
-    /// extent resolves later; unlike it, it is *transient* — no pass after
+    /// domain resolves later; unlike it, it is *transient* — no pass after
     /// `channelize` may observe one.
     ///
     /// The second field is the domain's **introduction level** (the inference
@@ -190,7 +385,7 @@ pub enum Type {
     /// issued by the runtime (the prototype's `CommitTime`). It is the domain of
     /// transactional histories (`Txn ⇒ V`), the codomain of the per-site
     /// `begin_<site>` oracles, and the type of a transaction handle. Like
-    /// `DataSource`, it has no enumerable static extent — its positions exist only
+    /// `DataSource`, it has no enumerable static domain — its positions exist only
     /// in the tile. See src/ccl/design/mutability.md.
     Txn,
     /// The type of a **history** handle: a function `domain ⇒ value` that a
@@ -232,7 +427,6 @@ pub enum Type {
     },
     // Planned:
     // Pi { param: String, param_ty: Box<Type>, body_ty: Box<Type> }
-    // Refinement { base: Box<Type>, predicate: Box<Expr> }
 }
 
 /// Which flavour of [`Type::History`] a handle is — a mutable variable (`:=`) or a
@@ -296,16 +490,23 @@ impl fmt::Display for Type {
             // it as `∅` instead of computing `n - 1` and underflowing.
             Type::UIntRange(0) => write!(f, "∅"),
             Type::UIntRange(n) => write!(f, "[0, {}]", n - 1),
+            // The arrow reflects the resolved `kind`: `⇒` for a compute
+            // capability (and an unresolved kind var), `⤇` for a data domain
+            // (see `FunKind::arrow`). Once kind inference resolves every arrow
+            // once resolved, a data collection renders `⤇`, making the domain/capability
+            // distinction legible in every type string.
             Type::Fun {
                 name: Some(x),
+                kind,
                 domain,
                 codomain,
-            } => write!(f, "(({x}: {domain}) ⇒ {codomain})"),
+            } => write!(f, "(({x}: {domain}) {} {codomain})", kind.arrow()),
             Type::Fun {
                 name: None,
+                kind,
                 domain,
                 codomain,
-            } => write!(f, "({domain} ⇒ {codomain})"),
+            } => write!(f, "({domain} {} {codomain})", kind.arrow()),
             Type::Tuple(ts) => {
                 let parts: Vec<_> = ts.iter().map(|t| t.to_string()).collect();
                 write!(f, "({})", parts.join(", "))
@@ -394,21 +595,53 @@ fn singleton_value(ty: &Type) -> Option<&TypedExpr> {
 }
 
 impl Type {
-    /// Helper for creating a non-dependent function type (`name: None`).
+    /// Helper for creating a non-dependent **compute** function type
+    /// (`name: None`, `kind: Compute`).
     pub fn fun(domain: Self, codomain: Self) -> Self {
         Type::Fun {
             name: None,
+            kind: FunKind::Compute,
             domain: Box::new(domain),
             codomain: Box::new(codomain),
         }
     }
 
-    /// Helper for creating a dependent (Pi) function type `(name: domain) ⇒ codomain`.
+    /// Helper for creating a dependent (Pi) **compute** function type
+    /// `(name: domain) ⇒ codomain`.
     pub fn pi(name: impl Into<crate::ccl::Name>, domain: Self, codomain: Self) -> Self {
         Type::Fun {
             name: Some(name.into()),
+            kind: FunKind::Compute,
             domain: Box::new(domain),
             codomain: Box::new(codomain),
+        }
+    }
+
+    /// Helper for creating a non-dependent **data** function type
+    /// (`name: None`, `kind: Data`) — a collection `domain ⤇ codomain`.
+    pub fn data_fun(domain: Self, codomain: Self) -> Self {
+        Type::Fun {
+            name: None,
+            kind: FunKind::Data,
+            domain: Box::new(domain),
+            codomain: Box::new(codomain),
+        }
+    }
+
+    /// Rebuild a function type copying `name` and `kind` from an `exemplar`
+    /// `Fun`, so a downstream rebuild (lambda elimination, inlining, planning)
+    /// can never silently flip a data arrow to compute or drop its Pi binder. A
+    /// non-`Fun` exemplar yields a plain `Compute` arrow with no binder — the
+    /// safe default at a site with no arrow to copy from.
+    pub fn fun_like(exemplar: &Type, domain: Self, codomain: Self) -> Self {
+        match exemplar {
+            Type::Fun { name, kind, .. } => Type::Fun {
+                name: name.clone(),
+                kind: kind.clone(),
+                domain: Box::new(domain),
+                codomain: Box::new(codomain),
+            },
+            _ => Type::fun(domain, codomain),
         }
     }
 
@@ -430,13 +663,24 @@ impl Type {
         }
     }
 
-    /// A structural copy with every Pi binder name erased (`Fun.name → None`).
+    /// A structural copy with every Pi binder name erased (`Fun.name → None`)
+    /// and every function **kind** canonicalized to `Compute`.
     ///
     /// The binder is load-bearing only inside the type solver (it carries
     /// dependent-refinement correspondences); downstream passes treat function
     /// types structurally and a `Some`/`None` binder is the same arrow to them.
     /// Use this when comparing types for structural equality across a pass that
     /// does not preserve the cosmetic binder.
+    ///
+    /// FunKind is normalized for the same reason: **lambda elimination preserves a
+    /// function's denotation but not its kind representation** — a data
+    /// collection (`⤇`) becomes a point-free form built from compute combinators
+    /// (`zip`, `apply`, `const`), so the reconstructed arrow reads `Compute`
+    /// though it denotes the same collection. The kind did its work at inference
+    /// (lossless conditional-collection joins at coalesce); post-elimination it is not preserved, so
+    /// the structural-equality asserts (and the feed-operand agreement check)
+    /// compare modulo it. (FunKind-aware subtyping therefore acts in
+    /// *Emit*-mode inference, not the post-elimination Check-mode pass.)
     ///
     /// Under the Barendregt convention the blindness needed at the remaining
     /// call sites (lambda elimination's type-preservation asserts) is exactly
@@ -452,6 +696,10 @@ impl Type {
                 domain, codomain, ..
             } => Type::Fun {
                 name: None,
+                // Canonicalize kind — elimination does not preserve it (see the
+                // doc above); comparing modulo it is what these structural asserts
+                // want.
+                kind: FunKind::Compute,
                 domain: Box::new(domain.without_pi_names()),
                 codomain: Box::new(codomain.without_pi_names()),
             },
@@ -1011,7 +1259,7 @@ mod tests {
         let cast_pred = |op: CompareKind| {
             TypedExpr::cast(
                 TypedExpr::var("xs"),
-                ccl_utils::refined_fn_type(Type::Hole, filter(op), Type::Hole),
+                ccl_utils::refined_data_fun(Type::Hole, filter(op), Type::Hole),
             )
         };
         let refinement = |pred: TypedExpr| Refinement::born(Rc::new(pred));

--- a/src/chl_parser/lexer.rs
+++ b/src/chl_parser/lexer.rs
@@ -101,7 +101,9 @@ pub enum Token {
     PlusEq,
     #[token("-=")]
     MinusEq,
-    /// Lambda body arrow `->` (also the planned pair / map-entry arrow, §2.4).
+    /// Lambda body arrow `->`. Also the planned pair / map-entry arrow — `a -> b`
+    /// for a two-tuple, `[k -> v, …]` for a map literal (`docs/chl-spec.md`,
+    /// "2.4 Atoms").
     /// Two chars, so maximal munch takes it over `-` then `>`.
     #[token("->")]
     Arrow,

--- a/tests/compilation_pipeline/joins_aggregates_groupby.rs
+++ b/tests/compilation_pipeline/joins_aggregates_groupby.rs
@@ -172,32 +172,32 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[1,2,3]",
-    "iterate ≫ [1, 2, 3]:([0, 2] ⇒ Int)",
+    "iterate ≫ [1, 2, 3]:([0, 2] ⤇ Int)",
     make_int_list(&[1,2,3])
 )]
 #[case(
     "x = [1,2,3]; x",
-    "let x : ([0, 2] ⇒ Int) = iterate ≫ [1, 2, 3]\nin x:([0, 2] ⇒ Int)",
+    "let x : ([0, 2] ⤇ Int) = iterate ≫ [1, 2, 3]\nin x:([0, 2] ⤇ Int)",
     make_int_list(&[1,2,3])
 )]
 #[case(
     "x = [1,2,3]; [y + 10 for y in x]",
-    "let x : ([0, 2] ⇒ Int) = iterate ≫ [1, 2, 3]\nin x ≫ (id, 10 ▷ const) ▷ zip ≫ add:([0, 2] ⇒ Int)",
+    "let x : ([0, 2] ⤇ Int) = iterate ≫ [1, 2, 3]\nin x ≫ (id, 10 ▷ const) ▷ zip ≫ add:([0, 2] ⤇ Int)",
     make_int_list(&[11,12,13])
 )]
 #[case(
     "[x + 10 + x for x in [1,2,3]]",
-    "iterate ≫ [1, 2, 3] ≫ ((id, 10 ▷ const) ▷ zip ≫ add, id) ▷ zip ≫ add:([0, 2] ⇒ Int)",
+    "iterate ≫ [1, 2, 3] ≫ ((id, 10 ▷ const) ▷ zip ≫ add, id) ▷ zip ≫ add:([0, 2] ⤇ Int)",
     make_int_list(&[12,14,16])
 )]
 #[case(
     "y = 10; [x + y for x in [1,2,3]]",
-    "let y : {Int | __elem ▷ ((id, 10 ▷ const) ▷ zip ≫ eq)} = 10\nin iterate ≫ [1, 2, 3] ≫ (id, y ▷ const) ▷ zip ≫ add:([0, 2] ⇒ Int)",
+    "let y : {Int | __elem ▷ ((id, 10 ▷ const) ▷ zip ≫ eq)} = 10\nin iterate ≫ [1, 2, 3] ≫ (id, y ▷ const) ▷ zip ≫ add:([0, 2] ⤇ Int)",
     make_int_list(&[11,12,13])
 )]
 #[case(
     "[x for x in [False,True] if x]",
-    "iterate ▷ ([false, true] ▷ restrict) ≫ cast([false, true]):({[0, 1] | __elem ▷ [false, true]} ⇒ Bool)",
+    "iterate ▷ ([false, true] ▷ restrict) ≫ cast([false, true]):({[0, 1] | __elem ▷ [false, true]} ⤇ Bool)",
     Tile::SealedFunction {
         domain: ColumnValue::UInts(vec![1]),
         codomain: Box::new(Tile::Scalar(ColumnValue::Bools(BitVec::from_elem(1, true)))),
@@ -207,7 +207,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + 10 for x in [1,2,3] if x == 2]",
-    "iterate ▷ (([1, 2, 3] ≫ (id, 2 ▷ const) ▷ zip ≫ eq) ▷ restrict) ≫ cast([1, 2, 3] ≫ (id, 10 ▷ const) ▷ zip ≫ add):({[0, 2] | __elem ▷ ([1, 2, 3] ≫ (id, 2 ▷ const) ▷ zip ≫ eq)} ⇒ Int)",
+    "iterate ▷ (([1, 2, 3] ≫ (id, 2 ▷ const) ▷ zip ≫ eq) ▷ restrict) ≫ cast([1, 2, 3] ≫ (id, 10 ▷ const) ▷ zip ≫ add):({[0, 2] | __elem ▷ ([1, 2, 3] ≫ (id, 2 ▷ const) ▷ zip ≫ eq)} ⤇ Int)",
     Tile::SealedFunction {
         domain: ColumnValue::UInts(vec![1]),
         codomain: Box::new(Tile::Scalar(ColumnValue::Ints(vec![12]))),
@@ -217,7 +217,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + y for x in [1,2,3] for y in [10,20]]",
-    "iterate ≫ (.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip ≫ add:(([0, 2], [0, 1]) ⇒ Int)",
+    "iterate ≫ (.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip ≫ add:(([0, 2], [0, 1]) ⤇ Int)",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![0, 0, 1, 1, 2, 2])),
@@ -233,7 +233,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[(x, y) for x in [1,2,3] for y in [10,20]]",
-    "iterate ≫ (.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip:(([0, 2], [0, 1]) ⇒ (Int, Int))",
+    "iterate ≫ (.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip:(([0, 2], [0, 1]) ⤇ (Int, Int))",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![0, 0, 1, 1, 2, 2])),
@@ -252,7 +252,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x for x in [1,2,3] for y in [10,20]]",
-    "iterate ≫ .0 ≫ [1, 2, 3]:(([0, 2], [0, 1]) ⇒ Int)",
+    "iterate ≫ .0 ≫ [1, 2, 3]:(([0, 2], [0, 1]) ⤇ Int)",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![0, 0, 1, 1, 2, 2])),
@@ -268,7 +268,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + y for x in [1,2,3] if x == 2 for y in [10,20] if y == 10]",
-    "iterate ▷ ((((.0 ≫ [1, 2, 3], 2 ▷ const) ▷ zip ≫ eq, (.1 ≫ [10, 20], 10 ▷ const) ▷ zip ≫ eq) ▷ zip ≫ and) ▷ restrict) ≫ cast((.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip ≫ add):({([0, 2], [0, 1]) | __elem ▷ (((.0 ≫ [1, 2, 3], 2 ▷ const) ▷ zip ≫ eq, (.1 ≫ [10, 20], 10 ▷ const) ▷ zip ≫ eq) ▷ zip ≫ and)} ⇒ Int)",
+    "iterate ▷ ((((.0 ≫ [1, 2, 3], 2 ▷ const) ▷ zip ≫ eq, (.1 ≫ [10, 20], 10 ▷ const) ▷ zip ≫ eq) ▷ zip ≫ and) ▷ restrict) ≫ cast((.0 ≫ [1, 2, 3], .1 ≫ [10, 20]) ▷ zip ≫ add):({([0, 2], [0, 1]) | __elem ▷ (((.0 ≫ [1, 2, 3], 2 ▷ const) ▷ zip ≫ eq, (.1 ≫ [10, 20], 10 ▷ const) ▷ zip ≫ eq) ▷ zip ≫ and)} ⤇ Int)",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![1])),
@@ -283,18 +283,32 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
     }
 )]
 #[case(
+    // An identity comprehension collapses to `iterate ≫ [1, 2, 3]`; because
+    // `wrap_with_iterate` stamps its result `Data` (an iterated collection is,
+    // by construction, a domain the runtime sweeps), it displays `⤇` in parity
+    // with the bare list literal `[1, 2, 3]` (case above) it denotes.
+    //
+    // These are **post-planning** types, so a `⇒` here does not mean inference
+    // typed the collection as a capability: lambda elimination and planning are
+    // denotation-preserving but *not* kind-preserving — a reconstructed arrow is
+    // canonicalized to `Compute` (`Type::without_pi_names`; see
+    // `src/ccl/design/type-inference.md`, "4.6 Data vs compute functions"). So
+    // the cases that keep `⤇` are the ones whose arrow rides through unrebuilt,
+    // and the `⇒` cases below are all arrows planning restructured (the
+    // `uncurry`/`map_domain` joins). Inference itself types every comprehension
+    // here `⤇`, let-bound and multi-source sources included.
     "[x for x in [x for x in [x for x in [1,2,3]]]]",
-    "iterate ≫ [1, 2, 3]:([0, 2] ⇒ Int)",
+    "iterate ≫ [1, 2, 3]:([0, 2] ⤇ Int)",
     make_int_list(&[1,2,3])
 )]
 #[case(
     "[x for x in [y for y in [1,2,3] if y < 3] if x < 2]",
-    "iterate ▷ (([1, 2, 3] ≫ (id, 3 ▷ const) ▷ zip ≫ lt) ▷ restrict) ▷ ((cast([1, 2, 3]) ≫ (id, 2 ▷ const) ▷ zip ≫ lt) ▷ restrict) ≫ cast(cast([1, 2, 3])):({{[0, 2] | __elem ▷ ([1, 2, 3] ≫ (id, 3 ▷ const) ▷ zip ≫ lt)} | __elem ▷ (cast([1, 2, 3]) ≫ (id, 2 ▷ const) ▷ zip ≫ lt)} ⇒ Int)",
+    "iterate ▷ (([1, 2, 3] ≫ (id, 3 ▷ const) ▷ zip ≫ lt) ▷ restrict) ▷ ((cast([1, 2, 3]) ≫ (id, 2 ▷ const) ▷ zip ≫ lt) ▷ restrict) ≫ cast(cast([1, 2, 3])):({{[0, 2] | __elem ▷ ([1, 2, 3] ≫ (id, 3 ▷ const) ▷ zip ≫ lt)} | __elem ▷ (cast([1, 2, 3]) ≫ (id, 2 ▷ const) ▷ zip ≫ lt)} ⤇ Int)",
     make_int_list(&[1])
 )]
 #[case(
     "[(x, x) for x in [(x, x) for x in [1,2,3]]]",
-    "iterate ≫ [1, 2, 3] ≫ (id, id) ▷ zip ≫ (id, id) ▷ zip:([0, 2] ⇒ ((Int, Int), (Int, Int)))",
+    "iterate ≫ [1, 2, 3] ≫ (id, id) ▷ zip ≫ (id, id) ▷ zip:([0, 2] ⤇ ((Int, Int), (Int, Int)))",
     Tile::SealedFunction {
         domain: ColumnValue::UInts(vec![0, 1, 2]),
         codomain: Box::new(Tile::Record(HashMap::from([
@@ -313,7 +327,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + y for x in ['a', 'b'] for y in ['c', 'd', 'e']]",
-    "iterate ≫ (.0 ≫ [\"a\", \"b\"], .1 ≫ [\"c\", \"d\", \"e\"]) ▷ zip ≫ concat:(([0, 1], [0, 2]) ⇒ String)",
+    "iterate ≫ (.0 ≫ [\"a\", \"b\"], .1 ≫ [\"c\", \"d\", \"e\"]) ▷ zip ≫ concat:(([0, 1], [0, 2]) ⤇ String)",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![0, 0, 0, 1, 1, 1])),
@@ -329,7 +343,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + 10 for x in testsource1() if x < 15]",
-    "iterate ▷ ((source(testsource1) ≫ (id, 15 ▷ const) ▷ zip ≫ lt) ▷ restrict) ≫ cast(source(testsource1) ≫ (id, 10 ▷ const) ▷ zip ≫ add):({source(testsource1) | __elem ▷ (source(testsource1) ≫ (id, 15 ▷ const) ▷ zip ≫ lt)} ⇒ Int)",
+    "iterate ▷ ((source(testsource1) ≫ (id, 15 ▷ const) ▷ zip ≫ lt) ▷ restrict) ≫ cast(source(testsource1) ≫ (id, 10 ▷ const) ▷ zip ≫ add):({source(testsource1) | __elem ▷ (source(testsource1) ≫ (id, 15 ▷ const) ▷ zip ≫ lt)} ⤇ Int)",
     make_int_list(&[10, 20])
 )]
 #[case("sum([1,2,3])", "(iterate ≫ [1, 2, 3]) ▷ sum:Int", Tile::Scalar(ColumnValue::Ints(vec![6])))]
@@ -485,7 +499,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case(
     "[x + y + z for x in [1] for y in [1, 2] for z in [1, 2, 3] if x == z and y == z and x + y == z + 1]",
-    "iterate ▷ (((((.0 ≫ [1], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq, (.1 ≫ [1, 2], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq) ▷ zip ≫ and, ((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, (.2 ≫ [1, 2, 3], 1 ▷ const) ▷ zip ≫ add) ▷ zip ≫ eq) ▷ zip ≫ and) ▷ restrict) ≫ cast(((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, .2 ≫ [1, 2, 3]) ▷ zip ≫ add):({([0, 0], [0, 1], [0, 2]) | __elem ▷ ((((.0 ≫ [1], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq, (.1 ≫ [1, 2], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq) ▷ zip ≫ and, ((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, (.2 ≫ [1, 2, 3], 1 ▷ const) ▷ zip ≫ add) ▷ zip ≫ eq) ▷ zip ≫ and)} ⇒ Int)",
+    "iterate ▷ (((((.0 ≫ [1], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq, (.1 ≫ [1, 2], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq) ▷ zip ≫ and, ((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, (.2 ≫ [1, 2, 3], 1 ▷ const) ▷ zip ≫ add) ▷ zip ≫ eq) ▷ zip ≫ and) ▷ restrict) ≫ cast(((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, .2 ≫ [1, 2, 3]) ▷ zip ≫ add):({([0, 0], [0, 1], [0, 2]) | __elem ▷ ((((.0 ≫ [1], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq, (.1 ≫ [1, 2], .2 ≫ [1, 2, 3]) ▷ zip ≫ eq) ▷ zip ≫ and, ((.0 ≫ [1], .1 ≫ [1, 2]) ▷ zip ≫ add, (.2 ≫ [1, 2, 3], 1 ▷ const) ▷ zip ≫ add) ▷ zip ≫ eq) ▷ zip ≫ and)} ⤇ Int)",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([
             ("_0".into(), ColumnValue::UInts(vec![0])),

--- a/tests/compilation_pipeline/scalars_collections.rs
+++ b/tests/compilation_pipeline/scalars_collections.rs
@@ -224,3 +224,31 @@ fn test_let_nonscalar(#[case] code: &str, #[case] expected: Tile) {
 fn test_tuples(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
+
+// ---------------------------------------------------------------------------
+// The domain-join rejection: the safety chokepoint
+// ---------------------------------------------------------------------------
+
+/// A control-flow join of two differently-sized collections has no domain that holds
+/// both branches' rows, so it is **rejected**. What this pins is that the rejection
+/// happens end-to-end and *cleanly* — a returned compile error, never a panic and
+/// never a silent miscompile that quietly compiles one branch's domain. The
+/// alternative to rejecting is the lossless join (a dependent sum over the candidate
+/// domains), which is the collections work; until it exists this is the contract, and
+/// it is the whole reason a data function's kind is tracked separately from a
+/// capability's.
+#[test]
+fn conditional_collection_rejected_cleanly() {
+    use cambra::ccl::context::{GlobalContext, compile_program};
+    use cambra::interpreter::Consumer;
+    let mut ctx = GlobalContext::default();
+    let consumer: Box<dyn Consumer> = Box::new(|| {});
+    let errs = compile_program(&mut ctx, "sum([1, 2] if True else [1, 2, 3])", consumer)
+        .err()
+        .expect("a domain-joining program must fail to compile, not miscompile or panic");
+    let rendered = format!("{errs:?}");
+    assert!(
+        rendered.contains("collection domain conflict"),
+        "expected the domain-join rejection, got:\n{rendered}"
+    );
+}

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -291,7 +291,11 @@ fn test_aggregate_over_scalar_lambda_is_rejected() {
     // Regression that a capability supplied where a collection is demanded is a
     // clean error, not a
     // silent miskind or a debug panic.
-    let errs = infer_program_err("f = \\i -> i + 1\nsum(f)");
+    let errs = infer_program_err(
+        r"
+f = \i -> i + 1
+sum(f)",
+    );
     assert!(
         errs.iter().any(|e| matches!(
             e,
@@ -1287,12 +1291,30 @@ fn conditional_collection_rejects_under_every_consumer() {
     for program in [
         // Collapsing consumer: directly, through a `let`, through a UDF parameter.
         format!("sum({c})"),
-        format!("x = {c}\nsum(x)"),
-        format!("def f(c):\n    sum(c)\nf({c})"),
+        format!(
+            r"
+x = {c}
+sum(x)"
+        ),
+        format!(
+            r"
+def f(c):
+    sum(c)
+f({c})"
+        ),
         // Domain-preserving consumer: the same three routes.
         format!("[y + 1 for y in {c}]"),
-        format!("x = {c}\n[y + 1 for y in x]"),
-        format!("def f(c):\n    [y + 1 for y in c]\nf({c})"),
+        format!(
+            r"
+x = {c}
+[y + 1 for y in x]"
+        ),
+        format!(
+            r"
+def f(c):
+    [y + 1 for y in c]
+f({c})"
+        ),
     ] {
         assert!(
             !infer_program_err(&program).is_empty(),

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -51,15 +51,9 @@ fn infer_program_with_sources(code: &str, sources: &[(&str, Type)]) -> Type {
             output_extent,
         )));
         lctx.register_source(*name, stub);
-        // Sources are registered with type Fun(DataSource(name), elem_ty).
-        ictx.register_source_type(
-            name,
-            Type::Fun {
-                name: None,
-                domain: Box::new(Type::DataSource(name.to_string())),
-                codomain: Box::new(elem_ty.clone()),
-            },
-        );
+        // Registered by element type; the data-function type (`DataSource(name)
+        // ⤇ elem_ty`, `Data`) is constructed inside `register_source_type`.
+        ictx.register_source_type(name, elem_ty.clone());
     }
     let stmts = parse_module(code);
     let mut expr = lower_stmts(&stmts, &mut lctx)
@@ -96,14 +90,7 @@ fn infer_program_with_sources_err(code: &str, sources: &[(&str, Type)]) -> Vec<I
             output_extent,
         )));
         lctx.register_source(*name, stub);
-        ictx.register_source_type(
-            name,
-            Type::Fun {
-                name: None,
-                domain: Box::new(Type::DataSource(name.to_string())),
-                codomain: Box::new(elem_ty.clone()),
-            },
-        );
+        ictx.register_source_type(name, elem_ty.clone());
     }
     let stmts = parse_module(code);
     let mut expr = lower_stmts(&stmts, &mut lctx)
@@ -218,13 +205,100 @@ fn test_unary_op(#[case] code: &str, #[case] expected: Type) {
 
 #[test]
 fn test_list_literal() {
+    // A list literal is a **data** function (collection domain).
     assert_eq!(
         infer_program("[1, 2, 3]"),
-        Type::Fun {
-            name: None,
-            domain: Box::new(Type::UIntRange(3)),
-            codomain: Box::new(int())
-        }
+        Type::data_fun(Type::UIntRange(3), int())
+    );
+}
+
+/// A control-flow join of two collections with **different** domains. The domain of
+/// a data function *is* its data, so there is no domain both branches' rows fit in:
+/// the contravariant meet the compute lattice would take drops whichever rows the
+/// narrower domain lacks. The kind distinction is what turns that into a rejection
+/// (`CoalesceError::DomainJoinConflict`) instead of a silently short collection.
+/// `[1, 2]` is `[0, 1] ⤇ Int` and `[1, 2, 3]` is `[0, 2] ⤇ Int`, so this join has no
+/// answer the lattice can express.
+#[test]
+fn test_conditional_collection_join_is_rejected() {
+    let errs = infer_program_err("[1, 2] if True else [1, 2, 3]");
+    let rendered = format!("{errs:?}");
+    assert!(
+        rendered.contains("collection domain conflict"),
+        "expected the domain-join rejection, got:\n{rendered}"
+    );
+}
+
+#[test]
+fn test_conditional_collection_heterogeneous_domains_rejected() {
+    // A conditional over a list literal and a **registered source** has two
+    // unrelated domains (`[0, 2]` and `source(mysrc)`), so it rejects for the same
+    // reason. This is the regression for the source-categorization invariant: a
+    // registered source is a `Data` collection, and were it miscategorized as a
+    // `Compute` capability the join would become an honest domain meet and
+    // *succeed*, silently discarding one branch's rows. The rejection is the
+    // evidence the kind is right (`register_source_type` constructs the `Data`
+    // arrow; the kind is intrinsic, not caller-supplied).
+    let errs =
+        infer_program_with_sources_err("[1, 2, 3] if True else mysrc()", &[("mysrc", int())]);
+    let rendered = format!("{errs:?}");
+    assert!(
+        rendered.contains("collection domain conflict"),
+        "expected the domain-join rejection, got:\n{rendered}"
+    );
+}
+
+#[test]
+fn test_conditional_collection_same_domain_joins() {
+    // The join *is* defined where it changes nothing: both arms over one domain
+    // stay that collection. This is the arm that keeps the `Data` rule a rule about
+    // losing data rather than a blanket ban on joining collections.
+    assert_eq!(
+        infer_program("[1, 2] if True else [3, 4]"),
+        Type::data_fun(Type::UIntRange(2), int())
+    );
+}
+
+#[test]
+fn test_conditional_record_arms_join_by_field_intersection() {
+    // `emit_case` types arms by the lattice join, so two record arms with
+    // differing fields no longer fail; they join to the common-field
+    // intersection at positive polarity. `{a, b} if c else {a, c}` → `{a: …}`.
+    // The surviving field joins like any other merge point: both arms deposit
+    // the same `1`, so its singleton survives — width-narrowing to the common
+    // fields is orthogonal to which witnesses each shared field keeps. Pins the
+    // widening so a future change to record-arm polarity can't silently alter
+    // which conditionals type-check. (design/type-inference.md, Case-arm
+    // lattice joins)
+    assert_eq!(
+        infer_program("(a=1, b=2) if True else (a=1, c=3)").to_string(),
+        "{a: 1}"
+    );
+    // Arms disagreeing on the shared field keep the field but not the witness.
+    assert_eq!(
+        infer_program("(a=1, b=2) if True else (a=7, c=3)").to_string(),
+        "{a: Int}"
+    );
+}
+
+#[test]
+fn test_aggregate_over_scalar_lambda_is_rejected() {
+    // Summing a plain lambda: a bare `λ` is a capability, built concrete
+    // `Compute` (kind is a provenance property, not a domain guess). `sum`
+    // demands a `Data` collection to iterate, so the argument constraint is
+    // `(Int ⇒ Int) <: (?  ⤇ Int)` — the `Compute <: Data` violation, rejected up
+    // front in `constrain_kind` (emission), never routed through a kind var.
+    // Regression that a capability supplied where a collection is demanded is a
+    // clean error, not a
+    // silent miskind or a debug panic.
+    let errs = infer_program_err("f = \\i -> i + 1\nsum(f)");
+    assert!(
+        errs.iter().any(|e| matches!(
+            e,
+            InferError::TypeMismatch { ctx, .. }
+                if ctx.contains("compute function") && ctx.contains("data collection")
+        )),
+        "expected a compute-where-data-required rejection, got {errs:?}"
     );
 }
 
@@ -272,6 +346,7 @@ fn test_list_comp_identity() {
         infer_program("[x for x in [1, 2]]"),
         Type::Fun {
             name: None,
+            kind: cambra::ccl::FunKind::Data,
             domain: Box::new(Type::UIntRange(2)),
             codomain: Box::new(int())
         }
@@ -285,6 +360,7 @@ fn test_list_comp_arithmetic_body() {
         infer_program("[x + 1 for x in [1, 2]]"),
         Type::Fun {
             name: None,
+            kind: cambra::ccl::FunKind::Data,
             domain: Box::new(Type::UIntRange(2)),
             codomain: Box::new(int())
         }
@@ -299,6 +375,7 @@ fn test_list_comp_two_gens() {
         ty,
         Type::Fun {
             name: None,
+            kind: cambra::ccl::FunKind::Data,
             domain: Box::new(Type::Tuple(vec![Type::UIntRange(2), Type::UIntRange(2)])),
             codomain: Box::new(int())
         },
@@ -700,14 +777,14 @@ fn test_self_application_types() {
 f = \x -> x > 1
 f
 ",
-    Type::Fun { name: None, domain: Box::new(int()), codomain: Box::new(bool_ty()) }
+    Type::Fun { name: None, kind: cambra::ccl::FunKind::Compute, domain: Box::new(int()), codomain: Box::new(bool_ty()) }
 )]
 #[case::arithmetic(
     r"
 f = \x -> x + 1
 f
 ",
-    Type::Fun { name: None, domain: Box::new(int()), codomain: Box::new(int()) }
+    Type::Fun { name: None, kind: cambra::ccl::FunKind::Compute, domain: Box::new(int()), codomain: Box::new(int()) }
 )]
 fn test_lambda_unapplied(#[case] code: &str, #[case] expected: Type) {
     assert_eq!(infer_program(code), expected);
@@ -797,13 +874,13 @@ fn infer_and_check(code: &str) -> Type {
 
 /// A `Case` whose arms are *collections* survives the consistency wall, and the
 /// restriction **both** arms establish survives with it: two identical filtered
-/// comprehensions join to that same filtered extent, not to the bare `[0, 2]`.
+/// comprehensions join to that same filtered domain, not to the bare `[0, 2]`.
 ///
-/// A collection carries its extent as a refinement on its `Fun` *domain*, where
+/// A collection carries its filter as a refinement on its `Fun` *domain*, where
 /// subtyping is contravariant — which is why the arms must reach the node's type
 /// by a join rather than by relating each arm to a *stripped* sibling: stripping
 /// one side of a domain edge demands `[0, N] <: {[0, N] | p}` and rejects two arms
-/// that are the same expression, and stripping both discards an extent that no
+/// that are the same expression, and stripping both discards a domain that no
 /// branch widens.
 #[test]
 fn test_case_with_filtered_comprehension_arms_passes_consistency_wall() {
@@ -857,7 +934,7 @@ xs = [1, 2, 3]
     );
     assert!(
         matches!(&**codomain, Type::Fun { domain: d, .. } if matches!(&**d, Type::Refinement(..))),
-        "the element's filtered extent must survive, got {ty}"
+        "the element's filtered domain must survive, got {ty}"
     );
 }
 
@@ -876,15 +953,14 @@ fn test_case_arms_join(#[case] code: &str, #[case] expected: Type) {
     assert_eq!(infer_and_check(code), expected);
 }
 
-/// Arms whose extents differ. A function type's join *meets* its domain, so the
-/// two filters accumulate as two witnesses on one domain — the extent both arms
-/// admit — rather than one arm's filter being picked (which would claim positions
-/// the other branch does not produce). Nothing downstream can observe the choice
-/// yet: a logical `Case` over collections is rejected by lambda elimination, so
-/// this pins the typing rule, not a compiled extent.
+/// Arms whose domains differ, both refinements of the *same* source domain. Refinement
+/// is not a special case: `{[0, 2] | x > 1}` and `{[0, 2] | x < 3}` are two distinct
+/// domains, so this rejects exactly like two structurally unrelated domains. Meeting
+/// them would claim one domain satisfying both filters; picking either would claim
+/// positions the other branch does not produce.
 #[test]
-fn test_case_arms_with_different_filters_accumulate_witnesses() {
-    let ty = infer_and_check(
+fn test_case_arms_with_different_filters_are_rejected() {
+    let errs = infer_program_err(
         r"
 xs = [1, 2, 3]
 c = 1 > 0
@@ -894,20 +970,10 @@ else:
     [x for x in xs if x < 3]
 ",
     );
-    let Type::Fun { domain, .. } = &ty else {
-        panic!("expected a collection type, got {ty}");
-    };
-    let mut layers = 0;
-    let mut cur = &**domain;
-    while let Type::Refinement(inner, _) = cur {
-        layers += 1;
-        cur = inner;
-    }
-    assert_eq!(layers, 2, "expected both arms' witnesses, got {ty}");
-    assert_eq!(
-        *cur,
-        Type::UIntRange(3),
-        "expected the source extent, got {ty}"
+    let rendered = format!("{errs:?}");
+    assert!(
+        rendered.contains("collection domain conflict"),
+        "expected the domain-join rejection, got:\n{rendered}"
     );
 }
 
@@ -1136,7 +1202,12 @@ mod letrec_typing {
     /// `ι = [0,3]`, `ν = Int`.
     #[test]
     fn guarded_single_binding_letrec_typechecks() {
-        let cnt_ty = Type::fun(Type::UIntRange(3), int());
+        // The recurrence carrier is a *data collection* (`⤇`): `cnt` is indexed
+        // by the iteration domain `[0, 2]` and read back through `get_prev_seq`,
+        // whose history argument demands `Data`. Declaring it `Compute`
+        // (`Type::fun`) is the miskind the `Compute <: Data` rejection now
+        // catches at the recurrence's introduction.
+        let cnt_ty = Type::data_fun(Type::UIntRange(3), int());
         let def = Expr::lambda(
             "r",
             Type::UIntRange(3),
@@ -1201,5 +1272,31 @@ mod letrec_typing {
             .expect("mutually referencing bindings resolve");
         assert_eq!(ty, int());
         typecheck(&expr).expect("strict typecheck passes");
+    }
+}
+
+/// The domain-join rejection must not be reachable-around: a consumer downstream of
+/// the join cannot make it succeed, whichever way the domains arrive at the domain
+/// position. Directly, two arrow shapes meet there; through a `let` or a UDF
+/// parameter, the two domains arrive as bounds on one position instead. Both routes
+/// reject, and so does a consumer that *preserves* the domain (a comprehension) as
+/// well as one that collapses it (`sum`).
+#[test]
+fn conditional_collection_rejects_under_every_consumer() {
+    let c = "[1, 2] if True else [1, 2, 3]";
+    for program in [
+        // Collapsing consumer: directly, through a `let`, through a UDF parameter.
+        format!("sum({c})"),
+        format!("x = {c}\nsum(x)"),
+        format!("def f(c):\n    sum(c)\nf({c})"),
+        // Domain-preserving consumer: the same three routes.
+        format!("[y + 1 for y in {c}]"),
+        format!("x = {c}\n[y + 1 for y in x]"),
+        format!("def f(c):\n    [y + 1 for y in c]\nf({c})"),
+    ] {
+        assert!(
+            !infer_program_err(&program).is_empty(),
+            "expected a rejection, not a silent miscompile: {program}"
+        );
     }
 }


### PR DESCRIPTION
Introduces `FunKind` (`Compute` / `Data`) — whether a `Type::Fun`'s domain is a *capability* or a collection's *data* — and states the two rules that distinction exists to buy: **a data function's domain is invariant**, and **the join of two data functions is a Σ over their candidate domains**.

`FunKind` is a **provenance** property, not a function of the domain: the same domain can back a collection or a capability (`Map(Color, V)` vs `Color ⇒ V`), so it is stamped at introduction — list literals, `++`, registered sources, comprehensions, `groupby`, recurrence carriers and every `History` erasure are `Data`; builtins and ordinary lambdas are `Compute`. The previous domain-shape heuristic is deleted. A `FunKind::Var` is minted only where the kind is genuinely inferred (a parameter, a freshened scheme), and the solver resolves it at coalesce over the two-point lattice `Data ⊑ Compute`, defaulting to `Compute` when unconstrained.

## Data domains are invariant

A compute function's domain is contravariant, and rightly so: it is a parameter, nothing in the language can ask a capability which inputs it accepts, and accepting more than demanded only under-promises. A data function's domain is not like that, and the reason is not a slogan about the domain "being the data" — it is that the domain is **observable**, in two ways a record's absent field is not.

- It is **the loop bound the emitted program runs**. Op-conversion builds an iteration source as `IterateExtent::new(extent_of(D))` from the *static* domain. Handing an 11-row collection to a slot declared `[0,5] ⤇ V` does not forget rows the way `{a: Int, b: Int} <: {a: Int}` forgets `b`; it emits a program that reads six of them and reports the result as the collection's.
- It is **reproduced in eliminator results**. A comprehension has the shape `D ⤇ A ⇒ D ⤇ B`, so `D` occurs covariantly as well as contravariantly at application, and a variable in both positions is invariant by the ordinary variance calculus. A compute domain occurs contravariantly only, because nothing enumerates it — which is the entire content of the `Data`/`Compute` split, stated so it can be checked rather than asserted.

Invariance is spelled the only order-independent way available: **both domain edges, unconditionally**, when both kinds are concretely `Data`. Any rule conditioned on what a domain looks like *at the moment the edge fires* — whether it is still a variable, whether its refinement has arrived — would make typing depend on constraint emission order. Invariance is a property of two types, not of when they are compared.

Both directions is also all it takes. `Type::UIntRange` relating only by equality already rejects both base directions, and refinement *drop* is already rejected one step less obviously, since behind a contravariant domain it demands `D <: {D | p}`. What the reverse edge adds is the one case that inversion left admitted: refinement *acquisition*, `D ⤇ V <: {D | p} ⤇ V`, an unfiltered collection standing where a filtered domain is declared.

The rule is stable under a surface data domain, which matters because `Array(n, T)` is planned and any argument resting on "a data domain is unwritable today" would rot. Both things a contravariant reading would buy are better bought elsewhere, and the syntax is what makes them cheap: "works for any length" is *quantification* (`∀n. Array(n, T) ⇒ …`, an ordinary scheme the solver already freshens per use), and a deliberate prefix is a *term*, visible where it happens at a use-site-chosen extent, rather than a coercion hidden in a declaration at whatever width that declaration names.

## Their join is a Σ

Two collections over different domains are incomparable, so their least upper bound is a different element of the lattice: the dependent sum `Σ (w ∈ {Dᵢ}). w ⤇ V` over the candidate domains, whose witness is the runtime branch discriminant and which is eliminated by distributing the consumer over it. The lattice is **incomplete** without Σ, and that incompleteness — not a semantic rejection — is what a domain join currently runs into. Subtyping, joining, and the collapse case where the candidates turn out to be one domain (`xs if c else xs`) are then one model rather than three rules.

Σ is not yet representable, so the join has no answer to produce and **diagnoses** instead. That is acceptable only because it is loud: the alternative to a Σ is an error, not a silent miscompile.

The same fact surfaces at two phases, because a join can be forced from either. When a consumer imposes a concrete demand the domains meet at a `Fun`/`Fun` edge and the invariant domain rule reports it there (`ConstrainError::DataDomainMismatch`, carrying the two domains, since the codomain is never what disagrees). When nothing forces it — the joined collection is the program's own value, or is only let-bound — the candidates ride to coalesce as accumulated alternatives and are reported there (`CoalesceError::DomainJoinConflict`). Both are live from source, neither is redundant, and both render the same "collection domain conflict" wording because they are one fact.

That two-phase structure is forced. At the compact merge a positive `Data ⊔ Data` accumulates its domain **alternatives** (`union_domains` — union and dedup, never a meet); it cannot decide there whether they are really two domains, because a compact domain still carries inference-variable identity that `simplify_type` may merge afterwards. Coalesce materializes each to a `Type` and deduplicates again, and that second comparison is the one that decides.

The consequence for the collections work is recorded in the doc rather than left to be discovered: **candidate domains arrive at a domain variable, not only at a `Case` result**, so Σ has to satisfy both sites. A domain position is not privileged — Σ is the join wherever it arises.

## Kind-aware subtyping

The `Fun`-vs-`Fun` arm carries a kind edge over `Data ⊑ Compute`: `Data <: Compute` upcasts, a concrete `Compute <: Data` is rejected (`ConstrainError::ComputeWhereDataRequired`), and a kind var picks up `forced_compute`/`forced_data` flags whose disagreement is the coalesce-time face of the same error. A capability demanded as data — `sum(λ x → x + 1)` — is caught right at the edge with no domain inspection, which is why the old domain-shape guess is gone. The rejection is emission-only: the post-inference check runs a kind-blind `ConstrainCache`, because elimination preserves denotation but not kind representation and a kind-aware re-check would false-reject.

## Documentation

The model is `src/ccl/design/type-inference.md`, "4.6 Data vs compute functions", in two sections — "Data domains are invariant" and "The domain join is a Σ" — plus "Deliberately incomplete here", which records the three real gaps: Σ itself, at both of the sites above; `KindMerge::Conflict` being covered only by hand-constructed compact graphs, with the source-level route unknown and the constraint-level face of the same rejection reachable; and the heterogeneous-scalar union, which stays an `IncompatibleBounds` error until strict scalar consumers can impose concrete bounds.