### PR TITLE
mutability-conditionals 2/7: value-Case compilation via literal union-of-restricts

### DIFF
--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -6,7 +6,8 @@ use std::rc::Rc;
 
 use crate::ccl::scope::{ScopedItem, for_each_scoped_item};
 use crate::ccl::{
-    BaseType, Builtin, Expr, Lit, Name, PredicateId, Refinement, Type, TypedExprNode,
+    BaseType, BinOpKind, Branch, Builtin, Expr, Lit, LogicKind, Name, PredicateId, Refinement,
+    Type, TypedExprNode, UnaryOpKind,
 };
 
 /// Returns `true` if `expr` directly references the given built-in primitive.
@@ -126,6 +127,63 @@ pub fn apply_function(expr: Expr, function: Expr, output_ty: Type) -> Expr {
         function.with_ty(Type::fun(expr_ty, output_ty.clone())),
     )
     .with_ty(output_ty)
+}
+
+/// Build arm `i`'s effective **first-match** predicate `gᵢ ∧ ¬g₀ ∧ … ∧ ¬gᵢ₋₁`,
+/// encoding a `Case`'s "first matching guard wins" semantics: arm `i` fires only
+/// where its own guard holds and no earlier arm's did. `prior` holds `g₀ … gᵢ₋₁`
+/// in order; `guard` is `gᵢ`. Every guard is a `Bool`-typed expression over the
+/// same element, so the synthesized conjunction is `Bool` too — typed here
+/// because the callers (post-inference desugar, lambda elimination, the
+/// transaction path walk) must be type-preserving.
+///
+/// Shared by [`crate::ccl::channelize`] (feed fan-out), [`crate::ccl::lambda_elim`]
+/// (value-`Case` compilation), and the transaction path walk — every conditional
+/// fan-out in the pipeline partitions its domain with the same encoding.
+pub fn synthesize_arm_predicate(guard: &Expr, prior: &[Expr]) -> Expr {
+    let bool_ty = Type::Base(BaseType::Bool);
+    let mut pred = guard.clone();
+    for g in prior {
+        let mut neg = Expr::unary(UnaryOpKind::Not, g.clone());
+        neg.ty = bool_ty.clone();
+        let mut conj = Expr::binop(pred, BinOpKind::BoolLogic(LogicKind::And), neg);
+        conj.ty = bool_ty.clone();
+        pred = conj;
+    }
+    pred
+}
+
+/// Returns `true` if `b` is a trailing `true → Case{…}` arm whose body is itself
+/// a guard-only value `Case` — the shape an `elif` chain lowers to
+/// (`a if p else b if q else c`; the `else` binds the nested conditional).
+fn is_trailing_nested_case(b: &Branch) -> bool {
+    b.pattern.is_none()
+        && matches!(&b.guard.node, TypedExprNode::Lit(Lit::Bool(true)))
+        && matches!(
+            &b.body.node,
+            TypedExprNode::Case { scrutinee: None, branches }
+                if branches.iter().all(|ib| ib.pattern.is_none())
+        )
+}
+
+/// Flatten `elif` chains: a trailing `true → Case{…}` arm splices its inner
+/// branches into the outer list, so a value-`Case` fan-out sees one flat
+/// partition `[g₀ → e₀; g₁ → e₁; …; true → eₙ]` rather than a nest of `Case`s.
+/// The first-match encoding ([`synthesize_arm_predicate`]) composes the guards
+/// correctly across the flattened arms. Shared by the value-`Case` compilation
+/// ([`crate::ccl::lambda_elim`]) and the comprehension element fan-out
+/// ([`crate::ccl::lower`]).
+pub fn flatten_trailing_value_case(mut branches: Vec<Branch>) -> Vec<Branch> {
+    while branches.last().is_some_and(is_trailing_nested_case) {
+        let last = branches.pop().expect("checked non-empty via last()");
+        if let TypedExprNode::Case {
+            branches: inner, ..
+        } = last.body.node
+        {
+            branches.extend(inner);
+        }
+    }
+    branches
 }
 
 /// Builds a composition of expressions, setting the types based on the input
