### PR TITLE
Lowering: enforce def/lambda parameter type annotations (were silently dropped)

### DIFF
--- a/src/ccl/lower/functions.rs
+++ b/src/ccl/lower/functions.rs
@@ -113,10 +113,22 @@ pub(super) fn uncurry_params(
             _ => Type::Hole,
         };
         let mut lam = Expr::lambda(params[0].name.as_str(), param_ty.clone(), body_expr);
-        if matches!(param_ty, Type::History { .. })
-            && let TypedExprNode::Lambda { param, .. } = &mut lam.node
-        {
-            param.user_annotation = Some(param_ty);
+        if let TypedExprNode::Lambda { param, .. } = &mut lam.node {
+            if matches!(param_ty, Type::History { .. }) {
+                // `Mut[…]` pass-by-reference: the annotation rides `user_annotation`
+                // for the mutability discipline check (rule 3).
+                param.user_annotation = Some(param_ty);
+            } else if let Some(ann) = &params[0].annotation
+                && mut_param_history_type(&params[0]).is_none()
+            {
+                // Any *other* annotation (`int`, `List[T]`, …) is a
+                // **checking-mode** declaration: attach it so `emit_lambda` binds
+                // the param at its declared type and an ill-typed argument is
+                // rejected at the call site. Without this the annotation was
+                // silently dropped and the param inferred purely from its body (so
+                // `def g(a: int)` with an identity body accepted any argument).
+                param.user_annotation = Some(lower_type_annotation(ann)?);
+            }
         }
         return Ok(lam);
     }
@@ -156,7 +168,24 @@ pub(super) fn uncurry_params(
         let proj = Expr::apply(Expr::var(&tuple_name), Expr::proj_index(i));
         substitute_param_in_body(acc, &Name::raw(arg.name.as_str()), &proj)
     });
-    Ok(Expr::lambda(&tuple_name, Type::Hole, body_with_subs))
+    // Attach the *tuple* of per-parameter annotations (checking mode), mirroring the
+    // single-parameter case: each annotated position is enforced at the call site,
+    // unannotated positions ride `Hole` (inferred). Skip if no parameter is
+    // annotated. (This arm has no `Mut` params — those are curried above.)
+    let elem_anns: Vec<Type> = params
+        .iter()
+        .map(|p| match &p.annotation {
+            Some(ann) => lower_type_annotation(ann),
+            None => Ok(Type::Hole),
+        })
+        .collect::<Result<_, _>>()?;
+    let mut lam = Expr::lambda(&tuple_name, Type::Hole, body_with_subs);
+    if elem_anns.iter().any(|t| !matches!(t, Type::Hole))
+        && let TypedExprNode::Lambda { param, .. } = &mut lam.node
+    {
+        param.user_annotation = Some(Type::Tuple(elem_anns));
+    }
+    Ok(lam)
 }
 
 /// Lower a CHL lambda expression to an [`Expr::Lambda`] via

--- a/tests/compilation_pipeline/mutability.rs
+++ b/tests/compilation_pipeline/mutability.rs
@@ -573,6 +573,40 @@ fn mut_arg_must_be_a_mutable_not_a_plain_value() {
         "mutable variable",
     );
 }
