### PR TITLE
mutability-conditionals 3/7: conditional induction writes

### DIFF
--- a/src/ccl/design/lowering.md
+++ b/src/ccl/design/lowering.md
@@ -71,17 +71,15 @@ and [mut_elim: eliminating overwrite mutability](mutability.md#mut_elim-eliminat
 implementation lives in `src/ccl/mut_elim.rs` (the `For`/`MutWrite` → `LetRec`
 → `Transact` via loop planning) and `src/ccl/channelize.rs` (feed routing).
 
-**Conditionals in loop bodies (designed, not yet implemented).** Today a mutation
-nested inside an `if` in a loop body is detected (`find_nested_mutation_var`) and
-**rejected** at lowering. The in-flight conditionals stack *will* add a
-`ChlStmt::If` arm to the direct-mirror loop-body lowering: each branch body will
-lower through the same recursive statement-chain helper and be emitted as a
+**Conditionals in loop bodies.** A mutation nested inside an `if` in a loop body
+lowers via a `ChlStmt::If` arm in the direct-mirror loop-body lowering: each branch
+body lowers through the same recursive statement-chain helper and is emitted as a
 statement-position `Case` — a faithful mirror, no path computation at lowering
 (mutability is a type-level fact lowering does not have). `find_mutation_loop_vars`
-will then recurse into the branches so `for x in src: if p: total += x` classifies
-as a mutation loop rather than being rejected; the branch merge is compiled
-downstream in `mut_elim`. A `for` or a `with begin():` nested inside an `if` inside
-a loop body stays rejected.
+recurses into the branches so `for x in src: if p: total += x` classifies as a
+mutation loop; the branch merge (the write leg and its carry) is compiled downstream
+in `mut_elim` (`transform_chain`). A `for` or a `with begin():` nested inside an `if`
+inside a loop body stays rejected.
 
 **Let-bindings in generator bodies** (`y = f(x); yield y`) lower to nested `Let` nodes inside the Lambda body, evaluated once per iteration of the enclosing loop.
 

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -110,6 +110,19 @@ Two surface facts are load-bearing for the realization and worth restating here:
   [live-read rewrite](#replies-live-cross-endpoint-reads-and-commit-ordered-taps) and the
   [`AsOf` engine](#the-runtime-engines) below.
 
+> **Design commitment — transactional mutability is deliberately *unordered*.** There is no
+> ordering guarantee between transactions on the same `Txn` variable beyond the existence of *a*
+> commit order the runtime picks; a program may not assume one transaction serializes before
+> another, and nothing in the compiler or engine should impose such an order. The arbitrary-position
+> fed-out read above is the direct consequence, **not a defect**: a trailing `with begin(): out <<
+> balance` after a loop whose first iteration *denies* may observe the register before the first commit
+> lands (its singleton read samples an early position). The only ways a `Txn` value interacts with
+> the world are: read/written **inside** a `with begin():` (rejected outside one — as a feed RHS or
+> anywhere else), or observed as a *definite* committed value through the **future `await_last`** —
+> the single sanctioned terminal read. Do **not** add inter-transaction ordering to "fix" the
+> early-read case; the unordering is the intended model, and `await_last` is where determinism comes
+> from when a program needs it.
+
 ## CCL representation
 
 ### Surface-marker nodes: `For`, `MutWrite`, `Begin`, `Feed`
@@ -750,54 +763,63 @@ today rather than silently mishandled.
 
 ### Value-selecting `Case` and conditional induction writes (partially implemented)
 
-> **Status: value-selecting `Case`s compile; conditional induction writes are designed but not
-> yet implemented.**
+> **Status: value-selecting `Case`s and conditional induction writes both compile.**
 >
-> **Implemented** (value selection compiles via the literal union-of-restricts): scalar / compute
-> ternaries (the C-form), data-collection selection (the gate fan-out, reconciled to the Σ by
-> Σ-introduction), source-less conditional feeds, a **conditional element** in a
-> comprehension (`[a if g(x) else b for x in xs]`, fanned out over the source by the
-> element-dependent gate), and a comprehension **over a conditional collection** (`[f(x) for x in
-> (xs if c else ys)]`, the source `Case` floats out of the map). **Not yet implemented**:
-> conditional *induction writes* (`if 𝑝: total += x`, the per-leg writer sites + `DispatchRecurse`
-> below — still rejected at lowering); a conditional *between* standalone comprehensions
-> (`([…]) if c else ([…])` — a comprehension used as a value is compute-kinded, so its arms meet
-> rather than join; the deferred kind-inference work); and a per-element conditional at a site with
-> no visible iteration source (a UDF body, or a comprehension `if`-filter beside the element `Case`).
+> **Implemented**: scalar / compute ternaries (the C-form), data-collection selection (the gate
+> fan-out, reconciled to the Σ by Σ-introduction), source-less conditional
+> feeds, a **conditional element** in a comprehension (`[a if g(x) else b for x in xs]`, fanned out
+> over the source by the element-dependent gate), a comprehension **over a conditional collection**
+> (`[f(x) for x in (xs if c else ys)]`, the source `Case` floats out of the map), a conditional
+> **between** standalone comprehensions (`([…]) if c else ([…])` — the maps carry `Data` after kind
+> inference, so their arms join into a Σ), a **conditional induction write** (`if 𝑝: total += x`
+> — one commit-gated writer over the changelog, below), and an **`if`/`else` that writes both arms**
+> of one accumulator (`if 𝑝: acc += a else: acc += b`) — the per-accumulator value-`Case` write set
+> compiles via the value-preserving `filter_values` union-of-restricts inside the writer lambda (see
+> below and `../../interpreter/design-operators.md`). That desugar also resolves the former residual —
+> a value-selecting `Case` inside a lambda with no visible iteration source (a UDF body, or a
+> comprehension `if`-filter beside the element `Case`). **Not yet implemented**: a conditional *feed*
+> on an induction path (naturally partial — a follow-up).
 
-The *filter* `Case` (`[𝑔 → action; true → unit]` → `Restrict`) and now the value-selecting `Case`
-compile; a conditional induction write (`if 𝑝: total += x`) is still rejected at lowering. The
-compilation is a **literal union of restricts** — the CCL algebra stays restricts + unions — and an
-**off-path arm is never evaluated**, so a guard-protected partial expression (`x // y if y != 0 else
-0`) never faults on the path its guard excludes. A **data-collection** fan-out is lazy structurally:
-an arm whose gate is false restricts to an empty extent, and an empty extent is never iterated. The
-**scalar** value-`Case` C-form gates a `Units(1)` driver and swaps in each arm's constant via
-`MapResultToConst`; when a false gate empties the driver (all rows deleted), `MapResultToConst` returns
-a terminal-empty tile *without* pulling the arm's constant — so the off-path value (a `//`, `%`, or
-index that the gate guards) is never computed. Every fan-out shares one first-match encoding,
-`πᵢ = 𝑔ᵢ ∧ ¬⋁ⱼ˂ᵢ 𝑔ⱼ` (`synthesize_arm_predicate` in `ccl_utils`, shared between channelize, the
-value fan-outs, and the transaction path walk):
+The *filter* `Case` (`[𝑔 → action; true → unit]` → `Restrict`), the value-selecting `Case`, and the
+conditional induction write all compile. The value-`Case` compilation is a **literal union of
+restricts** — the CCL algebra stays restricts + unions — and an **off-path arm is never evaluated**,
+so a guard-protected partial expression (`x // y if y != 0 else 0`) never faults on the path its guard
+excludes. A **data-collection** fan-out is lazy structurally: an arm whose gate is false restricts to
+an empty extent, and an empty extent is never iterated. The **scalar** value-`Case` C-form gates a
+`Units(1)` driver and swaps in each arm's constant via `MapResultToConst`; when a false gate empties
+the driver (all rows deleted), `MapResultToConst` returns a terminal-empty tile *without* pulling the
+arm's constant — so the off-path value (a `//`, `%`, or index that the gate guards) is never computed.
+Every fan-out shares one first-match encoding, `πᵢ = 𝑔ᵢ ∧ ¬⋁ⱼ˂ᵢ 𝑔ⱼ` (`synthesize_arm_predicate` in
+`ccl_utils`, shared between channelize, the value fan-outs, and the transaction path walk).
 
-```
-target = ⧺ᵢ (source | 𝑝ᵢ ≫ (λ 𝑟 → 𝑣ᵢ))                                  -- channel: partial off-path
-total  = ⧺ᵢ (source | 𝑝ᵢ ≫ (λ 𝑟 → 𝑣ᵢ)) ⧺ (source | ¬⋁ᵢ𝑝ᵢ ≫ (λ 𝑟 → get_prev_seq(total, 𝑟, init)))
-```
+A **conditional induction write** takes a different, simpler route than the value fan-out: it rides
+the induction accumulator's own `{commit, writes}` **decision** rather than a union of restricted
+sources. `lower_loop_body_chain` lowers `if 𝑝: acc += e` to a statement-position `Case`
+(`[𝑝 → acc += e; true → unit]`), and `mut_elim::transform_chain`'s `Case` arm merges its
+branches into **one uniform, carry-complete writer decision over the full loop source**:
+`commit = ⋁ⱼ π̂ⱼ` (the disjunction of the writing branches' first-match guards), and each accumulator's
+`writesᵢ = Case[π̂ⱼ → wⱼᵢ; …; true → snapshotᵢ]` — a per-accumulator value-`Case` whose trailing `true`
+arm is the **carry** (the entering accumulator). `commit: false` positions are dropped from the
+changelog store (`InductionStore`, see `../../interpreter/design-operators.md`) — sparse — and the
+carry arm makes the write value **total at every position** (so the dense `Recurse` path, which
+cycles on `.writes` for an async source, honors the guard by carrying rather than dropping it). So
+the `Overwrite`/`Feed` distinction and the carry-forward live *inside one decision on one writer* — no
+per-leg restricted source, no complement leg, and none of the cyclic-convergence hazard a
+restricted-source multi-leg realization carried. Recognition packages it as an ordinary single-writer
+`Transact`; op-conversion routes it to the changelog store, and reads fold the changelog densely
+(`StoreDenseRead`). The per-accumulator value-`Case` is value-selecting inside the writer lambda,
+compiled to the **value-preserving `filter_values` union-of-restricts** (`⧺ᵢ filter_values(π̂ᵢ) ≫ eᵢ`;
+`Builtin::FilterValues` → the `Filter` tile op, flat-merged with `UnionOperator::new_flat`) — an
+off-path arm is never evaluated, so a **partial op** (`//`) in a written value never faults at a
+guard-rejected position. See `../../interpreter/design-operators.md`.
 
-The presence or absence of the complement arm *is* the `Overwrite`/`Feed` distinction, and the union
-is **between letrec bindings, not inside one decision body**: a conditional mutable write emits one
-writer-site *leg per path* — the write leg over `{𝑟 : 𝐷 | π̂}` and the **carry-forward leg** over
-the complement `{𝑟 : 𝐷 | ¬̂π}` whose body passes the snapshot through — each guarded by
-`get_prev_seq` over the ⧺-union of all legs' per-key views (a shape the guardedness check already
-admits). Per-leg bindings let decision records differ per path, and a conditional feed on a path
-is **naturally partial**: `Feed(d, __legⱼ ≫ .to_k)` over the leg's restricted domain — no flag
-field. The phase walks the loop body as a *path enumeration* (a statement-position `Case` forks
-per branch plus the implicit complement; the rest of the chain clones into each path; guards
-resolve in the fork point's read-your-writes env), recognition generalizes the single-writer
-induction group to one `Transact` with one writer per leg, and op-conversion realizes the union by
-**ordered dispatch** (`DispatchRecurse`, see `../../interpreter/design-operators.md`): one
-iteration of the base extent, each position fed to exactly the leg whose predicate holds —
-faithful to the ⧺ because the leg predicates partition the domain, and position-aligned by
-construction.
+Both a **finite** loop and an **async** (streaming) source drive an induction accumulator — the
+model treats a finite domain as a stream that terminates (§Liveness). At the realization level this
+is *one* concept but currently *two* operators: the changelog `InductionStore` for the finite
+single-writer case, a dense `Recurse` fallback for async/tap loops. Collapsing them onto the single
+changelog realization (so the finite/async distinction disappears from the code as it has from the
+model) is a mapped interpreter cleanup — see *Planned: one changelog realization for every loop* in
+`../../interpreter/design-operators.md`.
 
 The value-`Case` positions ride the same union-of-restricts:
 

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -898,26 +898,65 @@ fn elim_lambda_impl(
         }
 
         // A value-selecting `Case` inside a bare lambda body (`λ x → Case{[gᵢ → eᵢ]}`),
-        // where the gate `gᵢ(x)` varies with the element. A *comprehension*
-        // element conditional (`[a if g(x) else b for x in xs]`) is fanned out at
+        // where the gate `gᵢ(x)` varies with the element. A *comprehension* element
+        // conditional (`[a if g(x) else b for x in xs]`) is fanned out at
         // comprehension lowering (`lower::comprehension::fan_out_element_case`) into
-        // `⧺ᵢ src|π̂ᵢ ≫ eᵢ`, so it never reaches here. This arm catches the residual
-        // shapes — a per-element conditional in a lambda whose *iteration source is
-        // not visible at lowering* (a UDF body, a comprehension with an extra
-        // `if`-filter alongside the element `Case`) — which need the same source
-        // fan-out but at a site without a source in hand. Deferred (a documented
-        // follow-up; see `design/mutability.md`
-        // "Value-selecting `Case` and conditional induction writes (partially implemented)").
+        // `⧺ᵢ src|π̂ᵢ ≫ eᵢ`, so it never reaches here. This arm handles the residual
+        // shapes — a per-element conditional in a lambda whose *iteration source is not
+        // visible at lowering* (a writer decision body: `if 𝑝: a := … else: b := …`, a
+        // per-key carry-forward merge, an `if/else`-both-write accumulator).
+        //
+        // It desugars to the same **union of domain-restricts** as every other
+        // value-`Case` — `⧺ᵢ (filter_values(π̂ᵢ) ≫ eᵢ)` — but over the *lambda
+        // parameter's* fed element stream (the writer body's runtime input) rather
+        // than a visible comprehension source or the `UIntRange(1)` C-form driver.
+        // Each arm filters the fed stream to the sub-domain its first-match gate
+        // `π̂ᵢ = gᵢ ∧ ¬⋁ⱼ<ᵢ gⱼ` admits (`filter_values` keeps the element value, unlike
+        // the position-domain `Restrict`), then maps by `eᵢ`. So a **partial op**
+        // (`//`, `%`) in `eᵢ` is evaluated only where its guard holds — never eagerly
+        // at a rejected position. The partition is exhaustive (a trailing `true` arm —
+        // the carry in a writer decision), so the arms reassemble the full
+        // `param_ty ⇒ V` column by position (op-conversion fans the fed input to each
+        // union operand).
         TypedExprNode::Case {
             scrutinee: None,
             branches,
         } if branches.iter().all(|b| b.pattern.is_none()) => {
-            Err(LambdaElimError::Unsupported(format!(
-                "per-element conditional (a value-selecting `Case` inside `λ {param} → …`) is \
-                 not compilable at a site with no visible iteration source. A comprehension \
-                 element conditional (`[a if g({param}) else b for {param} in xs]`), a top-level \
-                 ternary, a conditional collection, and a conditional feed all compile today."
-            )))
+            let value_ty = body_ty.clone();
+            let mut prior_guards: Vec<Expr> = Vec::new();
+            let mut arms: Vec<Expr> = Vec::with_capacity(branches.len());
+            for br in branches {
+                // First-match gate π̂ᵢ as a scalar bool in `param` (the nesting the
+                // old `select` encoded, made explicit), eliminated to the
+                // element-varying predicate morphism `param_ty ⇒ Bool`.
+                let pi_hat = synthesize_arm_predicate(&br.guard, &prior_guards);
+                prior_guards.push(br.guard);
+                let gate_fn = elim_lambda(ctx, param, param_ty, pi_hat)?;
+                let value_fn = elim_lambda(ctx, param, param_ty, br.body)?;
+                // `filter_values(π̂ᵢ) ≫ eᵢ`: filter the fed element stream to the gate
+                // (keeping the element value), then map by `eᵢ`. The filtered stream
+                // is typed by the plain `param` domain, **not** a `{param | π̂ᵢ}`
+                // refinement: the `filter_values` op *is* the runtime filter, and a
+                // refinement type would make planning inject its own (value-dropping,
+                // position-domain) `restrict` at this site. The arms' runtime domains
+                // are disjoint by first-match, so the `UnionOperator` merges them
+                // without overlap despite the identical static type.
+                let filter = apply_primitive(
+                    gate_fn,
+                    Builtin::FilterValues,
+                    Type::data_fun(param_ty.clone(), param_ty.clone()),
+                );
+                arms.push(
+                    typed_compose(vec![filter, value_fn])
+                        .with_ty(Type::data_fun(param_ty.clone(), value_ty.clone())),
+                );
+            }
+            match arms.len() {
+                0 => unreachable!("a value-selecting Case has at least one branch"),
+                1 => Ok(arms.pop().expect("len == 1")),
+                _ => Ok(Expr::collection_union(arms)
+                    .with_ty(Type::data_fun(param_ty.clone(), value_ty))),
+            }
         }
 
         // Unsupported constructs.

--- a/src/ccl/lower/loops.rs
+++ b/src/ccl/lower/loops.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use super::*;
 use crate::{
     ccl::{Branch, Expr, Lit, Type, TypedBinding, TypedExprNode},
-    chl_parser::ast::{AssignTarget, Expr as ChlExpr, Spanned, Stmt as ChlStmt},
+    chl_parser::ast::{AssignTarget, Expr as ChlExpr, IfBranch, Spanned, Stmt as ChlStmt},
 };
 
 // ---------------------------------------------------------------------------
@@ -572,15 +572,43 @@ pub(super) fn find_mutation_loop_vars(
 ) -> Vec<String> {
     let mut vars = Vec::new();
     let mut seen = HashSet::new();
+    collect_mutation_loop_vars(body, mutation_scope, &mut vars, &mut seen);
+    vars
+}
+
+/// Recurse the accumulator scan into `if`/`elif`/`else` branches: a `+=` / `:=`
+/// under a conditional is still a loop-carried accumulator (the conditional
+/// induction write becomes one recurrence leg per path). We descend into `if`
+/// branches only — **not** inner `for` loops (nested-loop mutation is still
+/// unsupported, and a write buried in an inner `for` must stay invisible here so
+/// the caller's `find_nested_mutation_var` reject still fires) nor `with begin()`
+/// blocks (those carry their own transactional keys).
+fn collect_mutation_loop_vars(
+    body: &[Spanned<ChlStmt>],
+    scope: &HashSet<String>,
+    vars: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) {
     for stmt in body {
         if let Some(name) = mutation_target_name(stmt)
-            && mutation_scope.contains(name)
+            && scope.contains(name)
             && seen.insert(name.to_string())
         {
             vars.push(name.to_string());
         }
+        if let ChlStmt::If {
+            branches,
+            else_body,
+        } = &stmt.node
+        {
+            for branch in branches {
+                collect_mutation_loop_vars(&branch.body, scope, vars, seen);
+            }
+            if let Some(else_body) = else_body {
+                collect_mutation_loop_vars(else_body, scope, vars, seen);
+            }
+        }
     }
-    vars
 }
 
 /// The first top-level plain `=` ([`ChlStmt::Assign`]) in `body` that rebinds a
@@ -689,148 +717,7 @@ pub(super) fn lower_direct_mirror_loop(
     // body — shadow it so a body read of a like-named transactional register is
     // read as the loop local, not gated as an out-of-block register read.
     let chain = ctx.with_shadowed([iter_var.clone()], |ctx| {
-        let mut chain = ctx.tag_machinery(Expr::lit(Lit::Unit), for_span, "lower.loop_unit");
-        for stmt in body_stmts.iter().rev() {
-            chain = match &stmt.node {
-                // `x = value` — a plain immutable binding. Inside a loop body it
-                // is a per-iteration shadowing `let`, *never* a mutable write: `=`
-                // is not a mutation operator (accumulators are written with `:=`
-                // / `+=`). A loop-carried accumulator therefore never appears here.
-                ChlStmt::Assign { target, value } => {
-                    let name = extract_name_target(target, "assignment")?;
-                    check_mut_write_context(&name, stmt.span, ctx)?;
-                    let val = lower_expr(value, ctx)?;
-                    ctx.tag_image(Expr::let_bind(name, val, chain), stmt.span)
-                }
-                ChlStmt::AugAssign { target, op, value } => {
-                    let name = extract_name_target(target, "augmented assignment")?;
-                    check_mut_write_context(&name, stmt.span, ctx)?;
-                    let val = lower_aug_binop(&name, *op, value, stmt.span, ctx)?;
-                    if acc_names.contains(&name) {
-                        let write = ctx.tag_image(Expr::mut_write(name, val), stmt.span);
-                        ctx.tag_image(Expr::expr_stmt(write, chain), stmt.span)
-                    } else {
-                        ctx.tag_image(Expr::let_bind(name, val, chain), stmt.span)
-                    }
-                }
-                // `x := value` — a mutable write inside the loop body. A write to
-                // an accumulator is a `MutWrite` (the recurrence the phase
-                // threads); a `:=` to any other name is a per-iteration local
-                // `let`. An annotated `:=` intro inside the loop is rejected, like
-                // the `Mut(…)` declaration below — accumulators are declared
-                // before the loop.
-                ChlStmt::MutAssign {
-                    target,
-                    annotation,
-                    value,
-                } => {
-                    let name = extract_name_target(target, "mutable assignment")?;
-                    if annotation.is_some() && !acc_names.contains(&name) {
-                        return Err(LoweringError::unsupported(
-                            stmt.span,
-                            "a `:=` accumulator declaration inside a for-loop body is not \
-                             supported; declare the accumulator before the loop",
-                        ));
-                    }
-                    check_mut_write_context(&name, stmt.span, ctx)?;
-                    let val = lower_expr(value, ctx)?;
-                    if acc_names.contains(&name) {
-                        let write = ctx.tag_image(Expr::mut_write(name, val), stmt.span);
-                        ctx.tag_image(Expr::expr_stmt(write, chain), stmt.span)
-                    } else {
-                        ctx.tag_image(Expr::let_bind(name, val, chain), stmt.span)
-                    }
-                }
-                // `y: T = value` — an ordinary annotated per-iteration local, the
-                // annotated counterpart of the plain `y = value` binding above.
-                // Lowers to an annotated shadowing `let` (never a `MutWrite`: a
-                // `Mut(…)` accumulator must be declared *before* the loop, matching
-                // `lower_for_body_stmts`).
-                ChlStmt::AnnAssign {
-                    target,
-                    annotation,
-                    value,
-                } => {
-                    let name = extract_name_target(target, "annotated assignment")?;
-                    if mut_annotation_parts(annotation).is_some() {
-                        return Err(LoweringError::unsupported(
-                            stmt.span,
-                            "a `Mut(…)` declaration inside a for-loop body is not \
-                             supported; declare the accumulator before the loop",
-                        ));
-                    }
-                    let ann = lower_type_annotation(annotation)?;
-                    let val = lower_expr(value, ctx)?;
-                    ctx.tag_image(Expr::let_bind_annotated(name, val, chain, ann), stmt.span)
-                }
-                // `o << value` — an in-loop feed. Emitted as a raw `Feed` marker
-                // (reads stay bare); the phase resolves its value in the
-                // read-your-writes environment and hoists it out of the loop.
-                ChlStmt::Expr(value)
-                    if let ChlExpr::Feed {
-                        target: feed_target,
-                        value: feed_value,
-                    } = &value.node =>
-                {
-                    let defer_name = match &feed_target.node {
-                        ChlExpr::Name(id) => id.as_str().to_string(),
-                        _ => {
-                            return Err(LoweringError::unsupported(
-                                feed_target.span,
-                                "feed target: only simple name targets are supported",
-                            ));
-                        }
-                    };
-                    let lowered = lower_expr(feed_value, ctx)?;
-                    let feed = ctx.tag_image(Expr::feed(defer_name, lowered), value.span);
-                    ctx.tag_machinery(Expr::expr_stmt(feed, chain), stmt.span, "lower.stmt_seq")
-                }
-                // `yield value` — a feed into the surrounding generator's defer.
-                ChlStmt::Expr(value) if let ChlExpr::Yield(y) = &value.node => {
-                    let defer_name = yield_defer.ok_or_else(|| {
-                        LoweringError::unsupported(
-                            value.span,
-                            "yield outside a generator for-loop context",
-                        )
-                    })?;
-                    let lowered = lower_expr(y, ctx)?;
-                    let feed =
-                        ctx.tag_image(Expr::feed(defer_name.to_string(), lowered), value.span);
-                    ctx.tag_machinery(Expr::expr_stmt(feed, chain), stmt.span, "lower.stmt_seq")
-                }
-                // A bare expression statement — the `Feed`/`Yield` guards above
-                // did not match, so this is an ordinary side-effect (e.g. a call
-                // to a pass-by-reference writer, `bump(cnt)`). Sequence it before
-                // the rest; its value is discarded (the loop body is a statement).
-                // Post-inline it may reveal a `MutWrite` (accumulator loop) or turn
-                // out pure (the phase drops the loop as a no-op).
-                ChlStmt::Expr(value) => {
-                    let lowered = lower_expr(value, ctx)?;
-                    ctx.tag_machinery(Expr::expr_stmt(lowered, chain), stmt.span, "lower.stmt_seq")
-                }
-                // `with begin(): <block>` — a per-iteration transaction, emitted
-                // as a `Begin` marker (one statement in the loop body). Its
-                // atomic writes/reads live in the block; sibling induction `+=`
-                // writes and `<<` feeds around it stay on this loop body.
-                // `transact_phase` strips the `Begin` into a commit-record site
-                // keyed on this loop and leaves the induction remainder for the
-                // recurrence — which is what lets one loop mix both.
-                ChlStmt::With { .. } => {
-                    let block = lower_with_block(stmt, ctx)?;
-                    let begin = ctx.tag_image(Expr::begin(block), stmt.span);
-                    ctx.tag_machinery(Expr::expr_stmt(begin, chain), stmt.span, "lower.stmt_seq")
-                }
-                _ => {
-                    return Err(LoweringError::unsupported(
-                        stmt.span,
-                        "only assignments (`x = …`, `x op= …`), `<<` feeds, \
-                         `yield`, `with begin():` transactions, and bare \
-                         side-effect calls are supported inside a for-loop body",
-                    ));
-                }
-            };
-        }
-        Ok::<Expr, LoweringError>(chain)
+        lower_loop_body_chain(body_stmts, acc_names, yield_defer, false, for_span, ctx)
     })?;
 
     // The direct-mirror `For` images the for statement; the sequencing
@@ -851,6 +738,249 @@ pub(super) fn lower_direct_mirror_loop(
         Expr::expr_stmt(for_node, continuation),
         for_span,
         "lower.stmt_seq",
+    ))
+}
+
+/// Lower a for-loop body's statement list to the direct-mirror statement chain
+/// (right-to-left, ending in `Unit`; the `For` body is a statement, not a
+/// value). Shared by [`lower_direct_mirror_loop`] and the conditional-write
+/// `ChlStmt::If` arm below, which recurses through it to lower each branch's
+/// body identically — so a `+=` under an `if` produces the same `MutWrite`
+/// marker it would at top level, just nested inside a statement-position `Case`.
+///
+/// `in_conditional` is `true` when lowering an `if`-branch body: a per-iteration
+/// `with begin():` transaction inside a conditional is not yet supported (the
+/// per-path transaction verdict — see `design/mutability.md`), so it is rejected
+/// there rather than emitted as a `Begin` marker.
+fn lower_loop_body_chain(
+    body_stmts: &[Spanned<ChlStmt>],
+    acc_names: &[String],
+    yield_defer: Option<&str>,
+    in_conditional: bool,
+    for_span: Span,
+    ctx: &mut LoweringContext,
+) -> Result<Expr, LoweringError> {
+    // Every node this chain mints is recorded: an unrecorded lowering mint is a
+    // `Leak::Unexplained` at the lowering boundary. A statement's own image gets
+    // `tag_image`; the `ExprStmt` that sequences one statement before the rest is
+    // manufactured plumbing (`src/ccl/design/provenance.md`, "The seam
+    // (`src/ccl/context.rs`)").
+    let mut chain = ctx.tag_machinery(Expr::lit(Lit::Unit), for_span, "lower.loop_unit");
+    for stmt in body_stmts.iter().rev() {
+        chain = match &stmt.node {
+            // `x = value` — a plain immutable binding. Inside a loop body it
+            // is a per-iteration shadowing `let`, *never* a mutable write: `=`
+            // is not a mutation operator (accumulators are written with `:=`
+            // / `+=`). A loop-carried accumulator therefore never appears here.
+            ChlStmt::Assign { target, value } => {
+                let name = extract_name_target(target, "assignment")?;
+                check_mut_write_context(&name, stmt.span, ctx)?;
+                let val = lower_expr(value, ctx)?;
+                ctx.tag_image(Expr::let_bind(name, val, chain), stmt.span)
+            }
+            ChlStmt::AugAssign { target, op, value } => {
+                let name = extract_name_target(target, "augmented assignment")?;
+                check_mut_write_context(&name, stmt.span, ctx)?;
+                let val = lower_aug_binop(&name, *op, value, stmt.span, ctx)?;
+                if acc_names.contains(&name) {
+                    let write = ctx.tag_image(Expr::mut_write(name, val), stmt.span);
+                    ctx.tag_image(Expr::expr_stmt(write, chain), stmt.span)
+                } else {
+                    ctx.tag_image(Expr::let_bind(name, val, chain), stmt.span)
+                }
+            }
+            // `x := value` — a mutable write inside the loop body. A write to
+            // an accumulator is a `MutWrite` (the recurrence the phase
+            // threads); a `:=` to any other name is a per-iteration local
+            // `let`. An annotated `:=` intro inside the loop is rejected, like
+            // the `Mut(…)` declaration below — accumulators are declared
+            // before the loop.
+            ChlStmt::MutAssign {
+                target,
+                annotation,
+                value,
+            } => {
+                let name = extract_name_target(target, "mutable assignment")?;
+                if annotation.is_some() && !acc_names.contains(&name) {
+                    return Err(LoweringError::unsupported(
+                        stmt.span,
+                        "a `:=` accumulator declaration inside a for-loop body is not \
+                         supported; declare the accumulator before the loop",
+                    ));
+                }
+                check_mut_write_context(&name, stmt.span, ctx)?;
+                let val = lower_expr(value, ctx)?;
+                if acc_names.contains(&name) {
+                    let write = ctx.tag_image(Expr::mut_write(name, val), stmt.span);
+                    ctx.tag_image(Expr::expr_stmt(write, chain), stmt.span)
+                } else {
+                    ctx.tag_image(Expr::let_bind(name, val, chain), stmt.span)
+                }
+            }
+            // `y: T = value` — an ordinary annotated per-iteration local, the
+            // annotated counterpart of the plain `y = value` binding above.
+            // Lowers to an annotated shadowing `let` (never a `MutWrite`: a
+            // `Mut(…)` accumulator must be declared *before* the loop, matching
+            // `lower_for_body_stmts`).
+            ChlStmt::AnnAssign {
+                target,
+                annotation,
+                value,
+            } => {
+                let name = extract_name_target(target, "annotated assignment")?;
+                if mut_annotation_parts(annotation).is_some() {
+                    return Err(LoweringError::unsupported(
+                        stmt.span,
+                        "a `Mut(…)` declaration inside a for-loop body is not \
+                         supported; declare the accumulator before the loop",
+                    ));
+                }
+                let ann = lower_type_annotation(annotation)?;
+                let val = lower_expr(value, ctx)?;
+                ctx.tag_image(Expr::let_bind_annotated(name, val, chain, ann), stmt.span)
+            }
+            // `o << value` — an in-loop feed. Emitted as a raw `Feed` marker
+            // (reads stay bare); the phase resolves its value in the
+            // read-your-writes environment and hoists it out of the loop.
+            ChlStmt::Expr(value)
+                if let ChlExpr::Feed {
+                    target: feed_target,
+                    value: feed_value,
+                } = &value.node =>
+            {
+                let defer_name = match &feed_target.node {
+                    ChlExpr::Name(id) => id.as_str().to_string(),
+                    _ => {
+                        return Err(LoweringError::unsupported(
+                            feed_target.span,
+                            "feed target: only simple name targets are supported",
+                        ));
+                    }
+                };
+                let lowered = lower_expr(feed_value, ctx)?;
+                let feed = ctx.tag_image(Expr::feed(defer_name, lowered), value.span);
+                ctx.tag_machinery(Expr::expr_stmt(feed, chain), stmt.span, "lower.stmt_seq")
+            }
+            // `yield value` — a feed into the surrounding generator's defer.
+            ChlStmt::Expr(value) if let ChlExpr::Yield(y) = &value.node => {
+                let defer_name = yield_defer.ok_or_else(|| {
+                    LoweringError::unsupported(
+                        value.span,
+                        "yield outside a generator for-loop context",
+                    )
+                })?;
+                let lowered = lower_expr(y, ctx)?;
+                let feed = ctx.tag_image(Expr::feed(defer_name.to_string(), lowered), value.span);
+                ctx.tag_machinery(Expr::expr_stmt(feed, chain), stmt.span, "lower.stmt_seq")
+            }
+            // `if p: … [else: …]` — a conditional write path. Lowered to a
+            // statement-position filter-`Case` (`[gᵢ → branchᵢ; true → else|unit]`)
+            // that `letrec_phase` forks into one recurrence leg per path (the
+            // write legs plus the carry-forward complement). See
+            // `src/ccl/design/mutability.md`, "Value-selecting `Case` and
+            // conditional induction writes (partially implemented)".
+            ChlStmt::If {
+                branches,
+                else_body,
+            } => {
+                let case = build_loop_if_case(
+                    branches,
+                    else_body.as_deref(),
+                    acc_names,
+                    yield_defer,
+                    stmt.span,
+                    ctx,
+                )?;
+                ctx.tag_machinery(Expr::expr_stmt(case, chain), stmt.span, "lower.stmt_seq")
+            }
+            // A bare expression statement — the `Feed`/`Yield` guards above
+            // did not match, so this is an ordinary side-effect (e.g. a call
+            // to a pass-by-reference writer, `bump(cnt)`). Sequence it before
+            // the rest; its value is discarded (the loop body is a statement).
+            // Post-inline it may reveal a `MutWrite` (accumulator loop) or turn
+            // out pure (the phase drops the loop as a no-op).
+            ChlStmt::Expr(value) => {
+                let lowered = lower_expr(value, ctx)?;
+                ctx.tag_machinery(Expr::expr_stmt(lowered, chain), stmt.span, "lower.stmt_seq")
+            }
+            // `with begin(): <block>` inside an `if` in the loop body: a per-path
+            // transaction site is unsound (§4.3 transaction verdict) — rejected.
+            ChlStmt::With { .. } if in_conditional => {
+                return Err(LoweringError::unsupported(
+                    stmt.span,
+                    "a `with begin():` transaction inside an `if` in a for-loop body \
+                     is not supported; move it to the loop's top level",
+                ));
+            }
+            // `with begin(): <block>` — a per-iteration transaction, emitted
+            // as a `Begin` marker (one statement in the loop body). Its
+            // atomic writes/reads live in the block; sibling induction `+=`
+            // writes and `<<` feeds around it stay on this loop body.
+            // `transact_phase` strips the `Begin` into a commit-record site
+            // keyed on this loop and leaves the induction remainder for the
+            // recurrence — which is what lets one loop mix both.
+            ChlStmt::With { .. } => {
+                let block = lower_with_block(stmt, ctx)?;
+                let begin = ctx.tag_image(Expr::begin(block), stmt.span);
+                ctx.tag_machinery(Expr::expr_stmt(begin, chain), stmt.span, "lower.stmt_seq")
+            }
+            _ => {
+                return Err(LoweringError::unsupported(
+                    stmt.span,
+                    "only assignments (`x = …`, `x op= …`), `<<` feeds, \
+                     `yield`, `if` guards, `with begin():` transactions, and bare \
+                     side-effect calls are supported inside a for-loop body",
+                ));
+            }
+        };
+    }
+    Ok(chain)
+}
+
+/// Build the statement-position filter-`Case` for an `if`/`elif`/`else` in a
+/// for-loop body (a conditional induction write / feed). Each branch's body is
+/// lowered through [`lower_loop_body_chain`] (so nested writes and feeds lower
+/// identically to top-level ones); a missing `else` becomes an implicit
+/// `true → unit` carry-forward branch — the position where the accumulator
+/// keeps its previous value. `letrec_phase` forks this `Case` into one
+/// recurrence leg per branch.
+fn build_loop_if_case(
+    branches: &[IfBranch],
+    else_body: Option<&[Spanned<ChlStmt>]>,
+    acc_names: &[String],
+    yield_defer: Option<&str>,
+    stmt_span: Span,
+    ctx: &mut LoweringContext,
+) -> Result<Expr, LoweringError> {
+    let mut out = Vec::with_capacity(branches.len() + 1);
+    for br in branches {
+        let guard = lower_expr(&br.cond, ctx)?;
+        let body =
+            lower_loop_body_chain(&br.body, acc_names, yield_defer, true, br.cond.span, ctx)?;
+        out.push(Branch {
+            pattern: None,
+            guard,
+            body,
+        });
+    }
+    let else_chain = match else_body {
+        Some(eb) => lower_loop_body_chain(eb, acc_names, yield_defer, true, stmt_span, ctx)?,
+        // The implicit carry-forward arm: manufactured, so it is tagged here rather
+        // than carrying a statement's image.
+        None => ctx.tag_machinery(Expr::lit(Lit::Unit), stmt_span, "lower.loop_if_carry"),
+    };
+    out.push(Branch {
+        pattern: None,
+        guard: ctx.tag_machinery(Expr::lit(Lit::Bool(true)), stmt_span, "lower.loop_if_carry"),
+        body: else_chain,
+    });
+    // The `Case` images the `if` statement inside the loop body.
+    Ok(ctx.tag_image(
+        Expr::new(TypedExprNode::Case {
+            scrutinee: None,
+            branches: out,
+        }),
+        stmt_span,
     ))
 }
 
@@ -1215,19 +1345,31 @@ x";
     /// variable and points at the nesting, rather than falling through
     /// to the generator-for fallback's generic "must end in yield".
     #[test]
-    fn test_mutation_nested_in_if_rejected() {
+    fn test_mutation_nested_in_if_else_now_lowers() {
+        // A mutation nested under an `if`/`else` is a conditional induction
+        // write — no longer rejected. Both legs become branches of the
+        // statement-position filter-`Case`; `letrec_phase` forks them into
+        // per-path recurrence legs.
         let code = "\
 x := 0
 for i in [1, 2]:
     if i > 0:
         x := x + i
+    else:
+        x := x - i
 x";
         let stmts = parse_module(code);
-        let err = expect_one_lowering_error(&stmts);
-        let LoweringError::Unsupported { message: msg, .. } = &err;
-        assert!(
-            msg.contains("nested") && msg.contains("`x`"),
-            "error should call out nested mutation of `x`: {msg}"
+        let ccl = lower_stmts(&stmts, &mut LoweringContext::default())
+            .into_result()
+            .expect("conditional if/else induction write should lower");
+        let s = symbolic(&ccl);
+        assert_eq!(
+            s,
+            "let x = 0\n\
+             in for i in [1, 2] do { i > 0 → x := x + i; unit; \
+             true → x := x - i; unit }; unit; x",
+            "if/else conditional write lowers to a two-branch filter-Case, each \
+             leg carrying its own MutWrite: {s}"
         );
     }
 
@@ -1286,6 +1428,33 @@ f";
         assert!(
             s.contains("let a = 5") && s.contains("x + a"),
             "should have pre-loop let and body referencing it: {s}"
+        );
+    }
+
+    /// A conditional induction write `if p: x += i` lowers the loop body to
+    /// a statement-position filter-`Case` — the write leg under the guard and an
+    /// implicit `true → unit` carry-forward branch — with the accumulator write a
+    /// `MutWrite` marker inside the guarded branch. `letrec_phase` forks this into
+    /// per-path recurrence legs.
+    #[test]
+    fn test_lower_conditional_induction_write() {
+        let code = "\
+x := 0
+for i in [1, 2, 3]:
+    if i > 1:
+        x += i
+x";
+        let stmts = parse_module(code);
+        let ccl = lower_stmts(&stmts, &mut LoweringContext::default())
+            .into_result()
+            .expect("conditional induction write should lower");
+        let s = symbolic(&ccl);
+        assert_eq!(
+            s,
+            "let x = 0\n\
+             in for i in [1, 2, 3] do { i > 1 → x := x + i; unit; true → unit }; unit; x",
+            "conditional write lowers to a statement-position filter-Case with the \
+             MutWrite in the guarded leg and a `true → unit` carry-forward complement"
         );
     }
 }

--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -278,10 +278,11 @@ pub(super) fn lower_final_stmt(
                     return Err(LoweringError::unsupported(
                         last.span,
                         format!(
-                            "mutation of `{nested}` is nested inside an `if` or \
-                             inner `for` in this for-loop body; only top-level \
-                             mutations of outer-scope variables are supported \
-                             today.  Move the mutation to the top of the loop \
+                            "mutation of `{nested}` is nested inside an inner \
+                             `for` in this for-loop body; nested-loop mutation \
+                             is not yet supported (a conditional `if p: \
+                             {nested} += …` write is supported — only an inner \
+                             `for` is not).  Move the mutation to the outer loop \
                              body, or rewrite using a generator expression."
                         ),
                     ));
@@ -668,11 +669,12 @@ pub(super) fn lower_middle_stmt(
                 return Err(LoweringError::unsupported(
                     stmt.span,
                     format!(
-                        "mutation of `{nested}` is nested inside an `if` or \
-                     inner `for` in this for-loop body; only top-level \
-                     mutations of outer-scope variables are supported \
-                     today.  Move the mutation to the top of the loop \
-                     body, or rewrite using a generator expression."
+                        "mutation of `{nested}` is nested inside an inner `for` \
+                     in this for-loop body; nested-loop mutation is not yet \
+                     supported (a conditional `if p: {nested} += …` write is \
+                     supported — only an inner `for` is not).  Move the mutation \
+                     to the outer loop body, or rewrite using a generator \
+                     expression."
                     ),
                 ));
             }

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -46,8 +46,11 @@
 use std::collections::HashMap;
 
 use crate::ccl::{
-    BaseType, Builtin, Expr, F_COMMIT, F_WRITES, HistoryKind, Lit, Name, Type, TypedBinding,
-    TypedExprNode, letrec::check_letrec_causal, symbolic::symbolic,
+    BaseType, Branch, Builtin, Expr, F_COMMIT, F_WRITES, HistoryKind, Lit, Name, Type,
+    TypedBinding, TypedExprNode,
+    ccl_utils::{strip_refinements, synthesize_arm_predicate},
+    letrec::check_letrec_causal,
+    symbolic::symbolic,
 };
 
 // ---------------------------------------------------------------------------
@@ -593,9 +596,13 @@ pub(crate) fn hoist_feeds(mut body: Expr, feeds: Vec<(Name, Expr)>) -> Expr {
 /// feed rides the decision as a `to_<feed>` field, hoisted to
 /// `Feed(defer, __hist ≫ .to_<feed>)` for `channelize` to route.
 fn transform_loop(target: TypedBinding, iter: Expr, loop_body: Expr, cont: Expr) -> Expr {
+    // Every reference to an accumulator is either in the loop (a read-your-writes
+    // read) or downstream of it (the trailing final read), so these two trees
+    // carry every `Mut(V, D)` this loop's registers have.
+    let reg_vtys = register_value_tys([&loop_body, &cont]);
     // Accumulators in first-write order, with their value types.
     let mut accs: Vec<(Name, Type)> = Vec::new();
-    collect_writes(&loop_body, &mut accs);
+    collect_writes(&loop_body, &reg_vtys, &mut accs);
     if accs.is_empty() {
         // A loop with no accumulator. If its body feeds — a stateless generator,
         // or a `with begin():` read-only transaction (`for r in iter: with
@@ -610,10 +617,18 @@ fn transform_loop(target: TypedBinding, iter: Expr, loop_body: Expr, cont: Expr)
         return rewrite(cont);
     }
 
+    // A conditional induction write (`if p: total += x`) lowers to a
+    // statement-position guard-`Case`; `transform_chain` merges its branches into
+    // one always-commit decision with a per-accumulator value-`Case` write set
+    // (see its `Case` arm). So the conditional case folds through the SAME
+    // single-writer path as a plain loop — one writer over the full source, no
+    // per-leg restricted sources — which recognition packages as a single-writer
+    // `Transact` and op-conversion routes to the changelog `InductionStore`.
+
     // Fold the accumulators into a decision-factored history binding, then wrap it
     // in a nested `LetRec`: re-point the continuation's trailing reads at the
     // extracted finals, recurse into it, prepend the reads, and hoist the feeds.
-    let fold = fold_induction_loop(&target, &iter, loop_body);
+    let fold = fold_induction_loop(&target, &iter, loop_body, &reg_vtys);
     let mut cont = cont;
     for (acc, x_final) in &fold.renames {
         rename_uses(&mut cont, acc, x_final);
@@ -687,13 +702,18 @@ impl InductionFold {
 
 /// See [`InductionFold`]. Caller must guard on a non-empty accumulator set
 /// (an accumulator-free loop is a feed-only/no-op loop, handled separately).
+///
+/// `reg_vtys` supplies each accumulator's value type ([`register_value_tys`]);
+/// the caller builds it over the widest tree it holds, so that a register read
+/// only *downstream* of the loop still contributes its `Mut(V, D)`.
 pub(crate) fn fold_induction_loop(
     target: &TypedBinding,
     iter: &Expr,
     loop_body: Expr,
+    reg_vtys: &HashMap<Name, Type>,
 ) -> InductionFold {
     let mut accs: Vec<(Name, Type)> = Vec::new();
-    collect_writes(&loop_body, &mut accs);
+    collect_writes(&loop_body, reg_vtys, &mut accs);
     assert!(
         !accs.is_empty(),
         "fold_induction_loop: caller must guard on a non-empty accumulator set"
@@ -729,9 +749,23 @@ pub(crate) fn fold_induction_loop(
     );
 
     // Walk the body: build the RYW chain, collect feeds, and produce the
-    // terminal `{commit: true, writes, to_<feed>*}` decision record.
+    // terminal `{commit: true, writes, to_<feed>*}` decision record. `entering`
+    // is each accumulator's *raw* value on loop-body entry (`__p ▷ .i`, before any
+    // write this iteration) — the baseline a statement-`Case` compares against to
+    // decide `commit`, so an *unconditional* write before/around the `Case` still
+    // forces a change (see `conditional_decision`).
+    let entering: Vec<Expr> = accs
+        .iter()
+        .map(|(n, _)| {
+            env.get(n)
+                .expect("accumulator seeded in the RYW environment")
+                .clone()
+        })
+        .collect();
     let mut feeds: Vec<FeedSite> = Vec::new();
-    let chain = transform_chain(loop_body, &mut env, &accs, &writes_ty, &mut feeds);
+    let chain = transform_chain(
+        loop_body, &mut env, &accs, &writes_ty, &entering, &mut feeds,
+    );
 
     // The decision codomain: `{commit, writes}` plus one field per feed site.
     let mut decision_fields: Vec<(String, Type)> = vec![
@@ -913,20 +947,110 @@ fn collect_feed_only(expr: Expr, env: &mut HashMap<Name, Expr>, feeds: &mut Vec<
     }
 }
 
-/// Collect `MutWrite` targets in first-write order with their written types.
-fn collect_writes(expr: &Expr, out: &mut Vec<(Name, Type)>) {
+/// The value type `V` of every mutable register referenced anywhere in `roots`.
+///
+/// A register's `V` is the **join** over its seed and all of its writes, and
+/// inference has already computed it: it is the `V` of the `Mut(V, D)` that each
+/// *reference* to the register carries. (The mutability rides reference types
+/// rather than the binding slot — see [`emit_let`](crate::ccl::infer)'s `Mut`
+/// arm — so the seed binding records only the seed's own type.) Reading it here
+/// is what keeps this phase's view of a register identical to the one the
+/// `Transact` rule derives, instead of each rebuilding a value type from
+/// whichever single contribution it happens to hold.
+///
+/// Binders are α-unique by this point (`uniquify` runs before inference), so one
+/// map over the whole tree cannot conflate two registers.
+pub(crate) fn register_value_tys<'a>(
+    roots: impl IntoIterator<Item = &'a Expr>,
+) -> HashMap<Name, Type> {
+    /// The register value a reference type denotes, if it is a register at all.
+    /// A mutable variable is never wrapped in anything but `Refinement` before
+    /// this phase, and only an *overwrite* history is a register — a `Feed`
+    /// channel reads as its whole stream rather than as a value.
+    fn as_register_value(mut ty: &Type) -> Option<&Type> {
+        while let Type::Refinement(inner, _) = ty {
+            ty = inner;
+        }
+        match ty {
+            Type::History {
+                value,
+                kind: HistoryKind::Overwrite,
+                ..
+            } => Some(value),
+            _ => None,
+        }
+    }
+    fn walk(e: &Expr, out: &mut HashMap<Name, Type>) {
+        if let TypedExprNode::Var(name) = &e.node
+            && let Some(value) = as_register_value(&e.ty)
+        {
+            out.insert(name.clone(), value.clone());
+        }
+        e.walk_children(|c| walk(c, out));
+    }
+    let mut out = HashMap::new();
+    for r in roots {
+        walk(r, &mut out);
+    }
+    out
+}
+
+/// Collect `MutWrite` targets in first-write order with their value types, taken
+/// from `reg_vtys` — the join inference recorded on the register's `Mut(V, D)`.
+///
+/// A register with no entry is one no reference types as a `Mut`: either nothing
+/// reads it (only writes mention it, so its value type is unobservable), or the
+/// tree records reads at the deref'd value directly, as the phase's own
+/// hand-built test trees do. The written type then stands in, **stripped** — a
+/// register takes no refinement from any single contribution, and an unstripped
+/// one would be a witness acquired by erasure rather than by `cast`
+/// (`src/ccl/design/type-inference.md`, "Refinements as witness sets").
+fn collect_writes(expr: &Expr, reg_vtys: &HashMap<Name, Type>, out: &mut Vec<(Name, Type)>) {
     if let TypedExprNode::MutWrite { name, value } = &expr.node
         && !out.iter().any(|(n, _)| n == name)
     {
-        out.push((name.clone(), value.ty.clone()));
+        let vty = reg_vtys
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| strip_refinements(&value.ty));
+        out.push((name.clone(), vty));
     }
-    expr.walk_children(|c| collect_writes(c, out));
+    expr.walk_children(|c| collect_writes(c, reg_vtys, out));
 }
 
 /// Whether `expr` contains a `Feed` marker (backs the no-op-loop invariant
 /// check in [`transform_loop`]).
 fn body_has_feed(expr: &Expr) -> bool {
     matches!(expr.node, TypedExprNode::Feed { .. }) || expr.any_child(body_has_feed)
+}
+
+/// Replace the terminal `Unit` of a statement chain with `tail` — splicing the
+/// post-`Case` remainder onto the end of a branch's chain (both end in `Unit`).
+fn splice_after_unit(chain: Expr, tail: Expr) -> Expr {
+    match chain.node {
+        TypedExprNode::Lit(Lit::Unit) => tail,
+        TypedExprNode::Let {
+            binding,
+            bound_expr,
+            body,
+        } => Expr::let_in(binding, *bound_expr, splice_after_unit(*body, tail)),
+        TypedExprNode::ExprStmt { expr, body } => {
+            Expr::expr_stmt(*expr, splice_after_unit(*body, tail))
+        }
+        // A non-chain terminal: recursion has reached a leaf that is not the
+        // `Unit` sentinel a lowered chain ends in, so there is nowhere to splice
+        // `tail`. This is reachable only if `tail` is itself empty — otherwise we
+        // would silently drop continuation code (the worst failure for a
+        // statement chain). Lowering guarantees every spliceable branch ends in
+        // `Unit`, so assert the tail is trivial here rather than discarding it.
+        other => {
+            debug_assert!(
+                matches!(tail.node, TypedExprNode::Lit(Lit::Unit)),
+                "splice_after_unit would drop a non-trivial tail onto a non-`Unit` terminal"
+            );
+            Expr::new(other)
+        }
+    }
 }
 
 /// Walk the direct-mirror statement chain, threading the read-your-writes
@@ -940,6 +1064,7 @@ fn transform_chain(
     env: &mut HashMap<Name, Expr>,
     accs: &[(Name, Type)],
     writes_ty: &Type,
+    entering: &[Expr],
     feeds: &mut Vec<FeedSite>,
 ) -> Expr {
     match expr.node {
@@ -949,19 +1074,102 @@ fn transform_chain(
             body,
         } => {
             let bound = subst_env(*bound_expr, env);
-            let rest = transform_chain(*body, env, accs, writes_ty, feeds);
+            let rest = transform_chain(*body, env, accs, writes_ty, entering, feeds);
             Expr::let_in(b, bound, rest)
+        }
+        // A statement-position guard-`Case` (`if p: acc += e`, lowered by
+        // `lower_loop_body_chain` to `{gᵢ → branch; true → carry}`): merge its
+        // branches into a single always-commit decision whose write set is a
+        // per-accumulator first-match value-`Case`. A non-writing (carry) branch
+        // contributes the accumulator's snapshot, so `commit: true` writing the
+        // unchanged value is a no-op — the conditional change rides the *values*
+        // (each value-`Case` compiles via the C-form at `lambda_elim`), not a
+        // per-position commit gate. One writer over the full source, so no
+        // restricted per-leg sources and no cyclic desync — the changelog
+        // (`InductionStore`) realization the dense multi-leg `Recurse` replaced.
+        TypedExprNode::ExprStmt { expr: effect, body }
+            if matches!(
+                &effect.node,
+                TypedExprNode::Case {
+                    scrutinee: None,
+                    ..
+                }
+            ) =>
+        {
+            let TypedExprNode::Case { branches, .. } = effect.node else {
+                unreachable!("guarded by the match arm")
+            };
+            let rest = *body;
+            // Each branch: splice the post-`Case` remainder onto its chain, walk it
+            // with a cloned RYW env, and take (first-match predicate, write set).
+            // The write sets come from `decision_writes` — fully inlined (point-free
+            // over `__p`), so they are safe to use as `Case` arms and to compare
+            // structurally.
+            let mut priors: Vec<Expr> = Vec::new();
+            let mut all: Vec<(Expr, Vec<Expr>)> = Vec::new();
+            for br in branches {
+                // The first-match predicate, resolved through the RYW env so the
+                // loop item / accumulators read their writer-body snapshot slots
+                // (`__p.k` / `__p.i`) rather than the raw loop binder — the
+                // `commit` field must be point-free like `writes`.
+                let pi = subst_env(synthesize_arm_predicate(&br.guard, &priors), env);
+                priors.push(br.guard.clone());
+                let spliced = splice_after_unit(br.body, rest.clone());
+                let mut branch_env = env.clone();
+                let mut branch_feeds: Vec<FeedSite> = Vec::new();
+                let dec = transform_chain(
+                    spliced,
+                    &mut branch_env,
+                    accs,
+                    writes_ty,
+                    entering,
+                    &mut branch_feeds,
+                );
+                // NOTE (known limitation, lifted upstack): a feed inside a
+                // conditional induction branch (`for …: if p: out << …`) is NOT
+                // rejected at lowering — lowering only rejects `with begin()` in a
+                // loop branch, not a `<<`/`yield`. So such a feed reaches here and
+                // trips this assert (a compiler panic) rather than a graceful
+                // error. This is deliberately left as-is on this branch: the
+                // induction-unification work carries reply taps on the changelog
+                // store and removes this whole `branch_feeds` path, so a conditional
+                // feed riding an accumulator compiles there. Until then it panics.
+                assert!(
+                    branch_feeds.is_empty(),
+                    "a feed on a conditional induction path is not yet supported (unblocked by the changelog-tap induction realization)"
+                );
+                all.push((pi, decision_writes(&dec)));
+            }
+            // The lowered `Case` always ends in the `true → carry` complement — the
+            // write set on the path where no guard fired. That carry already has any
+            // **unconditional** write (before the `Case`, or after it in `rest`,
+            // spliced into every branch) applied, so it is the correct value-`Case`
+            // fallthrough — and it must be *inlined* (which it is, via
+            // `decision_writes`), never the raw `env` slot (a `let`-bound name would
+            // escape the writer lambda). The other branches that differ from it are
+            // the conditional writes.
+            let (_, carry) = all.pop().expect("a lowered guard-Case has a `true` arm");
+            let writing: Vec<(Expr, Vec<Expr>)> =
+                all.into_iter().filter(|(_, w)| *w != carry).collect();
+            conditional_decision(writing, carry, entering, writes_ty)
         }
         TypedExprNode::ExprStmt { expr: effect, body } => {
             match effect.node {
-                // A write advances the read-your-writes environment.
+                // A write advances the read-your-writes environment by *inlining*
+                // the written value (point-free over `__p`), not binding a `let` —
+                // the same substitution model `transact_phase::walk_block` uses.
+                // Inlining keeps every captured value self-contained: an
+                // unconditional write followed by a statement-`Case` leaves no dead
+                // `let` wrapping the decision (which would break the value-`Case`
+                // C-form compilation of the write set), and a feed reached after a
+                // write can be hoisted without stranding a branch-local binder.
                 TypedExprNode::MutWrite { name, value } => {
                     let val = subst_env(*value, env);
-                    let vty = val.ty.clone();
-                    let fresh = Name::fresh(name.base());
-                    env.insert(name.clone(), tvar(&fresh, vty.clone()));
-                    let rest = transform_chain(*body, env, accs, writes_ty, feeds);
-                    Expr::let_in(binding(fresh, vty), val, rest)
+                    // The value is inlined into `env`, not `let`-bound: a writer's
+                    // decision body reads it (via `decision_writes`), and a
+                    // `let`-bound name would escape the writer lambda.
+                    env.insert(name.clone(), val);
+                    transform_chain(*body, env, accs, writes_ty, entering, feeds)
                 }
                 // A feed is captured (value resolved in the current env) and
                 // dropped from the chain; it becomes a `to_<feed>` field on
@@ -974,7 +1182,7 @@ fn transform_chain(
                         field,
                         value: val,
                     });
-                    transform_chain(*body, env, accs, writes_ty, feeds)
+                    transform_chain(*body, env, accs, writes_ty, entering, feeds)
                 }
                 // A bare `unit` statement is a no-op: drop it and continue. This
                 // is the discarded terminal of a spliced pass-by-reference writer
@@ -984,7 +1192,7 @@ fn transform_chain(
                 // the loop-body continuation), which `flatten_spine` right-
                 // associates onto the spine but does not elide.
                 TypedExprNode::Lit(Lit::Unit) => {
-                    transform_chain(*body, env, accs, writes_ty, feeds)
+                    transform_chain(*body, env, accs, writes_ty, entering, feeds)
                 }
                 // A nested statement sequence spliced as one effect — an inlined
                 // writer body whose head is *not* a `MutWrite` (e.g. a `Feed`, so
@@ -996,7 +1204,7 @@ fn transform_chain(
                     body: inner_b,
                 } => {
                     let spliced = Expr::expr_stmt(*inner_e, Expr::expr_stmt(*inner_b, *body));
-                    transform_chain(spliced, env, accs, writes_ty, feeds)
+                    transform_chain(spliced, env, accs, writes_ty, entering, feeds)
                 }
                 other => panic!(
                     "letrec phase: unexpected statement in loop body: {}",
@@ -1039,6 +1247,160 @@ fn transform_chain(
             symbolic(&Expr::throwaway(other).with_ty(expr.ty))
         ),
     }
+}
+
+/// The `writes` tuple elements of a `{commit, writes(, to_*)}` decision record
+/// (as [`transform_chain`] builds it) — one *self-contained* expression per
+/// accumulator, in accumulator order. A branch's write introduces RYW `let`s
+/// (`let total = __p.0 + __p.1 in {…, writes: (total)}`) that the merged
+/// value-`Case` arms live outside of, so peel and inline those bindings.
+fn decision_writes(dec: &Expr) -> Vec<Expr> {
+    let mut env: HashMap<Name, Expr> = HashMap::new();
+    let mut cur = dec;
+    loop {
+        match &cur.node {
+            TypedExprNode::Let {
+                binding,
+                bound_expr,
+                body,
+            } => {
+                let bound = subst_env((**bound_expr).clone(), &env);
+                env.insert(binding.name.clone(), bound);
+                cur = body;
+            }
+            TypedExprNode::Record(fields) => {
+                let writes = &fields
+                    .iter()
+                    .find(|(f, _)| f == F_WRITES)
+                    .expect("letrec phase: a writer decision has a `writes` field")
+                    .1;
+                let TypedExprNode::Tuple(elts) = &writes.node else {
+                    panic!("letrec phase: a decision `writes` is a positional tuple");
+                };
+                return elts.iter().map(|e| subst_env(e.clone(), &env)).collect();
+            }
+            _ => panic!(
+                "letrec phase: a branch decision is `let* in {{commit, writes}}`, got {}",
+                symbolic(dec)
+            ),
+        }
+    }
+}
+
+/// Build the writer decision `{commit, writes}` for a statement-`Case`, from its
+/// *writing* branches (first-match predicate + write set each) and the entering
+/// accumulator `snapshot`.
+///
+/// One uniform, **carry-complete** shape covers every arity — one conditional
+/// write, `if/else`-both-write, `elif`-with-writes, and the pure-guard carry:
+///
+/// - `commit = ⋁ⱼ ĝⱼ` — the disjunction of the writing branches' first-match
+///   guards (`false` when nothing writes). This gates the *sparse* changelog: a
+///   position no writing guard admits records no change (the `InductionStore`
+///   inherits the value), so a run of carries costs nothing.
+/// - `writesᵢ = Case[ĝ₀ → w₀ᵢ; …; ĝₙ → wₙᵢ; true → snapshotᵢ]` — a per-accumulator
+///   first-match value-`Case` whose trailing `true` arm is the **carry** (the
+///   entering accumulator). The carry arm makes the write value *total at every
+///   position*: `lambda_elim` compiles this `Case` as a union of domain-restricts
+///   (`⧺ⱼ wⱼᵢ ↾ π̂ⱼ`), so a **partial op** (`//`, `%`) in a write value is only
+///   evaluated at the positions its guard admits — never at a carried position.
+///
+/// Carry-completeness is also what makes the dense `Recurse` path correct for an
+/// **async source**: that path cycles on `.writes` (not `.commit`), and `writes`
+/// now carries `snapshotᵢ` (the previous accumulator) wherever no guard fires, so
+/// the guard is honored by the value rather than silently dropped.
+fn conditional_decision(
+    writing: Vec<(Expr, Vec<Expr>)>,
+    carry: Vec<Expr>,
+    entering: &[Expr],
+    writes_ty: &Type,
+) -> Expr {
+    let bool_ty = Type::Base(BaseType::Bool);
+    let mut commit_guards: Vec<Expr> = writing.iter().map(|(g, _)| g.clone()).collect();
+    // An **unconditional** write (before the `Case`, or after it in `rest`, spliced
+    // into every branch) is baked into the `carry` — so `carry ≠ entering` means the
+    // accumulator changed at *every* position, and the change must commit
+    // everywhere. Add the `true` path: without it a conditional-only `commit =
+    // ⋁ writing` would leave the unconditional write uncommitted (a carry) at
+    // non-firing positions, silently reverting it to the previous value.
+    if carry.as_slice() != entering {
+        let mut t = Expr::new(TypedExprNode::Lit(Lit::Bool(true)));
+        t.ty = bool_ty.clone();
+        commit_guards.push(t);
+    }
+    let commit = disjoin_guards(commit_guards.into_iter(), &bool_ty);
+    let write_elts: Vec<Expr> = (0..carry.len())
+        .map(|i| {
+            // No conditional write for accumulator `i` → just the carry value (the
+            // unconditional-write-applied value, or the raw entering value if none).
+            if writing.is_empty() {
+                return carry[i].clone();
+            }
+            let mut case_branches: Vec<Branch> = writing
+                .iter()
+                .map(|(g, w)| Branch {
+                    pattern: None,
+                    guard: g.clone(),
+                    body: w[i].clone(),
+                })
+                .collect();
+            let mut carry_guard = Expr::new(TypedExprNode::Lit(Lit::Bool(true)));
+            carry_guard.ty = bool_ty.clone();
+            case_branches.push(Branch {
+                pattern: None,
+                guard: carry_guard,
+                body: carry[i].clone(),
+            });
+            let vty = carry[i].ty.clone();
+            let mut c = Expr::new(TypedExprNode::Case {
+                scrutinee: None,
+                branches: case_branches,
+            });
+            c.ty = vty;
+            c
+        })
+        .collect();
+    decision_record(commit, write_elts, writes_ty)
+}
+
+/// Disjoin guard expressions into one boolean (`false` when empty) — the writer
+/// decision's `commit` gate, true exactly when some writing branch fires.
+fn disjoin_guards(guards: impl Iterator<Item = Expr>, bool_ty: &Type) -> Expr {
+    let mut acc: Option<Expr> = None;
+    for g in guards {
+        acc = Some(match acc {
+            None => g,
+            Some(prev) => {
+                let mut o = Expr::binop(
+                    prev,
+                    crate::ccl::BinOpKind::BoolLogic(crate::ccl::LogicKind::Or),
+                    g,
+                );
+                o.ty = bool_ty.clone();
+                o
+            }
+        });
+    }
+    acc.unwrap_or_else(|| {
+        let mut f = Expr::new(TypedExprNode::Lit(Lit::Bool(false)));
+        f.ty = bool_ty.clone();
+        f
+    })
+}
+
+/// Assemble a writer decision record `{commit, writes: (write_elts…)}`.
+fn decision_record(commit: Expr, write_elts: Vec<Expr>, writes_ty: &Type) -> Expr {
+    let mut writes = Expr::tuple(write_elts);
+    writes.ty = writes_ty.clone();
+    let mut rec = Expr::new(TypedExprNode::Record(vec![
+        (F_COMMIT.to_string(), commit),
+        (F_WRITES.to_string(), writes),
+    ]));
+    rec.ty = Type::Record(vec![
+        (F_COMMIT.to_string(), Type::Base(BaseType::Bool)),
+        (F_WRITES.to_string(), writes_ty.clone()),
+    ]);
+    rec
 }
 
 /// Rename every use of `from` (bare `Var`s and `MutWrite` targets) to `to`,

--- a/src/ccl/ops.rs
+++ b/src/ccl/ops.rs
@@ -303,6 +303,20 @@ pub enum Builtin {
     /// `not_fn : Bool → Bool` — boolean negation as a morphism.
     NotFn,
 
+    /// `filter_values : (D ⇒ Bool) ⇒ ({d: D | p(d)} ⇒ V)` — a **value-preserving**
+    /// mid-chain filter. `Apply(p, FilterValues)` requires `input=Some(_)` (the
+    /// `D ⇒ V` stream to filter) and keeps each surviving element's **codomain
+    /// value** `V` — unlike `Restrict`, which returns the domain identity
+    /// `{D | p} ⇒ {D | p}` for a source a downstream map re-indexes. Compiles to
+    /// the `Filter` tile operator (input stream + predicate, output = filtered
+    /// input). Lambda elimination emits it to desugar a value-selecting `Case`
+    /// whose gate varies with the element (`λ x → Case{[gᵢ(x) → eᵢ(x)]}`, a writer
+    /// decision body) into a **union of domain-restricts** `⧺ᵢ (filter_values(π̂ᵢ)
+    /// ≫ eᵢ)`: each arm filters the fed element stream to its first-match gate,
+    /// then maps — so a partial op (`//`, `%`) in `eᵢ` runs only where its guard
+    /// holds, never eagerly at a rejected position.
+    FilterValues,
+
     // Aggregations (codomain of a function-typed input → scalar).
     /// `sum`.
     Sum,
@@ -453,6 +467,7 @@ impl Builtin {
             Self::BinOp(op) => op.fn_name(),
             Self::Neg => "neg",
             Self::NotFn => "not_fn",
+            Self::FilterValues => "filter_values",
             Self::Sum => "sum",
             Self::Max => "max",
             Self::FinalOrDefault => "final_or_default",

--- a/src/ccl/planning/iterate.rs
+++ b/src/ccl/planning/iterate.rs
@@ -484,9 +484,16 @@ pub(super) fn is_iteration_bearing(expr: &Expr) -> bool {
             // over the trigger and op-conversion rejects a non-empty input — so an
             // as-of-led chain is already iteration-bearing; prepending an
             // `iterate` would strand the as_of mid-chain.
+            // `FilterValues` heads a value-`Case` fan-out arm inside a writer body
+            // (`filter_values(π̂) ≫ eᵢ`); it consumes the fed element stream as its
+            // source and op-conversion rejects a non-empty extra input, so a
+            // filter-values-led chain is already source-bearing — like `Restrict`,
+            // wrapping it with an `iterate` would strand the filter mid-chain.
             Some(b) => {
-                matches!(b, Builtin::Iterate | Builtin::Restrict | Builtin::AsOf)
-                    || b.iterates_arg()
+                matches!(
+                    b,
+                    Builtin::Iterate | Builtin::Restrict | Builtin::AsOf | Builtin::FilterValues
+                ) || b.iterates_arg()
             }
             // Non-builtin function position (`Proj`, `Var`, curried
             // `Apply`, …): op-conversion's catch-all `Apply` arm

--- a/src/ccl/planning/loops.rs
+++ b/src/ccl/planning/loops.rs
@@ -79,11 +79,15 @@ pub(crate) fn plan_loops(expr: Expr) -> Expr {
         if is_txn_group(&bindings) {
             return recognize_txn_group(bindings, body);
         }
-        assert_eq!(
+        // An induction group is a single writer: a plain `mut` loop, and — since
+        // the conditional case folds to one always-commit-with-a-value-`Case` /
+        // `commit`-gated writer over the full source (`transform_chain`'s `Case`
+        // arm) rather than per-leg restricted bindings — a conditional write too.
+        debug_assert_eq!(
             bindings.len(),
             1,
-            "letrec recognition: a non-transaction group must be a single-binding \
-             induction group in v1"
+            "an induction letrec group is a single writer (a conditional write folds \
+             to one commit-gated writer, not a per-leg group)"
         );
         let (h, def) = bindings.into_iter().next().unwrap();
         return recognize_group(h, def, body);

--- a/src/ccl/simplify.rs
+++ b/src/ccl/simplify.rs
@@ -483,10 +483,26 @@ fn try_compose_identity(expr: &mut Expr) -> bool {
 /// to `domain(f) → codomain(g)`.
 ///
 /// Operates pairwise in an n-ary compose; trailing elements are preserved.
+/// Whether `expr` is a value-preserving filter application `filter_values(p)` —
+/// `Apply(p, Builtin::FilterValues)`. Such an upstream restricts the domain at
+/// runtime, so it must survive [`try_const_reduce`] (dropping it would apply the
+/// constant everywhere).
+fn is_filter_values_led(expr: &Expr) -> bool {
+    matches!(
+        &expr.node,
+        TypedExprNode::Apply { function, .. } if is_builtin(function, Builtin::FilterValues)
+    )
+}
+
 fn try_const_reduce(expr: &mut Expr) -> bool {
     try_pairwise_in_compose(
         expr,
-        |_left, right| as_const(right).is_some(),
+        // A `left ≫ const(g)` collapses to `const(g)` carrying `left`'s *type*
+        // domain — sound only when `left` is a pure reshaping. `filter_values`
+        // restricts the domain at *runtime* and carries no refinement for planning
+        // to re-materialise (unlike `restrict`), so collapsing it would drop the
+        // filter and apply the constant at every position — never reduce past one.
+        |left, right| as_const(right).is_some() && !is_filter_values_led(left),
         |left, right| {
             let Some(g) = as_const(&right) else {
                 unreachable!()

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -69,7 +69,7 @@ use crate::ccl::{
     FieldKey, HistoryKind, Lit, Name, ProjKey, Type, TypedBinding, TypedExprNode, WriterSite,
     ccl_utils::is_free_in_value,
     letrec::check_letrec_causal,
-    mut_elim::{fold_induction_loop, hoist_feeds},
+    mut_elim::{fold_induction_loop, hoist_feeds, register_value_tys},
 };
 
 /// Recognize a **fed-out register read** and rewrite it to an as-of join, *before*
@@ -680,7 +680,11 @@ fn fold_cross_domain_loops(expr: Expr, cross_reads: &HashSet<Name>, out: &mut Cr
         let TypedExprNode::For { target, iter, body } = effect.node else {
             unreachable!("guarded above")
         };
-        let fold = fold_induction_loop(&target, &iter, *body);
+        // The loop body and the continuation between them carry every reference to
+        // this loop's accumulators, so their `Mut(V, D)`s give each one the value
+        // type inference joined for it.
+        let reg_vtys = register_value_tys([&*body, &*cont]);
+        let fold = fold_induction_loop(&target, &iter, *body, &reg_vtys);
         for (i, (acc, vty)) in fold.accs.iter().enumerate() {
             if cross_reads.contains(acc) {
                 let final_var = fold

--- a/src/interpreter/commit_operator.rs
+++ b/src/interpreter/commit_operator.rs
@@ -132,9 +132,57 @@ impl CommitEngine {
         }
     }
 
+    /// An empty engine for a **position-driven induction store**: no tick-0 init
+    /// seed (the accumulator's init is the reader's fold default, supplied by
+    /// `get_prev_seq`), driven by [`step`](Self::step) rather than
+    /// [`attempt`](Self::attempt). Undecided until the first `step`.
+    ///
+    /// Test-only: production `InductionStore`/commit engines seed tick 0 via
+    /// [`CommitEngine::new`]. This unseeded form models the pre-first-`step`
+    /// state directly for the `step`/carry unit tests.
+    #[cfg(test)]
+    pub fn for_induction() -> Self {
+        Self {
+            committed: BTreeMap::new(),
+            latest_write: HashMap::new(),
+            next_ts: 0,
+        }
+    }
+
+    /// The watermark frontier: all ticks `≤ watermark()` are decided. `None`
+    /// before anything is decided (an induction engine before its first
+    /// [`step`](Self::step); a commit engine always has its tick-0 init).
+    pub fn decided_watermark(&self) -> Option<CommitTs> {
+        self.next_ts.checked_sub(1)
+    }
+
     /// The watermark frontier: all ticks `≤ watermark()` are decided.
     pub fn watermark(&self) -> CommitTs {
         self.next_ts - 1
+    }
+
+    /// Position-driven induction step (the sequential, no-conflict dual of
+    /// [`attempt`](Self::attempt)): advance the decided frontier to `position`
+    /// **unconditionally** — every iteration position is decided — and record a
+    /// write at tick = `position` iff `writes` is `Some`. A `None` is a **carry**:
+    /// no change, the accumulator holds from the latest earlier write. Because the
+    /// tick *is* the position (not allocate-on-commit), the changelog is sparse in
+    /// position space while the frontier tracks the whole extent — so a store with
+    /// a trailing run of carries still reports the right decided region. There is
+    /// no conflict/retry: a single writer visits each position once in order.
+    pub fn step(&mut self, position: CommitTs, writes: Option<HashMap<Value, Value>>) {
+        debug_assert!(
+            self.decided_watermark().is_none_or(|w| position > w),
+            "induction positions advance strictly monotonically (got {position}, watermark {:?})",
+            self.decided_watermark()
+        );
+        self.next_ts = position + 1;
+        if let Some(w) = writes {
+            for k in w.keys() {
+                self.latest_write.insert(k.clone(), position);
+            }
+            self.committed.insert(position, w);
+        }
     }
 
     /// Validate and (if valid) commit one proposal. Allocate-on-commit: a valid
@@ -226,10 +274,21 @@ impl CommitEngine {
     pub fn render_full_store_tile(&self) -> Tile {
         let ticks: Vec<usize> = self.committed.keys().copied().collect();
         let deltas: Vec<Value> = self.committed.values().map(map_to_value).collect();
+        // The decided frontier is the watermark; an induction engine that has not
+        // stepped yet is undecided (`False`). The frontier is `LessThanEq(w)` even
+        // when the latest position(s) carried no write, so a trailing run of
+        // carries stays decided — the changelog is sparse but the frontier is not.
+        let frontier = match self.decided_watermark() {
+            Some(w) => Predicate::LessThanEq(Value::UInt(w)),
+            None => Predicate::False,
+        };
         Tile::Store {
             changes: ColumnValue::from_uints(ticks),
             deltas: ColumnValue::Variants(deltas),
-            frontier: Predicate::LessThanEq(Value::UInt(self.watermark())),
+            frontier,
+            // A rendered store is *live* by default; a producer that knows its
+            // writers are finished flips `terminal` (keeping the numeric frontier).
+            terminal: false,
         }
     }
 }
@@ -280,32 +339,17 @@ fn read_initial_scalar(producer: &mut dyn TileProducer) -> Result<Value, InitDra
 /// converging (the doc's "a couple of pulls" claim).
 const MAX_INIT_PULLS: usize = 8;
 
-/// The frontier of a store tile's change ticks + `frontier` predicate (the
-/// watermark decode behind [`store_frontier`]). `LessThanEq(w)` reads the
-/// watermark directly; the terminal `True` flip reconstructs it from the last
-/// (largest) change tick. `None` for an undecided/empty changelog.
+/// The watermark of a store tile's `frontier` predicate (the decode behind
+/// [`store_frontier`]). A store always carries its watermark as `LessThanEq(w)`
+/// — terminality is a separate flag, never a `True` frontier that would discard
+/// `w` — so the watermark reads directly and counts trailing carries. `None` for
+/// an undecided/empty changelog.
 fn frontier_from_domain(domain: &ColumnValue, domain_predicate: &Predicate) -> Option<CommitTs> {
     if domain.is_empty() {
         return None;
     }
     match domain_predicate {
         Predicate::LessThanEq(Value::UInt(f)) => Some(*f),
-        Predicate::True => {
-            debug_assert!(
-                (0..domain.len()).all(|i| {
-                    i == 0
-                        || matches!(
-                            (domain.index_at(i - 1), domain.index_at(i)),
-                            (Value::UInt(a), Value::UInt(b)) if a <= b
-                        )
-                }),
-                "store tile ticks are rendered in ascending order; the last is the watermark"
-            );
-            match domain.index_at(domain.len() - 1) {
-                Value::UInt(t) => Some(t),
-                _ => None,
-            }
-        }
         _ => None,
     }
 }
@@ -903,9 +947,10 @@ impl TileProducer for CommitProducer {
         // happen) — `all()` over the empty writer set is `true`, which is what we
         // want, so there is no `is_empty()` guard.
         if self.writer_terminal.iter().all(|&t| t)
-            && let Tile::Store { frontier, .. } = &mut store
+            && let Tile::Store { terminal, .. } = &mut store
         {
-            *frontier = Predicate::True;
+            // Close the frontier (no more commits), keeping its numeric watermark.
+            *terminal = true;
         }
         debug_assert!(
             store.check_from(&self.output_tiling),
@@ -966,6 +1011,258 @@ fn source_value_at(codomain: &Tile, i: usize) -> Value {
                 .collect(),
         ),
         other => panic!("cross-domain writer source column is not scalar/record: {other:?}"),
+    }
+}
+
+/// A **position-driven induction store** (a `mut` loop accumulator, plain or with
+/// a conditional write `if p: total += x`) built on the same [`CommitEngine`] +
+/// [`Tile::Store`] changelog machinery as the concurrent [`CommitOperator`], but
+/// driven by *iteration position* rather than by concurrent proposals.
+///
+/// There is exactly one writer, visiting each iteration position once in order:
+/// no proposals, no conflicts, no retries. The accumulator recurrence — position
+/// `i` reads `xᵢ₋₁` and decides `xᵢ` — is driven **sequentially inside the
+/// producer**: the driver holds the engine, folds the previous accumulator out of
+/// it ([`CommitEngine::read_as_of`], defaulting below the earliest change to the
+/// key's init), feeds the body `(prev…, item)` through a [`BodyInputBuffer`], reads
+/// the body's `{commit, writes}` decision, and [`step`](CommitEngine::step)s the
+/// engine — a `commit: true` position appends a change, a `commit: false` (a
+/// failed guard) is a **carry** (no change; the value inherits).
+///
+/// The key structural difference from the retired dense `Recurse` realization:
+/// the accumulator lives in the engine, not on a cyclic tile, so there is **no
+/// cyclic `FanOut`** — the previous value is always available before the body
+/// needs it, and a conditional write's carry positions simply produce no change
+/// rather than having to synthesize a same-value "write" on a complement leg.
+/// A plain (unconditional) `mut` loop is the degenerate `commit: true`-everywhere
+/// case (a dense changelog); a conditional write is sparse in position space
+/// while the frontier still tracks the whole extent.
+pub struct InductionStore {
+    /// Per accumulator key, its runtime key and the acyclic operator producing
+    /// its tick-0 fold default (the accumulator's init; read once at subscribe,
+    /// like [`CommitOperator::with_init_ops`]). Written in `write_keys` order.
+    init_ops: Vec<(Value, Box<dyn TileOperator>)>,
+    /// The writer body `λ (prev…, item) → {commit, writes(, to_<defer>…)}`,
+    /// compiled around a [`BodyInputSource`] over `buffer`.
+    body_op: Box<dyn TileOperator>,
+    /// The iteration source `Fun(D, item)` — the loop extent's items in order.
+    source_op: Box<dyn TileOperator>,
+    /// The body-input buffer the driver pushes `(prev…, item)` rows onto.
+    buffer: BodyInputBuffer,
+    /// Accumulator keys the body reads a snapshot of, in body-parameter order
+    /// (for an induction store these are exactly the accumulators it writes).
+    read_keys: Vec<Value>,
+    /// Keys written, in decision-`writes` order: the accumulator registers, then
+    /// any reply-tap (`to_<defer>`) keys.
+    write_keys: Vec<Value>,
+    /// Reply-tap decision fields, appended to each write set (see
+    /// [`body_decision_at`]). Empty for a store with no feed.
+    tap_fields: Vec<String>,
+    output_tiling: Tiling,
+}
+
+impl InductionStore {
+    /// Assemble an induction store. `init_ops`/`read_keys`/`write_keys` follow the
+    /// same conventions as the commit store's writer, with `read_keys ==` the
+    /// accumulator keys and `write_keys` the accumulators followed by tap keys.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        init_ops: Vec<(Value, Box<dyn TileOperator>)>,
+        body_op: Box<dyn TileOperator>,
+        source_op: Box<dyn TileOperator>,
+        buffer: BodyInputBuffer,
+        read_keys: Vec<Value>,
+        write_keys: Vec<Value>,
+        tap_fields: Vec<String>,
+        key_extent: Extent,
+        value_extent: Extent,
+    ) -> Self {
+        let output_tiling = full_store_tiling(&key_extent, &value_extent);
+        Self {
+            init_ops,
+            body_op,
+            source_op,
+            buffer,
+            read_keys,
+            write_keys,
+            tap_fields,
+            output_tiling,
+        }
+    }
+}
+
+impl TileOperator for InductionStore {
+    fn tiling(&self) -> &Tiling {
+        &self.output_tiling
+    }
+
+    fn subscribe(
+        &mut self,
+        _intent_guard: TileGuard,
+        mut consumer: Box<dyn Consumer>,
+        scheduler: &mut Scheduler,
+    ) -> Box<dyn TileProducer> {
+        // Forward source/body progress to this store's consumer: an async loop
+        // source (a data source arriving over scheduler notifications) delivers
+        // its elements incrementally, and each arrival must wake a downstream
+        // reader so it re-pulls and the drive loop processes the new positions.
+        // Without this the store stalls at whatever prefix arrived by the first
+        // pull (a batch/list source is complete on the first pull, so it never
+        // needed the wiring — but an async source does). Kick once to start.
+        let consumer = Rc::new(RefCell::new(move || consumer.notify()));
+        consumer.borrow_mut().notify();
+        // Resolve each accumulator's tick-0 fold default. The init op is acyclic
+        // (it never reads the store), so a single drain to a scalar is sound —
+        // the same seeding path as `CommitOperator::with_init_ops`.
+        let mut inits: HashMap<Value, Value> = HashMap::with_capacity(self.init_ops.len());
+        for (key, mut op) in std::mem::take(&mut self.init_ops) {
+            let g = op.tiling().universal_guard();
+            let mut producer = op.subscribe(g, Box::new(|| {}), scheduler);
+            let value = read_initial_scalar(&mut *producer).unwrap_or_else(|e| match e {
+                InitDrainFailure::Empty => panic!(
+                    "InductionStore: init op for accumulator {key:?} produced an empty scalar \
+                     (no value to seed the accumulator)"
+                ),
+                InitDrainFailure::Diverged => panic!(
+                    "InductionStore: init op for accumulator {key:?} never settled to a scalar \
+                     within {MAX_INIT_PULLS} pulls (an acyclic init resolves on the first pull)"
+                ),
+            });
+            inits.insert(key, value);
+        }
+        let source_producer = {
+            let g = self.source_op.tiling().universal_guard();
+            self.source_op
+                .subscribe(g, Box::new(consumer.clone()), scheduler)
+        };
+        let body_producer = {
+            let g = self.body_op.tiling().universal_guard();
+            self.body_op
+                .subscribe(g, Box::new(consumer.clone()), scheduler)
+        };
+        Box::new(InductionStoreProducer {
+            base: ProducerBase::new(InductionStoreProducer::alloc_id(), &self.output_tiling),
+            // Seed tick 0 with the accumulators' inits, so the changelog is
+            // self-describing: `read_as_of`/`store_value_at` fold to the init below
+            // the first *iteration* change (a leading carry) without an external
+            // default. Iterations therefore occupy ticks 1.., a `+ 1` offset the
+            // drive loop and the dense read both apply.
+            engine: CommitEngine::new(inits),
+            body_producer,
+            source_producer,
+            buffer: self.buffer.clone(),
+            read_keys: self.read_keys.clone(),
+            write_keys: self.write_keys.clone(),
+            tap_fields: self.tap_fields.clone(),
+            output_tiling: self.output_tiling.clone(),
+            processed: 0,
+            source_complete: false,
+        })
+    }
+}
+
+struct InductionStoreProducer {
+    base: ProducerBase,
+    engine: CommitEngine,
+    body_producer: Box<dyn TileProducer>,
+    source_producer: Box<dyn TileProducer>,
+    buffer: BodyInputBuffer,
+    read_keys: Vec<Value>,
+    write_keys: Vec<Value>,
+    tap_fields: Vec<String>,
+    /// The full-store output tiling — for a debug-time shape check on the rendered
+    /// store tile.
+    output_tiling: Tiling,
+    /// Iteration positions already fed to the body and stepped into the engine.
+    /// Monotonic; the drive resumes here each pull as the source grows.
+    processed: usize,
+    /// Whether the iteration source is complete (its last pull was terminal). A
+    /// batch source (a list — the usual loop extent) is complete on the first pull.
+    source_complete: bool,
+}
+
+impl TileProducer for InductionStoreProducer {
+    impl_producer_base!();
+
+    fn get_impl(&mut self, _projection_guard: TileGuard) -> Tile {
+        let src = self
+            .source_producer
+            .get(self.source_producer.tiling().universal_guard());
+        self.source_complete = src.is_terminal();
+        let items = decode_source_items(&src);
+        // Drive each not-yet-processed position in order. Tick 0 is the seeded
+        // init, so iteration `pos` occupies tick `pos + 1`: it reads the previous
+        // accumulator as of tick `pos` (the init at `pos == 0`, else the latest
+        // change ≤ that tick — a leading carry inherits the seed), feeds the body,
+        // and steps tick `pos + 1`. The engine must be stepped through `pos` before
+        // we fold, hence the sequential push-body-step loop. The body's decision
+        // gates commit (append the change) vs carry (`step(_, None)` — the value
+        // inherits from tick 0 / the latest earlier change).
+        while self.processed < items.len() {
+            let pos = self.processed;
+            let snap_in: Vec<Value> = self
+                .read_keys
+                .iter()
+                .map(|k| {
+                    self.engine
+                        .read_as_of(pos, k)
+                        .expect("tick 0 seeds every accumulator, so a prev read always resolves")
+                })
+                .collect();
+            self.buffer
+                .borrow_mut()
+                .rows
+                .push((snap_in, items[pos].clone()));
+            let body_tile = self
+                .body_producer
+                .get(self.body_producer.tiling().universal_guard());
+            let Some((commit, writes)) = body_decision_at(&body_tile, pos, &self.tap_fields) else {
+                // The decision for a freshly-pushed row of a self-contained
+                // induction body is always ready on the pull. A `None` means the
+                // body has not converged at this position — for the loop shapes
+                // that reach here (no cross-loop broadcast in the body) this does
+                // not happen, so stop the drive and re-render; the harness re-pulls
+                // a non-terminal store to make progress.
+                break;
+            };
+            let write_set: Option<HashMap<Value, Value>> = if commit {
+                debug_assert_eq!(
+                    writes.len(),
+                    self.write_keys.len(),
+                    "the decision's write set aligns with the store's write keys"
+                );
+                Some(self.write_keys.iter().cloned().zip(writes).collect())
+            } else {
+                None // carry: the accumulator holds from tick 0 / the latest change
+            };
+            self.engine.step(pos + 1, write_set);
+            self.processed = pos + 1;
+        }
+        let mut store = self.engine.render_full_store_tile();
+        // Signal terminality once the source is complete and every position has
+        // been decided: the accumulator is final, so the frontier *closes*
+        // (`terminal`) and a downstream `ExtractLast`/`final_or_default` resolves.
+        // The frontier keeps its `LessThanEq(w)` watermark, which spans the whole
+        // extent including a trailing run of carries — so `len`/`store_frontier`
+        // no longer undercount to the last change tick when the tail is all carry.
+        if self.source_complete
+            && self.processed >= items.len()
+            && let Tile::Store { terminal, .. } = &mut store
+        {
+            *terminal = true;
+        }
+        debug_assert!(
+            store.check_from(&self.output_tiling),
+            "rendered induction store tile does not match the full-store tiling"
+        );
+        store
+    }
+
+    fn release_impl(&mut self, _obsolete_guard: TileGuard) {
+        // The induction store is a finite batch driven to completion in one pull
+        // sweep; its whole changelog is retained for the accumulator-final read.
+        // Read-side commit-log GC (the long-lived-store bound) is a follow-up —
+        // tracked with the trailing-carry frontier gap in the pivot design notes.
     }
 }
 
@@ -1087,20 +1384,27 @@ impl TileProducer for StoreValueStreamProducer {
         // (consumer-driven; no producer-side drive-to-fixpoint). The store's writer
         // steps one commit per pull and re-arms itself on the wakeup queue, which
         // fans through the cyclic `FanOut` to re-pull this stream as commits land;
-        // terminality flows through the store's `frontier` predicate below.
+        // terminality flows through the store's `terminal` flag below.
         let sg = self.store_producer.tiling().universal_guard();
         let store = self.store_producer.get(sg);
-        // The store's watermark predicate (`frontier`) is carried through unchanged
-        // — terminality flows to this stream. Fold the changelog directly.
+        // Fold the changelog directly. Terminality flows to this stream: a closed
+        // store (`terminal`) yields a `True` output domain predicate so a
+        // downstream terminal read resolves; a live store carries its `LessThanEq`
+        // watermark through.
         let Tile::Store {
             changes,
             deltas,
             frontier,
+            terminal,
         } = &store
         else {
             return self.tiling().empty_tile();
         };
-        let domain_predicate = frontier.clone();
+        let domain_predicate = if *terminal {
+            Predicate::True
+        } else {
+            frontier.clone()
+        };
         // Project each change tick's delta map to `key`'s value. A register carries
         // the last written value forward across ticks that don't touch `key` (so a
         // read sees the latest write ≤ that tick — the step interpolation); a reply
@@ -1169,6 +1473,178 @@ impl TileProducer for StoreValueStreamProducer {
                     .release(TileGuard::Function(FunctionGuard::Domain(pred)));
             }
         }
+    }
+}
+
+/// A **dense** induction-accumulator read: `key`'s value at *every* position of
+/// the loop extent `D`, folded from the [`Tile::Store`] changelog —
+/// `Fun(D, V)` where position `p ↦ store_value_at(store, p, key)` (carry-forward,
+/// defaulting to `init` below the first change).
+///
+/// This is the induction counterpart of [`StoreValueStream`] (a commit
+/// register's per-tick stream). The difference is the domain: a register stream
+/// is indexed by *commit tick* (sparse change events), but an induction
+/// accumulator co-iterated into another store (e.g. `for r in …: cnt += 1; with
+/// begin(): store := store + cnt`) must present a *dense* function over the loop
+/// extent so it aligns (via `fan_in`) with the co-iterated `iter`. Because
+/// [`store_value_at`] folds by scanning changes `≤ p` — **independent of the
+/// store's frontier** — this reads every position correctly even across a
+/// trailing run of carries, so it needs neither the frontier watermark nor the
+/// extent recorded on the tile: the positions come from the `trigger`
+/// (`IterateExtent`-style enumeration of `D`), the values from the fold.
+///
+/// A scalar-final read (`total` after the loop) is `ExtractLast` over this dense
+/// stream; a co-iterated read is the stream itself — one reader serves both.
+pub struct StoreDenseRead {
+    /// Output tiling `SealedFunction { domain: D, codomain: Scalar(V) }`.
+    tiling: Tiling,
+    /// Enumerates the loop extent `D` (its positions drive the output domain, so
+    /// it aligns with any co-iterated source over the same `D`).
+    trigger: Box<dyn TileOperator>,
+    /// The induction store (a [`Tile::Store`] fan branch).
+    store_op: Box<dyn TileOperator>,
+    /// The accumulator key to project.
+    key: Value,
+    value_extent: Extent,
+}
+
+impl StoreDenseRead {
+    pub fn new(
+        trigger: Box<dyn TileOperator>,
+        store_op: Box<dyn TileOperator>,
+        key: Value,
+        value_extent: Extent,
+    ) -> Self {
+        let Tiling::SealedFunction { domain, .. } = trigger.tiling() else {
+            panic!(
+                "StoreDenseRead trigger must be a SealedFunction (the loop extent), got {}",
+                trigger.tiling()
+            );
+        };
+        debug_assert!(
+            matches!(store_op.tiling(), Tiling::Store { .. }),
+            "StoreDenseRead source must be a Store, got {}",
+            store_op.tiling()
+        );
+        let tiling = Tiling::SealedFunction {
+            domain: domain.clone(),
+            codomain: Box::new(Tiling::Scalar(value_extent.clone())),
+        };
+        Self {
+            tiling,
+            trigger,
+            store_op,
+            key,
+            value_extent,
+        }
+    }
+}
+
+impl TileOperator for StoreDenseRead {
+    fn tiling(&self) -> &Tiling {
+        &self.tiling
+    }
+    fn subscribe(
+        &mut self,
+        _intent_guard: TileGuard,
+        mut consumer: Box<dyn Consumer>,
+        scheduler: &mut Scheduler,
+    ) -> Box<dyn TileProducer> {
+        // Wake the consumer on store progress (a new decided position) and on
+        // trigger progress. Route both through a shared notifier, and kick once.
+        let consumer = Rc::new(RefCell::new(move || consumer.notify()));
+        consumer.borrow_mut().notify();
+        let trigger_producer = {
+            let g = self.trigger.tiling().universal_guard();
+            self.trigger
+                .subscribe(g, Box::new(consumer.clone()), scheduler)
+        };
+        let store_producer = {
+            let g = self.store_op.tiling().universal_guard();
+            self.store_op
+                .subscribe(g, Box::new(consumer.clone()), scheduler)
+        };
+        Box::new(StoreDenseReadProducer {
+            base: ProducerBase::new(StoreDenseReadProducer::alloc_id(), &self.tiling),
+            trigger_producer,
+            store_producer,
+            key: self.key.clone(),
+            value_extent: self.value_extent.clone(),
+        })
+    }
+}
+
+struct StoreDenseReadProducer {
+    base: ProducerBase,
+    trigger_producer: Box<dyn TileProducer>,
+    store_producer: Box<dyn TileProducer>,
+    key: Value,
+    value_extent: Extent,
+}
+
+impl TileProducer for StoreDenseReadProducer {
+    impl_producer_base!();
+
+    fn get_impl(&mut self, _projection_guard: TileGuard) -> Tile {
+        // The loop-extent positions (the output domain) — the same positions a
+        // co-iterated `iter` presents, so the two `fan_in` cleanly.
+        let trigger = self
+            .trigger_producer
+            .get(self.trigger_producer.tiling().universal_guard());
+        let Tile::SealedFunction {
+            domain: positions,
+            domain_predicate: trigger_pred,
+            ..
+        } = trigger
+        else {
+            return self.tiling().empty_tile();
+        };
+        // Sample the induction store once (consumer-driven; no producer-side
+        // drive-to-fixpoint), then fold `key` at each position. The induction writer
+        // drives its whole loop per pull (every arrived position steps the engine in
+        // one `get_impl`), so a batch source converges in this single sample; an
+        // async source's later arrivals re-pull us through the store's
+        // source-forwarding consumer. Iterations occupy ticks 1.. (tick 0 is the
+        // seeded init), so loop position `p` reads tick `p + 1` — the accumulator
+        // *after* iteration `p`. `store_value_at` scans changes ≤ that tick, so a
+        // carry position inherits the latest earlier write, and a leading carry folds
+        // to the tick-0 init — no external default needed, and never `None` (tick 0
+        // is seeded). The `store.is_terminal()` gate below keeps this read
+        // non-terminal until the store is fully decided, so the consumer re-pulls.
+        let sg = self.store_producer.tiling().universal_guard();
+        let store = self.store_producer.get(sg);
+        let mut values: Vec<Value> = Vec::with_capacity(positions.len());
+        for i in 0..positions.len() {
+            let Value::UInt(p) = positions.index_at(i) else {
+                unreachable!("induction loop-extent positions are UInt");
+            };
+            values.push(
+                store_value_at(&store, p + 1, &self.key)
+                    .expect("tick 0 seeds every accumulator, so the fold always resolves"),
+            );
+        }
+        // The dense read is decided over `D` once the store is terminal (every
+        // position folded to its final value); until then it tracks the trigger's
+        // own completion but stays non-terminal so the consumer re-pulls.
+        let domain_predicate = if store.is_terminal() {
+            trigger_pred
+        } else {
+            Predicate::False
+        };
+        Tile::SealedFunction {
+            domain: positions,
+            codomain: Box::new(Tile::Scalar(ColumnValue::from_values(
+                values,
+                &self.value_extent,
+            ))),
+            domain_predicate,
+            deleted: bit_set::BitSet::new(),
+        }
+    }
+
+    fn release_impl(&mut self, _obsolete_guard: TileGuard) {
+        // A finite induction accumulator read is retained whole for its
+        // co-iterating consumer; prefix GC is the long-lived-store follow-up.
     }
 }
 
@@ -1481,10 +1957,7 @@ impl TileProducer for AsOfProducer {
             } => domain_predicate.clone(),
             _ => Predicate::False,
         };
-        let store_terminal = matches!(
-            &source_tile,
-            Tile::Store { frontier, .. } if *frontier == Predicate::True
-        );
+        let store_terminal = source_tile.is_terminal();
         // Latch timing distinguishes a **live** trigger from a **batch** one — the
         // consumer-driven replacement for the retired in-`get` drive-to-fixpoint:
         //
@@ -2400,6 +2873,7 @@ impl TileProducer for TransactWriterProducer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::interpreter::tile_operators::{Constant, FanOut, IterateExtent};
     use crate::interpreter::validate_tile;
 
     fn int(n: i64) -> Value {
@@ -2413,6 +2887,354 @@ mod tests {
     /// Build a read/write set or initial state from `(account, balance)` pairs.
     fn balances(pairs: &[(&str, i64)]) -> HashMap<Value, Value> {
         pairs.iter().map(|(k, v)| (acct(k), int(*v))).collect()
+    }
+
+    /// Position-driven induction: `x := 0; for i in [1,2,3,4]: if i > 2: x += i`.
+    /// The guard (`i > 2`) fires at positions 2 and 3; positions 0 and 1 carry.
+    /// Modelled as sparse `step`s over the iteration extent — a change only where
+    /// the guard fires, a carry (`None`) elsewhere — the changelog stays sparse
+    /// while the frontier tracks the whole extent, and folded reads recover the
+    /// carry-forward accumulator `[0, 0, 3, 7]`.
+    #[test]
+    fn induction_conditional_write_folds_carry_forward() {
+        let acc = acct("acc");
+        let mut e = CommitEngine::for_induction();
+        // prev read defaults to init (0) below the earliest change; the write at a
+        // committing position is prev + item.
+        e.step(0, None); // i=1, guard false → carry (x_0 = 0)
+        e.step(1, None); // i=2, guard false → carry (x_1 = 0)
+        e.step(2, Some(balances(&[("acc", 3)]))); // i=3 → x_2 = 0 + 3
+        e.step(3, Some(balances(&[("acc", 7)]))); // i=4 → x_3 = 3 + 4
+
+        assert_eq!(
+            e.watermark(),
+            3,
+            "frontier reaches the last position, not the last write"
+        );
+        // Folded reads: carries inherit (None → the reader's init default), writes resolve.
+        assert_eq!(e.read_as_of(0, &acc), None); // carry → init 0
+        assert_eq!(e.read_as_of(1, &acc), None); // carry → init 0
+        assert_eq!(e.read_as_of(2, &acc), Some(int(3)));
+        assert_eq!(e.read_as_of(3, &acc), Some(int(7))); // final total
+
+        // The rendered store: a sparse changelog (2 change ticks) whose *length*
+        // is the decided frontier region (4 positions), not the change count.
+        let tile = e.render_full_store_tile();
+        assert!(validate_tile(&tile));
+        let Tile::Store {
+            changes, frontier, ..
+        } = &tile
+        else {
+            panic!("induction render is a Store");
+        };
+        assert_eq!(
+            changes.len(),
+            2,
+            "only the two committing positions are changes"
+        );
+        assert_eq!(*frontier, Predicate::LessThanEq(Value::UInt(3)));
+        assert_eq!(
+            tile.len(),
+            4,
+            "Store length is the decided region [0, 3], not changes.len()"
+        );
+    }
+
+    /// A test iteration source: one terminal `SealedFunction(pos → item)` tile
+    /// over a fixed item list (the loop extent), mirroring a lowered `cast(iter,
+    /// …)` loop source.
+    struct ItemSource {
+        tiling: Tiling,
+        tile: Tile,
+    }
+
+    impl ItemSource {
+        fn new(items: &[i64]) -> Self {
+            let tiling = Tiling::SealedFunction {
+                domain: Extent::Base(BaseType::UInt),
+                codomain: Box::new(Tiling::Scalar(value_extent())),
+            };
+            let tile = Tile::SealedFunction {
+                domain: ColumnValue::from_uints((0..items.len()).collect()),
+                codomain: Box::new(Tile::Scalar(ColumnValue::from_values(
+                    items.iter().map(|n| int(*n)).collect(),
+                    &value_extent(),
+                ))),
+                domain_predicate: Predicate::True,
+                deleted: bit_set::BitSet::new(),
+            };
+            Self { tiling, tile }
+        }
+    }
+
+    impl TileOperator for ItemSource {
+        fn tiling(&self) -> &Tiling {
+            &self.tiling
+        }
+        fn subscribe(
+            &mut self,
+            _intent_guard: TileGuard,
+            _consumer: Box<dyn Consumer>,
+            _scheduler: &mut Scheduler,
+        ) -> Box<dyn TileProducer> {
+            Box::new(ProposalSourceProducer {
+                base: ProducerBase::new(ProposalSourceProducer::alloc_id(), &self.tiling),
+                tile: self.tile.clone(),
+            })
+        }
+    }
+
+    /// A single-accumulator induction-write decision body: over its `(prev, item)`
+    /// input (a `BodyInputSource`), emits `{commit: guard(item), writes: {_0: prev
+    /// + item}}` per row. A `commit: false` row is a carry (the accumulator holds).
+    /// Models the recognized body of `for i in xs: if guard(i): acc += i`.
+    struct AddIfBody {
+        input: Box<dyn TileOperator>,
+        tiling: Tiling,
+        /// The guard threshold: `commit` iff `item > threshold` (`i64::MIN` ⇒ an
+        /// unconditional loop, `commit` everywhere).
+        threshold: i64,
+    }
+
+    impl AddIfBody {
+        fn new(input: Box<dyn TileOperator>, threshold: i64) -> Self {
+            let tiling = Tiling::SealedFunction {
+                domain: Extent::Base(BaseType::UInt),
+                codomain: Box::new(Tiling::Record(HashMap::from([
+                    (
+                        F_COMMIT.to_string(),
+                        Tiling::Scalar(Extent::Base(BaseType::Bool)),
+                    ),
+                    (
+                        F_WRITES.to_string(),
+                        Tiling::Record(HashMap::from([(
+                            tuple_field(0),
+                            Tiling::Scalar(value_extent()),
+                        )])),
+                    ),
+                ]))),
+            };
+            Self {
+                input,
+                tiling,
+                threshold,
+            }
+        }
+    }
+
+    impl TileOperator for AddIfBody {
+        fn tiling(&self) -> &Tiling {
+            &self.tiling
+        }
+        fn subscribe(
+            &mut self,
+            _intent_guard: TileGuard,
+            consumer: Box<dyn Consumer>,
+            scheduler: &mut Scheduler,
+        ) -> Box<dyn TileProducer> {
+            let input =
+                self.input
+                    .subscribe(self.input.tiling().universal_guard(), consumer, scheduler);
+            Box::new(AddIfBodyProducer {
+                base: ProducerBase::new(AddIfBodyProducer::alloc_id(), &self.tiling),
+                input,
+                threshold: self.threshold,
+            })
+        }
+    }
+
+    struct AddIfBodyProducer {
+        base: ProducerBase,
+        input: Box<dyn TileProducer>,
+        threshold: i64,
+    }
+
+    impl TileProducer for AddIfBodyProducer {
+        impl_producer_base!();
+        fn get_impl(&mut self, _projection_guard: TileGuard) -> Tile {
+            let in_tile = self.input.get(self.input.tiling().universal_guard());
+            let Tile::SealedFunction {
+                domain, codomain, ..
+            } = in_tile
+            else {
+                panic!("AddIfBody input is a SealedFunction");
+            };
+            let Tile::Record(fields) = *codomain else {
+                panic!("AddIfBody input codomain is a Record {{_0: prev, _1: item}}");
+            };
+            let prev = record_field(&fields, &tuple_field(0));
+            let item = record_field(&fields, &tuple_field(1));
+            let mut commits = Vec::with_capacity(domain.len());
+            let mut news = Vec::with_capacity(domain.len());
+            for j in 0..domain.len() {
+                let (Value::Int(p), Value::Int(i)) = (prev.index_at(j), item.index_at(j)) else {
+                    panic!("AddIfBody prev/item are Ints");
+                };
+                commits.push(Value::Bool(i > self.threshold));
+                news.push(int(p + i));
+            }
+            Tile::SealedFunction {
+                domain,
+                codomain: Box::new(Tile::Record(HashMap::from([
+                    (
+                        F_COMMIT.to_string(),
+                        Tile::Scalar(ColumnValue::from_values(
+                            commits,
+                            &Extent::Base(BaseType::Bool),
+                        )),
+                    ),
+                    (
+                        F_WRITES.to_string(),
+                        Tile::Record(HashMap::from([(
+                            tuple_field(0),
+                            Tile::Scalar(ColumnValue::from_values(news, &value_extent())),
+                        )])),
+                    ),
+                ]))),
+                domain_predicate: Predicate::False,
+                deleted: bit_set::BitSet::new(),
+            }
+        }
+        fn release_impl(&mut self, _obsolete_guard: TileGuard) {}
+    }
+
+    /// Drive an `InductionStore` for a single-accumulator loop end-to-end through
+    /// the tile protocol and return the converged store tile.
+    fn drive_induction(items: &[i64], threshold: i64, init: i64) -> Tile {
+        let buffer: BodyInputBuffer = Rc::new(RefCell::new(WriterBuffer::default()));
+        let body_input = BodyInputSource::new(buffer.clone(), vec![value_extent()], value_extent());
+        let body = AddIfBody::new(Box::new(body_input), threshold);
+        let source = ItemSource::new(items);
+        let acc = acct("acc");
+        let mut op = InductionStore::new(
+            vec![(
+                acc.clone(),
+                Box::new(Constant::new(int(init), value_extent())),
+            )],
+            Box::new(body),
+            Box::new(source),
+            buffer,
+            vec![acc.clone()],
+            vec![acc],
+            Vec::new(),
+            key_extent(),
+            value_extent(),
+        );
+        let guard = op.tiling().universal_guard();
+        let mut producer = op.subscribe(guard, Box::new(|| {}), &mut Scheduler::new());
+        producer.get(producer.tiling().universal_guard())
+    }
+
+    /// `acc := 0; for i in [1,2,3,4]: if i > 2: acc += i` driven through the whole
+    /// induction-store operator: the guard fires at positions 2,3 (items 3,4); the
+    /// changelog carries a sparse two-change history but the accumulator folds to
+    /// the carry-forward total `7`, and the frontier covers the full extent.
+    #[test]
+    fn induction_store_conditional_write_e2e() {
+        let tile = drive_induction(&[1, 2, 3, 4], 2, 0);
+        assert!(validate_tile(&tile));
+        assert!(
+            tile.is_terminal(),
+            "a complete batch source drives the store terminal"
+        );
+        let acc = acct("acc");
+        // Final accumulator value: 0 (carry) → 0 (carry) → 3 → 7.
+        assert_eq!(store_current(&tile, &acc).map(|(_, v)| v), Some(int(7)));
+        let Tile::Store { changes, .. } = &tile else {
+            panic!("induction store output is a Store");
+        };
+        assert_eq!(
+            changes.len(),
+            3,
+            "tick 0 (the init seed) plus the two firing positions (items 3, 4); the rest carry"
+        );
+    }
+
+    /// A plain (unconditional) `mut` loop is the degenerate `commit`-everywhere
+    /// case: `acc := 10; for i in [1,2,3]: acc += i` → 16, a dense changelog.
+    #[test]
+    fn induction_store_unconditional_write_e2e() {
+        let tile = drive_induction(&[1, 2, 3], i64::MIN, 10);
+        assert!(validate_tile(&tile));
+        assert!(tile.is_terminal());
+        assert_eq!(
+            store_current(&tile, &acct("acc")).map(|(_, v)| v),
+            Some(int(16))
+        );
+        let Tile::Store { changes, .. } = &tile else {
+            panic!("induction store output is a Store");
+        };
+        assert_eq!(
+            changes.len(),
+            4,
+            "tick 0 (the init seed) plus every committing position (a dense changelog)"
+        );
+    }
+
+    /// Build an `InductionStore` behind a fan and read `acc` densely over the loop
+    /// extent via `StoreDenseRead`; return the dense `Fun(D, V)` values in order.
+    fn dense_read(items: &[i64], threshold: i64, init: i64) -> Vec<i64> {
+        let buffer: BodyInputBuffer = Rc::new(RefCell::new(WriterBuffer::default()));
+        let body_input = BodyInputSource::new(buffer.clone(), vec![value_extent()], value_extent());
+        let body = AddIfBody::new(Box::new(body_input), threshold);
+        let source = ItemSource::new(items);
+        let acc = acct("acc");
+        let store = InductionStore::new(
+            vec![(
+                acc.clone(),
+                Box::new(Constant::new(int(init), value_extent())),
+            )],
+            Box::new(body),
+            Box::new(source),
+            buffer,
+            vec![acc.clone()],
+            vec![acc.clone()],
+            Vec::new(),
+            key_extent(),
+            value_extent(),
+        );
+        let fan = Rc::new(FanOut::new(Box::new(store)));
+        let trigger = IterateExtent::new(Extent::uint_range(items.len()));
+        let mut reader = StoreDenseRead::new(Box::new(trigger), fan.branch(), acc, value_extent());
+        let guard = reader.tiling().universal_guard();
+        let mut producer = reader.subscribe(guard, Box::new(|| {}), &mut Scheduler::new());
+        let tile = producer.get(producer.tiling().universal_guard());
+        assert!(validate_tile(&tile));
+        assert!(
+            tile.is_terminal(),
+            "a complete batch drives the dense read terminal"
+        );
+        let Tile::SealedFunction { codomain, .. } = tile else {
+            panic!("dense read is a SealedFunction");
+        };
+        let Tile::Scalar(col) = *codomain else {
+            panic!("dense read codomain is a scalar column");
+        };
+        (0..col.len())
+            .map(|i| match col.index_at(i) {
+                Value::Int(v) => v,
+                other => panic!("dense read value is an Int, got {other:?}"),
+            })
+            .collect()
+    }
+
+    /// The dense per-position read of a **conditional** accumulator: the guard
+    /// (`i > 2`) fires at positions 2, 3, so `acc` is `[0, 0, 3, 7]` — leading
+    /// carries fold to the `init` (0), then the running total. This is the shape a
+    /// co-iterated read (`zip(iter, acc)`) consumes, recovered from the sparse
+    /// two-change changelog by folding at every extent position.
+    #[test]
+    fn dense_read_conditional_accumulator_carries_forward() {
+        assert_eq!(dense_read(&[1, 2, 3, 4], 2, 0), vec![0, 0, 3, 7]);
+    }
+
+    /// The dense read of a plain (unconditional) accumulator: every position
+    /// writes, so `acc := 10; acc += i` over `[1,2,3]` reads `[11, 13, 16]` — a
+    /// dense function with no carries, exactly as the retired `.writes.(index)`
+    /// projection produced.
+    #[test]
+    fn dense_read_unconditional_accumulator() {
+        assert_eq!(dense_read(&[1, 2, 3], i64::MIN, 10), vec![11, 13, 16]);
     }
 
     /// Two writers touch the *same* key from the same snapshot: the first
@@ -2708,6 +3530,7 @@ mod tests {
             changes,
             deltas,
             frontier,
+            ..
         } = &tile
         else {
             panic!("expected Store");
@@ -2870,15 +3693,19 @@ mod tests {
         let tile = producer.get(producer.tiling().universal_guard());
         assert!(validate_tile(&tile));
         let Tile::Store {
-            changes, frontier, ..
+            changes,
+            frontier,
+            terminal,
+            ..
         } = &tile
         else {
             panic!("expected Store store tile");
         };
         // Tick 1 (A) committed; B's grant was stale → no tick consumed. The
-        // (materialized) writer is terminal, so the store is fully decided.
+        // (materialized) writer is terminal, so the store is closed at watermark 1.
         assert_eq!(changes, &ColumnValue::from_uints(vec![0, 1]));
-        assert_eq!(frontier, &Predicate::True);
+        assert_eq!(frontier, &Predicate::LessThanEq(Value::UInt(1)));
+        assert!(terminal);
         assert_eq!(store_at(&tile, &acct("pool")), Some((1, 30)));
     }
 
@@ -2893,14 +3720,20 @@ mod tests {
 
         let tile = producer.get(producer.tiling().universal_guard());
         let Tile::Store {
-            changes, frontier, ..
+            changes,
+            frontier,
+            terminal,
+            ..
         } = &tile
         else {
             panic!("expected Store store tile");
         };
         assert_eq!(changes, &ColumnValue::from_uints(vec![0, 1, 2]));
-        // Both proposals committed and the writer is terminal → store decided.
-        assert_eq!(frontier, &Predicate::True);
+        // Both proposals committed and the writer is terminal → store closed at
+        // watermark 2 (the frontier keeps its numeric watermark; terminality is
+        // the separate flag).
+        assert_eq!(frontier, &Predicate::LessThanEq(Value::UInt(2)));
+        assert!(terminal);
         assert_eq!(store_at(&tile, &acct("pool")), Some((2, 20)));
     }
 
@@ -2999,9 +3832,7 @@ mod tests {
     fn single_writer_cycle() {
         let commit = CommitOperator::new(balances(&[("n", 0)]), key_extent(), value_extent(), 1);
         let set_writer = commit.writer_input_setter(0);
-        let store_fan = Rc::new(crate::interpreter::tile_operators::FanOut::new_cyclic(
-            Box::new(commit),
-        ));
+        let store_fan = Rc::new(FanOut::new_cyclic(Box::new(commit)));
         // The body reads a branch of the store (the operator's own output).
         let body = CounterBody::new(store_fan.branch(), acct("n"), 3);
         set_writer(Box::new(body));
@@ -3163,9 +3994,7 @@ mod tests {
             CommitOperator::new(balances(&[("pool", 100)]), key_extent(), value_extent(), 2);
         let set_a = commit.writer_input_setter(0);
         let set_b = commit.writer_input_setter(1);
-        let store_fan = Rc::new(crate::interpreter::tile_operators::FanOut::new_cyclic(
-            Box::new(commit),
-        ));
+        let store_fan = Rc::new(FanOut::new_cyclic(Box::new(commit)));
         set_a(Box::new(TokenWriter::new(
             store_fan.branch(),
             acct("pool"),
@@ -3210,9 +4039,7 @@ mod tests {
             CommitOperator::new(balances(&[("pool", 100)]), key_extent(), value_extent(), 2);
         let set_a = commit.writer_input_setter(0);
         let set_b = commit.writer_input_setter(1);
-        let store_fan = Rc::new(crate::interpreter::tile_operators::FanOut::new_cyclic(
-            Box::new(commit),
-        ));
+        let store_fan = Rc::new(FanOut::new_cyclic(Box::new(commit)));
         set_a(Box::new(TokenWriter::new(
             store_fan.branch(),
             acct("pool"),
@@ -3335,9 +4162,7 @@ mod tests {
     fn read_as_of_resolves_at_watermark() {
         let commit = CommitOperator::new(balances(&[("n", 0)]), key_extent(), value_extent(), 1);
         let set_writer = commit.writer_input_setter(0);
-        let store_fan = Rc::new(crate::interpreter::tile_operators::FanOut::new_cyclic(
-            Box::new(commit),
-        ));
+        let store_fan = Rc::new(FanOut::new_cyclic(Box::new(commit)));
         set_writer(Box::new(CounterBody::new(store_fan.branch(), acct("n"), 3)));
 
         let mut reader = StoreReadAsOf::new(store_fan.branch(), acct("n"), 2);
@@ -3464,9 +4289,7 @@ mod tests {
         let commit = CommitOperator::new(init, key_extent(), value_extent(), 2);
         let set_a = commit.writer_input_setter(0);
         let set_b = commit.writer_input_setter(1);
-        let store_fan = Rc::new(crate::interpreter::tile_operators::FanOut::new_cyclic(
-            Box::new(commit),
-        ));
+        let store_fan = Rc::new(FanOut::new_cyclic(Box::new(commit)));
         set_a(Box::new(BankWriter::new(store_fan.branch(), a)));
         set_b(Box::new(BankWriter::new(store_fan.branch(), b)));
 
@@ -3604,8 +4427,8 @@ mod tests {
 
         // Once the store is terminal, so is the stream — and `ExtractLast` over
         // it gives the final value 60 (the latest committed entry).
-        if let Tile::Store { frontier, .. } = &mut store_tile {
-            *frontier = Predicate::True;
+        if let Tile::Store { terminal, .. } = &mut store_tile {
+            *terminal = true;
         }
         let stream = StoreValueStream::new(
             Box::new(FixedSource {
@@ -3631,9 +4454,10 @@ mod tests {
 
     // --- Engine render → step-function fold ---------------------------------
 
-    /// A rendered [`Tile::Store`] folds consistently whether live (the `frontier`
-    /// predicate carries the watermark `≤ w`) or terminal (the predicate flips to
-    /// `True` and the frontier is reconstructed from the last change tick).
+    /// A rendered [`Tile::Store`] folds consistently whether live or terminal.
+    /// Terminality is a *separate* flag from the watermark: the numeric `frontier`
+    /// predicate `≤ w` is kept in both states, and setting the `terminal` flag
+    /// only signals "no more writes" — it does not rewrite the frontier.
     #[test]
     fn render_folds_consistently_live_and_terminal() {
         let mut e = CommitEngine::new(balances(&[("alice", 100), ("bob", 50)]));
@@ -3662,11 +4486,11 @@ mod tests {
             balances(&[("alice", 70), ("bob", 20)])
         );
 
-        // Terminal: flipping `frontier` to `True` must reconstruct the frontier
-        // from the last change tick, identically.
+        // Terminal: setting the separate `terminal` flag (the numeric frontier
+        // `≤ 2` is kept, not rewritten) must fold identically.
         let mut terminal = live.clone();
-        if let Tile::Store { frontier, .. } = &mut terminal {
-            *frontier = Predicate::True;
+        if let Tile::Store { terminal, .. } = &mut terminal {
+            *terminal = true;
         }
         assert_eq!(store_frontier(&terminal), Some(2));
         assert_eq!(store_current(&terminal, &acct("alice")), Some((2, int(70))));
@@ -3685,6 +4509,7 @@ mod tests {
             changes: ColumnValue::from_uints(vec![]),
             deltas: ColumnValue::Variants(vec![]),
             frontier: Predicate::LessThanEq(Value::UInt(0)),
+            terminal: false,
         };
         assert_eq!(store_frontier(&undecided), None);
     }
@@ -3755,6 +4580,7 @@ mod tests {
             changes,
             deltas,
             frontier,
+            terminal: false,
         };
         assert!(validate_tile(&tile), "store_tile built an invalid tile");
         tile
@@ -3777,13 +4603,21 @@ mod tests {
     fn store_frontier_reads_watermark_and_terminal() {
         let live = skew_store(2);
         assert_eq!(store_frontier(&live), Some(2));
-        // A fully-committed store flips `frontier` to `True`; the frontier is
-        // then the last (largest) change tick.
+        // A terminal store keeps its `LessThanEq(w)` watermark (terminality is the
+        // separate flag), so `store_frontier` reads `w` directly — even when the
+        // watermark is *past the last change tick* (trailing carries). Here the
+        // last change is at tick 3 but the decided watermark is 5: the frontier is
+        // 5, not 3 (the former `True`-reconstruction undercounted to the last
+        // change).
         let done = store_tile(
             &[(0, &[("alice", 100)]), (3, &[("alice", 70)])],
-            Predicate::True,
+            Predicate::LessThanEq(Value::UInt(5)),
         );
-        assert_eq!(store_frontier(&done), Some(3));
+        assert_eq!(store_frontier(&done), Some(5));
+        // `Tile::len` counts decided *positions* (watermark + 1), spanning the
+        // trailing carries at ticks 4 and 5 — not the 2 change ticks, nor the last
+        // change tick + 1 (4) the former `True`-reconstruction would have given.
+        assert_eq!(done.len(), 6);
         // Empty changelog and non-store tiles have no frontier.
         assert_eq!(store_frontier(&store_tile(&[], Predicate::False)), None);
         assert_eq!(
@@ -3879,6 +4713,7 @@ mod tests {
             changes: ColumnValue::from_uints(vec![0, 1]),
             deltas: ColumnValue::Variants(vec![map_to_value(&balances(&[("a", 1)]))]),
             frontier: Predicate::False,
+            terminal: false,
         }));
         // Non-ascending change ticks.
         assert!(!validate_tile(&Tile::Store {
@@ -3888,6 +4723,7 @@ mod tests {
                 map_to_value(&balances(&[("a", 2)])),
             ]),
             frontier: Predicate::False,
+            terminal: false,
         }));
     }
 }

--- a/src/interpreter/design-operators.md
+++ b/src/interpreter/design-operators.md
@@ -176,6 +176,10 @@ during compilation; producers are created on demand at runtime.
 | `ExtractLast` | two inputs: `source` (`SealedFunction(D → Scalar(T))`) and `default` (`Scalar(T)`) | `Scalar(T)` | Extracts the last codomain value of `source` once it signals terminal.  When `source` is terminal but emits zero values (e.g. a mutation loop whose body ran zero times because its iteration source was empty), emits the `default` scalar's value instead — keeping post-loop accumulators total.  Returns an empty scalar before `source` is terminal.  On the first terminal pull it releases both `source` and `default` universally — a final-consumer signal that propagates back through `FanOut`/`Memo`/mutation-loop bodies to the underlying data source. |
 | `UnionOperator` | N inputs of `SealedFunction(dᵢ → Scalar(C))` tilings | `SealedFunction(Union(d₀,…,dₙ₋₁) → Scalar(C'))` | Merges N sealed-function operators into one by forming the discriminated union of their domains and deduplicating their codomains. The output domain is `Extent::Union` of all input domains; the codomain is shared when all inputs agree, or `Scalar(Union(…))` (deduplicated) otherwise. `UnionProducer::release_impl` splits an incoming `Predicate::Union` guard and forwards each per-variant predicate to the corresponding input, so release propagates correctly through the merge. |
 
+**Pointwise `FunctionDef`s** (applied element-wise via `MapResult(input, Constant(FunctionDef))`, not standalone operators): `BinOp(op)` over a `{_0, _1}` record column, `UnaryOp(op)` over one column, and `RecordField(f)` projecting a field.
+
+**Value-selecting `Case` in a writer decision body** (a conditional induction write `if 𝑝: acc += a else: acc += b`, or a `with begin():` per-key routing merge — a gate that varies with the element at a site with **no visible iteration source**). `lambda_elim` compiles it to the same **union of domain-restricts** as every other value-`Case`, over the *fed* element stream: `⧺ᵢ (filter_values(π̂ᵢ) ≫ eᵢ)`, first-match `π̂ᵢ`. `filter_values` (`Builtin::FilterValues` → the `Filter` tile operator, input stream + predicate) is a **value-preserving** filter — unlike `Restrict` (which returns the domain identity `{D|p}⇒{D|p}` for a source a map re-indexes), it keeps each surviving element's value `V`, so `eᵢ` maps the kept elements directly and a **partial op** (`//`) in `eᵢ` runs only where its guard holds — never eagerly at a rejected position (the retired `Select` computed both arms and faulted on the off-path one). The arms filter the *same* fed stream disjointly (first-match), so their union is a **flat merge** (`UnionOperator::new_flat`): it stays on one domain extent (not a tagged `Extent::Union`) and reassembles the full column sorted by position, co-iterating with the decision record's sibling `commit`/`writes` fields. A sourceless value-`Case` (a top-level ternary) still takes the `UIntRange(1)`-driver C-form + `final_or_default` (a tagged union dispatch); the writer-body case differs only in filtering the fed stream rather than a synthetic driver.
+
 TODOs for implementing hash joins:
 
 - Add support for MapResult to take a `CurriedFunction(A → UInt → B)` as the function argument, which will then convert `SealedFunction(C → A)` to `CurriedFunction(C → UInt → B)`
@@ -187,7 +191,7 @@ TODOs for implementing hash joins:
 The transaction engine that backs a `Type::Txn` [`Transact`](../ccl/design/ir.md#transact--the-domain-parameterized-recurrence-carrier) store: concurrent writers propose transactions against a shared multi-key register, and the operator serializes them onto one monotonic `CommitTs` clock with optimistic-concurrency validation (allocate-on-commit + backward validation + serialize-and-retry). Op-conversion's `build_commit_store` assembles it. The design splits into a **pure engine** and its **tile adapters**:
 
 - **`CommitEngine`** (tile-free, unit-tested) — the serialization logic. The store is `CommitTs ⇀ (Key ⇀ Value)`, held as per-tick write-set deltas with a per-key latest-write index. `attempt(proposal)` allocates the next tick and commits iff no read key was overwritten after the proposal's snapshot (else `Stale`, and the writer retries at the advanced watermark). `read_as_of(t, key)` folds the delta history; `gc_released_prefix(through)` reclaims released committed versions below the frontier, keeping each key's latest write.
-- **`CommitOperator` / `CommitProducer`** — the store tile adapter. Output tiling `Store(CommitTs → Scalar(Key ⇀ Value))` (`full_store_tiling`) — a [`Tile::Store`] *changelog*, not a `SealedFunction`: each change tick carries that tick's write-set delta, and a tick absent from the changelog is *decided-absent* (its value holds from the latest earlier change), so consumers must **fold** it (`store_current` / `store_value_at`), never index it. This is what makes `store_current` well-defined on a live, non-terminal store — the fix for the `ExtractLast`-over-a-live-store hang. The watermark rides the `frontier` predicate (`LessThanEq(w)` while committing, flips to `True` once every writer is terminal). Each writer input is wired *after* construction via `writer_input_setter(k)`, so the operator is built inside a cyclic `FanOut` and each writer reads the store back before proposing (the `Recurse` feedback idiom, generalized to N writers). On each `get`, the producer drains every writer's new proposals in writer-index order (the serialization order) and `release`s each committed step back to its writer (the commit-ack that advances it). A store release names a prefix of decided ticks a consumer no longer reads at; the load-bearing GC is the engine's `gc_released_prefix` (keep-latest), while the per-consumer `FanOut` view folds the changelog whole, so `Tile::Store`'s `remove_guarded` is a no-op (a released tick is not a deletable position).
+- **`CommitOperator` / `CommitProducer`** — the store tile adapter. Output tiling `Store(CommitTs → Scalar(Key ⇀ Value))` (`full_store_tiling`) — a [`Tile::Store`] *changelog*, not a `SealedFunction`: each change tick carries that tick's write-set delta, and a tick absent from the changelog is *decided-absent* (its value holds from the latest earlier change), so consumers must **fold** it (`store_current` / `store_value_at`), never index it. This is what makes `store_current` well-defined on a live, non-terminal store — the fix for the `ExtractLast`-over-a-live-store hang. The watermark rides the `frontier` predicate as `LessThanEq(w)` throughout; terminality (no more commits) is a separate `terminal` flag on the tile, flipped once every writer is terminal — the frontier keeps its numeric watermark either way, so a terminal store with trailing carries is not undercounted. Each writer input is wired *after* construction via `writer_input_setter(k)`, so the operator is built inside a cyclic `FanOut` and each writer reads the store back before proposing (the `Recurse` feedback idiom, generalized to N writers). On each `get`, the producer drains every writer's new proposals in writer-index order (the serialization order) and `release`s each committed step back to its writer (the commit-ack that advances it). A store release names a prefix of decided ticks a consumer no longer reads at; the load-bearing GC is the engine's `gc_released_prefix` (keep-latest), while the per-consumer `FanOut` view folds the changelog whole, so `Tile::Store`'s `remove_guarded` is a no-op (a released tick is not a deletable position).
 - **`TransactWriter` / `TransactWriterProducer`** — one *fused* writer per `with begin():` site (fused, not fanned: a stateful append-only proposal stream cannot be split across fanned branches without desyncing). Each pull reads the cyclic store, folds `(frontier, snapshot)` for its read keys, feeds `(snap…, item)` into its body via a `WriterBuffer`/`BodyInputSource`, and — per `(item, frontier)` (idempotent retry-suppression) — appends a `{snap, reads, writes}` proposal when the body grants (`commit: true`) or advances locally when it denies. Reply taps (`out << e` inside a block) ride the decision record as write-only keys committed atomically with the transaction. When a commit decision reads an induction accumulator *written by the same loop* at its request position (`store += cnt`), the accumulator is zipped into the writer *source* (`zip((reqs, __cnt.acc))`), so the `item` is a `(loop_item, acc(r))` `Record` the body destructures — `decode_source_items` decodes a `Record` codomain per position. When it reads an accumulator written by a *different, completed loop*, the decision instead broadcasts that loop's **final** value (a `Constant` via `MapResultToConst`); its `ExtractLast` is empty until the sibling loop's `Recurse` drains, so the decision body reads `None` until it converges. The writer **steps one source item per pull** and re-arms itself on the scheduler's deferred-wakeup queue (`WakeupQueue::request`) whenever an item remains to process (`current < n_items`), returning non-terminal — the same one-step-per-pull convergence idiom `Recurse` uses (#291). This single re-arm drives the cyclic store forward across pulls and covers every non-terminal continuation uniformly: a **commit** (`current` advances on the commit-ack `release`, so the next pull takes the next item), a **deny** (`current` advances here with no commit — invisible in the store frontier, so a frontier-growth signal alone would miss it), and a **not-ready** decision (`current` unadvanced, the pending body-input row reused so a re-push does not duplicate a buffer position against the body's `Memo`). It is the writer's re-arm — not any reader — that converges the store: the wakeup fans through the cyclic `FanOut` notify closure to every store branch, re-pulling the `AsOf` / `StoreValueStream` readers as commits land. A writer **drained but live** (`current >= n_items`, source not yet complete) does *not* re-arm, so an idle live server does not busy-poll — a future arrival wakes it through its source-forwarding consumer. This retires the readers' former producer-side drive-to-fixpoint (`drive_store_to_fixpoint`, deleted). Drain order rotates for fairness (round-robin `drain_start`) and retained state is bounded (superseded proposals dropped via `drop_superseded`). The proposal stream is an offset window: released (committed) prefixes are compacted away, keeping writer state bounded on a long-lived store.
 - **`BodyInputSource` / `BodyInputSourceProducer`** — serves the writer body its `(snapshot…, item)` input off the shared `WriterBuffer`. It is **release-aware**: the body op fans this source through `FanOut`/`Memo` (which pull it repeatedly per round), so it emits only positions past its released cursor — re-emitting a released position would make the `Memo`'s append-merge duplicate a domain position (an invalid tile). This makes it delta-producing, like the induction body's `fan_in` input.
 - **`StoreValueStream` / `StoreValueStreamProducer`** — folds the shared store's [`Tile::Store`] changelog to project one key's commit-value stream `CommitTs ⇀ V` (carrying values forward across ticks that wrote other keys — the step interpolation). Its own *output* is a `SealedFunction(CommitTs → Scalar(V))` — a genuine per-key value-over-time, each tick a decided value. It backs the **in-block reply tap** (`out << e` inside a block, a per-commit commit-tick-indexed event stream — `carry_forward: false`) and the read-your-writes register carry (`carry_forward: true`). A fed-out register read (`__reg.k` outside its block) does *not* reduce this via `ExtractLast` — that "terminal register value" path does not exist; every such read folds the store as-of via `AsOf` (below). `ExtractLast` reduces only genuinely-terminating histories (a post-loop induction accumulator, the broadcast source).
@@ -318,7 +322,7 @@ Three arms share an input across multiple downstream consumers:
   input-driven arms by domain position. This is the cross-domain co-iteration a
   commit writer's source uses — `zip((reqs, __cnt.acc))` pairs the request stream
   with a request-indexed induction accumulator read so a commit decision can read
-  the accumulator at its request position (`with begin(): store += cnt`).
+  the accumulator at its request position (`with begin(): balance += cnt`).
 
 - **`Let { bound_expr, body }`** fans the parent input into both the bound
   expression and the body (described above).
@@ -349,30 +353,96 @@ what to emit based only on its own AST shape and the input flowing in.
 
 ---
 
-## Designed, not yet implemented
+## Induction stores as a changelog: `InductionStore` and `StoreDenseRead`
 
-Operator work specified by the in-flight conditionals stack; listed here so the
-specs live next to their peers. Each graduates into the sections above when its PR
-lands.
+An induction store (a `mut`-loop accumulator, possibly with a conditional write) is the
+**degenerate no-conflict dual of the commit store**, and shares its machinery: it is a
+[`Tile::Store`] changelog driven by iteration *position* instead of by concurrent
+proposals. Op-conversion (`build_induction_store_single`) routes a **single-writer,
+tap-free** induction store over a **static** (finite, non-async) extent here; a **reply
+tap** (a feed riding the loop) or an **async data-source** extent falls back to a dense
+`Recurse` whose body stream is `D ⇀ {commit, writes}`, read by `.writes.(index)`.
+(Multi-writer is *not* a fallback case — recognition folds every conditional write to one
+writer, so `build_induction_store` rejects any writer count ≠ 1 outright rather than
+carrying a multi-leg branch.)
 
-### `DispatchRecurse` — multi-leg induction (conditional store writes)
+This finite/async split is an **incompleteness, not a semantic distinction** — and the only
+place in the substrate that makes it. Everywhere else the tiling protocol treats a finite
+source as a stream that happens to terminate: comprehensions, joins, aggregates, and the
+dense mutation loop all run over a literal list *and* a `DataSource` through one graph
+(monotonic tile growth + pull-until-the-frontier-stalls). The changelog drive should serve
+both too; that it does not yet is why the dense `Recurse` fallback still exists. See
+[*Planned: one changelog realization for every loop*](#planned-one-changelog-realization-for-every-loop)
+below for the mapped path to removing the fork.
 
-A conditional induction write compiles to one writer-site *leg per path* — each leg a
-decision body over a predicate-restricted slice of one shared base extent, including a
-carry-forward leg over the complement (see [mutability.md](../ccl/design/mutability.md), "Value-selecting `Case` and conditional induction writes (partially implemented)"). `build_induction_store` today hard-wires exactly one
-writer (`let [w] = writers`); `DispatchRecurse` extends `Recurse` to N legs:
+**`InductionStore` — the position-driven producer.** It owns a `CommitEngine` seeded at
+tick 0 with the accumulators' inits (so the changelog is self-describing — a read below
+the first *iteration* change folds to the seed), and drives the accumulator recurrence
+**sequentially inside the producer**: for each iteration position it folds the previous
+accumulator out of the engine, feeds the writer body `(prev…, item)` through a
+[`BodyInputSource`] buffer, reads the `{commit, writes}` decision, and `step`s the engine
+— a `commit: true` position appends a change (tick `pos + 1`), a `commit: false` (a failed
+guard) is a **carry** (no change; the value inherits). Because the accumulator lives in the
+engine, not on a cyclic tile, there is **no cyclic `FanOut`** — the previous value is always
+available before the body needs it. This dissolves the cyclic-convergence desync that a
+restricted-source multi-leg realization suffered: there is one writer over the *full*
+source, and a conditional write's carry positions simply produce no change rather than a
+synthesized same-value write on a complement leg.
 
-- One `IterateExtent(D)` over the shared base extent, in base order — the legs' ⧺-union
-  is realized by **ordered dispatch**, never by materializing a tagged union (which would
-  re-tag positions and desync the body-input buffers).
-- Per position: evaluate the leg predicates (disjoint and exhaustive by construction —
-  the phase synthesized first-match predicates plus the complement; a runtime
-  debug-assert checks exactly one matches) and feed the position to only the matching
-  leg's body buffer, `(snapshot…, item)` tuple convention unchanged.
-- The interleaved decision stream is the store's body stream; the recurrence cycle on
-  `.writes` and the release semantics are `Recurse`'s, per leg. Leg predicates compile
-  against the same body-input shape, so a guard reading the accumulator
-  (`if total < 10: total += x`) works.
+**`StoreDenseRead` — the dense changelog read.** A `__reg.k` read folds the changelog at
+*every* position of the loop extent → `Fun(D, V)`: an `IterateExtent(D)` trigger supplies
+the domain positions (so it aligns via `fan_in` with any co-iterated source over the same
+`D`), and each position `p` reads tick `p + 1` via `store_value_at` (which scans changes
+≤ that tick — **independent of the store frontier**, so a carry position inherits the
+latest earlier write and a leading carry folds to the tick-0 seed). One reader serves both
+shapes: a **scalar-final** read (`total` after the loop) is `ExtractLast` over this dense
+stream; a **co-iterated** read (an accumulator threaded into another store, e.g.
+`for r in …: cnt += 1; with begin(): balance := balance + cnt`) is the dense function itself.
+This replaces the dense `.writes.(index)` projection with a fold, unifying induction reads
+with commit-register reads.
+
+Folding by position keeps the read independent of the store's own length — the positions
+come from the trigger, the values from the fold. And the trailing-carry undercount that
+once lurked in `Tile::len`/`store_frontier` is now closed at the source: a `Tile::Store`
+carries terminality on a separate `terminal` flag and always keeps its numeric watermark as
+`frontier = LessThanEq(w)` (never a `True` that discards `w`), so `len`/`store_frontier`
+read `w` directly — spanning a trailing run of carries — instead of reconstructing it from
+the last *change* tick.
+
+### Planned: one changelog realization for every loop
+
+Removing the finite/async fork means teaching **both ends** of the changelog path — the
+drive and the dense read — to handle an async (incrementally-arriving, releasable) source;
+the finite case is then just the terminating instance, and the dense `Recurse` fallback
+retires. A probe that routed async loops through `build_induction_store_single` mapped the
+work into three pieces (and validated that the *value* comes out right — the store is a
+correct, terminal changelog — so this is realization plumbing, not a model gap):
+
+1. **Drive — position-aware + releasing.** Read the source by its *absolute domain
+   position*, not a 0-based codomain index: an async source's domain arrives **unordered**
+   (a probe saw `[1, 0]`) and **compacts** as its consumed prefix is released, so a 0-based
+   read misaligns. Sort the arrived `(pos, item)` pairs, drive positions `≥ processed`, and
+   release the consumed source (universally once terminal). With this the drive computes the
+   correct accumulator for a finite list, an async plain `mut` loop, and an async
+   conditional loop.
+
+2. **Read — fold the *live* trigger.** `StoreDenseRead`'s trigger is a **static**
+   `IterateExtent(D)`; over an async source it enumerates only the statically-known
+   positions and misses live arrivals (a probe read `30` where the correct — and correctly
+   rendered, terminal — accumulator was `60`). The dense read must fold the source's **live
+   trigger** (its actual arrival domain), exactly as the rest of the substrate iterates a
+   `DataSource`, so the fold spans every arrived position.
+
+3. **Memory bounding (the long-lived-store bound).** A never-terminating
+   stream must bound both the retained source and the changelog. Incremental (non-terminal)
+   prefix release and keep-latest changelog GC both interact with the drive's **own**
+   `read_as_of` carry — the drive reads the changelog it is writing — so a naive
+   reader-driven release drops commits the drive still needs (a probe produced `30`, then
+   `10`, as GC/release ate the recurrence's past). The GC must keep each key's latest write
+   and be gated by the drive's frontier, not merely a reader's released prefix.
+
+Until these land, the dense `Recurse` path remains for async/tap loops: it is correct, just
+a second realization of the same concept — the smell this section exists to retire.
 
 ## Open Challenges
 

--- a/src/interpreter/operator_conversion.rs
+++ b/src/interpreter/operator_conversion.rs
@@ -21,11 +21,11 @@ use crate::{
         // (aliased `CommitWriter` to avoid clashing with the CCL `TransactWriter`
         // node-field carrier imported from `ccl` above).
         commit_operator::{
-            AsOf, AsOfField, BodyInputBuffer, BodyInputSource, CommitOperator, StoreValueStream,
-            TransactWriter as CommitWriter, WriterBuffer,
+            AsOf, AsOfField, BodyInputBuffer, BodyInputSource, CommitOperator, InductionStore,
+            StoreDenseRead, StoreValueStream, TransactWriter as CommitWriter, WriterBuffer,
         },
         tile_operators::{
-            Aggregate, Constant, Converse, ExtractAggregate, ExtractLast, FanOut,
+            Aggregate, Constant, Converse, ExtractAggregate, ExtractLast, FanOut, Filter,
             FlattenTupleDomain, IterateExtent, MapAggregate, MapDomain, MapExtractAggregate,
             MapResult, MapResultToConst, MapResultToConstMode, MapResultWithSource, Memo,
             PermuteRecordDomain, Recurse, Restrict, TileOperator, Tiling, Uncurry, UnionOperator,
@@ -230,8 +230,15 @@ enum StoreReadKind {
     /// An induction-domain store (a `mut` loop): the fan wraps a [`Recurse`]
     /// whose body stream is `D ⇀ {commit, writes}`; a read projects
     /// `.writes.(index)` — the accumulator's history `D ⇀ V`, reduced to its
-    /// last value downstream.
+    /// last value downstream. The retired dense realization, kept for the
+    /// ≥2-writer conditional path until recognition emits a single writer.
     Induction,
+    /// An induction store backed by an [`InductionStore`] over a [`Tile::Store`]
+    /// changelog: a read is a [`StoreDenseRead`] folding the changelog at every
+    /// position of the loop extent (`StoreReadInfo::induction_extent`) into the
+    /// dense history `D ⇀ V` — the changelog counterpart of `Induction`'s
+    /// `.writes.(index)`, serving both scalar-final and co-iterated reads.
+    InductionChangelog,
 }
 
 /// How to read one key (variable) of a transactional store. The scalar-read
@@ -266,6 +273,10 @@ struct StoreReadInfo {
     keys: HashMap<String, KeyReadInfo>,
     /// Which engine backs the store (selects the read projection).
     kind: StoreReadKind,
+    /// The loop extent `D` an [`InductionChangelog`](StoreReadKind::InductionChangelog)
+    /// read enumerates (its [`StoreDenseRead`] trigger). `None` for a `Commit` or
+    /// dense `Induction` store.
+    induction_extent: Option<Extent>,
 }
 
 /// Compilation context for tile compilation.
@@ -685,18 +696,13 @@ fn convert_impl(
         // Compiles directly to a `UnionOperator` over the N operand
         // collections.
         TypedExprNode::CollectionUnion(operands) => {
-            expect_no_input(input, "collection_union")?;
             if operands.len() < 2 {
                 return Err(ConversionError::Unsupported(format!(
                     "collection_union expects at least 2 inputs, got {}",
                     operands.len()
                 )));
             }
-            let ops = operands
-                .iter()
-                .map(|e| convert_impl(e, None, ctx))
-                .collect::<Result<Vec<_>, _>>()?;
-            Ok(Box::new(UnionOperator::new(ops)))
+            union_operand_ops(operands, input, ctx)
         }
 
         // `Apply(Tuple(ops), Builtin::CollectionUnion)` — the point-free
@@ -707,7 +713,6 @@ fn convert_impl(
         TypedExprNode::Apply { argument, function }
             if as_builtin(function) == Some(Builtin::CollectionUnion) =>
         {
-            expect_no_input(input, "collection_union")?;
             let TypedExprNode::Tuple(elts) = &argument.node else {
                 return Err(ConversionError::Unsupported(format!(
                     "collection_union expects a Tuple argument, got {:?}",
@@ -720,11 +725,7 @@ fn convert_impl(
                     elts.len()
                 )));
             }
-            let ops = elts
-                .iter()
-                .map(|e| convert_impl(e, None, ctx))
-                .collect::<Result<Vec<_>, _>>()?;
-            Ok(Box::new(UnionOperator::new(ops)))
+            union_operand_ops(elts, input, ctx)
         }
 
         // `as_of((trigger, source))` — the live cross-endpoint read. For each
@@ -844,6 +845,27 @@ fn convert_impl(
             let upstream = expect_input(input, "restrict")?;
             let pred_op = convert_impl(argument, Some(upstream), ctx)?;
             Ok(Box::new(Restrict::new(pred_op)))
+        }
+
+        // filter_values(p): the **value-preserving** mid-chain filter (a writer
+        // decision body's value-`Case` fan-out arm). Requires `input=Some(_)` — the
+        // `D ⇒ V` element stream. Unlike `restrict` (which returns the domain
+        // identity for a source a map re-indexes), this keeps each surviving
+        // element's value `V`, so the arm's `≫ eᵢ` maps the elements directly. The
+        // fed input feeds both the `Filter` value stream and the predicate, so it is
+        // fanned to the two.
+        TypedExprNode::Apply { argument, function }
+            if as_builtin(function) == Some(Builtin::FilterValues) =>
+        {
+            let upstream = expect_input(input, "filter_values")?;
+            // `Memo` the shared upstream: `Filter` pulls it as both the value stream
+            // and (through the predicate) the boolean stream, and a re-entrant /
+            // per-proposal driver (the transaction writer) pulls the body repeatedly
+            // — without the memo the two fan branches desync (one sees a position
+            // the other has already consumed).
+            let fan = Rc::new(FanOut::new(Box::new(Memo::new(upstream))));
+            let pred_op = convert_impl(argument, Some(fan.branch()), ctx)?;
+            Ok(Box::new(Filter::new(fan.branch(), pred_op)))
         }
 
         // cast(value): pure type-level assertion — re-views `value` under
@@ -1392,6 +1414,7 @@ fn build_commit_store(
         fan: store_fan,
         keys: keys_map,
         kind: StoreReadKind::Commit,
+        induction_extent: None,
     })
 }
 
@@ -1407,19 +1430,27 @@ fn build_induction_store(
     writers: &[WriterSite],
     ctx: &mut OpConversionContext,
 ) -> Result<StoreReadInfo, ConversionError> {
-    // A `mut` loop is a single writer (its footprint is the loop's accumulators).
-    let [w] = writers else {
-        return Err(ConversionError::Unsupported(format!(
-            "an induction-domain store has exactly one writer (a `mut` loop), got {}",
+    // Recognition folds a conditional induction write (`if p: total += x`) to a
+    // single carry-complete, commit-gated writer over the full source — the
+    // multi-leg `DispatchRecurse` realization is never born. So an induction
+    // store always has exactly one writer; reject any other count loudly rather
+    // than let a downstream `.next()` on a would-be multi-op list silently drop
+    // the extra writers in release (the `debug_assert` alone is compiled out).
+    if writers.len() != 1 {
+        return Err(ConversionError::TypeError(format!(
+            "induction store expects exactly one writer (recognition folds a \
+             conditional write to one commit-gated writer), got {}",
             writers.len()
         )));
-    };
+    }
     let n_accs = keys.len();
-    debug_assert_eq!(
-        n_accs,
-        w.write_keys.len(),
-        "a mut loop writes every accumulator key"
-    );
+    for w in writers {
+        debug_assert_eq!(
+            n_accs,
+            w.write_keys.len(),
+            "every induction leg writes every accumulator key"
+        );
+    }
     // At least one accumulator: an accumulator-free loop routes through
     // `transform_feed_only_loop` in the phase and never reaches here. Make the
     // precondition explicit — the `n_accs > 1` branches below `fan_in` the
@@ -1428,6 +1459,27 @@ fn build_induction_store(
         n_accs >= 1,
         "an induction store has at least one accumulator"
     );
+
+    // The sole writer, with no reply taps, over a **static** (finite, non-async)
+    // extent — a plain `mut` loop, and (once recognition emits the `commit:
+    // guard` form) a conditional write — compiles to the position-driven
+    // `InductionStore` over the `Tile::Store` changelog, read densely via
+    // `StoreDenseRead`. Two cases stay on the dense `Recurse` path below: a
+    // reply tap (a feed riding the loop), and an **async data-source** extent
+    // (whose incremental sliding-window + source-release drive the `InductionStore`
+    // loop does not yet handle — a follow-up; the dense `Recurse` handles it).
+    if writers.len() == 1 && body_tap_fields(&writers[0].body.ty).is_empty() {
+        let raw_domain = writers[0].source.ty.domain().ok_or_else(|| {
+            ConversionError::TypeError(format!(
+                "induction-store writer source must have function type, got {}",
+                writers[0].source.ty
+            ))
+        })?;
+        let extent = ctx.extent_of(&crate::ccl::ccl_utils::strip_refinements(&raw_domain))?;
+        if extent_is_static(&extent) {
+            return build_induction_store_single(keys, &writers[0], ctx);
+        }
+    }
 
     // Position-0 seed: one accumulator → its init op; several → a packed
     // `_0.._{n-1}` record via `fan_in` (the `Recurse` codomain is one packed
@@ -1442,24 +1494,30 @@ fn build_induction_store(
         fan_in(arms)
     };
 
-    // Iteration domain from the writer source `Fun(D, item)`, iterated internally
-    // by `IterateExtent` (matching the retired `Loop` arm); the item stream rides
-    // the compiled `source`.
-    let domain_ty = w.source.ty.domain().ok_or_else(|| {
+    // The iteration extent. The sole writer's source is the full `Fun(D, item)`
+    // over the whole extent `D` (a conditional write carries its guard in the
+    // decision `commit`, not a restricted source), so the recurrence iterates
+    // `D` directly.
+    let base_domain = writers[0].source.ty.domain().ok_or_else(|| {
         ConversionError::TypeError(format!(
             "induction-store writer source must have function type, got {}",
-            w.source.ty
+            writers[0].source.ty
         ))
     })?;
-    let domain_op: Box<dyn TileOperator> = Box::new(IterateExtent::new(ctx.extent_of(&domain_ty)?));
+    let base_extent = ctx.extent_of(&base_domain)?;
+    let domain_op: Box<dyn TileOperator> = Box::new(IterateExtent::new(base_extent.clone()));
     let recurse = Recurse::new(init_op, domain_op);
     let set_recursive_input = recurse.recursive_input_setter();
     let prev_acc_fan = Rc::new(FanOut::new_cyclic(Box::new(recurse)));
-    let source_op = convert_impl(&w.source, None, ctx)?;
-    // Body input `(acc₀, …, acc_{n-1}, item)`: the previous accumulator snapshot
-    // then the item — the shape the writer body's `let acc_i = p.i … let item =
-    // p.n` destructuring expects. Single accumulator → prev is the scalar;
-    // several → unpack the packed prev-acc record into its `_0.._{n-1}` fields.
+
+    // The single decision body reads the shared prev-accumulator cycle (a fresh
+    // fan branch) and its own source. Body input `(acc₀, …, acc_{n-1}, item)`:
+    // the previous accumulator snapshot then the item — the shape the writer
+    // body's `let acc_i = p.i … let item = p.n` destructuring expects. Single
+    // accumulator → prev is the scalar; several → unpack the packed prev-acc
+    // record into its `_0.._{n-1}` fields.
+    let writer = &writers[0];
+    let source_op = convert_impl(&writer.source, None, ctx)?;
     let body_input = if n_accs == 1 {
         fan_in(vec![prev_acc_fan.branch(), source_op])
     } else {
@@ -1470,8 +1528,8 @@ fn build_induction_store(
         arms.push(source_op);
         fan_in(arms)
     };
-    let body_op = convert_impl(&w.body, Some(body_input), ctx)?;
-    let body_fan = Rc::new(FanOut::new_cyclic(Box::new(Memo::new(body_op))));
+    let merged = convert_impl(&writer.body, Some(body_input), ctx)?;
+    let body_fan = Rc::new(FanOut::new_cyclic(Box::new(Memo::new(merged))));
     // Cycle on `.writes` — the proposed new accumulator(s). Single accumulator →
     // unwrap the 1-tuple; several → the packed tuple itself (its `_0.._{n-1}`
     // fields feed the body input).
@@ -1500,6 +1558,137 @@ fn build_induction_store(
         fan: body_fan,
         keys: keys_map,
         kind: StoreReadKind::Induction,
+        induction_extent: None,
+    })
+}
+
+/// Whether an extent is *static* — a finite, non-async iteration domain that the
+/// [`InductionStore`] drive loop can sweep in one pass. False if a
+/// [`Extent::DataSourceDomain`] appears anywhere (an async source arrives over
+/// scheduler notifications as a sliding window, which the changelog drive loop
+/// does not yet handle — such loops stay on the dense `Recurse` path).
+fn extent_is_static(extent: &Extent) -> bool {
+    match extent {
+        Extent::DataSourceDomain(_) => false,
+        Extent::Base(_) | Extent::UIntRange(_) => true,
+        Extent::Function { domain, codomain } => {
+            extent_is_static(domain) && extent_is_static(codomain)
+        }
+        Extent::Record(fields) => fields.values().all(extent_is_static),
+        Extent::Union(variants) => variants.iter().all(extent_is_static),
+        Extent::Restricted { base, .. } => extent_is_static(base),
+    }
+}
+
+/// Build a single-writer induction store as a position-driven [`InductionStore`]
+/// over a [`Tile::Store`] changelog. Mirrors [`build_commit_store`]'s writer
+/// setup — the body reads `(prev…, item)` through a [`BodyInputSource`] the store
+/// feeds — but the store is driven by iteration position (no cyclic `Recurse`,
+/// no conflict/retry). Reads register as [`StoreReadKind::InductionChangelog`]:
+/// each `__reg.k` folds the changelog densely over the loop extent via
+/// [`StoreDenseRead`], serving both a scalar-final read (`ExtractLast` over it)
+/// and a co-iterated read (the dense `Fun(D, V)` itself).
+fn build_induction_store_single(
+    keys: &[TransactKey],
+    w: &WriterSite,
+    ctx: &mut OpConversionContext,
+) -> Result<StoreReadInfo, ConversionError> {
+    let key_extent = Extent::Base(BaseType::String);
+    let runtime_key = |n: &Name| Value::String(n.field_key().into());
+
+    // Each accumulator becomes a register key: its init op (the fold default, read
+    // once at subscribe) plus a dense-read entry carrying the init as the
+    // leading-carry fold default.
+    let mut keys_map: HashMap<String, KeyReadInfo> = HashMap::with_capacity(keys.len());
+    let mut init_ops: Vec<(Value, Box<dyn TileOperator>)> = Vec::new();
+    let mut value_extents: Vec<Extent> = Vec::new();
+    for k in keys {
+        let field = k.name.field_key();
+        let rk = Value::String(field.clone().into());
+        let value_extent = ctx.extent_of(&k.init.ty)?;
+        if !value_extents.contains(&value_extent) {
+            value_extents.push(value_extent.clone());
+        }
+        init_ops.push((rk.clone(), convert_impl(&k.init, None, ctx)?));
+        keys_map.insert(
+            field,
+            KeyReadInfo {
+                runtime_key: rk,
+                value_extent,
+                index: 0, // unused: dense reads fold by runtime_key
+                carry_forward: true, // an accumulator persists across positions
+                          // A literal init is the leading-carry fold default. A
+                          // *conditional* single-writer loop does have leading carries
+                          // (positions before the first committing write); those read the
+                          // accumulator's seed, supplied by the tick-0 init in
+                          // `CommitEngine::new(inits)` — not this default, which anchors a
+                          // computed-init empty fold.
+            },
+        );
+    }
+
+    // The body reads each accumulator's snapshot then the loop item, fed through a
+    // buffer the store owns (`BodyInputSource`) — the same body shape a commit
+    // writer expects (`let accᵢ = p.i … let item = p.r`).
+    let item_ty = w.source.ty.codomain().ok_or_else(|| {
+        ConversionError::TypeError(format!(
+            "induction-store writer source must have function type, got {}",
+            w.source.ty
+        ))
+    })?;
+    let item_extent = ctx.extent_of(&item_ty)?;
+    let raw_domain = w.source.ty.domain().ok_or_else(|| {
+        ConversionError::TypeError(format!(
+            "induction-store writer source must have function type, got {}",
+            w.source.ty
+        ))
+    })?;
+    let induction_extent = ctx.extent_of(&crate::ccl::ccl_utils::strip_refinements(&raw_domain))?;
+    let source_op = convert_impl(&w.source, None, ctx)?;
+    let read_extents: Vec<Extent> = w
+        .read_keys
+        .iter()
+        .map(|rk| {
+            keys_map
+                .get(&rk.field_key())
+                .map(|info| info.value_extent.clone())
+                .ok_or_else(|| {
+                    ConversionError::Unsupported(format!(
+                        "induction read key {rk} is not a store key"
+                    ))
+                })
+        })
+        .collect::<Result<_, _>>()?;
+    let buffer: BodyInputBuffer = Rc::new(RefCell::new(WriterBuffer::default()));
+    let body_input = BodyInputSource::new(buffer.clone(), read_extents, item_extent);
+    let body_op = convert_impl(&w.body, Some(Box::new(body_input)), ctx)?;
+
+    let value_extent = match value_extents.len() {
+        0 => Extent::Base(BaseType::Unit),
+        1 => value_extents.pop().expect("len == 1"),
+        _ => Extent::Union(value_extents),
+    };
+
+    let store = InductionStore::new(
+        init_ops,
+        body_op,
+        source_op,
+        buffer,
+        w.read_keys.iter().map(runtime_key).collect(),
+        w.write_keys.iter().map(runtime_key).collect(),
+        Vec::new(), // no reply taps on this path (checked by the caller's dispatch)
+        key_extent,
+        value_extent,
+    );
+    // A non-cyclic fan: unlike a commit store, no writer reads this store back
+    // (the driver folds the accumulator out of its own engine), so the only
+    // consumers are the downstream `__reg.k` dense reads.
+    let fan = Rc::new(FanOut::new(Box::new(store)));
+    Ok(StoreReadInfo {
+        fan,
+        keys: keys_map,
+        kind: StoreReadKind::InductionChangelog,
+        induction_extent: Some(induction_extent),
     })
 }
 
@@ -1588,7 +1777,7 @@ fn convert_store_read(
     field: &str,
     ctx: &mut OpConversionContext,
 ) -> Result<Box<dyn TileOperator>, ConversionError> {
-    let (fan, kind, key) = {
+    let (fan, kind, induction_extent, key) = {
         let info = ctx.lookup_store(store_name).ok_or_else(|| {
             ConversionError::Unsupported(format!("unknown transactional store {store_name}"))
         })?;
@@ -1600,7 +1789,12 @@ fn convert_store_read(
                 k.carry_forward,
             )
         });
-        (info.fan.clone(), info.kind, key)
+        (
+            info.fan.clone(),
+            info.kind,
+            info.induction_extent.clone(),
+            key,
+        )
     };
     match (kind, key) {
         // A `Txn` store key: the raw commit history `Fun(Txn, V)` as a
@@ -1616,6 +1810,26 @@ fn convert_store_read(
                 carry_forward,
             )))
         }
+        // An `InductionChangelog` accumulator: its dense history `D ⇀ V` is the
+        // changelog folded at every position of the loop extent via
+        // [`StoreDenseRead`] (an `IterateExtent(D)` trigger + the store branch).
+        // `recognize` wraps a scalar read in `final_or_default`, reduced to the
+        // final value via `ExtractLast`; a co-iterated read consumes the dense
+        // function directly. Leading carries fold to the tick-0 seed, so the reader
+        // needs no external default.
+        (StoreReadKind::InductionChangelog, Some((runtime_key, value_extent, _, _))) => {
+            let extent = induction_extent.ok_or_else(|| {
+                ConversionError::Unsupported(format!(
+                    "induction-changelog store {store_name} has no loop extent"
+                ))
+            })?;
+            Ok(Box::new(StoreDenseRead::new(
+                Box::new(IterateExtent::new(extent)),
+                fan.branch(),
+                runtime_key,
+                value_extent,
+            )))
+        }
         // An induction store key (a `mut` loop accumulator): its history `D ⇀ V`
         // is `.writes.(index)` off the `Recurse` body stream `D ⇀ {commit,
         // writes, …}`. `plan_loops` wraps the read in `final_or_default`, reduced
@@ -1629,6 +1843,12 @@ fn convert_store_read(
         // directly off the writer body fan (a sibling of `.writes`), yielding the
         // per-position stream `Fun(domain, V)` the consumer/sink reads.
         (StoreReadKind::Induction, None) => proj_named_field(fan.branch(), field),
+        // An `InductionChangelog` store exposes only its accumulator keys as dense
+        // reads; it carries no reply taps (the caller's dispatch routes tap-bearing
+        // loops to the dense `Induction` path), so an absent key is a bug.
+        (StoreReadKind::InductionChangelog, None) => Err(ConversionError::Unsupported(format!(
+            "induction-changelog store {store_name} has no key {field}"
+        ))),
         (StoreReadKind::Commit, None) => Err(ConversionError::Unsupported(format!(
             "store {store_name} has no key {field}"
         ))),
@@ -1696,6 +1916,42 @@ fn apply_binop(
         input,
         Box::new(Constant::new(fn_value, fn_extent)),
     )))
+}
+
+/// Build the `UnionOperator` for a `CollectionUnion`. With no input (the top-level
+/// / comprehension union, or a Σ / C-form dispatch), each operand is a
+/// self-contained collection and the union is **tagged** (`UnionOperator::new`) —
+/// distinct-extent arms keep their `Extent::Union` domain, which `final_or_default`
+/// dispatches over. With a **fed input** — a value-`Case` fan-out inside a writer
+/// body (`⧺ᵢ (filter_values(π̂ᵢ) ≫ eᵢ)`) — fan the input to every operand (each
+/// filters its own branch of the same element stream) and **flat-merge**
+/// (`UnionOperator::new_flat`): the arms share one domain extent and disjoint
+/// positions, so the union stays on that extent and co-iterates with the sibling
+/// `commit` field of the decision record.
+fn union_operand_ops(
+    operands: &[Expr],
+    input: Option<Box<dyn TileOperator>>,
+    ctx: &mut OpConversionContext,
+) -> Result<Box<dyn TileOperator>, ConversionError> {
+    match input {
+        None => {
+            let ops = operands
+                .iter()
+                .map(|e| convert_impl(e, None, ctx))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(Box::new(UnionOperator::new(ops)))
+        }
+        Some(inp) => {
+            // `Memo` the shared fed input so the fan's branches (one per arm) stay
+            // consistent under a re-entrant / per-proposal driver.
+            let fan = Rc::new(FanOut::new(Box::new(Memo::new(inp))));
+            let ops = operands
+                .iter()
+                .map(|e| convert_impl(e, Some(fan.branch()), ctx))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(Box::new(UnionOperator::new_flat(ops)))
+        }
+    }
 }
 
 /// Apply a built-in unary operation to the input stream.

--- a/src/interpreter/tile_operators/union.rs
+++ b/src/interpreter/tile_operators/union.rs
@@ -22,6 +22,10 @@ pub struct UnionOperator {
     tiling: Tiling,
     /// Input operators; each must have a `SealedFunction` tiling.
     inputs: Vec<Box<dyn TileOperator>>,
+    /// Flat-merge mode (see [`new_flat`](Self::new_flat)): arms share one domain
+    /// extent with disjoint positions, merged into a single flat `SealedFunction`
+    /// (sorted by domain key) rather than a tagged `ColumnValue::Union`.
+    flat: bool,
 }
 
 impl UnionOperator {
@@ -67,7 +71,88 @@ impl UnionOperator {
             domain: Extent::Union(domains),
             codomain: Box::new(codomain),
         };
-        Self { tiling, inputs }
+        Self {
+            tiling,
+            inputs,
+            flat: false,
+        }
+    }
+
+    /// A **flat-merge** union: arms over the *same* base extent (disjoint runtime
+    /// subsets of one domain) merge back to that base rather than a tagged
+    /// `Extent::Union`, so the result co-iterates with a sibling field. This is the
+    /// writer-body value-`Case` fan-out `⧺ᵢ filter_values(π̂ᵢ) ≫ eᵢ`: every arm
+    /// filters the *same* fed element stream, so their domains share one extent and
+    /// their positions are disjoint by first-match. (The tagged [`new`](Self::new)
+    /// is for a sourceless union whose arms have genuinely distinct extents — a Σ /
+    /// C-form dispatch read by `final_or_default`.)
+    pub fn new_flat(inputs: Vec<Box<dyn TileOperator>>) -> Self {
+        let mut op = Self::new(inputs);
+        op.flat = true;
+        if let Tiling::SealedFunction { domain, codomain } = op.tiling {
+            let deduped = dedup_extents(match domain {
+                Extent::Union(ds) => ds,
+                other => vec![other],
+            });
+            let domain = if deduped.len() == 1 {
+                deduped.into_iter().next().unwrap()
+            } else {
+                Extent::Union(deduped)
+            };
+            op.tiling = Tiling::SealedFunction { domain, codomain };
+        }
+        op
+    }
+}
+
+/// Flat-merge disjoint `SealedFunction` arms into one flat tile, sorted by domain
+/// key. Each arm is a filtered slice of the *same* fed element stream (a
+/// writer-body value-`Case` fan-out `⧺ᵢ filter_values(π̂ᵢ) ≫ eᵢ`), so the arms'
+/// (`UInt`) positions are disjoint and reassemble the full column — which then
+/// co-iterates with the decision record's sibling `commit` field. Scalar codomain
+/// only (the value a decision field produces); the shared fed predicate is taken
+/// from the first arm (all arms carry it).
+fn flat_merge(tiles: Vec<Tile>, value_extent: &Extent) -> Tile {
+    let mut pairs: Vec<(usize, Value)> = Vec::new();
+    let mut domain_predicate = Predicate::False;
+    for (i, tile) in tiles.into_iter().enumerate() {
+        let Tile::SealedFunction {
+            domain,
+            codomain,
+            domain_predicate: dp,
+            deleted,
+        } = tile
+        else {
+            panic!("flat_merge: expected SealedFunction arm, got {tile:?}");
+        };
+        if i == 0 {
+            domain_predicate = dp;
+        }
+        let Tile::Scalar(values) = *codomain else {
+            panic!(
+                "flat_merge: writer-body value-Case arm has a Scalar codomain, got {codomain:?}"
+            );
+        };
+        for row in 0..domain.len() {
+            if deleted.contains(row) {
+                continue;
+            }
+            let Value::UInt(pos) = domain.index_at(row) else {
+                panic!("flat_merge: writer-body fan-out arms have UInt (position) domains");
+            };
+            pairs.push((pos, values.index_at(row)));
+        }
+    }
+    // Disjoint by first-match, so a stable sort by position reassembles the full
+    // column in the fed order — matching the sibling `commit` field's domain.
+    pairs.sort_by_key(|(pos, _)| *pos);
+    let positions: Vec<usize> = pairs.iter().map(|(pos, _)| *pos).collect();
+    let values: Vec<Value> = pairs.into_iter().map(|(_, v)| v).collect();
+    Tile::SealedFunction {
+        domain: ColumnValue::from_uints(positions),
+        codomain: Box::new(Tile::Scalar(ColumnValue::from_values(values, value_extent))),
+        domain_predicate,
+        deleted: BitSet::new(),
     }
 }
 
@@ -117,6 +202,7 @@ impl TileOperator for UnionOperator {
         Box::new(UnionProducer {
             base: ProducerBase::new(UnionProducer::alloc_id(), &self.tiling),
             inputs: input_producers,
+            flat: self.flat,
         })
     }
 }
@@ -126,6 +212,8 @@ impl TileOperator for UnionOperator {
 struct UnionProducer {
     base: ProducerBase,
     inputs: Vec<Box<dyn TileProducer>>,
+    /// Flat-merge mode (see [`UnionOperator::new_flat`]).
+    flat: bool,
 }
 
 impl TileProducer for UnionProducer {
@@ -144,6 +232,14 @@ impl TileProducer for UnionProducer {
             .iter_mut()
             .map(|p| p.get(p.tiling().universal_guard()))
             .collect();
+
+        if self.flat {
+            let value_extent = match self.tiling() {
+                Tiling::SealedFunction { codomain, .. } => codomain.extent(),
+                other => panic!("flat union tiling is a SealedFunction, got {other}"),
+            };
+            return flat_merge(tiles, &value_extent);
+        }
 
         let mut domains: Vec<ColumnValue> = Vec::new();
         let mut codomains: Vec<Tile> = Vec::new();
@@ -264,6 +360,14 @@ impl TileProducer for UnionProducer {
                     input.release(TileGuard::Function(FunctionGuard::Domain(pred)));
                 }
             }
+            // A **flat** union has one flat domain (not per-variant tags), so a
+            // released prefix over it forwards to every arm — each arm holds a
+            // disjoint subset of those positions and ignores the rest.
+            TileGuard::Function(FunctionGuard::Domain(pred)) if self.flat => {
+                for input in &mut self.inputs {
+                    input.release(TileGuard::Function(FunctionGuard::Domain(pred.clone())));
+                }
+            }
             other => panic!("UnionProducer::release_impl: unexpected guard {other:?}"),
         }
     }
@@ -274,7 +378,6 @@ mod tests {
     use super::*;
     use crate::interpreter::{BaseType, ColumnValue, Extent};
     use std::cell::RefCell;
-    use std::rc::Rc;
 
     // ── UnionProducer::release_impl ───────────────────────────────────────────
 
@@ -347,6 +450,7 @@ mod tests {
                     log: log1.clone(),
                 }),
             ],
+            flat: false,
         };
 
         (producer, log0, log1)

--- a/src/interpreter/tiling/tile.rs
+++ b/src/interpreter/tiling/tile.rs
@@ -102,10 +102,22 @@ pub enum Tile {
         /// [`crate::interpreter::commit_operator::map_to_value`]). A key absent
         /// from a tick's delta was not written at that tick (its value holds).
         deltas: ColumnValue,
-        /// The decided frontier: every tick at or below its bound is decided.
-        /// `Predicate::True` once the store is fully committed (no more writes),
-        /// which is the only condition under which a *terminal* read resolves.
+        /// The decided frontier: `LessThanEq(w)` means every tick `≤ w` is decided
+        /// — the watermark `w` counts trailing carries (positions past the last
+        /// *change*), because a store is a right-continuous step function over its
+        /// whole decided prefix, not a list of change events. `False` while
+        /// undecided (never stepped). **Not** `True`: terminality is the separate
+        /// `terminal` axis so the numeric watermark is never discarded (a terminal
+        /// store with trailing carries keeps `LessThanEq(w)`, so `len` and
+        /// `store_frontier` read `w` directly instead of undercounting to the last
+        /// change tick).
         frontier: Predicate,
+        /// Whether the frontier is *closed* — no further commits will ever land, so
+        /// a *terminal* read (`ExtractLast` / `final_or_default`) resolves. Distinct
+        /// from the decided *extent* (`frontier`): a live store decided up to `w`
+        /// has `terminal == false`; the same store, once its writers finish, flips
+        /// `terminal` to `true` while keeping `frontier = LessThanEq(w)`.
+        terminal: bool,
     },
 }
 
@@ -132,8 +144,21 @@ impl Tile {
                 domain2, deleted, ..
             } => domain2.len() - deleted.len(),
             Tile::Aggregation { accumulator, .. } => accumulator.len(),
-            // The number of change events in the changelog.
-            Tile::Store { changes, .. } => changes.len(),
+            // A `Store` is a right-continuous *step function* over its decided
+            // prefix, not a list of change events: a tick absent from `changes`
+            // but at or below the frontier is *decided* (its value inherits from
+            // the latest earlier change). So the length is the number of
+            // **decided domain positions** — the frontier watermark `+ 1` — not
+            // `changes.len()` (which counts only the ticks that carried a write).
+            //
+            // The watermark reads straight off `LessThanEq(w)`, which counts
+            // trailing carries (positions past the last change) because terminality
+            // rides the separate `terminal` flag, not a `True` frontier that would
+            // discard `w`. An undecided (`False`) frontier has no decided positions.
+            Tile::Store { frontier, .. } => match frontier {
+                Predicate::LessThanEq(Value::UInt(w)) => w + 1,
+                _ => 0,
+            },
         }
     }
 
@@ -189,10 +214,11 @@ impl Tile {
             Tile::Aggregation { terminal, .. } => {
                 terminal.as_single().map(|t| t.as_bool()).unwrap_or(false)
             }
-            // A store is terminal once its commit frontier is decided-forever
-            // (no more writes will commit) — the only state in which a *terminal*
-            // read of it resolves.
-            Tile::Store { frontier, .. } => frontier.as_bool().unwrap_or(false),
+            // A store is terminal once its commit frontier is closed (no more
+            // writes will commit) — the only state in which a *terminal* read of
+            // it resolves. Terminality is its own flag; the `frontier` predicate
+            // keeps the numeric watermark either way.
+            Tile::Store { terminal, .. } => *terminal,
         }
     }
 
@@ -290,25 +316,29 @@ impl Tile {
             // any already present (the changelog only grows forward in commit
             // time), so appending preserves the ascending order the fold relies
             // on. The frontier advances to the union — for the watermark
-            // `LessThanEq(w)` this is `LessThanEq(max(w_self, w_other))`, and
-            // `True` (fully committed) absorbs. Mirrors the `SealedFunction` arm
-            // sans `deleted`: a store releases by physically dropping a decided
-            // prefix (see `remove_guarded`), never by logical tombstoning.
+            // `LessThanEq(w)` this is `LessThanEq(max(w_self, w_other))`; the
+            // `terminal` flag ORs (either side declaring the frontier closed closes
+            // it). Mirrors the `SealedFunction` arm sans `deleted`: a store releases
+            // by physically dropping a decided prefix (see `remove_guarded`), never
+            // by logical tombstoning.
             (
                 Tile::Store {
                     changes: s_changes,
                     deltas: s_deltas,
                     frontier: s_frontier,
+                    terminal: s_terminal,
                 },
                 Tile::Store {
                     changes: o_changes,
                     deltas: o_deltas,
                     frontier: o_frontier,
+                    terminal: o_terminal,
                 },
             ) => {
                 s_changes.append(o_changes);
                 s_deltas.append(o_deltas);
                 *s_frontier = s_frontier.union(&o_frontier);
+                *s_terminal = *s_terminal || o_terminal;
             }
             (s, o) => panic!("Incompatible tiles {s:?} and {o:?}"),
         };
@@ -616,9 +646,12 @@ impl Tile {
             // The store's guard is over its commit-time domain (the change
             // ticks), like a `SealedFunction` — consumers release a prefix of it.
             Tile::Store {
-                changes, frontier, ..
+                changes,
+                frontier,
+                terminal,
+                ..
             } => {
-                if frontier.is_true() {
+                if *terminal {
                     TileGuard::Function(FunctionGuard::Domain(Predicate::True))
                 } else {
                     TileGuard::Function(FunctionGuard::Domain(

--- a/src/interpreter/tiling/tiling_kind.rs
+++ b/src/interpreter/tiling/tiling_kind.rs
@@ -170,11 +170,12 @@ impl Tiling {
                 terminal: ColumnValue::Bools(BitVec::new()),
                 accumulator: ColumnValue::from_values(Vec::new(), accumulator),
             },
-            // An empty store: no change events yet, frontier undecided.
+            // An empty store: no change events yet, frontier undecided, live.
             Tiling::Store { domain, .. } => Tile::Store {
                 changes: ColumnValue::from_values(Vec::new(), domain),
                 deltas: ColumnValue::Variants(Vec::new()),
                 frontier: Predicate::False,
+                terminal: false,
             },
         }
     }

--- a/tests/compilation_pipeline/conditionals.rs
+++ b/tests/compilation_pipeline/conditionals.rs
@@ -523,3 +523,122 @@ fn test_conditional_element_result() {
     let result = run_pipeline("[(x * 10 if x > 2 else 0) for x in [1, 2, 3, 4]]");
     assert_eq!(codomain_ints(&result), vec![0, 0, 30, 40]);
 }
+
+// ---------------------------------------------------------------------------
+// Conditional induction writes — `if p: acc += e` in a mutation loop.
+//
+// `lower_loop_body_chain` lowers the `if` to a statement-`Case`; `transform_chain`
+// merges its branches into one writer decision — a single conditional write is
+// `{commit: ĝ, writes: prev+e}` (a `!commit` position carries in the changelog).
+// One writer over the full source → a single-writer `Transact` → the changelog
+// `InductionStore`, read densely and reduced to the final accumulator.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// Guard fires for 3, 4 → total = 3 + 4 = 7; positions 0, 1 carry.
+#[case(
+    "total := 0\nfor x in [1, 2, 3, 4]:\n    if x > 2:\n        total += x\ntotal",
+    7
+)]
+// Guard fires for none → total stays at its init.
+#[case(
+    "total := 0\nfor x in [1, 2, 3]:\n    if x > 10:\n        total += x\ntotal",
+    0
+)]
+// Guard fires for all → same as an unconditional accumulate (1+2+3 = 6).
+#[case(
+    "total := 0\nfor x in [1, 2, 3]:\n    if x > 0:\n        total += x\ntotal",
+    6
+)]
+// A non-zero init the leading carries fold to (only 3 fires → 100 + 3 = 103).
+#[case(
+    "total := 100\nfor x in [1, 2, 3]:\n    if x == 3:\n        total += x\ntotal",
+    103
+)]
+// Fire early, then an **all-carry tail**: x=3 (position 0) writes +3; x=1
+// (position 1) carries. The last *change* is at position 0, but the final
+// accumulator is at position 1 — so the scalar-final `ExtractLast` must read the
+// carried tail, not stop at the last change tick. Pins the terminality/watermark
+// decoupling (a sparse writer whose tail carries reads its true final value).
+#[case(
+    "total := 0\nfor x in [3, 1]:\n    if x > 2:\n        total += x\ntotal",
+    3
+)]
+// A **partial op** (`//`) in the written value, guarded away from its bad input.
+// The write value is compiled lazily (`filter_values(x != 0) ≫ (total // x)`), so
+// `total // x` is evaluated only where `x != 0` — never at the `x == 0` position
+// it would fault on. x=2 → 100 // 2 = 50; x=0 → guard false, carry → 50.
+#[case(
+    "total := 100\nfor x in [2, 0]:\n    if x != 0:\n        total := total // x\ntotal",
+    50
+)]
+// An **absolute** conditional write (`total := 5`, a constant not reading the
+// accumulator): the arm is `filter_values(x > 2) ≫ const(5)`. The filter routes
+// the constant to the guard's positions only — `try_const_reduce` must not
+// collapse `filter_values ≫ const` to a bare `const` (which would set 5 at every
+// position). x=1,2 carry init 9; x=3,4 set 5 → final 5.
+#[case(
+    "total := 9\nfor x in [1, 2, 3, 4]:\n    if x > 2:\n        total := 5\ntotal",
+    5
+)]
+// An **unconditional** write *before* a conditional write on the same accumulator.
+// The unconditional `+= 1` applies at every position and must commit even where
+// the guard fails — the guard change rides *on top* of it. x=1 → +1 (=1); x=2 →
+// +1 then +10 (=12); x=3 → +1 then +10 (=23). A commit gate that only fired on the
+// guard would drop the `+= 1` at x=1 (regressing to the prior value).
+#[case(
+    "x := 0\nfor i in [1, 2, 3]:\n    x := x + 1\n    if i > 1:\n        x := x + 10\nx",
+    23
+)]
+// Same, with the unconditional write *after* the conditional (spliced into every
+// path). x=1 → +1 (=1); x=2 → +10 then +1 (=12); x=3 → +10 then +1 (=23).
+#[case(
+    "x := 0\nfor i in [1, 2, 3]:\n    if i > 1:\n        x := x + 10\n    x := x + 1\nx",
+    23
+)]
+// **Sibling** `if`s (not `elif`) writing the *same* accumulator: the write set is
+// a nested value-`Case`, and `commit` is forced true wherever the carry differs
+// from the entering value. i=1: +100 (=100); i=2: +2 then +100 (=202); i=3: +3
+// (=205). Final 205.
+#[case(
+    "a := 0\nfor i in [1, 2, 3]:\n    if i > 1:\n        a := a + i\n    if i < 3:\n        a := a + 100\na",
+    205
+)]
+fn test_conditional_induction_write(#[case] code: &str, #[case] expected: i64) {
+    check_scalar(code, Value::Int(expected));
+}
+
+// Two **separate** accumulators in one loop — one unconditional, one conditional.
+// `cnt` commits on every position (its carry always differs from the entering
+// value); `total` rides its own conditional value-`Case`. cnt = 3 (all), total =
+// 2+3 = 5. Encoded as `cnt * 10 + total` = 35 to pin both independently.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn test_conditional_induction_two_accumulators() {
+    check_scalar(
+        "cnt := 0\ntotal := 0\nfor i in [1, 2, 3]:\n    cnt := cnt + 1\n    if i > 1:\n        total := total + i\ncnt * 10 + total",
+        Value::Int(35),
+    );
+}
+
+// An `if`/`else` that writes the *same* accumulator on both arms: the write set
+// is a per-position value-`Case` (`writes.total = Case[x>2 → prev+x; true →
+// prev+1]`), compiled by the lazy value-preserving `filter_values`
+// union-of-restricts inside the writer lambda (`⧺ᵢ filter_values(π̂ᵢ) ≫ eᵢ`; each
+// arm's value is evaluated only where its guard holds — no eager both-arm eval).
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// x=1,2 → +1 (else); x=3,4 → +x. total = 1+1+3+4 = 9.
+#[case(
+    "total := 0\nfor x in [1, 2, 3, 4]:\n    if x > 2:\n        total += x\n    else:\n        total += 1\ntotal",
+    9
+)]
+// elif chain, all arms write. x=1→+10, x=2→+20, x=3→+30. total = 60.
+#[case(
+    "total := 0\nfor x in [1, 2, 3]:\n    if x == 1:\n        total += 10\n    elif x == 2:\n        total += 20\n    else:\n        total += 30\ntotal",
+    60
+)]
+fn test_conditional_induction_if_else_both_write(#[case] code: &str, #[case] expected: i64) {
+    check_scalar(code, Value::Int(expected));
+}

--- a/tests/compilation_pipeline/conditionals.rs
+++ b/tests/compilation_pipeline/conditionals.rs
@@ -538,22 +538,42 @@ fn test_conditional_element_result() {
 #[timeout(Duration::from_secs(10))]
 // Guard fires for 3, 4 → total = 3 + 4 = 7; positions 0, 1 carry.
 #[case(
-    "total := 0\nfor x in [1, 2, 3, 4]:\n    if x > 2:\n        total += x\ntotal",
+    r"
+total := 0
+for x in [1, 2, 3, 4]:
+    if x > 2:
+        total += x
+total",
     7
 )]
 // Guard fires for none → total stays at its init.
 #[case(
-    "total := 0\nfor x in [1, 2, 3]:\n    if x > 10:\n        total += x\ntotal",
+    r"
+total := 0
+for x in [1, 2, 3]:
+    if x > 10:
+        total += x
+total",
     0
 )]
 // Guard fires for all → same as an unconditional accumulate (1+2+3 = 6).
 #[case(
-    "total := 0\nfor x in [1, 2, 3]:\n    if x > 0:\n        total += x\ntotal",
+    r"
+total := 0
+for x in [1, 2, 3]:
+    if x > 0:
+        total += x
+total",
     6
 )]
 // A non-zero init the leading carries fold to (only 3 fires → 100 + 3 = 103).
 #[case(
-    "total := 100\nfor x in [1, 2, 3]:\n    if x == 3:\n        total += x\ntotal",
+    r"
+total := 100
+for x in [1, 2, 3]:
+    if x == 3:
+        total += x
+total",
     103
 )]
 // Fire early, then an **all-carry tail**: x=3 (position 0) writes +3; x=1
@@ -562,7 +582,12 @@ fn test_conditional_element_result() {
 // carried tail, not stop at the last change tick. Pins the terminality/watermark
 // decoupling (a sparse writer whose tail carries reads its true final value).
 #[case(
-    "total := 0\nfor x in [3, 1]:\n    if x > 2:\n        total += x\ntotal",
+    r"
+total := 0
+for x in [3, 1]:
+    if x > 2:
+        total += x
+total",
     3
 )]
 // A **partial op** (`//`) in the written value, guarded away from its bad input.
@@ -570,7 +595,12 @@ fn test_conditional_element_result() {
 // `total // x` is evaluated only where `x != 0` — never at the `x == 0` position
 // it would fault on. x=2 → 100 // 2 = 50; x=0 → guard false, carry → 50.
 #[case(
-    "total := 100\nfor x in [2, 0]:\n    if x != 0:\n        total := total // x\ntotal",
+    r"
+total := 100
+for x in [2, 0]:
+    if x != 0:
+        total := total // x
+total",
     50
 )]
 // An **absolute** conditional write (`total := 5`, a constant not reading the
@@ -579,7 +609,12 @@ fn test_conditional_element_result() {
 // collapse `filter_values ≫ const` to a bare `const` (which would set 5 at every
 // position). x=1,2 carry init 9; x=3,4 set 5 → final 5.
 #[case(
-    "total := 9\nfor x in [1, 2, 3, 4]:\n    if x > 2:\n        total := 5\ntotal",
+    r"
+total := 9
+for x in [1, 2, 3, 4]:
+    if x > 2:
+        total := 5
+total",
     5
 )]
 // An **unconditional** write *before* a conditional write on the same accumulator.
@@ -588,13 +623,25 @@ fn test_conditional_element_result() {
 // +1 then +10 (=12); x=3 → +1 then +10 (=23). A commit gate that only fired on the
 // guard would drop the `+= 1` at x=1 (regressing to the prior value).
 #[case(
-    "x := 0\nfor i in [1, 2, 3]:\n    x := x + 1\n    if i > 1:\n        x := x + 10\nx",
+    r"
+x := 0
+for i in [1, 2, 3]:
+    x := x + 1
+    if i > 1:
+        x := x + 10
+x",
     23
 )]
 // Same, with the unconditional write *after* the conditional (spliced into every
 // path). x=1 → +1 (=1); x=2 → +10 then +1 (=12); x=3 → +10 then +1 (=23).
 #[case(
-    "x := 0\nfor i in [1, 2, 3]:\n    if i > 1:\n        x := x + 10\n    x := x + 1\nx",
+    r"
+x := 0
+for i in [1, 2, 3]:
+    if i > 1:
+        x := x + 10
+    x := x + 1
+x",
     23
 )]
 // **Sibling** `if`s (not `elif`) writing the *same* accumulator: the write set is
@@ -602,7 +649,14 @@ fn test_conditional_element_result() {
 // from the entering value. i=1: +100 (=100); i=2: +2 then +100 (=202); i=3: +3
 // (=205). Final 205.
 #[case(
-    "a := 0\nfor i in [1, 2, 3]:\n    if i > 1:\n        a := a + i\n    if i < 3:\n        a := a + 100\na",
+    r"
+a := 0
+for i in [1, 2, 3]:
+    if i > 1:
+        a := a + i
+    if i < 3:
+        a := a + 100
+a",
     205
 )]
 fn test_conditional_induction_write(#[case] code: &str, #[case] expected: i64) {
@@ -617,7 +671,14 @@ fn test_conditional_induction_write(#[case] code: &str, #[case] expected: i64) {
 #[timeout(Duration::from_secs(10))]
 fn test_conditional_induction_two_accumulators() {
     check_scalar(
-        "cnt := 0\ntotal := 0\nfor i in [1, 2, 3]:\n    cnt := cnt + 1\n    if i > 1:\n        total := total + i\ncnt * 10 + total",
+        r"
+cnt := 0
+total := 0
+for i in [1, 2, 3]:
+    cnt := cnt + 1
+    if i > 1:
+        total := total + i
+cnt * 10 + total",
         Value::Int(35),
     );
 }
@@ -631,12 +692,28 @@ fn test_conditional_induction_two_accumulators() {
 #[timeout(Duration::from_secs(10))]
 // x=1,2 → +1 (else); x=3,4 → +x. total = 1+1+3+4 = 9.
 #[case(
-    "total := 0\nfor x in [1, 2, 3, 4]:\n    if x > 2:\n        total += x\n    else:\n        total += 1\ntotal",
+    r"
+total := 0
+for x in [1, 2, 3, 4]:
+    if x > 2:
+        total += x
+    else:
+        total += 1
+total",
     9
 )]
 // elif chain, all arms write. x=1→+10, x=2→+20, x=3→+30. total = 60.
 #[case(
-    "total := 0\nfor x in [1, 2, 3]:\n    if x == 1:\n        total += 10\n    elif x == 2:\n        total += 20\n    else:\n        total += 30\ntotal",
+    r"
+total := 0
+for x in [1, 2, 3]:
+    if x == 1:
+        total += 10
+    elif x == 2:
+        total += 20
+    else:
+        total += 30
+total",
     60
 )]
 fn test_conditional_induction_if_else_both_write(#[case] code: &str, #[case] expected: i64) {

--- a/tests/compilation_pipeline/sources_incremental.rs
+++ b/tests/compilation_pipeline/sources_incremental.rs
@@ -505,6 +505,58 @@ fn test_incremental_global_aggregate() {
 
 /// Mutation loop summing values from an incremental source, semantically
 /// equivalent to `sum(source1())` but exercising `Recurse` instead of
+/// A *conditional* induction write over an async source: `if i > 15: x := x + i`.
+/// An async (`DataSourceDomain`) extent routes to the dense `Recurse` path, which
+/// cycles on `.writes` (not `.commit`). The writer decision is *carry-complete*
+/// (`writes.x = Case[i > 15 → x + i; true → x]`), so a rejected position carries the
+/// previous accumulator rather than accumulating unconditionally — the guard is
+/// honored by the value, not silently dropped. Source `[10, 20, 30]`, guard `> 15`:
+/// only 20 and 30 accumulate, so the final `x = 50` (a dropped guard would give 60).
+#[test_log::test]
+fn test_incremental_conditional_mutation_loop() {
+    let code = "\
+x := 0
+for i in source1():
+    if i > 15:
+        x := x + i
+x";
+    let mut ctx = GlobalContext::default();
+    let test_source = Rc::new(RefCell::new(TestDataSource::new(
+        "source1",
+        Type::Base(BaseType::Int),
+        Extent::Base(BaseType::Int),
+    )));
+    ctx.register_source(test_source.clone());
+
+    let consumer: Box<dyn Consumer> = Box::new(move || {});
+    let mut compiled = compile_program(&mut ctx, code, consumer).unwrap_or_render("<test>", code);
+    let mut producer = compiled.main_mut().unwrap().producer.take().unwrap();
+
+    test_source.borrow_mut().add_data(&[
+        (Value::UInt(0), Value::Int(10)),
+        (Value::UInt(1), Value::Int(20)),
+        (Value::UInt(2), Value::Int(30)),
+    ]);
+    test_source
+        .borrow_mut()
+        .set_yield_predicate(Predicate::True);
+    ctx.scheduler().check_for_notifications();
+
+    let empty = Tile::Scalar(ColumnValue::Ints(vec![]));
+    let mut result = empty.clone();
+    for _ in 0..4 {
+        result = producer.get(producer.tiling().universal_guard());
+        if result != empty {
+            break;
+        }
+    }
+    assert_eq!(
+        result,
+        Tile::Scalar(ColumnValue::Ints(vec![50])),
+        "conditional induction over an async source must honor the guard (20 + 30), not sum all (60)"
+    );
+}
+
 /// `MapAggregate`.  Verifies that `Recurse` correctly:
 /// - Re-reads its `domain` input as the source grows in batches.
 /// - Holds back the final emission until the source signals it's done.


### PR DESCRIPTION
## Conditional induction writes

PR 3/7 of the mutability-conditionals stack, on value-Case compilation (2/7). Delivers
conditional mutation inside an induction loop — `for x in xs: if p: total += x` — the
`mutability.md` motivating example. The model: a conditional write becomes **one
carry-complete writer** over a `Tile::Store` changelog (the write arm on `{r | π̂}`, the
complement arm carrying the snapshot forward), folded to a single commit-gated decision;
the union appears only in history slots, where the existing guarded-slot grammar already
admits it.

### What changes

- **Lower if-in-loop to a statement-Case** (`lower/loops.rs`), with `collect_mutation_loop_vars`
  recursing into branches (and correctly excluding inner `for` / `with begin()`).
- **Induction accumulators as a `Tile::Store` changelog** — induction routes through the
  changelog `InductionStore` and recognition folds the conditional write to one
  commit-gated writer (multi-writer dispatch is never born).
- **Value-Case inside a writer lambda** — the C-form from 2/7 applied inside a decision
  body, evaluated lazily (the off-path arm is not forced).
- **Uniform carry-complete write decision** — every path (write or carry) produces a full
  decision record, so trailing reads see one merged view.
- **`Tile::Store`: separate terminality from the watermark** — a store's "no more writes"
  signal is decoupled from its position watermark, so a conditional (sparse) writer bounds
  correctly and a loop whose tail carries reads its true final accumulator.
- **Commit unconditional writes beside a conditional** — an unconditional write *before* a
  conditional (`x := x+1; if p: x := x+10`) now commits on every position (the commit gate
  compares the carried expression against the entering snapshot at compile time; a
  differing carry forces commit), fixing a silent-drop where the unconditional increment
  was lost.

### Docs
`src/ccl/design/mutability.md` (conditional induction writes graduate to the changelog
realization); `src/interpreter/design-operators.md`; the induction-unification design plan
and the unordered-mutability design commitment; `docs/plan.md`.

Green under `./ci.sh`.



Continues cambra-dev/cambra-old#304 (review history there).