@@ -478,7 +536,7 @@ pub fn sync_cast_targets(expr: &mut Expr) {
 /// element by the point-free function `predicate : base ⇒ Bool` (stored as
 /// `__elem ▷ predicate`, see [`bare_predicate_of_fn`]). Returns `base` unchanged
 /// when the predicate is trivially true.
-fn refine_with(base: Type, predicate: &Expr) -> Type {
+pub(crate) fn refine_with(base: Type, predicate: &Expr) -> Type {
     if is_trivially_true_predicate(predicate) {
         return base;
     }

--- a/src/ccl/channelize.rs
+++ b/src/ccl/channelize.rs
@@ -111,9 +111,9 @@ use std::fmt;
 use std::rc::Rc;
 
 use crate::ccl::{
-    BaseType, BinOpKind, Branch, Expr, HistoryKind, Lit, LogicKind, Name, Pattern, Refinement,
-    Type, TypedBinding, TypedExpr, TypedExprNode, UnaryOpKind,
-    ccl_utils::{count_free, typed_compose},
+    BaseType, Branch, Expr, HistoryKind, Lit, Name, Pattern, Refinement, Type, TypedBinding,
+    TypedExpr, TypedExprNode,
+    ccl_utils::{count_free, synthesize_arm_predicate, typed_compose},
     letrec::check_letrec_causal,
 };
 
@@ -214,19 +214,21 @@ impl fmt::Display for DeferError {
 /// Recognize a guard-only `Case` that feeds `defer_name` in one or more arms —
 /// the desugar-stage counterpart of `lambda_elim`'s `is_filter_case_body`.
 ///
-/// Shape (as lowered from `if g₀: d << v₀ elif g₁: d << v₁ …` in a for-loop
-/// body): `Case { None, [g₀ → body₀; …; gₙ₋₁ → bodyₙ₋₁; true → unit] }`, where
-/// each non-trailing `bodyᵢ` is either `Feed(defer_name, vᵢ)` (a feeding arm)
-/// or `Unit` (a non-feeding arm), and the trailing arm is the implicit
-/// `true → unit` fallthrough.
+/// Shape (as lowered from `if g₀: d << v₀ elif g₁: d << v₁ … [else: d << vₑ]` in
+/// a for-loop body): `Case { None, [g₀ → body₀; …; true → bodyₜ] }`, where each
+/// `bodyᵢ` is either `Feed(defer_name, vᵢ)` (a feeding arm) or `Unit` (a
+/// non-feeding arm). The trailing `true`-guarded arm is the `else` body when
+/// present (a feed) or the implicit fallthrough (`Unit`) when absent — both are
+/// ordinary arms here, so an `else` that feeds fans out just like a guard arm
+/// (its first-match predicate is `¬⋁ⱼ gⱼ`).
 ///
-/// Returns each non-trailing arm's `(guard, feed_value?)` in source order —
-/// `feed_value` is `None` for a non-feeding arm, whose guard still participates
-/// in later arms' predicate synthesis ([`synthesize_arm_predicate`]). Returns
-/// `None` (not fannable) if there is a scrutinee, no `true → unit` fallthrough,
-/// an arm binds a pattern, or an arm body is neither this defer's feed nor
-/// `Unit` — so a `Case` mixing this defer's feeds with other effects falls
-/// through to the generic handling rather than being silently collapsed.
+/// Returns each arm's `(guard, feed_value?)` in source order — `feed_value` is
+/// `None` for a non-feeding arm, whose guard still participates in later arms'
+/// predicate synthesis ([`synthesize_arm_predicate`]). Returns `None` (not
+/// fannable) if there is a scrutinee, the trailing guard is not `true`, an arm
+/// binds a pattern, or an arm body is neither this defer's feed nor `Unit` — so a
+/// `Case` mixing this defer's feeds with other effects falls through to the
+/// generic handling rather than being silently collapsed.
 fn try_extract_fanout_feed(body: &Expr, defer_name: &Name) -> Option<Vec<(Expr, Option<Expr>)>> {
     let TypedExprNode::Case {
         scrutinee: None,
@@ -238,16 +240,16 @@ fn try_extract_fanout_feed(body: &Expr, defer_name: &Name) -> Option<Vec<(Expr, 
     if branches.len() < 2 {
         return None;
     }
-    let (last, rest) = branches.split_last().expect("len >= 2");
-    // The trailing arm must be the implicit `true → unit` fallthrough.
-    if !matches!(&last.guard.node, TypedExprNode::Lit(Lit::Bool(true)))
-        || !matches!(&last.body.node, TypedExprNode::Lit(Lit::Unit))
-    {
+    // The trailing arm is the fallthrough / `else` — its guard must be `true`.
+    if !matches!(
+        &branches.last().expect("len >= 2").guard.node,
+        TypedExprNode::Lit(Lit::Bool(true))
+    ) {
         return None;
     }
-    let mut arms = Vec::with_capacity(rest.len());
+    let mut arms = Vec::with_capacity(branches.len());
     let mut any_feed = false;
-    for b in rest {
+    for b in branches {
         // A guard-only arm never binds a pattern.
         if b.pattern.is_some() {
             return None;
@@ -262,25 +264,6 @@ fn try_extract_fanout_feed(body: &Expr, defer_name: &Name) -> Option<Vec<(Expr, 
         }
     }
     any_feed.then_some(arms)
-}
-
-/// Build arm `i`'s effective predicate `gᵢ ∧ ¬g₀ ∧ … ∧ ¬gᵢ₋₁`, encoding a
-/// `Case`'s "first matching guard wins" semantics: arm `i` fires only where its
-/// own guard holds and no earlier arm's did. `prior` holds `g₀ … gᵢ₋₁` in
-/// order; `guard` is `gᵢ`. Every guard is a `Bool`-typed expression over the
-/// same loop element, so the synthesized conjunction is `Bool` too — typed here
-/// (desugar runs post-inference and must be type-preserving).
-fn synthesize_arm_predicate(guard: &Expr, prior: &[Expr]) -> Expr {
-    let bool_ty = Type::Base(BaseType::Bool);
-    let mut pred = guard.clone();
-    for g in prior {
-        let mut neg = Expr::unary(UnaryOpKind::Not, g.clone());
-        neg.ty = bool_ty.clone();
-        let mut conj = Expr::binop(pred, BinOpKind::BoolLogic(LogicKind::And), neg);
-        conj.ty = bool_ty.clone();
-        pred = conj;
-    }
-    pred
 }
 
 /// Attempt to apply the defer-returning lift to a `Let` binding.
@@ -2628,16 +2611,54 @@ fn extract_for_defer(
                 // that the fan-out sites above intercept, so there is no
                 // iteration source to restrict per arm. The loop-sourced
                 // multi-arm fan-out (`if g: d << v` and `if/elif` in a for-loop
-                // body) is handled at those sites via `try_extract_fanout_feed`,
-                // one refined-source channel per arm `i` predicated on
-                // `gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`. A *source-less* conditional feed has no
-                // refinement to hang the guard on, so reject it rather than
-                // mishandle. (The former Record-based fan-out is retired — it
-                // published an ill-typed `Unit` empty-channel for no-feed arms,
-                // a silent miscompile.)
-                return Err(DeferError::PartialFeedCaseUnsupported(
-                    defer_name.to_string(),
-                ));
+                // body) is handled at those sites via `try_extract_fanout_feed`.
+                //
+                // A *source-less* conditional feed (`if c: d << 1 else: d << 2`,
+                // outside any loop) has no iteration source, so each feeding arm
+                // becomes a **gated one-shot lift** over the `Unit` driver:
+                // `λ __unused : {Unit | π̂ᵢ} → vᵢ`, first-match `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`
+                // (a source-less feed; see `design/mutability.md`). Lambda elimination const-lifts
+                // each to the value-`Case` C-form arm, planning materializes the
+                // gate, and the channel union publishes exactly the selected arm's
+                // value — empty (a naturally-partial feed) when no arm fires. A
+                // *scrutinee / pattern* feed cannot be gated by a boolean
+                // predicate, so it stays rejected.
+                let guard_only =
+                    scrutinee.is_none() && per_branch.iter().all(|(p, ..)| p.is_none());
+                if !guard_only {
+                    return Err(DeferError::PartialFeedCaseUnsupported(
+                        defer_name.to_string(),
+                    ));
+                }
+                let unit_ty = Type::Base(BaseType::Unit);
+                let mut prior_guards: Vec<Expr> = Vec::new();
+                for (_, guard, branch_feeds, _) in &per_branch {
+                    let pred = synthesize_arm_predicate(guard, &prior_guards);
+                    prior_guards.push(guard.clone());
+                    // `{Unit | π̂ᵢ}` — the gate is constant in the driver element.
+                    // Store `π̂ᵢ` *directly* as the refinement's bare predicate (it
+                    // does not mention `__elem`): planning's `fn_of_bare_predicate`
+                    // slow-paths that through lambda elimination, desugaring the
+                    // `and`/`not` into point-free form — the same path the
+                    // loop-sourced fan-out relies on. A degenerate literal-`true`
+                    // gate leaves the driver unrefined (an unconditional feed).
+                    let refined = if matches!(&pred.node, TypedExprNode::Lit(Lit::Bool(true))) {
+                        unit_ty.clone()
+                    } else {
+                        Type::Refinement(
+                            Box::new(unit_ty.clone()),
+                            Refinement {
+                                predicate: Rc::new(pred),
+                            },
+                        )
+                    };
+                    for v in branch_feeds {
+                        feeds.push(Expr::lambda("__unused", refined.clone(), v.clone()));
+                    }
+                }
+                // Fall through: the residual value in every arm is now feed-free
+                // (`Unit` for a bare `d << v` arm), so the `Case` below denotes the
+                // statement's (discarded) value.
             }
             TypedExprNode::Case {
                 scrutinee,
@@ -2944,6 +2965,33 @@ mod tests {
         assert!(
             run(with_d, false).is_ok(),
             "a multi-arm Case feeding the defer must fan out, not be rejected"
+        );
+    }
+
+    /// A *source-less scrutinee* feed stays rejected. The guard-only source-less
+    /// feed (`if c: d << v`) channelizes to gated `Unit` lifts, but a
+    /// scrutinee/pattern `Case` cannot be gated by a boolean first-match
+    /// predicate, so `guard_only` is false and the narrowed
+    /// `PartialFeedCaseUnsupported` fires. (No surface syntax lowers to a
+    /// scrutinee feed yet, so this defensive path is only reachable at the IR
+    /// level — pinned here.)
+    #[test]
+    fn run_source_less_scrutinee_feed_rejected() {
+        let feeding_arm = Branch {
+            pattern: None,
+            guard: Expr::lit(Lit::Bool(true)),
+            body: Expr::feed("d", lit(1)),
+        };
+        let case_expr = Expr::new(TypedExprNode::Case {
+            scrutinee: Some(Box::new(lit(0))),
+            branches: vec![feeding_arm],
+        });
+        let with_d = Expr::let_bind("d", Expr::new(TypedExprNode::Defer), case_expr);
+        let err = run(with_d, false)
+            .expect_err("a source-less scrutinee feed must stay rejected, not channelize");
+        assert!(
+            matches!(err, DeferError::PartialFeedCaseUnsupported(_)),
+            "expected PartialFeedCaseUnsupported, got {err:?}"
         );
     }
 

--- a/src/ccl/design/lowering.md
+++ b/src/ccl/design/lowering.md
@@ -71,6 +71,18 @@ and [mut_elim: eliminating overwrite mutability](mutability.md#mut_elim-eliminat
 implementation lives in `src/ccl/mut_elim.rs` (the `For`/`MutWrite` → `LetRec`
 → `Transact` via loop planning) and `src/ccl/channelize.rs` (feed routing).
 
+**Conditionals in loop bodies (designed, not yet implemented).** Today a mutation
+nested inside an `if` in a loop body is detected (`find_nested_mutation_var`) and
+**rejected** at lowering. The in-flight conditionals stack *will* add a
+`ChlStmt::If` arm to the direct-mirror loop-body lowering: each branch body will
+lower through the same recursive statement-chain helper and be emitted as a
+statement-position `Case` — a faithful mirror, no path computation at lowering
+(mutability is a type-level fact lowering does not have). `find_mutation_loop_vars`
+will then recurse into the branches so `for x in src: if p: total += x` classifies
+as a mutation loop rather than being rejected; the branch merge is compiled
+downstream in `mut_elim`. A `for` or a `with begin():` nested inside an `if` inside
+a loop body stays rejected.
+
 **Let-bindings in generator bodies** (`y = f(x); yield y`) lower to nested `Let` nodes inside the Lambda body, evaluated once per iteration of the enclosing loop.
 
 **Pre-loop lets** (assignments before the outer `for` in a function body) are handled by `lower_stmts` — they wrap the generator expression in `Let` nodes. The `for` lowering itself (`lower_generator_for`) only handles the loop and its body.

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -748,6 +748,94 @@ request-indexed, but not commit-ordered. To gate or commit-order a reply, put it
 These features belong to the model above but are not yet built. Each is rejected at compile time
 today rather than silently mishandled.
 
+### Value-selecting `Case` and conditional induction writes (partially implemented)
+
+> **Status: value-selecting `Case`s compile; conditional induction writes are designed but not
+> yet implemented.**
+>
+> **Implemented** (value selection compiles via the literal union-of-restricts): scalar / compute
+> ternaries (the C-form), data-collection selection (the gate fan-out, reconciled to the Σ by
+> Σ-introduction), source-less conditional feeds, a **conditional element** in a
+> comprehension (`[a if g(x) else b for x in xs]`, fanned out over the source by the
+> element-dependent gate), and a comprehension **over a conditional collection** (`[f(x) for x in
+> (xs if c else ys)]`, the source `Case` floats out of the map). **Not yet implemented**:
+> conditional *induction writes* (`if 𝑝: total += x`, the per-leg writer sites + `DispatchRecurse`
+> below — still rejected at lowering); a conditional *between* standalone comprehensions
+> (`([…]) if c else ([…])` — a comprehension used as a value is compute-kinded, so its arms meet
+> rather than join; the deferred kind-inference work); and a per-element conditional at a site with
+> no visible iteration source (a UDF body, or a comprehension `if`-filter beside the element `Case`).
+
+The *filter* `Case` (`[𝑔 → action; true → unit]` → `Restrict`) and now the value-selecting `Case`
+compile; a conditional induction write (`if 𝑝: total += x`) is still rejected at lowering. The
+compilation is a **literal union of restricts** — the CCL algebra stays restricts + unions — and an
+**off-path arm is never evaluated**, so a guard-protected partial expression (`x // y if y != 0 else
+0`) never faults on the path its guard excludes. A **data-collection** fan-out is lazy structurally:
+an arm whose gate is false restricts to an empty extent, and an empty extent is never iterated. The
+**scalar** value-`Case` C-form gates a `Units(1)` driver and swaps in each arm's constant via
+`MapResultToConst`; when a false gate empties the driver (all rows deleted), `MapResultToConst` returns
+a terminal-empty tile *without* pulling the arm's constant — so the off-path value (a `//`, `%`, or
+index that the gate guards) is never computed. Every fan-out shares one first-match encoding,
+`πᵢ = 𝑔ᵢ ∧ ¬⋁ⱼ˂ᵢ 𝑔ⱼ` (`synthesize_arm_predicate` in `ccl_utils`, shared between channelize, the
+value fan-outs, and the transaction path walk):
+
+```
+target = ⧺ᵢ (source | 𝑝ᵢ ≫ (λ 𝑟 → 𝑣ᵢ))                                  -- channel: partial off-path
+total  = ⧺ᵢ (source | 𝑝ᵢ ≫ (λ 𝑟 → 𝑣ᵢ)) ⧺ (source | ¬⋁ᵢ𝑝ᵢ ≫ (λ 𝑟 → get_prev_seq(total, 𝑟, init)))
+```
+
+The presence or absence of the complement arm *is* the `Overwrite`/`Feed` distinction, and the union
+is **between letrec bindings, not inside one decision body**: a conditional mutable write emits one
+writer-site *leg per path* — the write leg over `{𝑟 : 𝐷 | π̂}` and the **carry-forward leg** over
+the complement `{𝑟 : 𝐷 | ¬̂π}` whose body passes the snapshot through — each guarded by
+`get_prev_seq` over the ⧺-union of all legs' per-key views (a shape the guardedness check already
+admits). Per-leg bindings let decision records differ per path, and a conditional feed on a path
+is **naturally partial**: `Feed(d, __legⱼ ≫ .to_k)` over the leg's restricted domain — no flag
+field. The phase walks the loop body as a *path enumeration* (a statement-position `Case` forks
+per branch plus the implicit complement; the rest of the chain clones into each path; guards
+resolve in the fork point's read-your-writes env), recognition generalizes the single-writer
+induction group to one `Transact` with one writer per leg, and op-conversion realizes the union by
+**ordered dispatch** (`DispatchRecurse`, see `../../interpreter/design-operators.md`): one
+iteration of the base extent, each position fed to exactly the leg whose predicate holds —
+faithful to the ⧺ because the leg predicates partition the domain, and position-aligned by
+construction.
+
+The value-`Case` positions ride the same union-of-restricts:
+
+- **Scalar / compute-typed selection** (a ternary, a per-key merge inside a decision body)
+  — *implemented* (`lambda_elim::build_value_case_cform`): restricts of gated one-shot lifts over
+  the `UIntRange(1)` driver, extracted by the rewrite itself —
+  `((unit | π̂₀ ≫ const 𝑒₀) ⧺ … ⧺ (unit | π̂ₙ ≫ const 𝑒ₙ), 𝑒ₙ) ▷ final_or_default` — exhaustive by
+  the trailing `true` arm, so the union has exactly one element and the outer type is unchanged.
+  The gate is constant in the driver element; the existing `Restrict` masks the extent by the
+  constant boolean directly (no new runtime capability).
+- **Data-typed selection** (`zs = xs if c else ys`) — *implemented*
+  (`lambda_elim::build_value_case_fanout`): each arm's whole collection restricted by a
+  constant-in-element gate, unioned; the union carries the Σ the type system gave the `Case` (see
+  `design/type-inference.md` §4.6), and the strict wall reconciles its structural `Variant`-domain
+  type against the Σ by **Σ-introduction** (the compiled gated partition realizes the whole sum —
+  the finite-Σ = gated-coproduct iso, legs' base domains set-equal to the candidates), or against
+  the same-domain collapse's plain data fun. `elif` chains flatten to one N-choice
+  partition first. A conditional collection is *consumed* (aggregate, program result) via the
+  `Σ <: Fun` subtyping rule, and *through a comprehension* by floating the source `Case` out of the
+  map (see the comprehension bullet below).
+- **Source-less conditional feeds** (`if c: o << 1 else: o << 2` outside any loop) — *implemented*
+  (`channelize`): each feeding arm becomes a gated one-shot lift `λ __unused : {Unit | π̂ᵢ} → 𝑣ᵢ`,
+  one channel per arm — replacing `PartialFeedCaseUnsupported` for guard-only `Case`s. A
+  scrutinee / pattern feed stays rejected; a no-else partial feed is still blocked earlier at
+  lowering (bare `if` as a value expression).
+- **Comprehension over / with a conditional** — *implemented* (`lower::comprehension`). Two shapes,
+  both fanning out the source (a value `Case` has no fixed driver, so it must gate the *iteration
+  source*, not a `Units(1)` one): a conditional **element** (`[a if g(x) else b for x in xs]`) fans
+  the source out by each arm's *element-dependent* gate — `⧺ᵢ [eᵢ for x in xs if π̂ᵢ]`, a union of
+  filtered maps (`fan_out_element_case`); a conditional **source** (`[e for x in (xs if c else ys)]`)
+  floats the source `Case` out of the map — `Case{gᵢ → [e for x in srcᵢ]}`, each arm a data-kinded
+  `Compose` so the arms `sigma_join` (`float_comp_source_case`). Both reduce to constructs already
+  compiled (the filter refinement, the gate fan-out); neither duplicates the loop, only the map.
+- **Bound-then-used values in a loop feed** (`x = 𝑒₁ if 𝑝 else 𝑒₂; o << f(x)`) — *deferred*
+  (case-float in the loop-body / feed path, distinct from the comprehension forms above):
+  `𝐶[Case{[𝑔ᵢ → 𝑒ᵢ]}] → Case{[𝑔ᵢ → 𝐶[𝑒ᵢ]]}` (sound by purity) then the channel fan-out generalized
+  from feed-arms to value-arms — only the fed context duplicates, never the loop.
+
 ### General in-transaction conditionals (and conditional writes)
 
 A `with begin():` block admits a single bare `if 𝑝:` **deny guard** — the transaction commits iff
@@ -761,23 +849,13 @@ of every mutable write and feed** (an empty taken path — including a missing `
 **each write key is a `Case` merged over the branch structure** (read-your-writes; a branch that does
 not write a key keeps its snapshot value). This is keyword-free, subsumes the current deny
 (`if 𝑝: x := 𝑒` → one write at path `𝑝` → `commit = 𝑝`), and admits value-selection, cross-key
-routing, `elif`, nesting (conjunction), and sequencing.
-
-The same path-condition fan-out is what a **conditional induction write** needs. A conditional feed
-(`if 𝑝: o << x`) is absent off-path; a conditional mutable write (`if 𝑝: total += x`) instead carries
-the previous value forward off-path — one extra **carry-forward** arm over the complement domain:
-
-```
-target = ⧺ᵢ (source | 𝑝ᵢ ≫ (λ 𝑟 → 𝑣ᵢ))                                  -- channel: partial off-path
-total  = ⧺ᵢ (source | 𝑝ᵢ ≫ (λ 𝑟 → 𝑣ᵢ)) ⧺ (source | ¬⋁ᵢ𝑝ᵢ ≫ (λ 𝑟 → get_prev_seq(total, 𝑟, init)))
-```
-
-The presence or absence of that carry-forward arm *is* the `Overwrite`/`Feed` distinction. **Blocker:**
-both need a *value-selecting* `Case` (`x = if 𝑝: 𝑒₁ else: 𝑒₂`) as a compiled construct, but only the
-*filter* `Case` (`[𝑔 → action; true → unit]` → `Restrict`) compiles today — a value `Case` errors at
-`lambda_elim`. The planned fix (refinement-based fan-out, lowering a value `Case` to a union of
-restricts `⧺ᵢ (source | pathᵢ ≫ 𝑒ᵢ)`) unblocks both the transaction conditionals and the same-shaped
-N-arm Case-with-feeds gap.
+routing, `elif`, nesting (conjunction), and sequencing. The per-key merges are value-selecting
+`Case`s over the snapshot, compiled by the scalar form above; the path walk itself is the next PR
+of the conditionals stack. One shape is settled by analysis: the block stays **one decision record
+per transaction** —
+per-path writer sites are unsound (a path predicate reads the snapshot, which exists only at the
+commit tick; one `begin()` is one serialization point; multi-key read-your-writes needs one
+snapshot and one write-set).
 
 ### `with t = begin():` transaction handle
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -576,10 +576,12 @@ The pipeline passes downstream of inference treat function types structurally an
 ## 4.6 Data vs compute functions
 
 > **Status: implemented, minus Σ.** The `FunKind` marker, kind inference,
-> kind-aware subtyping (the `Compute <: Data` rejection) and the invariant data
+> kind-aware subtyping (the `Compute <: Data` rejection), the invariant data
+> domain, and the compilation of a value-selecting `Case` whose arms share one
 > domain are all live. What is missing is the type the model says a domain join
 > *produces* — the Σ — so a join over distinct domains is diagnosed rather than
-> typed. See the callout below.
+> typed. The heterogeneous-scalar union is separately deferred. See the callout
+> below.
 
 The unresolved domain-join corner of §4.5 (O1/O4 — two collections meeting at one
 join point) is resolved by making a missing distinction explicit. The distinction
@@ -705,6 +707,31 @@ one source (`[x for x in xs if x > 1]` vs `[x for x in xs if x < 3]`) are two
 distinct domains and reject like any other pair — refinement is not a special case
 here. Meeting them would claim one domain satisfying both filters; picking either
 would claim positions the other branch does not produce.
+
+> **Landed — value-`Case` compilation at one domain.** `lambda_elim` compiles a
+> value-selecting `Case` to a union of **gated restricts**: one leg per arm, each the
+> arm's domain refined by that arm's branch predicate `π̂ᵢ` (compiled from the
+> original `if`/`elif` conditions), assembled as
+> `Fun{Data, Variant([{𝐷ᵢ | π̂ᵢ}]), 𝑐}`. The gates are exclusive and exhaustive, so
+> exactly one leg is non-empty at runtime — an invariant `lambda_elim` asserts at the
+> fan-out boundary (a non-exhaustive value-`Case` would realize an empty collection
+> on the uncovered path, a silent miscompile) rather than the solver re-proving.
+>
+> Where every arm shares one domain 𝐷 — the case the domain-join rule admits, and
+> the one loop-carried accumulators produce (`if p: acc := x else: acc := y`) — the
+> arms' join is the plain data function `𝐷 ⤇ 𝑐`, and the compiled partition subtypes
+> *that* directly: `is_index_partition_of` recognizes a `Variant` whose every
+> payload is 𝐷 under a gate, and relates each leg `{𝐷 | π̂ᵢ} <: 𝐷` by refinement
+> width — *covariant*, since this is an introduction rather than the function-domain
+> contravariance. It is guarded on the legs refining the same *concrete* target, so a
+> genuine heterogeneous `++` flowing into a fresh-var domain still takes the ordinary
+> contravariant arm (its domain var resolves to the `Variant`, iterating every leg).
+>
+> Arms at *different* domains have no join to subtype against — see
+> [The domain join is a Σ](#the-domain-join-is-a-σ) — so the fan-out is built
+> and reconciled only at one domain. Reconciling it against the lossless join of
+> several domains is the same dependent sum that rejection is standing in for, and
+> lands with it.
 
 **`Case` arms join by the lattice.** `emit_case` constrains *every* arm into a
 fresh result variable (`require_sub`) instead of requiring equality. Homogeneous

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -25,6 +25,7 @@ use crate::ccl::{Bound, HistoryKind, InferVar, InferVarId, Level, Refinement, Ty
 
 use super::type_level;
 use crate::ccl::FieldKey;
+use crate::ccl::ccl_utils::strip_refinements;
 
 // ---------------------------------------------------------------------------
 // Constraint solver
@@ -322,6 +323,28 @@ fn bridge_holder_gap(lo: &Subst, hi: &Subst) -> (Subst, Subst) {
     );
 }
 
+/// Whether `union_dom` is a gated **partition** of the single domain `target`:
+/// a `Variant` with contiguous `Index(0..n)` tags (n ≥ 1) whose every payload,
+/// with its gate refinement stripped, is structurally `target` (also stripped).
+/// This is the shape lambda_elim's value-`Case` fan-out gives *same-domain* arms
+/// — the signature bridge rule 2 realizes as the plain data function
+/// `target ⤇ W`. Requiring the stripped payloads to equal `target` keeps a
+/// genuine heterogeneous `++` flowing into a fresh-var domain out of this rule
+/// (its legs differ, or the target is an unresolved var, so the ordinary
+/// contravariant arm applies).
+fn is_index_partition_of(union_dom: &Type, target: &Type) -> bool {
+    let Type::Variant(tags) = union_dom else {
+        return false;
+    };
+    if tags.is_empty() {
+        return false;
+    }
+    let base = strip_refinements(target);
+    tags.iter()
+        .enumerate()
+        .all(|(i, (k, payload))| *k == FieldKey::Index(i) && strip_refinements(payload) == base)
+}
+
 /// Constrain `lhs‹sl› <: rhs‹sr›` — each side under its own context morphism,
 /// both mapping into the constraint's shared ambient frame.
 ///
@@ -390,6 +413,39 @@ fn constrain_go(
         // `Txn` is a nullary leaf: reflexively equal to itself, incomparable
         // to every other type (the catch-all `Mismatch` below).
         (Type::Txn, Type::Txn) => Ok(()),
+
+        // Bridge rule 2 (gated-partition `⧺` <: plain data function): the
+        // `Variant`-domain union `⧺ᵢ ({D | π̂ᵢ} ⤇ W)` that lambda_elim's
+        // value-`Case` fan-out produces for **same-domain** arms *is* the plain
+        // data function `D ⤇ W` — an exhaustive + disjoint partition of `D`
+        // (exhaustiveness guaranteed by the stamping phase, not proven here; see
+        // lambda_elim's `build_value_case_fanout` and `design/type-inference.md`
+        // §4.6). Each leg `{D | π̂ᵢ} <: D` by refinement width (covariant, not the
+        // function-domain contravariance below), codomain covariant. Fires only
+        // when every leg refines the *same concrete* target domain `D`, so a
+        // genuine heterogeneous `++` flowing into a fresh-var domain still takes
+        // the ordinary contravariant arm below (its domain var resolves to the
+        // `Variant`, iterating every leg).
+        (
+            Type::Fun {
+                kind: FunKind::Data,
+                domain: union_dom,
+                codomain: c0,
+                ..
+            },
+            Type::Fun {
+                domain: d1,
+                codomain: c1,
+                ..
+            },
+        ) if is_index_partition_of(union_dom, d1) => {
+            if let Type::Variant(tags) = union_dom.as_ref() {
+                for (_, payload) in tags {
+                    constrain_go(payload, d1, sl, sr, cache)?;
+                }
+            }
+            constrain_go(c0, c1, sl, sr, cache)
+        }
 
         // Function: contravariant on domain, covariant on codomain. The
         // codomain edge *derives* the binder correspondence — aligning the two

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -42,10 +42,13 @@
 
 use std::rc::Rc;
 
-use crate::ccl::ccl_utils::{cast_target_refinement, is_free, is_free_in_value, typed_compose};
+use crate::ccl::ccl_utils::{
+    apply_primitive, cast_target_refinement, flatten_trailing_value_case, is_free,
+    is_free_in_value, refine_with, strip_refinements, synthesize_arm_predicate, typed_compose,
+};
 use crate::ccl::infer::{dbg_typecheck_mv, debug_typecheck};
 use crate::ccl::simplify::simplify;
-use crate::ccl::{Builtin, Lit, Name, Refinement};
+use crate::ccl::{BaseType, Branch, Builtin, FieldKey, Lit, Name, Refinement};
 use crate::ccl::{Expr, Type, TypedExpr, TypedExprNode, symbolic::symbolic};
 
 // ---------------------------------------------------------------------------
@@ -296,6 +299,207 @@ fn extract_filter_case(body: Expr) -> (Expr, Expr) {
     } else {
         panic!("extract_filter_case: expected a filter-pattern Case body")
     }
+}
+
+// ---------------------------------------------------------------------------
+// Value-selecting Case compilation (the scalar C-form)
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if `ty` (peeling outer refinements) is a *collection* — a
+/// data or compute function. A value-selecting `Case` whose arms are collections
+/// takes the data-typed gate fan-out; a `Case` returning a scalar / compute value
+/// takes the C-form below.
+fn is_collection_result(ty: &Type) -> bool {
+    matches!(strip_refinements(ty), Type::Fun { .. })
+}
+
+/// Compile a guard-based **value-selecting** `Case` (a ternary or `if`/`elif`/
+/// `else` that returns a scalar / compute value) to the **C-form**: a union of
+/// gated one-shot lifts over the `UIntRange(1)` driver, extracted by
+/// `final_or_default`.
+///
+/// ```text
+/// Case{scrutinee: None, [g₀ → e₀; …; gₙ → eₙ]}   (gₙ is the exhaustive trailing `true`)
+///   ⟹  (⧺ᵢ const(eᵢ) : {UIntRange(1) | π̂ᵢ} ⤇ V,  eₙ) ▷ final_or_default
+/// ```
+///
+/// where `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ` ([`synthesize_arm_predicate`]). Each arm is a
+/// constant lift of its value over a one-position driver whose domain is
+/// *refined by the arm's first-match gate*. The gate is **constant in the
+/// driver element** (see `src/interpreter/design-operators.md`): it does not
+/// vary with the driver position, so the whole one-element domain survives (gate
+/// holds) or is emptied (gate fails). The partition is exhaustive (the trailing
+/// `true` guard), so exactly one arm survives and the union has one element;
+/// `final_or_default`'s default `eₙ` is a type anchor for the empty case that
+/// cannot occur. The outer type is the `Case`'s own value type `V`, unchanged,
+/// so lambda_elim's type-preservation assertion holds.
+fn build_value_case_cform(
+    ctx: &mut ElimContext,
+    branches: Vec<Branch>,
+    result_ty: Type,
+) -> Result<Expr, LambdaElimError> {
+    // Exhaustiveness invariant: a value-selecting `Case` must be total (a
+    // trailing `true` guard). `default_body` below becomes `final_or_default`'s
+    // default, and the whole first-match/`final_or_default` argument is sound only
+    // if the last arm is that unconditional fallback — a non-exhaustive `Case`
+    // reaching here would silently return the last arm's value with its gate
+    // false (an empty union → the wrong default). Lowering always appends the
+    // `true` complement (a ternary's `else`); assert it at this boundary.
+    debug_assert!(
+        branches
+            .last()
+            .is_some_and(|b| matches!(&b.guard.node, TypedExprNode::Lit(Lit::Bool(true)))),
+        "value-selecting Case must be exhaustive (trailing `true` guard)"
+    );
+    let bool_ty = Type::Base(BaseType::Bool);
+    let driver_dom = Type::UIntRange(1);
+
+    let mut prior_guards: Vec<Expr> = Vec::new();
+    let mut arms: Vec<Expr> = Vec::new();
+    let mut arm_domains: Vec<Type> = Vec::new();
+    let mut default_body: Option<Expr> = None;
+
+    for b in branches {
+        let guard = elim_lambdas(ctx, b.guard)?;
+        let body = elim_lambdas(ctx, b.body)?;
+        // First-match gate π̂ᵢ, lifted to a constant-in-element predicate
+        // `const(π̂ᵢ) : UIntRange(1) ⇒ Bool` over the driver. `synthesize_arm_predicate`
+        // combines the (already point-free) guards with raw `and`/`not` nodes, so
+        // eliminate once more to desugar those into applied-combinator form.
+        let gate_value = elim_lambdas(ctx, synthesize_arm_predicate(&guard, &prior_guards))?;
+        prior_guards.push(guard);
+        let gate_fn = apply_primitive(
+            gate_value,
+            Builtin::Const,
+            Type::fun(driver_dom.clone(), bool_ty.clone()),
+        );
+        // {UIntRange(1) | π̂ᵢ} — the gated one-shot driver domain. A trivially-true
+        // gate (a leading `if True`) leaves the driver unrefined (always fires).
+        let refined_dom = refine_with(driver_dom.clone(), &gate_fn);
+        arm_domains.push(refined_dom.clone());
+        // const(eᵢ) : {UIntRange(1) | π̂ᵢ} ⤇ V — lift the value over the gated driver.
+        let arm = apply_primitive(
+            body.clone(),
+            Builtin::Const,
+            Type::data_fun(refined_dom, result_ty.clone()),
+        );
+        arms.push(arm);
+        default_body = Some(body);
+    }
+
+    // A one-branch value `Case` denotes just that branch's value.
+    let default_body = default_body.expect("value-selecting Case has at least one branch");
+    if arms.len() == 1 {
+        return Ok(default_body);
+    }
+
+    // Union domain = Variant({Index(i): {UIntRange(1)|π̂ᵢ}}) — the same tagged
+    // union `emit_collection_union` produces, so op-conversion's `UnionOperator`
+    // dispatches to the surviving arm.
+    let union_dom = Type::Variant(
+        arm_domains
+            .into_iter()
+            .enumerate()
+            .map(|(i, d)| (FieldKey::Index(i), d))
+            .collect(),
+    );
+    let union_ty = Type::data_fun(union_dom, result_ty.clone());
+    let union = Expr::collection_union(arms).with_ty(union_ty.clone());
+
+    // (union, eₙ) ▷ final_or_default : V
+    let tuple_ty = Type::Tuple(vec![union_ty, result_ty.clone()]);
+    let arg = Expr::tuple(vec![union, default_body]).with_ty(tuple_ty);
+    Ok(apply_primitive(arg, Builtin::FinalOrDefault, result_ty))
+}
+
+/// The element (codomain) type a collection-valued `Case` produces — the codomain
+/// of the arms' joined data function. The arms share one domain (a join at distinct
+/// domains is rejected at inference), so they share one codomain. Peels outer
+/// refinements first.
+fn collection_value_ty(ty: &Type) -> Type {
+    match strip_refinements(ty) {
+        Type::Fun { codomain, .. } => *codomain,
+        other => other,
+    }
+}
+
+/// Compile a guard-based **value-selecting** `Case` whose arms are *collections*
+/// (data-typed) to the **gate fan-out**: each arm's whole collection,
+/// restricted by its constant first-match gate, unioned.
+///
+/// ```text
+/// Case{scrutinee: None, [g₀ → xs₀; …; gₙ → xsₙ]}   ⟹   ⧺ᵢ (xsᵢ | π̂ᵢ)
+/// ```
+///
+/// where `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ` ([`synthesize_arm_predicate`]). Each gate is
+/// **constant in the element** (see the C-form above), so an arm's collection
+/// survives whole (gate holds) or is emptied (gate fails); the partition is
+/// exhaustive, so exactly one arm is non-empty and the union is that arm's
+/// collection. The union's type is the tagged `Variant`-domain data function —
+/// the same shape `emit_collection_union` gives a `++`, which the strict wall
+/// reconciles against the arms' joined data function by `is_index_partition_of`
+/// (`src/ccl/design/type-inference.md`, "The domain join is a Σ"). The arms all share
+/// one domain — a join at distinct domains is rejected at inference — so every leg's
+/// payload is that one domain under its own gate.
+fn build_value_case_fanout(
+    ctx: &mut ElimContext,
+    branches: Vec<Branch>,
+    result_ty: Type,
+) -> Result<Expr, LambdaElimError> {
+    // Exhaustiveness invariant (as in [`build_value_case_cform`]): a total value
+    // selection has a trailing `true` guard, so exactly one arm survives the
+    // first-match partition and the union is that arm's whole collection. A
+    // non-exhaustive `Case` here would leave the union empty on the uncovered
+    // path (e.g. `sum` = 0) — a silent miscompile, not a rejection.
+    debug_assert!(
+        branches
+            .last()
+            .is_some_and(|b| matches!(&b.guard.node, TypedExprNode::Lit(Lit::Bool(true)))),
+        "value-selecting Case (fan-out) must be exhaustive (trailing `true` guard)"
+    );
+    let bool_ty = Type::Base(BaseType::Bool);
+    let value_ty = collection_value_ty(&result_ty);
+
+    let mut prior_guards: Vec<Expr> = Vec::new();
+    let mut arms: Vec<Expr> = Vec::new();
+
+    for b in branches {
+        let guard = elim_lambdas(ctx, b.guard)?;
+        let coll = elim_lambdas(ctx, b.body)?;
+        let arm_dom = coll.ty.domain().ok_or_else(|| {
+            LambdaElimError::Unsupported(format!(
+                "value-selecting Case arm is not a plain collection (nested conditional \
+                 collections are not yet supported): {}",
+                coll.ty
+            ))
+        })?;
+        // First-match gate, lifted to a constant-in-element predicate over the
+        // arm's own domain, then attached as a domain refinement (planning
+        // materializes it as the arm's `restrict`).
+        let gate_value = elim_lambdas(ctx, synthesize_arm_predicate(&guard, &prior_guards))?;
+        prior_guards.push(guard);
+        let gate_fn = apply_primitive(
+            gate_value,
+            Builtin::Const,
+            Type::fun(arm_dom.clone(), bool_ty.clone()),
+        );
+        let refined_dom = refine_with(arm_dom, &gate_fn);
+        arms.push(coll.with_ty(Type::data_fun(refined_dom, value_ty.clone())));
+    }
+
+    // A one-branch collection `Case` denotes just that arm's collection — no union
+    // needed, and nothing for the partition rule to reconcile.
+    if arms.len() == 1 {
+        return Ok(arms.pop().unwrap());
+    }
+
+    // The node keeps the `Case`'s own type — the arms' joined data function `D ⤇ V`
+    // — so lambda_elim stays type-preserving. The strict `typecheck` then reconciles
+    // the union's structural `Variant([{D | π̂ᵢ}])` domain against that `D` via
+    // `is_index_partition_of` (`src/ccl/design/type-inference.md`, "The domain join
+    // is a Σ"). Op-conversion compiles the union straight to a `UnionOperator`
+    // from its operands, whose domains are concrete domains.
+    Ok(Expr::collection_union(arms).with_ty(result_ty))
 }
 
 // ---------------------------------------------------------------------------
@@ -693,6 +897,29 @@ fn elim_lambda_impl(
             unreachable!("lambda_elim: Transact is born by recognition, after this pass")
         }
 
+        // A value-selecting `Case` inside a bare lambda body (`λ x → Case{[gᵢ → eᵢ]}`),
+        // where the gate `gᵢ(x)` varies with the element. A *comprehension*
+        // element conditional (`[a if g(x) else b for x in xs]`) is fanned out at
+        // comprehension lowering (`lower::comprehension::fan_out_element_case`) into
+        // `⧺ᵢ src|π̂ᵢ ≫ eᵢ`, so it never reaches here. This arm catches the residual
+        // shapes — a per-element conditional in a lambda whose *iteration source is
+        // not visible at lowering* (a UDF body, a comprehension with an extra
+        // `if`-filter alongside the element `Case`) — which need the same source
+        // fan-out but at a site without a source in hand. Deferred (a documented
+        // follow-up; see `design/mutability.md`
+        // "Value-selecting `Case` and conditional induction writes (partially implemented)").
+        TypedExprNode::Case {
+            scrutinee: None,
+            branches,
+        } if branches.iter().all(|b| b.pattern.is_none()) => {
+            Err(LambdaElimError::Unsupported(format!(
+                "per-element conditional (a value-selecting `Case` inside `λ {param} → …`) is \
+                 not compilable at a site with no visible iteration source. A comprehension \
+                 element conditional (`[a if g({param}) else b for {param} in xs]`), a top-level \
+                 ternary, a conditional collection, and a conditional feed all compile today."
+            )))
+        }
+
         // Unsupported constructs.
         body => Err(LambdaElimError::Unsupported(format!(
             "unsupported body kind in lambda elimination for param '{param}' in body {body:?}"
@@ -858,6 +1085,27 @@ fn elim_lambdas_impl(ctx: &mut ElimContext, expr: Expr) -> Result<Expr, LambdaEl
         }
 
         TypedExprNode::Error => crate::unexpected_error_node!(),
+
+        // Value-selecting guard `Case`: the literal union-of-restricts. A
+        // scalar / compute result takes the C-form (gated one-shot lifts +
+        // `final_or_default`); a data-collection result takes the gate fan-out
+        // (each whole arm restricted then unioned). A pattern-matching
+        // `Case` (`scrutinee: Some`) is not handled here yet.
+        TypedExprNode::Case {
+            scrutinee: None,
+            branches,
+        } if branches.iter().all(|b| b.pattern.is_none()) => {
+            // Flatten `elif` chains to one partition first, so a nested
+            // conditional collection collapses into a single N-choice fan-out.
+            let branches = flatten_trailing_value_case(branches);
+            let result = if is_collection_result(&ty) {
+                build_value_case_fanout(ctx, branches, ty)?
+            } else {
+                build_value_case_cform(ctx, branches, ty)?
+            };
+            debug_typecheck(&result);
+            Ok(result)
+        }
 
         // Control-flow constructs not yet supported.
         node @ TypedExprNode::Case { .. } => Err(LambdaElimError::Unsupported(format!(

--- a/src/ccl/lower/comprehension.rs
+++ b/src/ccl/lower/comprehension.rs
@@ -4,8 +4,10 @@
 use super::*;
 use crate::{
     ccl::{
-        BinOpKind, Expr, LogicKind, Name, Type,
-        ccl_utils::{make_cast, refined_data_fun},
+        BinOpKind, Branch, Expr, LogicKind, Name, Type, TypedExprNode,
+        ccl_utils::{
+            flatten_trailing_value_case, make_cast, refined_data_fun, synthesize_arm_predicate,
+        },
         uniquify,
     },
     chl_parser::ast::{AssignTarget, CompClause, Comprehension, Expr as ChlExpr, Spanned},
@@ -59,7 +61,7 @@ pub(super) fn lower_list_comp(
     let generators = group_comp_clauses(&comp.clauses)?;
 
     // ---- Phase 1: Lower each generator's source and register its loop variable ----
-    // We keep the source operators and index extents for later use when building the
+    // We keep the source operators and index domains for later use when building the
     // Apply/Lambda chains.  Each loop variable is pushed onto the lowering scope so
     // that body and predicate expressions can reference it.
     let mut gen_sources: Vec<Expr> = Vec::new();
@@ -119,8 +121,8 @@ pub(super) fn lower_list_comp(
     };
 
     // ---- Phase 4: Build the outer iteration variable ------------------------------
-    // Single generator: iterate directly over that source's index extent.
-    // Multiple generators: pack all index extents into a Record so the body can
+    // Single generator: iterate directly over that source's index domain.
+    // Multiple generators: pack all index domains into a Record so the body can
     // address each one via RecordField and the runtime produces the cartesian
     // product.
     // With a predicate: wrap in Restricted so the runtime filters via a correlation
@@ -141,6 +143,69 @@ pub(super) fn lower_list_comp(
             Expr::apply(vref, Expr::proj_index(i))
         }
     };
+
+    // ---- Phase 4.5: Float a value-`Case` source out of the comprehension --------
+    // `[e for x in (xs if c else ys)]` — a comprehension over a *conditional
+    // collection* — lowers with a value-`Case` source. Iterating it directly
+    // would bind the index variable to *both* choice domains (as the read index
+    // and the result domain), which inference rejects as an untagged-sum
+    // collision. Because the guards do not reference the comprehension variable,
+    // the `Case` floats out soundly: `[e for x in Case{gᵢ→srcᵢ}]` ⟹
+    // `Case{gᵢ → [e for x in srcᵢ]}` — each arm an ordinary map over a concrete
+    // collection, the enclosing `Case` a value-`Case` over collections (compiled by
+    // the gate fan-out). Single generator, no comprehension
+    // filter; a nested conditional source floats per arm by recursion. (A
+    // multi-generator or filtered comprehension over a conditional source is a
+    // follow-up — it falls through to the direct path.)
+    if single_gen
+        && pred_op.is_none()
+        && matches!(
+            &gen_sources[0].node,
+            TypedExprNode::Case { scrutinee: None, branches }
+                if branches.iter().all(|b| b.pattern.is_none())
+        )
+    {
+        let source = gen_sources.pop().expect("single generator has one source");
+        return Ok(float_comp_source_case(
+            source,
+            &gen_iter_vars[0],
+            &body,
+            &mut false,
+            comp.element.span,
+            ctx,
+        ));
+    }
+
+    // ---- Phase 4.6: Fan out a value-`Case` *element* into filtered maps ----------
+    // `[a if g(x) else b for x in xs]` — a comprehension whose *element* is a
+    // per-element conditional — lowers with a value-`Case` body. The `Case`
+    // cannot float out (its guards reference the comprehension variable `x`), so
+    // instead fan out the source by each arm's first-match gate:
+    // `[eᵢ if gᵢ … for x in xs]` ⟹ `⧺ᵢ [eᵢ for x in xs if π̂ᵢ]`,
+    // `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`. Each arm restricts the source by its
+    // (element-dependent) gate — the ordinary filter refinement — and maps by
+    // that arm's value; the gates partition the source, so the union recombines
+    // the arms by position into the fully-mapped collection. A `CollectionUnion`
+    // (not a `Case`), so the compute-kinded per-arm maps do not need to join.
+    // Single generator, no comprehension filter; the value arms may reference `x`.
+    if single_gen
+        && pred_op.is_none()
+        && matches!(
+            &body.node,
+            TypedExprNode::Case { scrutinee: None, branches }
+                if branches.iter().all(|b| b.pattern.is_none())
+        )
+    {
+        let source = gen_sources.pop().expect("single generator has one source");
+        return Ok(fan_out_element_case(
+            source,
+            &gen_iter_vars[0],
+            outer_var,
+            body,
+            comp.element.span,
+            ctx,
+        ));
+    }
 
     // ---- Phase 5: Build the body as a nested Apply/Lambda chain ------------------
     // Working innermost-first (reverse order) we wrap the accumulated expression:
@@ -205,7 +270,7 @@ pub(super) fn lower_list_comp(
         Ok(ctx.tag_machinery(make_cast(unrefined_lambda, target_ty), element_span, lc))
     } else {
         // A comprehension is a **data collection** (a map over its source's
-        // extent): stamp it `Data` by provenance. The `data_fun(_, _)` annotation
+        // domain): stamp it `Data` by provenance. The `data_fun(_, _)` annotation
         // is a concrete-kind stamp (`emit_node`), the unfiltered counterpart of
         // the filtered branch's `refined_data_fun` (also `Data`) cast target — so a
         // comprehension is data-by-construction, not by a domain guess. (Filtered
@@ -216,6 +281,145 @@ pub(super) fn lower_list_comp(
             comp.element.span,
             lc,
         ))
+    }
+}
+
+/// Float a value-`Case` *source* out of a single-generator comprehension:
+/// `[e for x in Case{gᵢ→srcᵢ}]` ⟹ `Case{gᵢ → [e for x in srcᵢ]}`. Sound because
+/// the guards do not reference the comprehension variable `x`. Recurses so a
+/// nested conditional source flattens per arm; a concrete (non-`Case`) source
+/// builds the ordinary map chain `λ __idx → __idx ▷ src ▷ (λ x → body)`.
+/// Hand out a tree copy of `origin` for one arm of a fan-out, **keep-first**: the
+/// first copy keeps the original's `NodeId`s and every later one is deep-freshened
+/// inside a lowering copy-frame, so its re-mints land as `Copy` steps mirroring the
+/// original's attribution. A fan-out places the same subtree under several arms and
+/// two main-tree nodes may not share an id — see `src/ccl/design/provenance.md`,
+/// "The id domain". (The same keep-first shape as the chained-comparison operand
+/// freshen in `lower::exprs`.)
+fn fan_out_copy(origin: &Expr, used: &mut bool, label: &'static str) -> Expr {
+    let mut copy = origin.clone();
+    if *used {
+        use crate::ccl::lineage::copy_frame;
+        let _frame = copy_frame(label);
+        copy.freshen_node_ids_deep();
+    }
+    *used = true;
+    copy
+}
+
+fn float_comp_source_case(
+    source: Expr,
+    iter_var: &str,
+    body: &Expr,
+    body_used: &mut bool,
+    span: Span,
+    ctx: &mut LoweringContext,
+) -> Expr {
+    let is_value_case = matches!(
+        &source.node,
+        TypedExprNode::Case { scrutinee: None, branches }
+            if branches.iter().all(|b| b.pattern.is_none())
+    );
+    if is_value_case {
+        let TypedExprNode::Case { branches, .. } = source.node else {
+            unreachable!("guarded by is_value_case")
+        };
+        let floated = branches
+            .into_iter()
+            .map(|b| Branch {
+                pattern: b.pattern,
+                guard: b.guard,
+                // The arm body *is* this arm's source collection; float into it.
+                body: float_comp_source_case(b.body, iter_var, body, body_used, span, ctx),
+            })
+            .collect();
+        // The rebuilt `Case` is the floated encoding of the rule, not an image of
+        // anything the user wrote.
+        return ctx.tag_machinery(
+            Expr::new(TypedExprNode::Case {
+                scrutinee: None,
+                branches: floated,
+            }),
+            span,
+            "lower.comp_source_case",
+        );
+    }
+    // Concrete source: `source ≫ (λ x → body)` — a `Compose`, *not* the apply
+    // chain Phase 5 builds. The compose form is equivalent (a map applies the
+    // body to each element) but `emit_compose` stamps it with the *source's*
+    // data kind (a map over a collection is itself a collection). That data kind
+    // is what lets two such arms of a conditional source join as collections
+    // (compiled by the gate fan-out) rather than colliding as compute-kinded
+    // lambdas whose index domains would meet.
+    let body = fan_out_copy(body, body_used, "lower.comp_source_case_body");
+    let cs = "lower.comp_source_case";
+    let elem_map = ctx.tag_machinery(Expr::lambda(iter_var, Type::Hole, body), span, cs);
+    ctx.tag_machinery(Expr::compose(vec![source, elem_map]), span, cs)
+}
+
+/// Fan out a single-generator comprehension whose *element* is a value-`Case`
+/// into a union of filtered maps: `[eᵢ if gᵢ … for x in src]` ⟹
+/// `⧺ᵢ [eᵢ for x in src if π̂ᵢ]`, first-match `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`. Each arm is a
+/// filtered map — the source restricted on its domain by the arm's
+/// (element-dependent) gate (a `cast` carrying the refinement, exactly the shape
+/// Phase 6 builds for a comprehension `if`-filter), composed with the arm's value
+/// map. The gates partition the source, so the `++`-union recombines the arms by
+/// position into the fully-mapped collection.
+fn fan_out_element_case(
+    source: Expr,
+    iter_var: &str,
+    outer_var: &str,
+    body: Expr,
+    span: Span,
+    ctx: &mut LoweringContext,
+) -> Expr {
+    let TypedExprNode::Case { branches, .. } = body.node else {
+        unreachable!("fan_out_element_case requires a Case body")
+    };
+    // Flatten a nested `elif` element (`a if p else b if q else c`, a trailing
+    // `true → Case{…}`) into one flat partition, so each arm is a plain value.
+    let branches = flatten_trailing_value_case(branches);
+    let mut prior_guards: Vec<Expr> = Vec::new();
+    // The source subtree is placed once per arm in the element map and once more in
+    // that arm's gate, so every use after the first must be a freshened copy.
+    let mut source_used = false;
+    let arms: Vec<Expr> = branches
+        .into_iter()
+        .map(|b| {
+            let gate = synthesize_arm_predicate(&b.guard, &prior_guards);
+            prior_guards.push(b.guard);
+            // Element map: `λ __idx → __idx ▷ src ▷ (λ x → eᵢ)`. Every node here is
+            // manufactured encoding of the fan-out rule — the arm *bodies* keep their
+            // own images, recorded when they were lowered.
+            let ec = "lower.comp_elem_case";
+            let idx_var = ctx.tag_machinery(Expr::var(Name::raw(outer_var)), span, ec);
+            let arm_src = fan_out_copy(&source, &mut source_used, "lower.comp_elem_case_source");
+            let read = ctx.tag_machinery(Expr::apply(idx_var, arm_src), span, ec);
+            let arm_body = ctx.tag_machinery(Expr::lambda(iter_var, Type::Hole, b.body), span, ec);
+            let applied = ctx.tag_machinery(Expr::apply(read, arm_body), span, ec);
+            let elem_map =
+                ctx.tag_machinery(Expr::lambda(outer_var, Type::Hole, applied), span, ec);
+            // Gate over the source domain: `__elem ▷ src ▷ (λ x → π̂ᵢ)` — the bare
+            // refinement predicate, matching Phase 6's loop-join filter shape.
+            let gate_on_source = Expr::apply(
+                Expr::apply(
+                    Expr::var(Name::elem()),
+                    fan_out_copy(&source, &mut source_used, "lower.comp_elem_case_source"),
+                ),
+                Expr::lambda(iter_var, Type::Hole, gate),
+            );
+            // `gate_on_source` rides the cast target's refinement predicate, so its
+            // interior is outside the NodeId domain — carried, never checked — and
+            // needs no tagging (`src/ccl/design/provenance.md`, "The id domain").
+            let target = refined_data_fun(Type::Hole, gate_on_source, Type::Hole);
+            ctx.tag_machinery(make_cast(elem_map, target), span, ec)
+        })
+        .collect();
+    // A one-arm value `Case` (degenerate) is just the single filtered map.
+    if arms.len() == 1 {
+        arms.into_iter().next().expect("checked len == 1")
+    } else {
+        ctx.tag_machinery(Expr::collection_union(arms), span, "lower.comp_elem_case")
     }
 }
 

--- a/src/ccl/lower/loops.rs
+++ b/src/ccl/lower/loops.rs
@@ -434,19 +434,13 @@ fn lower_for_body_terminal(
             branches,
             else_body,
         } => {
-            if else_body.is_some() {
-                return Err(LoweringError::unsupported(
-                    stmt.span,
-                    "if/else inside generator for-loop body is not supported; \
-                     use a plain if-guard (no else branch)",
-                ));
-            }
-            // `if` / `elif` (no `else`): one `Case` branch per guard, in source
-            // order, then a trailing `true → Unit` fallthrough. A feeding
-            // multi-arm `Case` is fanned out by `channelize` into one
-            // refined-source channel per feeding arm (predicate
-            // `gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`, encoding "first matching guard wins"), so `elif`
-            // is no longer gated here.
+            // `if` / `elif` [/ `else`]: one `Case` branch per guard, in source
+            // order. A feeding multi-arm `Case` is fanned out by `channelize` into
+            // one refined-source channel per feeding arm (predicate
+            // `gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`, first-matching-guard-wins), so `elif` and `else` are
+            // both ordinary arms. The trailing arm is the `else` body when present
+            // (guard `true`, so its first-match predicate is `¬⋁ⱼ gⱼ`), else a
+            // `true → Unit` fallthrough (positions no guard admits do nothing).
             let mut out_branches = Vec::with_capacity(branches.len() + 1);
             for branch in branches {
                 let cond = lower_expr(&branch.cond, ctx)?;
@@ -465,8 +459,24 @@ fn lower_for_body_terminal(
                     body: arm,
                 });
             }
-            // The guard-less fallthrough arm (`true → Unit`) is manufactured
-            // encoding; the `Case` itself images the `if` statement.
+            // The fallthrough arm's guard is manufactured encoding; the `Case`
+            // itself images the `if` statement. An `else` body is *not*
+            // manufactured — its nodes are recorded by their own lowering, and
+            // re-tagging its root here would overwrite that attribution with
+            // `Machinery` (last tag wins) — so only the `Unit` synthesized to
+            // stand in for a missing `else` is tagged.
+            let fallthrough = match else_body {
+                Some(else_body) => lower_for_body_stmts(
+                    else_body,
+                    defer_name,
+                    mutation_scope,
+                    frame_introduced.clone(),
+                    ctx,
+                )?,
+                None => {
+                    ctx.tag_machinery(Expr::lit(Lit::Unit), stmt.span, "lower.guard_fallthrough")
+                }
+            };
             out_branches.push(Branch {
                 pattern: None,
                 guard: ctx.tag_machinery(
@@ -474,7 +484,7 @@ fn lower_for_body_terminal(
                     stmt.span,
                     "lower.guard_fallthrough",
                 ),
-                body: ctx.tag_machinery(Expr::lit(Lit::Unit), stmt.span, "lower.guard_fallthrough"),
+                body: fallthrough,
             });
             Ok(ctx.tag_image(
                 Expr::new(TypedExprNode::Case {
@@ -1239,9 +1249,11 @@ x";
         );
     }
 
-    /// `if/else` inside a generator for-loop body is rejected.
+    /// `if/else` inside a generator for-loop body lowers: the `else` becomes the
+    /// trailing `true`-guarded `Case` arm (its first-match predicate `¬(x > 0)`),
+    /// which `channelize` fans out as its own feeding channel.
     #[test]
-    fn test_generator_if_else_in_body_rejected() {
+    fn test_generator_if_else_in_body_lowers() {
         let code = "\
 def bad(xs):
     for x in xs:
@@ -1251,15 +1263,9 @@ def bad(xs):
             yield 0
 bad";
         let stmts = parse_module(code);
-        let err = expect_one_lowering_error(&stmts);
-        match &err {
-            LoweringError::Unsupported { message: msg, .. } => {
-                assert!(
-                    msg.contains("if/else inside generator"),
-                    "error should mention if/else in generator: {msg}"
-                );
-            }
-        }
+        lower_stmts(&stmts, &mut LoweringContext::default())
+            .into_result()
+            .expect("if/else in a generator for-loop body should lower");
     }
 
     /// A for/yield loop preceded by assignments is supported: the preceding

--- a/src/interpreter/design-operators.md
+++ b/src/interpreter/design-operators.md
@@ -268,6 +268,17 @@ non-`Iterate` arm reaching op-conversion with `input=None` fails an assertion �
 a planner bug, not a user error.  Similarly, `Restrict` reaching op-conversion
 with `input=None` is a planner bug.
 
+**Constant-in-element predicates.** The scalar value-`Case` C-form
+(`(unit | π̂ ≫ const 𝑒) ⧺ …`) and the data-collection gate fan-out
+(`zs = xs if c else ys`) restrict a domain by a predicate that is *constant in
+the element* — the gate is the arm's first-match path condition, not a function
+of the position.  These compile through the ordinary `Restrict` path with no new
+operator: a `const(c)` gate with a non-literal `c` is *not* matched by
+`is_trivially_true_predicate` (which recognises only a literal `true`), so it
+yields a real `Restrict` that gates the whole extent — empty when the gate is
+false, identity when true — over both `Units(1)` one-shot drivers and full
+extents.
+
 ### Let-bindings and `BindingKind`
 
 `Let { binding, bound_expr, body }` fans the parent's input out to both children
@@ -337,6 +348,31 @@ In all three cases planning has ensured every iteration site has an explicit
 what to emit based only on its own AST shape and the input flowing in.
 
 ---
+
+## Designed, not yet implemented
+
+Operator work specified by the in-flight conditionals stack; listed here so the
+specs live next to their peers. Each graduates into the sections above when its PR
+lands.
+
+### `DispatchRecurse` — multi-leg induction (conditional store writes)
+
+A conditional induction write compiles to one writer-site *leg per path* — each leg a
+decision body over a predicate-restricted slice of one shared base extent, including a
+carry-forward leg over the complement (see [mutability.md](../ccl/design/mutability.md), "Value-selecting `Case` and conditional induction writes (partially implemented)"). `build_induction_store` today hard-wires exactly one
+writer (`let [w] = writers`); `DispatchRecurse` extends `Recurse` to N legs:
+
+- One `IterateExtent(D)` over the shared base extent, in base order — the legs' ⧺-union
+  is realized by **ordered dispatch**, never by materializing a tagged union (which would
+  re-tag positions and desync the body-input buffers).
+- Per position: evaluate the leg predicates (disjoint and exhaustive by construction —
+  the phase synthesized first-match predicates plus the complement; a runtime
+  debug-assert checks exactly one matches) and feed the position to only the matching
+  leg's body buffer, `(snapshot…, item)` tuple convention unchanged.
+- The interleaved decision stream is the store's body stream; the recurrence cycle on
+  `.writes` and the release semantics are `Recurse`'s, per leg. Leg predicates compile
+  against the same body-input shape, so a guard reading the accumulator
+  (`if total < 10: total += x`) works.
 
 ## Open Challenges
 

--- a/src/interpreter/tile_operators/map.rs
+++ b/src/interpreter/tile_operators/map.rs
@@ -487,23 +487,62 @@ impl TileProducer for MapResultToConstProducer {
             _ => i_tiling.universal_guard(),
         };
         let input_tile = self.input.get(input_guard);
-        let constant_tile = self.constant.get(c_tiling.universal_guard());
-
-        // The broadcast value must be fully known before we can replicate it
-        // across the input's domain: `repeat` fabricates nothing, it copies a
-        // single present value. A constant that is still absent (e.g. a scalar
-        // read from a sibling induction loop that has not yet converged) yields
-        // an empty (non-terminal) output — the consumer re-pulls once it lands,
-        // rather than us inventing a value for the unknown positions.
-        //
-        // This is one half of a single invariant — "never fabricate a position
-        // from a not-yet-converged sibling read." The other half is the
-        // co-presence truncate in `binop::zip_arithmetic`/`zip_concat`: a binop
-        // over a lagging operand combines only the common prefix instead of
-        // returning the longer side's tail. Keep the two in step.
-        if !constant_tile.is_terminal() {
-            return self.tiling().empty_tile();
+        // **Laziness — do not evaluate an off-path arm.** In the scalar value-`Case`
+        // C-form a false first-match gate empties this arm's `Units(1)` driver — the
+        // `Restrict` marks the driver row *deleted* rather than dropping it. When
+        // every driver row is deleted, the arm contributes no live rows, so the
+        // constant's value is never observed. Crucially we must not *pull* it: the
+        // arm's value may be a partial expression (`//`, `%`, an index) the gate
+        // exists to guard, and pulling it would evaluate e.g. `x // 0` and panic.
+        // Return a terminal-empty tile carrying the input's decidedness, so the
+        // union / `final_or_default` sees this arm resolve to nothing rather than
+        // waiting forever. The data-collection fan-out is lazy the same way (an
+        // emptied restrict is never iterated); this brings the scalar form in line.
+        if let Tile::SealedFunction {
+            domain,
+            deleted,
+            domain_predicate,
+            ..
+        } = &input_tile
+            && (0..domain.len()).all(|i| deleted.contains(i))
+        {
+            let mut out = self.tiling().empty_tile();
+            if let Tile::SealedFunction {
+                domain_predicate: out_pred,
+                ..
+            } = &mut out
+            {
+                // Carry the input's decidedness so a decided (false-gate) arm reads
+                // terminal-empty — the union / `final_or_default` sees it resolve to
+                // nothing rather than waiting forever.
+                *out_pred = domain_predicate.clone();
+            } else {
+                // MapResultToConst's output is always a function tiling; a
+                // non-`SealedFunction` here would silently drop the decidedness
+                // carry-over and leave a decided arm reading non-terminal forever.
+                unreachable!("MapResultToConst output tiling is always SealedFunction");
+            }
+            return out;
         }
+        let constant_tile = {
+            // The broadcast value must be fully known before we can replicate it
+            // across the input's domain: `repeat` fabricates nothing, it copies a
+            // single present value. A constant that is still absent (e.g. a scalar
+            // read from a sibling induction loop that has not yet converged) yields
+            // an empty (non-terminal) output — the consumer re-pulls once it lands,
+            // rather than us inventing a value for the unknown positions.
+            //
+            // This is one half of a single invariant — "never fabricate a position
+            // from a not-yet-converged sibling read." The other half is the
+            // co-presence truncate in `binop::zip_arithmetic`/`zip_concat`: a binop
+            // over a lagging operand combines only the common prefix instead of
+            // returning the longer side's tail. Keep the two in step.
+            let ct = self.constant.get(c_tiling.universal_guard());
+            if !ct.is_terminal() {
+                return self.tiling().empty_tile();
+            }
+            ct
+        };
 
         let mode = self.mode;
         process_tile_result(self.tiling(), input_tile, move |codomain| {

--- a/tests/compilation_pipeline.rs
+++ b/tests/compilation_pipeline.rs
@@ -26,6 +26,8 @@ mod helpers;
 
 #[path = "compilation_pipeline/comprehensions.rs"]
 mod comprehensions;
+#[path = "compilation_pipeline/conditionals.rs"]
+mod conditionals;
 #[path = "compilation_pipeline/feeds_cases.rs"]
 mod feeds_cases;
 #[path = "compilation_pipeline/generators_udf_poly.rs"]

--- a/tests/compilation_pipeline/conditionals.rs
+++ b/tests/compilation_pipeline/conditionals.rs
@@ -37,47 +37,108 @@ fn codomain_ints(tile: &Tile) -> Vec<i64> {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 // Basic ternary, both branches.
-#[case("c: Bool = True\n1 if c else 2", Value::Int(1))]
-#[case("c: Bool = False\n1 if c else 2", Value::Int(2))]
+#[case(
+    r"
+c: Bool = True
+1 if c else 2",
+    Value::Int(1)
+)]
+#[case(
+    r"
+c: Bool = False
+1 if c else 2",
+    Value::Int(2)
+)]
 // Guard is a computed comparison, not a bare variable.
-#[case("a: Int = 1\nb: Int = 2\n10 if a < b else 20", Value::Int(10))]
-#[case("a: Int = 5\nb: Int = 2\n10 if a < b else 20", Value::Int(20))]
+#[case(
+    r"
+a: Int = 1
+b: Int = 2
+10 if a < b else 20",
+    Value::Int(10)
+)]
+#[case(
+    r"
+a: Int = 5
+b: Int = 2
+10 if a < b else 20",
+    Value::Int(20)
+)]
 // The selected value is itself a computed expression over outer bindings.
-#[case("a: Int = 5\nc: Bool = True\na * 2 if c else a - 1", Value::Int(10))]
-#[case("a: Int = 5\nc: Bool = False\na * 2 if c else a - 1", Value::Int(4))]
+#[case(
+    r"
+a: Int = 5
+c: Bool = True
+a * 2 if c else a - 1",
+    Value::Int(10)
+)]
+#[case(
+    r"
+a: Int = 5
+c: Bool = False
+a * 2 if c else a - 1",
+    Value::Int(4)
+)]
 // `elif` chain — first matching guard wins.
 #[case(
-    "n: Int = 1\n100 if n == 1 else 200 if n == 2 else 300",
+    r"
+n: Int = 1
+100 if n == 1 else 200 if n == 2 else 300",
     Value::Int(100)
 )]
 #[case(
-    "n: Int = 2\n100 if n == 1 else 200 if n == 2 else 300",
+    r"
+n: Int = 2
+100 if n == 1 else 200 if n == 2 else 300",
     Value::Int(200)
 )]
 #[case(
-    "n: Int = 9\n100 if n == 1 else 200 if n == 2 else 300",
+    r"
+n: Int = 9
+100 if n == 1 else 200 if n == 2 else 300",
     Value::Int(300)
 )]
 // Ternary in an arithmetic context — the whole `Case` is a scalar `V`.
-#[case("c: Bool = True\n(1 if c else 2) + 10", Value::Int(11))]
+#[case(
+    r"
+c: Bool = True
+(1 if c else 2) + 10",
+    Value::Int(11)
+)]
 // Nested ternary in an arm.
 #[case(
-    "a: Int = 1\nb: Int = 1\n(100 if b == 1 else 101) if a == 1 else 200",
+    r"
+a: Int = 1
+b: Int = 1
+(100 if b == 1 else 101) if a == 1 else 200",
     Value::Int(100)
 )]
 #[case(
-    "a: Int = 1\nb: Int = 9\n(100 if b == 1 else 101) if a == 1 else 200",
+    r"
+a: Int = 1
+b: Int = 9
+(100 if b == 1 else 101) if a == 1 else 200",
     Value::Int(101)
 )]
 #[case(