+// A mutable variable passed to a *non*-`Mut` parameter is read by value (its
+// current value is copied in) — the callee cannot write it back. The parameter
+// annotation is a plain checking-mode declaration here, so the register's value
+// type must match it.
+#[test]
+fn nonmut_param_reads_mut_arg_current_value() {
+    check_scalar(
+        "cnt: Mut[int] := 5\ndef g(a: int):\n    a + 1\ng(cnt)",
+        cambra::interpreter::Value::Int(6),
+    );
+}
+// The enforced annotation has force even when the argument is a mutable
+// variable: a `str` parameter rejects an `int` register's value. Before
+// parameter annotations were carried through lowering this compiled — the
+// annotation was silently dropped and `a` inferred `int` from the argument.
+#[test]
+fn nonmut_param_annotation_enforced_against_mut_arg() {
+    expect_compile_error(
+        "cnt: Mut[int] := 0\ndef g(a: str):\n    a\ng(cnt)",
+        "mismatch",
+    );
+}
+// Pass-by-reference sibling of the above: a `Mut[int]` register cannot bind a
+// `Mut[str]` parameter — the value types must agree across the `(Mut, Mut)`
+// edge. (This path is unchanged by parameter-annotation enforcement; the `Mut`
+// annotation always seeded the binder type. Pinned here because nothing else
+// covers a `Mut` value-type clash at a call site.)
+#[test]
+fn mut_param_value_type_must_match_mut_arg() {
+    expect_compile_error(
+        "cnt: Mut[int] := 0\ndef g(c: Mut[str]):\n    c := \"x\"\ng(cnt)\ncnt",
+        "mismatch",
+    );
+}
 #[test]
 fn single_param_pass_by_ref_still_works() {
     check_scalar(

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -194,6 +194,43 @@ fn test_list_literal() {
     );
 }
 
+// A `def`/lambda parameter's type annotation is a **checking-mode declaration**
+// that lowering must carry to the lambda so inference enforces it at the call
+// site — mirroring variable ascription (`x: T = e`). Regression for a
+// long-standing lowering gap: `uncurry_params` attached only `Mut[…]`
+// annotations and dropped every other one, so a `def` param was inferred purely
+// from its body and any argument was accepted.
+#[test]
+fn test_def_param_annotation_enforced() {
+    // A scalar annotation is enforced at the call site: an identity body infers
+    // nothing on its own, so without the annotation any argument was accepted.
+    assert_eq!(infer_program("def g(a: int):\n    a\ng(1)"), int());
+    assert!(!infer_program_err("def g(a: int):\n    a\ng(\"x\")").is_empty());
+    // A `List[int]` annotation enforces the element type through the annotation.
+    assert_eq!(
+        infer_program("def g(a: List[int]):\n    sum(a)\ng([1, 2, 3])"),
+        int()
+    );
+    assert!(!infer_program_err("def g(a: List[int]):\n    sum(a)\ng([\"a\", \"b\"])").is_empty());
+    // An unannotated param still infers purely from use.
+    assert_eq!(infer_program("def g(a):\n    a\ng(\"x\")"), string());
+}
+
+#[test]
+fn test_multiarg_def_param_annotation_enforced() {
+    // Each tupled parameter's annotation is enforced independently.
+    assert_eq!(
+        infer_program("def g(a: int, b: str):\n    a\ng(1, \"x\")"),
+        int()
+    );
+    // Wrong type on `a` is rejected.
+    assert!(!infer_program_err("def g(a: int, b: str):\n    a\ng(\"x\", \"y\")").is_empty());
+    // Wrong type on `b` is rejected.
+    assert!(!infer_program_err("def g(a: int, b: str):\n    a\ng(1, 2)").is_empty());
+    // Fully unannotated params still infer from use.
+    assert_eq!(infer_program("def g(a, b):\n    a + b\ng(1, 2)"), int());
+}
+
 #[test]
 fn test_list_comp_identity() {
     // [x for x in [1, 2]] — element type inferred from inner list


### PR DESCRIPTION
`uncurry_params` attached a `user_annotation` only for `Mut[…]` pass-by-reference parameters; every other parameter annotation (`int`, `List[T]`, …) fell through to a bare `Type::Hole`, so the parameter was inferred purely from its body and the declared type was never checked against arguments. A `def g(a: int)` with an identity body accepted an argument of any type — the annotation was documentation with no force, unlike a variable ascription (`x: T = e`), which does enforce its annotation.

Attach the lowered annotation as the parameter's `user_annotation` in both the single-parameter and the multi-argument (tupled) paths, so `emit_lambda`'s checking mode binds the parameter at its declared type and an ill-typed argument is rejected at the call site.

## Interaction with `Mut` pass-by-reference

`Mut[…]` handling is deliberately unchanged. The `Mut` single-param path seeds the *real* binder type (`Mut[V, _]`), not just the annotation, because the body must be typed with the parameter already `Mut` (its `MutRead`/`MutWrite` nodes check against a `Mut`-typed binder, and the domain generalizes per call site) — leaving it a `Hole` and reconciling the annotation afterward fails. A plain `int`/`List[T]` annotation needs no such seeding; it is purely a boundary constraint, so this change only ever writes `user_annotation` and never touches the `Mut` exception.

The one observable interaction: a mutable variable passed to a *non*-`Mut` parameter is read **by value** (its current value is copied; the callee cannot write it back), and the parameter's declared value type is now enforced against it. Before this fix that mismatch compiled — the annotation was silently dropped and the parameter inferred its type from the argument.

## Tests

Full lower→infer path for single- and multi-argument annotated parameters (scalar type, `List[T]` element type, unannotated inference), plus the `Mut`-interaction cases above. Each enforcement test fails on `main` without the lowering change.

Extracted as a standalone fix from the `dmills/map-set-constructors` collections stack, where the gap was discovered.