-    "a: Int = 9\nb: Int = 1\n(100 if b == 1 else 101) if a == 1 else 200",
+    r"
+a: Int = 9
+b: Int = 1
+(100 if b == 1 else 101) if a == 1 else 200",
     Value::Int(200)
 )]
 // Degenerate constant guard folds to the first arm.
 #[case("7 if True else 8", Value::Int(7))]
 // String and bool arms — the C-form is value-agnostic.
-#[case("c: Bool = False\n\"yes\" if c else \"no\"", Value::String("no".into()))]
-#[case("c: Bool = True\nFalse if c else True", Value::Bool(false))]
+#[case(r#"
+c: Bool = False
+"yes" if c else "no""#, Value::String("no".into()))]
+#[case(
+    r"
+c: Bool = True
+False if c else True",
+    Value::Bool(false)
+)]
 fn test_value_ternary_scalar(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
@@ -91,13 +152,33 @@ fn test_value_ternary_scalar(#[case] code: &str, #[case] expected: Value) {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 // Off-path partial arm: guard false → the `10 // b` arm is skipped, not faulted.
-#[case("b: Int = 0\n0 if b == 0 else 10 // b", Value::Int(0))]
+#[case(
+    r"
+b: Int = 0
+0 if b == 0 else 10 // b",
+    Value::Int(0)
+)]
 // On-path partial arm still evaluates normally.
-#[case("b: Int = 2\n10 // b if b != 0 else 0", Value::Int(5))]
+#[case(
+    r"
+b: Int = 2
+10 // b if b != 0 else 0",
+    Value::Int(5)
+)]
 // Guard true selects the safe arm; the partial `else` is skipped.
-#[case("b: Int = 0\n99 if b == 0 else 10 // b", Value::Int(99))]
+#[case(
+    r"
+b: Int = 0
+99 if b == 0 else 10 // b",
+    Value::Int(99)
+)]
 // The partial arm is the (excluded) `else` of an explicit guard.
-#[case("b: Int = 0\n10 // b if b != 0 else 42", Value::Int(42))]
+#[case(
+    r"
+b: Int = 0
+10 // b if b != 0 else 42",
+    Value::Int(42)
+)]
 fn test_value_ternary_skips_partial_off_path_arm(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
@@ -119,11 +200,31 @@ fn test_value_ternary_skips_partial_off_path_arm(#[case] code: &str, #[case] exp
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 // Two arms at one domain.
-#[case("c: Bool = True\nsum([1, 2] if c else [3, 4])", Value::Int(3))]
-#[case("c: Bool = False\nsum([1, 2] if c else [3, 4])", Value::Int(7))]
+#[case(
+    r"
+c: Bool = True
+sum([1, 2] if c else [3, 4])",
+    Value::Int(3)
+)]
+#[case(
+    r"
+c: Bool = False
+sum([1, 2] if c else [3, 4])",
+    Value::Int(7)
+)]
 // Guard is a computed comparison.
-#[case("n: Int = 2\nsum([10, 20] if n == 1 else [1, 2])", Value::Int(3))]
-#[case("n: Int = 1\nsum([10, 20] if n == 1 else [1, 2])", Value::Int(30))]
+#[case(
+    r"
+n: Int = 2
+sum([10, 20] if n == 1 else [1, 2])",
+    Value::Int(3)
+)]
+#[case(
+    r"
+n: Int = 1
+sum([10, 20] if n == 1 else [1, 2])",
+    Value::Int(30)
+)]
 // `elif` over collections — first matching arm's collection wins. **Three legs over
 // one fiber**: the three arms all have domain `[0, 1)`, so the fan-out is a
 // three-leg `Variant` whose payloads are all that one domain under different gates.
@@ -131,15 +232,21 @@ fn test_value_ternary_skips_partial_off_path_arm(#[case] code: &str, #[case] exp
 // leg↔domain bijection would reject it — and what an `if`/`elif` accumulator write
 // produces.
 #[case(
-    "n: Int = 1\nsum([1] if n == 1 else [2] if n == 2 else [3])",
+    r"
+n: Int = 1
+sum([1] if n == 1 else [2] if n == 2 else [3])",
     Value::Int(1)
 )]
 #[case(
-    "n: Int = 2\nsum([1] if n == 1 else [2] if n == 2 else [3])",
+    r"
+n: Int = 2
+sum([1] if n == 1 else [2] if n == 2 else [3])",
     Value::Int(2)
 )]
 #[case(
-    "n: Int = 9\nsum([1] if n == 1 else [2] if n == 2 else [3])",
+    r"
+n: Int = 9
+sum([1] if n == 1 else [2] if n == 2 else [3])",
     Value::Int(3)
 )]
 fn test_value_case_collection_sum(#[case] code: &str, #[case] expected: Value) {
@@ -152,9 +259,17 @@ fn test_value_case_collection_sum(#[case] code: &str, #[case] expected: Value) {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_value_case_collection_result() {
-    let result = run_pipeline("c: Bool = True\n[1, 2] if c else [3, 4]");
+    let result = run_pipeline(
+        r"
+c: Bool = True
+[1, 2] if c else [3, 4]",
+    );
     assert_eq!(codomain_ints(&result), vec![1, 2]);
-    let result = run_pipeline("c: Bool = False\n[1, 2] if c else [3, 4]");
+    let result = run_pipeline(
+        r"
+c: Bool = False
+[1, 2] if c else [3, 4]",
+    );
     assert_eq!(codomain_ints(&result), vec![3, 4]);
 }
 
@@ -175,19 +290,60 @@ fn test_value_case_collection_result() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 // if/else — the selected arm's value is fed.
-#[case("c: Bool = True\nx = defer()\nif c:\n    x << 1\nelse:\n    x << 2\nx", vec![1])]
-#[case("c: Bool = False\nx = defer()\nif c:\n    x << 1\nelse:\n    x << 2\nx", vec![2])]
+#[case(r"
+c: Bool = True
+x = defer()
+if c:
+    x << 1
+else:
+    x << 2
+x", vec![1])]
+#[case(r"
+c: Bool = False
+x = defer()
+if c:
+    x << 1
+else:
+    x << 2
+x", vec![2])]
 // elif — first matching arm's value.
 #[case(
-    "n: Int = 1\nx = defer()\nif n == 1:\n    x << 10\nelif n == 2:\n    x << 20\nelse:\n    x << 30\nx",
+    r"
+n: Int = 1
+x = defer()
+if n == 1:
+    x << 10
+elif n == 2:
+    x << 20
+else:
+    x << 30
+x",
     vec![10]
 )]
 #[case(
-    "n: Int = 2\nx = defer()\nif n == 1:\n    x << 10\nelif n == 2:\n    x << 20\nelse:\n    x << 30\nx",
+    r"
+n: Int = 2
+x = defer()
+if n == 1:
+    x << 10
+elif n == 2:
+    x << 20
+else:
+    x << 30
+x",
     vec![20]
 )]
 #[case(
-    "n: Int = 9\nx = defer()\nif n == 1:\n    x << 10\nelif n == 2:\n    x << 20\nelse:\n    x << 30\nx",
+    r"
+n: Int = 9
+x = defer()
+if n == 1:
+    x << 10
+elif n == 2:
+    x << 20
+else:
+    x << 30
+x",
     vec![30]
 )]
 fn test_conditional_feed(#[case] code: &str, #[case] expected: Vec<i64>) {
@@ -207,9 +363,23 @@ fn test_conditional_feed(#[case] code: &str, #[case] expected: Vec<i64>) {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 // n=0 → else fires (42); the `100 // n` arm is not pulled.
-#[case("n: Int = 0\nx = defer()\nif n != 0:\n    x << 100 // n\nelse:\n    x << 42\nx", vec![42])]
+#[case(r"
+n: Int = 0
+x = defer()
+if n != 0:
+    x << 100 // n
+else:
+    x << 42
+x", vec![42])]
 // n=5 → the partial arm fires and evaluates normally (100 // 5 = 20).
-#[case("n: Int = 5\nx = defer()\nif n != 0:\n    x << 100 // n\nelse:\n    x << 42\nx", vec![20])]
+#[case(r"
+n: Int = 5
+x = defer()
+if n != 0:
+    x << 100 // n
+else:
+    x << 42
+x", vec![20])]
 fn test_conditional_feed_skips_partial_off_path_arm(
     #[case] code: &str,
     #[case] expected: Vec<i64>,
@@ -238,29 +408,41 @@ fn test_conditional_feed_skips_partial_off_path_arm(
 #[timeout(Duration::from_secs(10))]
 // Identity comprehension over a conditional collection.
 #[case(
-    "c: Bool = True\nsum([x for x in ([1, 2] if c else [3, 4])])",
+    r"
+c: Bool = True
+sum([x for x in ([1, 2] if c else [3, 4])])",
     Value::Int(3)
 )]
 #[case(
-    "c: Bool = False\nsum([x for x in ([1, 2] if c else [3, 4])])",
+    r"
+c: Bool = False
+sum([x for x in ([1, 2] if c else [3, 4])])",
     Value::Int(7)
 )]
 // Mapping comprehension over a conditional collection.
 #[case(
-    "c: Bool = True\nsum([x * 10 for x in ([1, 2] if c else [3, 4])])",
+    r"
+c: Bool = True
+sum([x * 10 for x in ([1, 2] if c else [3, 4])])",
     Value::Int(30)
 )]
 #[case(
-    "c: Bool = False\nsum([x * 10 for x in ([1, 2] if c else [3, 4])])",
+    r"
+c: Bool = False
+sum([x * 10 for x in ([1, 2] if c else [3, 4])])",
     Value::Int(70)
 )]
 // Nested conditional source (an `elif` in the iterable) floats per arm.
 #[case(
-    "n: Int = 2\nsum([x for x in ([1] if n == 1 else [2] if n == 2 else [3])])",
+    r"
+n: Int = 2
+sum([x for x in ([1] if n == 1 else [2] if n == 2 else [3])])",
     Value::Int(2)
 )]
 #[case(
-    "n: Int = 3\nsum([x for x in ([1] if n == 1 else [2] if n == 2 else [3])])",
+    r"
+n: Int = 3
+sum([x for x in ([1] if n == 1 else [2] if n == 2 else [3])])",
     Value::Int(3)
 )]
 fn test_comprehension_over_conditional(#[case] code: &str, #[case] expected: Value) {
@@ -275,15 +457,21 @@ fn test_comprehension_over_conditional(#[case] code: &str, #[case] expected: Val
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 #[case(
-    "c: Bool = True\nsum(([x for x in [1, 2]]) if c else ([y for y in [3, 4]]))",
+    r"
+c: Bool = True
+sum(([x for x in [1, 2]]) if c else ([y for y in [3, 4]]))",
     Value::Int(3)
 )]
 #[case(
-    "c: Bool = False\nsum(([x for x in [1, 2]]) if c else ([y for y in [3, 4]]))",
+    r"
+c: Bool = False
+sum(([x for x in [1, 2]]) if c else ([y for y in [3, 4]]))",
     Value::Int(7)
 )]
 #[case(
-    "c: Bool = True\nsum(([x * 10 for x in [1, 2]]) if c else ([y for y in [3, 4]]))",
+    r"
+c: Bool = True
+sum(([x * 10 for x in [1, 2]]) if c else ([y for y in [3, 4]]))",
     Value::Int(30)
 )]
 fn test_conditional_between_comprehensions(#[case] code: &str, #[case] expected: Value) {

--- a/tests/compilation_pipeline/conditionals.rs
+++ b/tests/compilation_pipeline/conditionals.rs
@@ -1,0 +1,337 @@
+//! Conditionals: value-selecting `Case` compilation via the literal
+//! union-of-restricts forms (the C-form and the data-typed gate fan-out).
+//!
+//! See `src/ccl/design/mutability.md`, "Value-selecting `Case` and conditional induction writes (partially implemented)".
+
+use std::time::Duration;
+
+use cambra::interpreter::{ColumnValue, Tile, Value};
+use rstest_log::rstest;
+
+use crate::helpers::*;
+
+/// Extract the codomain integers of a (possibly `Union`-domain) collection
+/// result tile, sorted. A conditional-collection result is a tagged union whose
+/// single non-empty variant carries the selected arm's elements.
+fn codomain_ints(tile: &Tile) -> Vec<i64> {
+    let Tile::SealedFunction { codomain, .. } = tile else {
+        panic!("expected a SealedFunction tile, got {tile:?}");
+    };
+    let Tile::Scalar(ColumnValue::Ints(v)) = codomain.as_ref() else {
+        panic!("expected an Ints scalar codomain, got {codomain:?}");
+    };
+    let mut v = v.clone();
+    v.sort_unstable();
+    v
+}
+
+// ---------------------------------------------------------------------------
+// Scalar / compute value selection — the C-form
+//
+// `x = e₁ if p else e₂` compiles to a union of gated one-shot lifts over the
+// `UIntRange(1)` driver, extracted by `final_or_default`. The gates partition
+// the driver by first-match (`πᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ`), so exactly one arm's
+// element survives.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// Basic ternary, both branches.
+#[case("c: Bool = True\n1 if c else 2", Value::Int(1))]
+#[case("c: Bool = False\n1 if c else 2", Value::Int(2))]
+// Guard is a computed comparison, not a bare variable.
+#[case("a: Int = 1\nb: Int = 2\n10 if a < b else 20", Value::Int(10))]
+#[case("a: Int = 5\nb: Int = 2\n10 if a < b else 20", Value::Int(20))]
+// The selected value is itself a computed expression over outer bindings.
+#[case("a: Int = 5\nc: Bool = True\na * 2 if c else a - 1", Value::Int(10))]
+#[case("a: Int = 5\nc: Bool = False\na * 2 if c else a - 1", Value::Int(4))]
+// `elif` chain — first matching guard wins.
+#[case(
+    "n: Int = 1\n100 if n == 1 else 200 if n == 2 else 300",
+    Value::Int(100)
+)]
+#[case(
+    "n: Int = 2\n100 if n == 1 else 200 if n == 2 else 300",
+    Value::Int(200)
+)]
+#[case(
+    "n: Int = 9\n100 if n == 1 else 200 if n == 2 else 300",
+    Value::Int(300)
+)]
+// Ternary in an arithmetic context — the whole `Case` is a scalar `V`.
+#[case("c: Bool = True\n(1 if c else 2) + 10", Value::Int(11))]
+// Nested ternary in an arm.
+#[case(
+    "a: Int = 1\nb: Int = 1\n(100 if b == 1 else 101) if a == 1 else 200",
+    Value::Int(100)
+)]
+#[case(
+    "a: Int = 1\nb: Int = 9\n(100 if b == 1 else 101) if a == 1 else 200",
+    Value::Int(101)
+)]
+#[case(
+    "a: Int = 9\nb: Int = 1\n(100 if b == 1 else 101) if a == 1 else 200",
+    Value::Int(200)
+)]
+// Degenerate constant guard folds to the first arm.
+#[case("7 if True else 8", Value::Int(7))]
+// String and bool arms — the C-form is value-agnostic.
+#[case("c: Bool = False\n\"yes\" if c else \"no\"", Value::String("no".into()))]
+#[case("c: Bool = True\nFalse if c else True", Value::Bool(false))]
+fn test_value_ternary_scalar(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// The off-path arm is **not evaluated**: a guard-protected partial expression
+// (`//` by a value the guard proves non-zero) must not fault on the path its
+// guard excludes. The scalar C-form lifts each arm over a gated `Units(1)`
+// driver, and `MapResultToConst` skips a false-gate arm's value entirely — so
+// `10 // b` is never computed when `b == 0`. (Before the laziness fix this
+// panicked with "attempt to divide by zero".)
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// Off-path partial arm: guard false → the `10 // b` arm is skipped, not faulted.
+#[case("b: Int = 0\n0 if b == 0 else 10 // b", Value::Int(0))]
+// On-path partial arm still evaluates normally.
+#[case("b: Int = 2\n10 // b if b != 0 else 0", Value::Int(5))]
+// Guard true selects the safe arm; the partial `else` is skipped.
+#[case("b: Int = 0\n99 if b == 0 else 10 // b", Value::Int(99))]
+// The partial arm is the (excluded) `else` of an explicit guard.
+#[case("b: Int = 0\n10 // b if b != 0 else 42", Value::Int(42))]
+fn test_value_ternary_skips_partial_off_path_arm(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Data-collection value selection — the gate fan-out
+//
+// `zs = xs if c else ys` compiles to `⧺ᵢ (xsᵢ | π̂ᵢ)`: each arm's whole
+// collection restricted by its constant gate, unioned. The result is the type the
+// type system gave the `Case`; exactly one gated arm is non-empty, so consuming
+// the union (here via `sum`) sees just that arm's elements.
+//
+// The union's tagged-`Variant` domain reconciles against the arms' joined data
+// function by `is_index_partition_of`: every leg is that one domain under its own
+// gate. Arms at *distinct* domains have no join to subtype against and are rejected
+// at inference, so the fan-out is only built at one domain.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// Two arms at one domain.
+#[case("c: Bool = True\nsum([1, 2] if c else [3, 4])", Value::Int(3))]
+#[case("c: Bool = False\nsum([1, 2] if c else [3, 4])", Value::Int(7))]
+// Guard is a computed comparison.
+#[case("n: Int = 2\nsum([10, 20] if n == 1 else [1, 2])", Value::Int(3))]
+#[case("n: Int = 1\nsum([10, 20] if n == 1 else [1, 2])", Value::Int(30))]
+// `elif` over collections — first matching arm's collection wins. **Three legs over
+// one fiber**: the three arms all have domain `[0, 1)`, so the fan-out is a
+// three-leg `Variant` whose payloads are all that one domain under different gates.
+// This is exactly what `is_index_partition_of` must accept — a positional
+// leg↔domain bijection would reject it — and what an `if`/`elif` accumulator write
+// produces.
+#[case(
+    "n: Int = 1\nsum([1] if n == 1 else [2] if n == 2 else [3])",
+    Value::Int(1)
+)]
+#[case(
+    "n: Int = 2\nsum([1] if n == 1 else [2] if n == 2 else [3])",
+    Value::Int(2)
+)]
+#[case(
+    "n: Int = 9\nsum([1] if n == 1 else [2] if n == 2 else [3])",
+    Value::Int(3)
+)]
+fn test_value_case_collection_sum(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// A conditional collection as the program result: the tagged union tile carries
+// exactly the selected arm (the other legs are gated empty). This pins the tile
+// shape, which the `sum` cases above only exercise through an aggregate.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn test_value_case_collection_result() {
+    let result = run_pipeline("c: Bool = True\n[1, 2] if c else [3, 4]");
+    assert_eq!(codomain_ints(&result), vec![1, 2]);
+    let result = run_pipeline("c: Bool = False\n[1, 2] if c else [3, 4]");
+    assert_eq!(codomain_ints(&result), vec![3, 4]);
+}
+
+// Consuming a conditional collection through a comprehension
+// (`[f(x) for x in (xs if c else ys)]`) is exercised below by
+// `test_comprehension_over_conditional`.
+
+// ---------------------------------------------------------------------------
+// Source-less conditional feeds
+//
+// `if c: d << v1 else: d << v2` (outside any loop) has no iteration source, so
+// each feeding arm becomes a gated one-shot lift `λ __unused : {Unit | π̂ᵢ} → vᵢ`
+// over the `Unit` driver. The channel union publishes exactly the selected arm's
+// value (empty when no arm fires — a naturally-partial feed). A `defer()` read
+// surfaces the channel.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// if/else — the selected arm's value is fed.
+#[case("c: Bool = True\nx = defer()\nif c:\n    x << 1\nelse:\n    x << 2\nx", vec![1])]
+#[case("c: Bool = False\nx = defer()\nif c:\n    x << 1\nelse:\n    x << 2\nx", vec![2])]
+// elif — first matching arm's value.
+#[case(
+    "n: Int = 1\nx = defer()\nif n == 1:\n    x << 10\nelif n == 2:\n    x << 20\nelse:\n    x << 30\nx",
+    vec![10]
+)]
+#[case(
+    "n: Int = 2\nx = defer()\nif n == 1:\n    x << 10\nelif n == 2:\n    x << 20\nelse:\n    x << 30\nx",
+    vec![20]
+)]
+#[case(
+    "n: Int = 9\nx = defer()\nif n == 1:\n    x << 10\nelif n == 2:\n    x << 20\nelse:\n    x << 30\nx",
+    vec![30]
+)]
+fn test_conditional_feed(#[case] code: &str, #[case] expected: Vec<i64>) {
+    assert_eq!(codomain_ints(&run_pipeline(code)), expected);
+}
+
+// Off-path laziness for the source-less feed: each arm is a gated one-shot lift
+// over the `Unit` driver, so only the fired arm's value is pulled — a
+// guard-protected partial op in the *unfired* arm is never evaluated. `100 // n`
+// must not fault at n = 0. (A non-lazy fan-out would divide by zero here.)
+//
+// Note: this laziness holds for the source-less feed (and the scalar C-form)
+// because each arm is a distinct gated one-shot lift. It does NOT extend to a
+// partial op inside a *filtered comprehension* body (`[100 // x for x in xs if
+// x != 0]`), where the filter is a logical delete and the map still evaluates
+// the deleted positions — a pre-existing limitation independent of conditionals.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// n=0 → else fires (42); the `100 // n` arm is not pulled.
+#[case("n: Int = 0\nx = defer()\nif n != 0:\n    x << 100 // n\nelse:\n    x << 42\nx", vec![42])]
+// n=5 → the partial arm fires and evaluates normally (100 // 5 = 20).
+#[case("n: Int = 5\nx = defer()\nif n != 0:\n    x << 100 // n\nelse:\n    x << 42\nx", vec![20])]
+fn test_conditional_feed_skips_partial_off_path_arm(
+    #[case] code: &str,
+    #[case] expected: Vec<i64>,
+) {
+    assert_eq!(codomain_ints(&run_pipeline(code)), expected);
+}
+
+// NOTE: a *source-less no-else* conditional feed (`if c: d << v`, a naturally
+// partial feed) is blocked earlier, at lowering — a bare `if` with no `else` is
+// rejected as a value-returning expression before channelize sees it. The source-less-feed path handles
+// the feed extraction once lowering admits the shape; the if/else and elif forms
+// above exercise it. A *scrutinee / pattern* feed stays rejected
+// (`PartialFeedCaseUnsupported`): a pattern match cannot be gated by a boolean.
+
+// ---------------------------------------------------------------------------
+// Comprehension over a conditional collection
+//
+// `[f(x) for x in (xs if c else ys)]` floats the source `Case` out of the map
+// (`lower::comprehension`) — `Case{gᵢ → [f(x) for x in srcᵢ]}` — with each arm
+// built as a `Compose` (`src ≫ λx→body`) so it carries the source's *data* kind.
+// The arms then join as collections and compile via the gate fan-out, rather than
+// colliding as compute-kinded lambdas over their index domains.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// Identity comprehension over a conditional collection.
+#[case(
+    "c: Bool = True\nsum([x for x in ([1, 2] if c else [3, 4])])",
+    Value::Int(3)
+)]
+#[case(
+    "c: Bool = False\nsum([x for x in ([1, 2] if c else [3, 4])])",
+    Value::Int(7)
+)]
+// Mapping comprehension over a conditional collection.
+#[case(
+    "c: Bool = True\nsum([x * 10 for x in ([1, 2] if c else [3, 4])])",
+    Value::Int(30)
+)]
+#[case(
+    "c: Bool = False\nsum([x * 10 for x in ([1, 2] if c else [3, 4])])",
+    Value::Int(70)
+)]
+// Nested conditional source (an `elif` in the iterable) floats per arm.
+#[case(
+    "n: Int = 2\nsum([x for x in ([1] if n == 1 else [2] if n == 2 else [3])])",
+    Value::Int(2)
+)]
+#[case(
+    "n: Int = 3\nsum([x for x in ([1] if n == 1 else [2] if n == 2 else [3])])",
+    Value::Int(3)
+)]
+fn test_comprehension_over_conditional(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// A conditional *between* two standalone comprehensions
+// (`([x for x in xs]) if c else ([y for y in ys])`). This is the case
+// kind inference unblocks: a comprehension used as a
+// value is a lambda whose kind var resolves to `Data` from its collection domain, so
+// the two `Case` arms join as collections instead of colliding as compute meets.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case(
+    "c: Bool = True\nsum(([x for x in [1, 2]]) if c else ([y for y in [3, 4]]))",
+    Value::Int(3)
+)]
+#[case(
+    "c: Bool = False\nsum(([x for x in [1, 2]]) if c else ([y for y in [3, 4]]))",
+    Value::Int(7)
+)]
+#[case(
+    "c: Bool = True\nsum(([x * 10 for x in [1, 2]]) if c else ([y for y in [3, 4]]))",
+    Value::Int(30)
+)]
+fn test_conditional_between_comprehensions(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Conditional element in a comprehension
+//
+// `[a if g(x) else b for x in xs]` — a per-element conditional — fans the source
+// out by each arm's *element-dependent* first-match gate
+// (`lower::comprehension::fan_out_element_case`): `⧺ᵢ [eᵢ for x in xs if π̂ᵢ]`.
+// Each arm is a filtered map (source restricted by the gate, mapped by the arm
+// value); the gates partition the source, so the `++`-union recombines the arms
+// by position into the fully-mapped collection. A `CollectionUnion`, so the
+// compute-kinded per-arm maps do not need to join.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// [1,2,3,4] with `x*10 if x>2 else 0` → [0,0,30,40].
+#[case(
+    "sum([(x * 10 if x > 2 else 0) for x in [1, 2, 3, 4]])",
+    Value::Int(70)
+)]
+// Both arms reference the element.
+#[case(
+    "sum([(x * 2 if x > 2 else x + 100) for x in [1, 2, 3, 4]])",
+    Value::Int(217)
+)]
+// Nested `elif` element flattens to a flat partition.
+#[case(
+    "sum([(100 if x == 1 else 200 if x == 2 else 300) for x in [1, 2, 3]])",
+    Value::Int(600)
+)]
+// Degenerate gates: always-true / never-true.
+#[case("sum([(x if x > 0 else 0) for x in [1, 2, 3]])", Value::Int(6))]
+#[case("sum([(99 if x > 100 else x) for x in [1, 2, 3]])", Value::Int(6))]
+fn test_conditional_element_comprehension(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// The conditional-element comprehension result is a tagged union — one variant
+// per arm, each carrying the elements the arm mapped.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn test_conditional_element_result() {
+    // x>2 → x*10 (positions 2,3 → 30,40); else 0 (positions 0,1 → 0,0).
+    let result = run_pipeline("[(x * 10 if x > 2 else 0) for x in [1, 2, 3, 4]]");
+    assert_eq!(codomain_ints(&result), vec![0, 0, 30, 40]);
+}

--- a/tests/compilation_pipeline/feeds_cases.rs
+++ b/tests/compilation_pipeline/feeds_cases.rs
@@ -346,6 +346,39 @@ d"#;
     );
 }
 
+/// An `if/else` where **both arms feed** a pure-feed loop (no accumulator). The
+/// `else` is an ordinary trailing arm (guard `true`, first-match predicate
+/// `¬(i < 2)`), so it fans out as its own refined-source channel — `channelize`
+/// refines the *source* domain per arm (a shared `Int` codomain), rather than
+/// leaving the guard on a `Unit` gated lift. As a function: 0 ↦ 0, 1 ↦ 1,
+/// 2 ↦ 100, 3 ↦ 100.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn if_else_both_feed_fan_out() {
+    let code = r#"o = defer()
+for i in [0, 1, 2, 3]:
+    if i < 2:
+        o << i
+    else:
+        o << 100
+o"#;
+    check_tile(
+        code,
+        Tile::SealedFunction {
+            domain: ColumnValue::Union {
+                tags: vec![0, 0, 1, 1],
+                variants: vec![
+                    ColumnValue::UInts(vec![0, 1]),
+                    ColumnValue::UInts(vec![2, 3]),
+                ],
+            },
+            codomain: Box::new(Tile::Scalar(ColumnValue::Ints(vec![0, 1, 100, 100]))),
+            domain_predicate: Predicate::Union(vec![Predicate::True, Predicate::True]),
+            deleted: BitSet::new(),
+        },
+    );
+}
+
 /// `<<=` sets a channel's whole stream, so its RHS must be a collection
 /// (a `Fun`). A scalar RHS is rejected by typing — the discipline that keeps
 /// every feed history a genuine `domain ⇒ value` stream (scalar values belong


### PR DESCRIPTION
## The problem: conditionals type-check but do not compile

A conditional used as a *value* — a ternary, an `if`/`elif`/`else` that produces something — gets all the way through inference and then dies. `1 if c else 2` has a perfectly good type (the arms join; `tests/type_check.rs` has covered this for a while), and then `lambda_elim` hits it and returns

```
unsupported node kind in lambda elimination: Case { .. }
```

Only the *filter* `Case` compiles today: the two-arm `[𝑔 → action; true → unit]` shape a comprehension `if`-clause lowers to, which becomes a `Restrict`. Every other `Case` is a hole. The pre-change design doc says so in as many words:

> **Blocker:** both need a *value-selecting* `Case` (`x = if 𝑝: 𝑒₁ else: 𝑒₂`) as a compiled construct, but only the *filter* `Case` (`[𝑔 → action; true → unit]` → `Restrict`) compiles today — a value `Case` errors at `lambda_elim`.

Concretely, everything in this list is rejected before this PR, at three different layers:

- `1 if c else 2`, `10 if a < b else 20`, `a * 2 if c else a - 1`, `elif` chains, nested ternaries, string/bool arms — `lambda_elim`.
- `xs if c else ys` as a collection, and consuming one (`sum([1, 2] if c else [3, 4])`) — `lambda_elim`.
- `[f(x) for x in (xs if c else ys)]` and `[a if g(x) else b for x in xs]` — `lambda_elim`.
- `if c: o << 1 else: o << 2` (a source-less conditional feed) — `channelize`, with `DeferError::PartialFeedCaseUnsupported`.
- `if`/`else` inside a generator for-loop body — `lowering`, with *"if/else inside generator for-loop body is not supported; use a plain if-guard (no else branch)"*.

## Why now

This is the load-bearing prerequisite for the next two PRs in the stack, not an isolated feature.

A conditional induction write (3/7, `if 𝑝: total += x`) compiles to a write leg over `{𝑟 : 𝐷 | π̂}` plus a carry-forward leg over the complement — and the carry-forward body is *a value selection over the snapshot*. Path-based `with begin():` conditionals (4/7) are the same shape one level up: the per-key merge that gives a branch which does not write a key its snapshot value **is** a value-selecting `Case`. Neither can be built while a value `Case` is a compile error, which is exactly what the blocker note above was recording.

It also sits directly on top of 1/7 (data/compute function kinds): kind inference is what makes `([x for x in xs]) if c else ([y for y in ys])` join as two collections rather than collide as two compute-kinded lambdas over their index domains. That case is tested here because 1/7 is what unblocked it.

Standing on its own merits: a ternary is table-stakes surface syntax, and the surprising part of the status quo is not that the fancier forms fail but that `1 if c else 2` does.

## Why selection becomes data instead of a branch

The obvious implementation is a branch: an operator that evaluates the guard and picks an arm. Rejected, because a branch instruction is foreign to the substrate. CCL's compiled algebra is restricts and unions over collections, and the runtime is a pull-based tile pipeline with no control-flow edge — introducing one means threading a new concept through op-conversion, planning, and the operator protocol, and it puts a construct in the IR that none of the existing rewrites know how to see through.

So instead the selection becomes *data*: each arm is gated by its first-match predicate `π̂ᵢ` (synthesized from the original guards as `𝑔ᵢ ∧ ¬𝑔₀ ∧ … ∧ ¬𝑔ᵢ₋₁`, `synthesize_arm_predicate` in `ccl_utils`), and the gated arms are unioned. The gates are exclusive and exhaustive, so exactly one arm contributes at runtime. There is no branch instruction anywhere in the result — the selection is a restrict, and every downstream pass already understands restricts and unions.

The one thing a branch gives you for free is that the untaken arm is not evaluated, and that has to be earned here rather than assumed. It is: see the laziness note below.

## The two forms

By what the arms produce.

**The C-form**, for scalar / compute arms (`build_value_case_cform`): each arm becomes a gated one-shot lift over a `UIntRange(1)` driver, and the union is extracted by `final_or_default`.

```
Case{[g₀ → e₀; …; gₙ → eₙ]}  ⟹  (⧺ᵢ const(eᵢ) : {UIntRange(1) | π̂ᵢ} ⤇ V,  eₙ) ▷ final_or_default
```

The gate is constant in the driver element, so the one-element domain either survives whole or is emptied; exhaustiveness (the trailing `true` arm) means the union has exactly one element and the outer type is the `Case`'s own `V`, unchanged. This is what makes ternaries, `elif` chains, nesting, and string/bool arms compile.

**The fan-out**, for collection arms (`build_value_case_fanout`): each arm's whole collection restricted by its gate, unioned as `Fun{Data, Variant([{𝐷 | π̂ᵢ}]), 𝑐}`. The arms share one domain 𝐷 — a join at distinct domains is rejected at inference — so every leg's payload is that one domain under a different gate.

**Off-path arms are not evaluated.** `0 if b == 0 else 10 // b` must not fault when `b == 0`, and the fan-out gets this structurally (an arm gated false restricts to an empty extent, and an empty extent is never iterated). The scalar C-form needed one runtime fix to match: `MapResultToConst` now returns a terminal-empty tile when every driver row is deleted, *without pulling the constant* — previously it pulled first and `10 // b` panicked with "attempt to divide by zero". The decidedness of the input's domain predicate is carried onto the empty tile so a decided false-gate arm reads terminal-empty rather than blocking the union forever.

## What comes with it

**One subtyping rule** (`is_index_partition_of`, in the solver's `constrain`). The fan-out's structural `Variant`-domain type has to reconcile against the plain data function the type system gave the `Case`. Each leg `{𝐷 | π̂ᵢ} <: 𝐷` relates by refinement width, *covariantly* — this is an introduction, not the function-domain contravariance. It is guarded on the legs refining the same *concrete* target, so a genuine heterogeneous `++` flowing into a fresh-var domain still takes the ordinary contravariant arm.

That guard is what makes the rule recognize by *shape* rather than by counting: three `elif` arms over one domain give a **three**-leg partition over **one** domain. A positional leg↔domain bijection would reject it — and that is precisely the shape an `if`/`elif` accumulator write produces in 3/7, so it is tested here.

**Two comprehension interactions**, which go in opposite directions because a value `Case` has no driver of its own and therefore must gate the *iteration source*:

- A conditional *source* (`[f(x) for x in (xs if c else ys)]`) floats the `Case` out of the map — `Case{gᵢ → [f(x) for x in srcᵢ]}` — with each arm built as a `Compose` so `emit_compose` stamps it with the source's `Data` kind. Without that the arms collide as compute-kinded lambdas over their index domains.
- A conditional *element* (`[a if g(x) else b for x in xs]`) fans the *source* out by each arm's element-dependent gate: `⧺ᵢ [eᵢ for x in xs if π̂ᵢ]`, filtered maps over one source whose gates partition it and whose union recombines them by position (`fan_out_element_case`).

**Conditional feeds** fall out of the same gated-lift machinery with no iteration source, over the `Unit` driver — one channel per feeding arm, replacing `PartialFeedCaseUnsupported` for guard-only `Case`s. And `channelize` plus the `map` tile operator carry the union through: a tagged-`Variant`-domain data function compiles straight to a `UnionOperator` over operands whose domains are concrete domains.

## Scope

Deliberately left rejected, each with a diagnostic rather than a miscompile:

- **Conditional induction writes** (`if 𝑝: total += x`) — 3/7. Designed in `design/mutability.md`, still rejected at lowering.
- **A per-element conditional at a site with no visible iteration source** — a UDF body, or a comprehension carrying an extra `if`-filter beside the element `Case`. Same source fan-out, but no source in hand at that site; the new `lambda_elim` arm names the shape in its error.
- **Scrutinee / pattern `Case`s** — a pattern match cannot be gated by a boolean, so `PartialFeedCaseUnsupported` stays for those.

## Tests

`tests/compilation_pipeline/conditionals.rs`, end-to-end through the pipeline: the C-form across guards / `elif` / nesting / partial off-path arms, the collection fan-out at one domain including the three-legs-one-domain case, conditional sources, conditional elements, conditionals between standalone comprehensions, and conditional feeds (including off-path laziness). Plus the lowering test that previously asserted `if/else` in a generator body was *rejected*, now asserting it lowers.
