### PR TITLE
ccl: the passes adopt the lineage recorder; both pane boundaries assert leak-free

### DIFF
--- a/src/ccl/channelize.rs
+++ b/src/ccl/channelize.rs
@@ -115,7 +115,29 @@ use crate::ccl::{
     TypedExpr, TypedExprNode,
     ccl_utils::{count_free, synthesize_arm_predicate, typed_compose},
     letrec::check_letrec_causal,
+    lineage::{self, LineageLog, Nature, RecorderSession},
+    provenance::NodeId,
 };
+
+/// A cluster defer's rewrite identity: its binder name, the enclosing
+/// `let d = Defer` node id, and the `Defer` node id. Threaded from `desugar`'s
+/// cluster collection through [`channelize_cluster`] so the cluster's lineage
+/// step can consume the scaffolding it removes — the cluster/defer origin ids
+/// threaded into `try_lift_defer`.
+struct ClusterDefer {
+    name: Name,
+    /// The `let dᵢ = Defer` wrapper node.
+    let_id: NodeId,
+    /// The `Defer` node bound by the wrapper.
+    defer_id: NodeId,
+}
+
+/// Collect every main-tree [`NodeId`] in `e` (itself and descendants), skipping
+/// type-refinement predicates — the node set the lineage steps reason about.
+fn collect_subtree_ids(e: &Expr, acc: &mut Vec<NodeId>) {
+    acc.push(e.node_id());
+    e.walk_children(|c| collect_subtree_ids(c, acc));
+}
 
 /// `true` when `ty` carries channelization-erasable residue — a `Hole` stamped
 /// on a node this pass constructed or invalidated, an unresolved `Infer` channel
@@ -266,6 +288,22 @@ fn try_extract_fanout_feed(body: &Expr, defer_name: &Name) -> Option<Vec<(Expr, 
     any_feed.then_some(arms)
 }
 
+/// Clone a **main-tree** subtree and freshen every NodeId in the copy, so a
+/// fan-out arm that duplicates a surviving source subtree never shares its
+/// ids (the duplicate-id source `post_desugar_ir` uniqueness would otherwise
+/// trip on). Each freshened node fires the `on_copy` lineage hook into the
+/// enclosing fan-out step, turning the clone into per-origin `Copy` records.
+///
+/// Deliberately **not** used for predicate-position clones (the guard copies
+/// that end up inside a `Type::Refinement` predicate): the predicate domain is
+/// out of scope for the tree walks, and freshening there would churn ids no
+/// walk ever observes.
+fn freshened_clone(e: &Expr) -> Expr {
+    let mut c = e.clone();
+    c.freshen_node_ids_deep();
+    c
+}
+
 /// Attempt to apply the defer-returning lift to a `Let` binding.
 ///
 /// Pattern: `let y = (let x = Defer in body_x) in body_y` where
@@ -281,8 +319,16 @@ fn try_extract_fanout_feed(body: &Expr, defer_name: &Name) -> Option<Vec<(Expr, 
 /// Also handles an optional `ExprStmt` prefix on `bound_expr`: the
 /// heads of any leading ExprStmts become a prefix that's prepended to
 /// the lifted body, with stale Feed/Define target names renamed to `y`.
-fn try_lift_defer(binding_name: &Name, bound_expr: &Expr, body: &Expr) -> Option<(Expr, Name)> {
+fn try_lift_defer(
+    binding_name: &Name,
+    bound_expr: &Expr,
+    body: &Expr,
+    outer_let_id: NodeId,
+) -> Option<(Expr, Name)> {
     let mut prefix: Vec<Expr> = Vec::new();
+    // The stripped `ExprStmt` envelope ids are consumed by the lift (their heads
+    // are re-wrapped into fresh envelopes below); capture them for the step.
+    let mut stripped_envelope_ids: Vec<NodeId> = Vec::new();
     let mut current = bound_expr.clone();
     loop {
         let cur_id = current.node_id;
@@ -291,6 +337,7 @@ fn try_lift_defer(binding_name: &Name, bound_expr: &Expr, body: &Expr) -> Option
                 expr: head,
                 body: tail,
             } => {
+                stripped_envelope_ids.push(cur_id);
                 prefix.push(*head);
                 current = *tail;
             }
@@ -306,7 +353,8 @@ fn try_lift_defer(binding_name: &Name, bound_expr: &Expr, body: &Expr) -> Option
             }
         }
     }
-    let (inner_name, inner_handle_ty, inner_body_x) = match current.node {
+    let inner_let_id = current.node_id;
+    let (inner_name, inner_handle_ty, inner_body_x, inner_defer_id) = match current.node {
         TypedExprNode::Let {
             binding: inner_binding,
             bound_expr: inner_be,
@@ -314,14 +362,28 @@ fn try_lift_defer(binding_name: &Name, bound_expr: &Expr, body: &Expr) -> Option
         } if matches!(inner_be.node, TypedExprNode::Defer)
             && is_defer_returning(&inner_body, &inner_binding.name) =>
         {
+            // Read the `Defer`'s id before moving `inner_be.ty` out of the box.
+            let inner_defer_id = inner_be.node_id();
             // Keep the inner defer's recorded handle type (`feed(ChanDom(F) ⇒
             // V)`) — the lifted binding must carry it so cluster discovery
             // keys the channel by the domain name consumer types reference,
             // not by the term name. (`Hole` on an untyped tree, harmlessly.)
-            (inner_binding.name, inner_be.ty, *inner_body)
+            (inner_binding.name, inner_be.ty, *inner_body, inner_defer_id)
         }
         _ => return None,
     };
+
+    // The lift is committed: open its step. It consumes the outer `Let`, the
+    // inner `let x = Defer` wrapper and its `Defer`, and the stripped `ExprStmt`
+    // envelopes; the fresh `Defer`/`Let` and re-wrapped envelopes built below are
+    // its births. A faithful `Expansion` of the defer-returning UDF inline, so
+    // blame is the same scaffolding ids. (Substitution's `Var`-overwrite drops
+    // and the replacement-`Var` duplication it leaves are not separately
+    // recorded here.)
+    let mut consumed = vec![outer_let_id, inner_let_id, inner_defer_id];
+    consumed.extend(stripped_envelope_ids);
+    let blame = consumed.clone();
+    let _lift = lineage::step("channelize.lift_defer", consumed, blame, Nature::Expansion);
 
     // `body_x[x → y]` — also renames Feed/Define targets named `x` to `y`.
     let inner_subst = desugar_rename(inner_body_x, &inner_name, binding_name);
@@ -568,6 +630,18 @@ pub fn run(expr: Expr, input_typed: bool) -> Result<Expr, DeferError> {
         assert_no_type_residue(&rewritten);
     }
     Ok(rewritten)
+}
+
+/// Channelize as [`run`], but also drain the [`LineageLog`] of the
+/// [`RewriteStep`](crate::ccl::lineage::RewriteStep)s this pass records. The log
+/// is drained even on error (the partial log is harmless).
+pub(crate) fn run_with_lineage(
+    expr: Expr,
+    input_typed: bool,
+) -> (Result<Expr, DeferError>, LineageLog) {
+    let session = RecorderSession::new();
+    let result = run(expr, input_typed);
+    (result, session.into_log())
 }
 
 /// The channel-domain name (and its inference level) carried by a feed
@@ -894,7 +968,23 @@ fn drop_expr_stmts(expr: Expr) -> Expr {
                 body: Box::new(drop_expr_stmts(*body)),
             }
         }
-        TypedExprNode::ExprStmt { body, .. } => return drop_expr_stmts(*body),
+        TypedExprNode::ExprStmt { expr: effect, body } => {
+            // The `ExprStmt` envelope and its effect (a `Unit` residue once feeds
+            // are extracted) are discarded with no surviving counterpart —
+            // `Nature::Machinery`, empty blame. Recorded as a `Transform` discard
+            // (produced empty) before recursing.
+            let mut consumed = vec![node_id];
+            collect_subtree_ids(&effect, &mut consumed);
+            {
+                let _g = lineage::step(
+                    "channelize.drop_expr_stmt",
+                    consumed,
+                    Vec::new(),
+                    Nature::Machinery,
+                );
+            }
+            return drop_expr_stmts(*body);
+        }
         TypedExprNode::Let {
             binding,
             bound_expr,
@@ -1148,7 +1238,14 @@ fn desugar(expr: Expr, ctx: &mut DesugarCtx) -> Result<Expr, DeferError> {
             {
                 chan_names.insert(binding.name.clone(), n);
             }
-            let mut defer_names = vec![binding.name];
+            // Capture each defer's `let`-wrapper and `Defer` node ids alongside
+            // its binder name, so the cluster's lineage step consumes the exact
+            // scaffolding channelization removes.
+            let mut defers = vec![ClusterDefer {
+                name: binding.name,
+                let_id: node_id,
+                defer_id: bound_expr.node_id(),
+            }];
             let mut current_body = *body;
             loop {
                 let cur_let_id = current_body.node_id;
@@ -1163,7 +1260,12 @@ fn desugar(expr: Expr, ctx: &mut DesugarCtx) -> Result<Expr, DeferError> {
                         {
                             chan_names.insert(b.name.clone(), n);
                         }
-                        defer_names.push(b.name);
+                        let defer_id = be.node_id();
+                        defers.push(ClusterDefer {
+                            name: b.name,
+                            let_id: cur_let_id,
+                            defer_id,
+                        });
                         current_body = *inner;
                     }
                     other => {
@@ -1182,7 +1284,7 @@ fn desugar(expr: Expr, ctx: &mut DesugarCtx) -> Result<Expr, DeferError> {
             // non-clustered defers (inner `let d = Defer in ...`
             // separated from this cluster by other lets).
             let body_rewritten = desugar(current_body, ctx)?;
-            channelize_cluster(&defer_names, &chan_names, body_rewritten, ctx)
+            channelize_cluster(&defers, &chan_names, body_rewritten, ctx)
         }
         TypedExprNode::Let {
             binding,
@@ -1200,7 +1302,9 @@ fn desugar(expr: Expr, ctx: &mut DesugarCtx) -> Result<Expr, DeferError> {
             // functions: `let y = f(arg)` where f's body is `let x =
             // Defer in x` inlines to `let y = (let x = Defer in x) in
             // body_y`, and the lift collapses the two scopes.
-            if let Some((lifted, inner_name)) = try_lift_defer(&binding.name, &bound_expr, &body) {
+            if let Some((lifted, inner_name)) =
+                try_lift_defer(&binding.name, &bound_expr, &body, node_id)
+            {
                 // The lift renames the inner defer binder to the outer name,
                 // but *consumer types outside the lifted subtree* may carry
                 // the inner handle's rigid `ChanDom`. Record the alias so the
@@ -1335,7 +1439,7 @@ fn desugar(expr: Expr, ctx: &mut DesugarCtx) -> Result<Expr, DeferError> {
 /// used directly, and top-level scalar feeds are lifted to `Fun(Unit,
 /// T)` via the `λ __unused → V` wrap inside `extract_for_defer`.
 fn channelize_cluster(
-    defer_names: &[Name],
+    defers: &[ClusterDefer],
     chan_names: &HashMap<Name, Name>,
     body: Expr,
     ctx: &mut DesugarCtx,
@@ -1344,7 +1448,7 @@ fn channelize_cluster(
     // body's Feed/Define replacements as we process each defer in turn.
     let mut channels: HashMap<Name, Expr> = HashMap::new();
     let mut rewritten = body;
-    for name in defer_names.iter().rev() {
+    for name in defers.iter().rev().map(|d| &d.name) {
         // Process innermost defer first so its feeds are picked up before
         // the outer defer's walk; the outer walk wouldn't see them anyway
         // since extract_for_defer matches by name.  Processing order is
@@ -1373,7 +1477,7 @@ fn channelize_cluster(
     // the read's handle type, whose domain is the referenced channel's own
     // `ChanDom` (closed later).
     if ctx.input_typed {
-        for name in defer_names {
+        for name in defers.iter().map(|d| &d.name) {
             if let Some(ch) = channels.get(name) {
                 let key = chan_names
                     .get(name)
@@ -1401,8 +1505,8 @@ fn channelize_cluster(
     // channels carry no guard, so a reference cycle among them
     // (`x <<= y; y <<= x`) has no well-founded solution — the same law that
     // governs overwrite recursion, applied by the same checker.
-    let mut group: Vec<(TypedBinding, Expr)> = Vec::with_capacity(defer_names.len());
-    for name in defer_names {
+    let mut group: Vec<(TypedBinding, Expr)> = Vec::with_capacity(defers.len());
+    for name in defers.iter().map(|d| &d.name) {
         if let Some(channel) = channels.remove(name) {
             group.push((
                 TypedBinding {
@@ -1422,6 +1526,14 @@ fn channelize_cluster(
             .clone();
         return Err(DeferError::MutuallyRecursiveCycle(name.base().to_string()));
     }
+    // Open the cluster's lineage step over the bind/emit: the `let dᵢ = Defer`
+    // scaffolding (each wrapper `Let` and its `Defer`) is consumed, and the
+    // carrier `LetRec` minted by `emit_cluster_letrec` inside is its birth. This
+    // is a faithful `Expansion` of the defer cluster, so blame is the same defer
+    // scaffolding ids (the carrier traces to the `defer`s it channelizes).
+    let consumed: Vec<NodeId> = defers.iter().flat_map(|d| [d.let_id, d.defer_id]).collect();
+    let blame = consumed.clone();
+    let _g = lineage::step("channelize.cluster", consumed, blame, Nature::Expansion);
     Ok(bind_cluster_at_scope(rewritten, group))
 }
 
@@ -1582,8 +1694,11 @@ fn emit_cluster_letrec(inner: Expr, group: Vec<(TypedBinding, Expr)>) -> Expr {
         return inner;
     }
     let ty = inner.ty.clone();
-    // A freshly-minted cluster carrier — not a rebuild of an input node, so it
-    // draws a fresh `NodeId` through the canonical `Expr::new` constructor.
+    // A freshly-minted cluster carrier — not a rebuild of an input node. Built
+    // through `Expr::new` (rather than a struct literal with a bare
+    // `NodeId::fresh()`) so the `on_mint` hook fires and the enclosing cluster
+    // step captures the carrier as its birth. Same single fresh-id draw either
+    // way, so minting order (and the golden fixtures) is unchanged.
     let mut carrier = Expr::new(TypedExprNode::LetRec {
         bindings: group,
         body: Box::new(inner),
@@ -1816,6 +1931,21 @@ fn combine_feed_values(mut feeds: Vec<Expr>) -> Expr {
     if feeds.len() == 1 {
         return feeds.pop().unwrap();
     }
+    // The fan-in union is a **pure insertion** over the surviving feed
+    // operands — the `CollectionUnion` node is minted with no lineage ancestor
+    // (its operands survive as its children), so it is attributed via blame to
+    // the fed-value operand roots, with empty `consumed`. This is the legal
+    // empty-consumed-with-blame shape. It is a SIBLING step, opened before the
+    // `channelize.cluster` step (the cluster carrier isn't minted yet), so each
+    // frame captures its own births; its blame is the surviving fed-value
+    // operand roots. The minted union is this step's captured birth.
+    let blame: Vec<NodeId> = feeds.iter().map(|f| f.node_id()).collect();
+    let _g = lineage::step(
+        "channelize.feed_union",
+        Vec::new(),
+        blame,
+        Nature::Expansion,
+    );
     let ty = collection_union_type(&feeds);
     Expr::collection_union(feeds).with_ty(ty)
 }
@@ -1992,12 +2122,18 @@ fn extract_for_defer(
             let lifted = if in_inner_scope || is_collection {
                 value
             } else {
+                // The `λ __unused → V` Unit-lift is a pure insertion over the
+                // surviving fed value: minted with no lineage ancestor, blamed to
+                // the value's root (which survives as its body). Empty consumed.
+                let blame = vec![value.node_id()];
+                let _g =
+                    lineage::step("channelize.feed_lift", Vec::new(), blame, Nature::Expansion);
                 Expr::lambda("__unused", Type::Base(BaseType::Unit), value)
             };
             feeds.push(lifted);
             // The `Feed` wrapper's id is reused onto this `Lit(Unit)` replacement
             // (the enclosing rebuild carries `node_id`) — a preserve, not a
-            // discard.
+            // discard, so no step is opened for it here.
             TypedExprNode::Lit(Lit::Unit)
         }
         TypedExprNode::Define { name, value } if &name == defer_name => {
@@ -2076,8 +2212,25 @@ fn extract_for_defer(
                         let let_ty =
                             crate::ccl::subst::Subst::discharge(&binding.name, bound_expr.clone())
                                 .apply_type(&original.ty);
-                        *feed = Expr::let_bind(binding.name.clone(), bound_expr.clone(), original)
-                            .with_ty(let_ty);
+                        // The wrap-`Let` is a pure insertion over the surviving
+                        // feed and a freshened copy of the bound expression:
+                        // open its step so the minted `Let` (blamed to the
+                        // wrapped material) and the freshened `bound_expr` copy
+                        // are recorded. Freshening keeps the copy's ids distinct
+                        // from `bound_expr`'s surviving occurrence in the body.
+                        let blame = vec![original.node_id(), bound_expr.node_id()];
+                        let _wrap = lineage::step(
+                            "channelize.wrap_let",
+                            Vec::new(),
+                            blame,
+                            Nature::Expansion,
+                        );
+                        *feed = Expr::let_bind(
+                            binding.name.clone(),
+                            freshened_clone(&bound_expr),
+                            original,
+                        )
+                        .with_ty(let_ty);
                     }
                 }
                 new_body
@@ -2174,6 +2327,20 @@ fn extract_for_defer(
                     // element-var typing; the guard itself lives on the domain.
                     let src_domain = new_argument.ty.domain().unwrap_or(Type::Hole);
                     let src_item = new_argument.ty.codomain().unwrap_or(Type::Hole);
+                    // Fan-out companion channels: the per-arm refined-source
+                    // scaffolding (predicate lambdas/applies, value lambdas) is
+                    // minted fresh over cloned, surviving source nodes, and the
+                    // collapsed source lambda's body is replaced by `Unit`.
+                    // Recorded as a blamed pure insertion attributed to the
+                    // iteration source. (The source lambda's dropped body and the
+                    // clones' shared ids are residual; this arm is not on the
+                    // leak-tested path.)
+                    let _fanout = lineage::step(
+                        "channelize.case_fanout",
+                        Vec::new(),
+                        vec![new_argument.node_id()],
+                        Nature::Expansion,
+                    );
                     let mut prior: Vec<Expr> = Vec::new();
                     for (guard, feed_value) in fanout_arms {
                         if let Some(value) = feed_value {
@@ -2185,7 +2352,10 @@ fn extract_for_defer(
                             let pred_on_source = Expr::apply(source_at_elem, pred_lambda)
                                 .with_ty(Type::Base(BaseType::Bool));
                             let refinement_struct = Refinement::born(Rc::new(pred_on_source));
-                            let mut refined_argument = new_argument.clone();
+                            // Main-tree channel source: freshen the clone (the
+                            // `source_at_elem` copy above rides the predicate and
+                            // is left shared — predicate domain out of scope).
+                            let mut refined_argument = freshened_clone(&new_argument);
                             refine_source_domain(&mut refined_argument, refinement_struct, ctx);
                             // stamp the channel at
                             // construction (the value lambda's codomain,
@@ -2233,15 +2403,31 @@ fn extract_for_defer(
                     in_inner_scope,
                     ctx,
                 )?;
-                for v in lambda_feeds {
-                    // `Apply { argument: source-element, function: λ p → v }`
-                    // applies the value lambda to the per-element source, so the
-                    // companion channel's type is the lambda's codomain `v.ty`
-                    // (the argument matches `param.ty`). Typed at construction.
-                    let v_ty = v.ty.clone();
-                    let channel_lambda = Expr::lambda(&param.name, param.ty.clone(), v);
-                    let channel = Expr::apply(new_argument.clone(), channel_lambda).with_ty(v_ty);
-                    feeds.push(channel);
+                {
+                    // Companion value-lambda channels: minted over the cloned
+                    // (surviving) iteration source, a blamed pure insertion
+                    // attributed to the fed values.
+                    let blame: Vec<NodeId> = lambda_feeds.iter().map(|f| f.node_id()).collect();
+                    let _companion = lineage::step(
+                        "channelize.apply_fanout",
+                        Vec::new(),
+                        blame,
+                        Nature::Expansion,
+                    );
+                    for v in lambda_feeds {
+                        // `Apply { argument: source-element, function: λ p → v }`
+                        // applies the value lambda to the per-element source, so
+                        // the companion channel's type is the lambda's codomain
+                        // `v.ty` (the argument matches `param.ty`). Typed at
+                        // construction.
+                        let v_ty = v.ty.clone();
+                        let channel_lambda = Expr::lambda(&param.name, param.ty.clone(), v);
+                        // Main-tree source clone: freshen so each companion
+                        // channel owns distinct ids.
+                        let channel = Expr::apply(freshened_clone(&new_argument), channel_lambda)
+                            .with_ty(v_ty);
+                        feeds.push(channel);
+                    }
                 }
                 let new_function = TypedExpr {
                     node: TypedExprNode::Lambda {
@@ -2390,6 +2576,15 @@ fn extract_for_defer(
                             };
                             let src_domain = source_prefix.ty.domain().unwrap_or(Type::Hole);
                             let src_item = source_prefix.ty.codomain().unwrap_or(Type::Hole);
+                            // See the Apply-fanout arm: blamed pure insertion of
+                            // the per-arm refined-source companion channels,
+                            // attributed to the iteration source prefix.
+                            let _fanout = lineage::step(
+                                "channelize.case_fanout",
+                                Vec::new(),
+                                vec![source_prefix.node_id()],
+                                Nature::Expansion,
+                            );
                             let mut prior: Vec<Expr> = Vec::new();
                             for (guard, feed_value) in fanout_arms {
                                 if let Some(value) = feed_value {
@@ -2403,7 +2598,10 @@ fn extract_for_defer(
                                         .with_ty(Type::Base(BaseType::Bool));
                                     let refinement_struct =
                                         Refinement::born(Rc::new(pred_on_source));
-                                    let mut refined_prefix = source_prefix.clone();
+                                    // Main-tree channel source: freshen the
+                                    // clone (the `source_at_elem` copy rides the
+                                    // predicate and is left shared).
+                                    let mut refined_prefix = freshened_clone(&source_prefix);
                                     refine_source_domain(
                                         &mut refined_prefix,
                                         refinement_struct,
@@ -2457,25 +2655,41 @@ fn extract_for_defer(
                         // up to (but not including) this element, which is
                         // exactly the surrounding context the feed value
                         // needs.
-                        for v in lambda_feeds {
-                            // `Expr::lambda` stamps `Fun(param.ty, v.ty)`; the
-                            // param carries the matched lambda's own (concrete)
-                            // type, so the companion value lambda is fully typed.
-                            // The compose type is `Fun(prefix-domain, v.ty)`;
-                            // a prefix that is itself a defer read carries its
-                            // handle's rigid `ChanDom` domain, closed by the
-                            // final `erase_chan_domains` substitution.
-                            let channel_lambda = Expr::lambda(&param.name, param.ty.clone(), v);
-                            let mut channel_elts = new_elts.clone();
-                            channel_elts.push(channel_lambda);
-                            // A single-element "compose" is just that
-                            // element; otherwise build a Compose.
-                            let channel_expr = if channel_elts.len() == 1 {
-                                channel_elts.into_iter().next().unwrap()
-                            } else {
-                                compose_typed_or_hole(channel_elts)
-                            };
-                            feeds.push(channel_expr);
+                        {
+                            // Companion compose channels: minted over cloned
+                            // (surviving) prefix elements, a blamed pure insertion
+                            // attributed to the fed values.
+                            let blame: Vec<NodeId> =
+                                lambda_feeds.iter().map(|f| f.node_id()).collect();
+                            let _companion = lineage::step(
+                                "channelize.compose_fanout",
+                                Vec::new(),
+                                blame,
+                                Nature::Expansion,
+                            );
+                            for v in lambda_feeds {
+                                // `Expr::lambda` stamps `Fun(param.ty, v.ty)`; the
+                                // param carries the matched lambda's own (concrete)
+                                // type, so the companion value lambda is fully
+                                // typed. The compose type is `Fun(prefix-domain,
+                                // v.ty)`; a prefix that is itself a defer read
+                                // carries its handle's rigid `ChanDom` domain,
+                                // closed by the final `erase_chan_domains` subst.
+                                let channel_lambda = Expr::lambda(&param.name, param.ty.clone(), v);
+                                // Main-tree prefix elements duplicated into the
+                                // companion compose: freshen each clone.
+                                let mut channel_elts: Vec<Expr> =
+                                    new_elts.iter().map(freshened_clone).collect();
+                                channel_elts.push(channel_lambda);
+                                // A single-element "compose" is just that
+                                // element; otherwise build a Compose.
+                                let channel_expr = if channel_elts.len() == 1 {
+                                    channel_elts.into_iter().next().unwrap()
+                                } else {
+                                    compose_typed_or_hole(channel_elts)
+                                };
+                                feeds.push(channel_expr);
+                            }
                         }
                         new_elts.push(TypedExpr {
                             node: TypedExprNode::Lambda {
@@ -2554,8 +2768,19 @@ fn extract_for_defer(
             if local_define.is_some() {
                 return Err(DeferError::NestedDefinition);
             }
-            for v in local_feeds {
-                feeds.push(Expr::lambda(&param.name, param.ty.clone(), v));
+            {
+                // Companion lambda-wrapped channels: a blamed pure insertion of
+                // the re-wrapping lambdas, attributed to the fed values.
+                let blame: Vec<NodeId> = local_feeds.iter().map(|f| f.node_id()).collect();
+                let _companion = lineage::step(
+                    "channelize.lambda_fanout",
+                    Vec::new(),
+                    blame,
+                    Nature::Expansion,
+                );
+                for v in local_feeds {
+                    feeds.push(Expr::lambda(&param.name, param.ty.clone(), v));
+                }
             }
             TypedExprNode::Lambda {
                 param,
@@ -2776,9 +3001,14 @@ mod tests {
             Expr::let_bind("x", Expr::new(TypedExprNode::Defer), inner_body).with_ty(int.clone());
         let bound_expr = Expr::expr_stmt(Expr::feed("x", lit(1)), inner);
         let body = var("y").with_ty(int.clone());
+        // The outer `let y = bound_expr in body` the caller holds: the lift
+        // consumes its id, so build the node rather than inventing an id that
+        // belongs to nothing.
+        let outer = Expr::let_bind("y", bound_expr.clone(), body.clone());
 
         let (lifted, inner_name) =
-            try_lift_defer(&Name::raw("y"), &bound_expr, &body).expect("the lift shape matches");
+            try_lift_defer(&Name::raw("y"), &bound_expr, &body, outer.node_id())
+                .expect("the lift shape matches");
         assert_eq!(inner_name, Name::raw("x"));
 
         // Every `ExprStmt` on the spine carries a type. Checking for the absence

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -17,10 +17,13 @@ use crate::{
             check_pre_desugar, infer, typecheck,
         },
         inline, lambda_elim,
-        lineage::{Leak, RecorderSession, SourceProjection, collapse_lowering},
+        lineage::{
+            Leak, LineageLog, LineageMap, RecorderSession, SourceProjection, collapse,
+            collapse_lowering,
+        },
         lower::{LoweringContext, LoweringError, lower_stmts},
         mut_elim, planning,
-        provenance::NodeId,
+        provenance::{NodeId, Pass},
         symbolic::{symbolic, symbolic_typed},
         transact_phase, uniquify,
     },
@@ -487,8 +490,13 @@ pub struct CompiledProgram {
     /// present, since an unrecorded mint surfaces as `Leak::Unexplained` at the
     /// fold. Produced by
     /// [`collapse_lowering`](crate::ccl::lineage::collapse_lowering) at the
-    /// lowering boundary, never mutated incrementally. It is always-on and the
-    /// release `InferError` diagnostics read it one-hop (spans of the blame node).
+    /// lowering boundary, never mutated incrementally. It is the base every later
+    /// pane fold bottoms out in, and the release `InferError` diagnostics read it
+    /// one-hop (spans of the blame node). The downstream pane projections
+    /// (post-inference, post-desugar) are **not** stored here — they are folded
+    /// from this projection + [`pass_lineage`](Self::pass_lineage) at
+    /// snapshot-serve time by [`materialize_panes`](Self::materialize_panes),
+    /// keyed on the ids of each retained snapshot tree.
     pub lowering_projection: SourceProjection,
     /// The **pre-inference** IR snapshot — the inspector's upstream (source-shaped,
     /// pre-monomorphization) pane, captured right after `uniquify` and before
@@ -501,8 +509,11 @@ pub struct CompiledProgram {
     /// shared/remapped `NodeId`s.
     ///
     /// Monomorphization runs *inside* `infer`, freshening cloned ids, so this
-    /// snapshot holds the pre-mono **originals**; every ordinary node keeps its
-    /// id identical across the pair. Its ids resolve against the
+    /// snapshot holds the pre-mono **originals**. Its fan-out to the post-mono
+    /// [`post_inference_ir`](Self::post_inference_ir) is exactly the
+    /// [`Pass::Mono`] lineage log in [`pass_lineage`](Self::pass_lineage) (one
+    /// upstream def → N downstream clones); every ordinary node keeps its id
+    /// identical across the pair. Its ids resolve against the
     /// [`lowering_projection`](Self::lowering_projection) (they are the pre-mono originals, keyed by lowering's
     /// directly-lowered attributions).
     pub pre_inference_ir: Expr,
@@ -511,11 +522,14 @@ pub struct CompiledProgram {
     /// This is `expr` captured **right after `infer`/`typecheck` and before
     /// `inline::inline_non_iterable_lambdas` consumes it**: fully typed, but
     /// still *source-shaped* (lambdas intact, not yet point-free — `inline`,
-    /// `lambda_elim`, and `planning` have not run).
+    /// `lambda_elim`, and `planning` have not run). Its node ids are the input
+    /// pane of the post-inference → post-desugar fold and resolve against the
+    /// materialized post-inference projection (see
+    /// [`materialize_panes`](Self::materialize_panes)).
     ///
     /// Distinct from [`ast`](Self::ast), which holds `join_planned` (the
     /// *post-planning* tree): `lambda_elim`/`planning` re-mint every `NodeId`,
-    /// so `ast`'s ids don't resolve against the lowering projection, and it is
+    /// so `ast`'s ids resolve to `None` in the table, and it is
     /// execution-shaped (point-free, fused) — the wrong tree for a source-level
     /// view. The inspector anchors here instead.
     pub post_inference_ir: Expr,
@@ -529,9 +543,38 @@ pub struct CompiledProgram {
     /// fan-ins) are present. Because monomorphization ran earlier (inside
     /// `infer`), this tree is post-mono like [`post_inference_ir`](Self::post_inference_ir).
     ///
-    /// Every id preserved through inline/transact/letrec/desugar is shared with
-    /// [`post_inference_ir`](Self::post_inference_ir).
+    /// The post-inference ⇄ post-desugar adjacency is folded from the
+    /// [`Pass::Inline`] + [`Pass::Desugar`] entries of
+    /// [`pass_lineage`](Self::pass_lineage) at snapshot-serve time (see
+    /// [`materialize_panes`](Self::materialize_panes)); every id preserved
+    /// through inline/transact/letrec/desugar is shared with
+    /// [`post_inference_ir`](Self::post_inference_ir) (a self-edge).
     pub post_desugar_ir: Expr,
+    /// Per-pass [`LineageLog`]s recorded by the lineage recorder
+    /// ([`crate::ccl::lineage`]), in pipeline order:
+    ///
+    /// * [`Pass::Mono`] — monomorphization's per-clone `Copy` steps and the
+    ///   `coalesce_generalized_let` wrapper `Transform` (bridges the
+    ///   pre-inference ⇄ post-inference panes),
+    /// * [`Pass::Inline`] — inline's beta/alias discard `Transform`s and fan-out
+    ///   `Copy` steps,
+    /// * [`Pass::Transact`] — the transaction rewrite's `transact.commit`
+    ///   Transform (consuming the `with begin():` markers) plus its commit-`LetRec`
+    ///   scaffolding births and `subst_env` snapshot copies,
+    /// * [`Pass::Letrec`] — the induction phase's `letrec.loop` Transform
+    ///   (consuming the loop spine) plus its history/decision births and copies,
+    ///   and
+    /// * [`Pass::Desugar`] — channelize's cluster/feed-union/lift/drop rewrites
+    ///   (Inline + Transact + Letrec + Desugar together bridge post-inference ⇄
+    ///   post-desugar, fully recorded — no catch-all).
+    ///
+    /// This is the **authoritative** lineage surface. [`materialize_panes`](Self::materialize_panes)
+    /// folds it at each pane boundary into the per-pane
+    /// [`SourceProjection`](crate::ccl::lineage::SourceProjection)s and pane-pair
+    /// [`LineageMap`](crate::ccl::lineage::LineageMap)s the inspector consumes.
+    // Consumed by the inspector model; unused within the compiler itself.
+    #[allow(dead_code)]
+    pub(crate) pass_lineage: Vec<(Pass, LineageLog)>,
     /// The parsed CHL surface AST — the source-of-truth for source-level
     /// (lexical) inspector queries.
     ///
@@ -574,6 +617,83 @@ impl CompiledProgram {
     pub fn sinks(&self) -> impl Iterator<Item = &CompiledOutput> {
         self.outputs.iter().filter(|o| !o.is_main())
     }
+
+    /// Fold [`pass_lineage`](Self::pass_lineage) at the two pane boundaries into
+    /// the per-pane [`SourceProjection`]s and pane-pair [`LineageMap`]s the
+    /// inspector consumes. Cold path (snapshot-serve only), never called by
+    /// `compile_program`:
+    ///
+    /// * pre-inference pane = the lowering projection (uniquify preserves ids);
+    /// * post-inference pane = fold the Mono log (lowering projection →
+    ///   post-inference ids);
+    /// * post-desugar pane = fold the concatenated Inline + Desugar logs
+    ///   (post-inference → post-desugar ids). Both boundaries are fully recorded.
+    // Consumed by the inspector model (a later commit in this stack).
+    #[allow(dead_code)]
+    pub(crate) fn materialize_panes(&self) -> MaterializedPanes {
+        debug_assert_eq!(
+            self.pass_lineage.first().map(|(p, _)| *p),
+            Some(Pass::Mono),
+            "pass_lineage must retain the Mono log first (the pre→post-inference boundary)"
+        );
+        let pre_ids = collect_tree_ids(&self.pre_inference_ir);
+        let post_inf_ids = collect_tree_ids(&self.post_inference_ir);
+        let post_des_ids = collect_tree_ids(&self.post_desugar_ir);
+
+        // Boundary 1: the Mono log (first entry) bridges pre → post-inference.
+        let (mono_map, post_inference, mono_leaks) = collapse(
+            &self.pass_lineage[..1],
+            &pre_ids,
+            &post_inf_ids,
+            &self.lowering_projection,
+        );
+        // The Mono boundary is fully recorded (mono Copy steps + the coalesce
+        // wrapper Transform consuming the whole original def subtree).
+        assert_leaks_clean(&mono_leaks, "pre-inference → post-inference (Mono)");
+
+        // Boundary 2: the Inline + Transact + Letrec + Desugar logs bridge
+        // post-inference → post-desugar. All four passes record their rewrites, so
+        // this boundary is fully recorded too — zero-leak, no catch-all bridge.
+        let (desugar_map, post_desugar, desugar_leaks) = collapse(
+            &self.pass_lineage[1..],
+            &post_inf_ids,
+            &post_des_ids,
+            &post_inference,
+        );
+        assert_leaks_clean(
+            &desugar_leaks,
+            "post-inference → post-desugar (Inline+Transact+Letrec+Desugar)",
+        );
+
+        MaterializedPanes {
+            pre_inference: self.lowering_projection.clone(),
+            post_inference,
+            post_desugar,
+            mono_map,
+            desugar_map,
+        }
+    }
+}
+
+/// The per-pane projections and pane-pair lineage maps materialized from
+/// [`CompiledProgram::pass_lineage`] — see
+/// [`CompiledProgram::materialize_panes`]. Inspector-facing; the pane
+/// projections drive `hover`/`resolve`/`spanIndex`/`build_inspect_tree`, and the
+/// maps drive the cross-pane `paneLinks` (shipped dense, self-edges included).
+// Consumed by the inspector model; unused within the compiler itself.
+#[allow(dead_code)]
+pub(crate) struct MaterializedPanes {
+    /// pre-inference pane projection (= the lowering projection).
+    pub(crate) pre_inference: SourceProjection,
+    /// post-inference pane projection.
+    pub(crate) post_inference: SourceProjection,
+    /// post-desugar pane projection.
+    pub(crate) post_desugar: SourceProjection,
+    /// pre-inference → post-inference lineage map (Mono fan-out). Dense: shipped
+    /// verbatim on the `paneLinks` wire, self-edges included.
+    pub(crate) mono_map: LineageMap<NodeId, NodeId>,
+    /// post-inference → post-desugar lineage map (Inline + Desugar).
+    pub(crate) desugar_map: LineageMap<NodeId, NodeId>,
 }
 
 /// Every main-tree node id reachable in `expr` (the `walk_children` node set,
@@ -589,11 +709,16 @@ pub(crate) fn collect_tree_ids(expr: &Expr) -> std::collections::HashSet<NodeId>
     acc
 }
 
-/// The lowering-boundary leak gate: the lowering log records every mint and
-/// copy at its site, so [`collapse_lowering`]'s fold must explain every
-/// output-tree node with **no** leak of any class — an `Unexplained` (an
-/// unrecorded lowering mint) is a recording bug, not tolerated residue.
-/// Debug/test only, single code path (`cfg!`, not `#[cfg]`).
+/// The boundary leak gate.
+///
+/// Both inspector pane boundaries are now **fully recorded** — every pass between
+/// two retained panes (Mono at boundary 1; Inline + Transact + Letrec + Desugar
+/// at boundary 2) emits its mints/consumes/copies as [`RewriteStep`]s — so the
+/// fold must explain every node with **no** leak of any class. There is no
+/// catch-all bridge — every node is explained by a recorded step: an
+/// `Unexplained` (an uncaptured mint) or a `Dropped`
+/// (an unconsumed vanishing node) is a recording bug, not tolerated residue.
+/// Debug/test only (the fold is the cold snapshot-serve path).
 fn assert_leaks_clean(leaks: &[Leak], boundary: &str) {
     if !cfg!(any(debug_assertions, test)) {
         return;
@@ -786,8 +911,10 @@ pub fn compile_program(
 
     // Retain the pre-inference IR for the inspector's upstream pane before
     // `infer` mutates `expr` in place. This is the source-shaped, pre-mono,
-    // still-hole-typed tree. Its ids resolve against the `lowering_projection`
-    // (the pre-mono originals). See `CompiledProgram::pre_inference_ir`.
+    // still-hole-typed tree; its fan-out to the post-inference snapshot (mono
+    // freshens clone ids inside `infer`) is recorded in the `Pass::Mono` lineage
+    // log captured below. Its ids resolve against the `lowering_projection` (the
+    // pre-mono originals). See `CompiledProgram::pre_inference_ir`.
     let pre_inference_ir = expr.clone();
 
     // Register every source (pre-registered + discovered during lowering) with
@@ -806,13 +933,20 @@ pub fn compile_program(
 
     // Inference runs on the user-shaped tree — before channelize — so type
     // errors are reported against the program the user wrote, not the
-    // channelized rewrite.
+    // channelized rewrite. Monomorphization runs *inside* `infer`; a
+    // `RecorderSession` installed across the boundary captures its per-clone
+    // `Copy` steps and the `coalesce_generalized_let` wrapper `Transform` into
+    // the `Pass::Mono` lineage log (the pre → post-inference pane bridge).
+    let mono_session = RecorderSession::new();
     let infer_outcome = infer(&mut expr, ctx.inference_ctx());
+    let mono_lineage = mono_session.into_log();
     // On failure, resolve each error's own blame node to a source span *here* —
     // the lowering projection is in scope and holds the lowered attribution (this
-    // is the always-on release read: one hop, no fold). Every error names a node;
-    // an id the projection doesn't cover (a node minted after lowering, e.g. by
-    // monomorphization) degrades to a span-less diagnostic.
+    // is the always-on release read: one hop, no fold, before any pane exists).
+    // Infer errors occur before the panes are materialized, so the lowering
+    // projection is the only lineage layer they can consult. Every error names a
+    // node; an id the projection doesn't cover (a node minted after lowering,
+    // e.g. by monomorphization) degrades to a span-less diagnostic.
     if let Err(errors) = infer_outcome {
         return Err(errors
             .into_iter()
@@ -879,12 +1013,20 @@ pub fn compile_program(
     // Retain the post-inference IR for the inspector before `inline` consumes
     // `expr`. This is the source-shaped, fully-typed anchor (lambdas intact, not
     // yet point-free; inline/transact/letrec/desugar/lambda_elim/planning have
-    // not run). `ast` (`join_planned`) is the *wrong* tree for a source
+    // not run). Its node ids are the input pane of the post-inference →
+    // post-desugar fold. `ast` (`join_planned`) is the *wrong* tree for a source
     // view — `lambda_elim`/`planning` re-mint ids and produce execution shape.
     // See `CompiledProgram::post_inference_ir`.
     let post_inference_ir = expr.clone();
 
-    expr = inline::inline_non_iterable_lambdas(expr);
+    // Runs inline under a `RecorderSession` so its construction steps (beta/alias
+    // discard `Transform`s + fan-out `Copy`s) are captured into a `LineageLog`
+    // retained on `CompiledProgram::pass_lineage` (`Pass::Inline`).
+    let (inlined, inline_lineage) = inline::inline_with_lineage(expr);
+    expr = inlined;
+    // Id-uniqueness tripwire at the inline boundary. Order-agnostic tree
+    // invariant; see `assert_unique_node_ids`.
+    assert_unique_node_ids(&expr, "post-inline");
     debug!("UDFs inlined CCL:\n{}", symbolic(&expr));
     check_pre_desugar(&expr).map_err(|errs| {
         if errs
@@ -929,7 +1071,14 @@ pub fn compile_program(
     // supported, and it is exactly the out-of-block form).
     transact_phase::check_no_guarded_induction_writes(&expr, &txn_registers)
         .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
+    // Runs the transact phase under a `RecorderSession` so its rewrite steps
+    // (site strips → commit `LetRec`, decision/history/tap mints, `subst_env`
+    // copies) are captured into a `LineageLog` retained on
+    // `CompiledProgram::pass_lineage` (`Pass::Transact`).
+    let transact_session = RecorderSession::new();
     expr = transact_phase::run(expr, &txn_registers);
+    let transact_lineage = transact_session.into_log();
+    assert_unique_node_ids(&expr, "post-transact");
     debug!("Transact phase CCL:\n{}", symbolic(&expr));
     check_pre_desugar(&expr).expect("transact phase produced an inconsistent tree");
 
@@ -941,7 +1090,14 @@ pub fn compile_program(
     // hoisted to an ordinary feed of the loop's history for desugar to route.
     // The tree still carries Defer/Feed here, so the walls are the relaxed
     // pre-desugar check.
+    // Runs the mut-elim (induction) phase under a `RecorderSession` so its rewrite
+    // steps (loop → causal `LetRec`, decision/history mints, `subst_env` copies)
+    // are captured into a `LineageLog` retained on `CompiledProgram::pass_lineage`
+    // (`Pass::Letrec`).
+    let letrec_session = RecorderSession::new();
     let phase_out = mut_elim::run(expr);
+    let letrec_lineage = letrec_session.into_log();
+    assert_unique_node_ids(&phase_out, "post-letrec-run");
     debug!("Letrec phase CCL:\n{}", symbolic(&phase_out));
     check_pre_desugar(&phase_out).expect("letrec phase produced an inconsistent tree");
 
@@ -955,9 +1111,25 @@ pub fn compile_program(
     // remain: channelization is type-preserving by construction and closes
     // channel domains by substitution; the strict `typecheck` below is the
     // release-visible enforcement.
-    let mut desugared = channelize::run(phase_out, /* input_typed= */ true).errs()?;
+    // Runs channelize under a `RecorderSession` so its construction steps
+    // (cluster/feed-union/lift/drop `RewriteStep`s) are captured into a
+    // `LineageLog` retained on `CompiledProgram::pass_lineage` (`Pass::Desugar`).
+    let (channelize_result, desugar_lineage) =
+        channelize::run_with_lineage(phase_out, /* input_typed= */ true);
+    let mut desugared = channelize_result.errs()?;
     debug!("Channelized:\n{}", symbolic(&desugared));
     typecheck(&desugared).expect("channelize produced an ill-typed tree");
+    // Id-uniqueness tripwire on the post-channelize tree. Freshen-at-duplication
+    // (inline's `Subst` clones + channelize's fan-out source clones) makes this
+    // hold unconditionally now — before that migration channelize's bare
+    // `.clone()`s left genuine duplicate ids here, so no such assert could
+    // exist. Order-agnostic tree invariant; see `assert_unique_node_ids`.
+    assert_unique_node_ids(&desugared, "post-desugar");
+
+    // Desugar-stage provenance is folded from the `Pass::Inline` + `Pass::Transact`
+    // + `Pass::Letrec` + `Pass::Desugar` lineage logs at snapshot-serve time
+    // (`CompiledProgram::materialize_panes`) — every pass fully recorded. Nothing
+    // is applied here.
 
     // Retain the post-channelize tree for the inspector's downstream pane. On the
     // post-inference desugar order this snapshot is *downstream* of
@@ -1103,6 +1275,17 @@ pub fn compile_program(
         pre_inference_ir,
         post_inference_ir,
         post_desugar_ir,
+        // Pipeline order — Mono FIRST (bridges pre→post-inference), then Inline +
+        // Transact + Letrec + Desugar (bridge post-inference→post-desugar), in the
+        // order the passes run. `materialize_panes` relies on Mono being index 0
+        // (it folds `[..1]` for boundary 1 and `[1..]` for boundary 2).
+        pass_lineage: vec![
+            (Pass::Mono, mono_lineage),
+            (Pass::Inline, inline_lineage),
+            (Pass::Transact, transact_lineage),
+            (Pass::Letrec, letrec_lineage),
+            (Pass::Desugar, desugar_lineage),
+        ],
         source_ast: module,
         source: code.to_string(),
     })
@@ -1111,6 +1294,70 @@ pub fn compile_program(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ccl::lineage::{Nature, SourceAttribution};
+
+    /// Compile a program for provenance inspection, returning the whole
+    /// [`CompiledProgram`].
+    fn compile_ok(code: &str) -> CompiledProgram {
+        let mut ctx = GlobalContext::default();
+        let consumer: Box<dyn Consumer> = Box::new(|| {});
+        compile_program(&mut ctx, code, consumer).expect("program compiles")
+    }
+
+    /// Provenance census of a stage tree against its materialized pane
+    /// [`SourceProjection`]: a count of every **main-tree** node (the
+    /// `walk_children` node-set) by attribution category — `Source`,
+    /// `Derived(<pass>)`, `Synthetic(<pass>)` (via [`attr_category`]),
+    /// or `unresolved` (no projection entry). A `BTreeMap` so the pinned rows are
+    /// order-stable and diff cleanly.
+    ///
+    /// This is the guardrail that converts a future pass churning ids without
+    /// recording into a *forced visible diff*: it shows up as `Synthetic`
+    /// inflation and fails the pinned row. With every pane boundary fully
+    /// recorded AND the lowering fold covering every node (each a `Source`
+    /// direct image or a `Synthetic(Lower)` plumbing leaf — an unrecorded mint
+    /// would be a `Leak::Unexplained` at `collapse_lowering`), `unresolved` is a
+    /// hard zero at every pane — asserted structurally in `census_ratchet`, not
+    /// ratcheted per row.
+    /// The flat provenance category string for a node's attribution — the
+    /// census row key and the label the mono/inline/desugar tests match on.
+    ///
+    /// Test-only: schema 3 ships the native `{via, nature, label}` tag on the
+    /// wire, so this categorization no longer lives on `SourceAttribution`. It
+    /// folds the two-axis tag back into the flat `Source` / `Derived(<via>)` /
+    /// `Synthetic(<via>)` vocabulary these ratchets pin.
+    fn attr_category(attr: &SourceAttribution) -> String {
+        match attr.rewritten.nature {
+            // A direct image (`Nature::Source`) is the census `Source` row — the
+            // wire null-compresses it, and the ratchet pins it unmoved.
+            Nature::Source => "Source".to_string(),
+            Nature::Expansion => format!("Derived({:?})", attr.rewritten.via),
+            Nature::Machinery => format!("Synthetic({:?})", attr.rewritten.via),
+        }
+    }
+
+    fn provenance_census(
+        stage_ir: &Expr,
+        projection: &SourceProjection,
+    ) -> std::collections::BTreeMap<String, usize> {
+        fn label(projection: &SourceProjection, id: NodeId) -> String {
+            match projection.get(&id) {
+                None => "unresolved".to_string(),
+                Some(attr) => attr_category(attr),
+            }
+        }
+        fn walk(
+            e: &Expr,
+            projection: &SourceProjection,
+            out: &mut std::collections::BTreeMap<String, usize>,
+        ) {
+            *out.entry(label(projection, e.node_id())).or_default() += 1;
+            e.walk_children(|c| walk(c, projection, out));
+        }
+        let mut out = std::collections::BTreeMap::new();
+        walk(stage_ir, projection, &mut out);
+        out
+    }
 
     /// Driver that runs `compile_program` for an error-only test, returning
     /// the collected error list. Discards the program — these tests only
@@ -1121,6 +1368,331 @@ mod tests {
         match compile_program(&mut ctx, code, consumer) {
             Ok(_) => panic!("expected compile error, got success"),
             Err(errs) => errs,
+        }
+    }
+
+    /// Compile-time canary for the always-on lowering session cost (a
+    /// *measurement hook*, not a gate — nothing is asserted here). The lowering
+    /// session installs in every
+    /// build now, recording at leaf grain (ordinary mints open no frame, so
+    /// `on_mint` stays a no-op) plus a copy frame per uncurry/compare-chain site,
+    /// followed by one O(nodes) fold. This times a representative compile so a
+    /// regression in that overhead is observable.
+    ///
+    /// Run manually (release, the meaningful configuration):
+    /// `cargo test --release -- --ignored lowering_session_cost_canary --nocapture`.
+    #[test]
+    #[ignore = "benchmark hook (not a gate); run manually with --release --nocapture"]
+    fn lowering_session_cost_canary() {
+        use std::time::Instant;
+        // A program exercising leaf recording (arithmetic/loop plumbing) plus a
+        // copy frame (the chained comparison's shared operand).
+        let code = "x := 0\nfor i in [1, 2, 3]:\n    x += i\n1 < x < 3\nx\n";
+        let iters = 2_000u32;
+        let start = Instant::now();
+        for _ in 0..iters {
+            let _ = compile_ok(code);
+        }
+        let elapsed = start.elapsed();
+        eprintln!(
+            "lowering-session canary: {iters} compiles in {elapsed:?} \
+             ({:?}/compile)",
+            elapsed / iters,
+        );
+    }
+
+    /// RT-4c: the provenance-census ratchet. Pins the exact per-category node
+    /// counts for a corpus of representative programs at each retained stage —
+    /// the *attribution* oracle, and the only one that reads
+    /// [`SourceAttribution`](crate::ccl::lineage::SourceAttribution) rather than
+    /// lineage fate. A pass that reattributes nodes moves a row, and that diff is
+    /// the commit's provenance-impact statement.
+    ///
+    /// # This test pins categories, not leaks
+    ///
+    /// **No leak of any class is tolerated anywhere**, so a census row can never
+    /// be a place one is blessed. `assert_leaks_clean` asserts *zero* of every
+    /// [`Leak`](crate::ccl::lineage::Leak) class at both pane boundaries, and
+    /// `unresolved` (a node the pane projection knows nothing about) is asserted a
+    /// hard zero at every pane in the loop below. Both gates run in this test,
+    /// since `materialize_panes` is what produces the projections it censuses.
+    ///
+    /// What the counts add on top is the one thing fate accounting cannot see:
+    /// *which* attribution a node carries. A node can be perfectly explained by a
+    /// recorded step — no leak — and still be attributed to the wrong pass or the
+    /// wrong nature, which is what a moved row reports.
+    ///
+    /// # A moving total is not a coverage signal
+    ///
+    /// Counts are **structural**: one entry per node *position* in the retained
+    /// tree. So a row's total tracks the size of the emitted tree, and any change
+    /// to what a pass emits moves it — including changes that originate upstream
+    /// of the lineage machinery entirely. A total that moves means "the tree has a
+    /// different number of nodes", never "provenance was lost"; the oracles for
+    /// loss are the two hard zeros above, which fire independently of any count.
+    /// Classify a moved total by diffing the *tree* (`symbolic`), not by reasoning
+    /// from the census.
+    ///
+    /// The `Source` / `Synthetic(Lower)` split follows the structural rule on
+    /// `LoweringContext::tag_source`: `Source` marks a lowered *expression root*,
+    /// so an image that is not a root — a callee `Var`, an interior comparison of
+    /// a chain, a statement-level `Let` — counts as `Synthetic(Lower)` while still
+    /// carrying the `"lower.image"` label. Count moving between those two
+    /// categories is a reclassification.
+    ///
+    /// # Re-bless procedure
+    /// Run `cargo test -q --lib census_ratchet -- --nocapture` (or read the assert
+    /// diff on failure) and classify **every** unit of drift into a named cause
+    /// before updating a row — separating reattribution (this commit's own
+    /// provenance change) from a tree-shape change (someone else's). Anything
+    /// unexplained is a STOP, not a re-bless.
+    #[test]
+    fn census_ratchet() {
+        use std::collections::BTreeMap;
+        /// A per-stage census (category → count).
+        type Census = BTreeMap<String, usize>;
+        /// One corpus row: program name, source, and expected census for the
+        /// three retained stages (pre-inference, post-inference, post-desugar).
+        type Row = (&'static str, &'static str, [Census; 3]);
+        fn bt(pairs: &[(&str, usize)]) -> Census {
+            pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+        }
+
+        let cases: &[Row] = &[
+            (
+                "arithmetic",
+                "x = 1 + 2\nx\n",
+                [
+                    // `let x = (1 + 2) in x`: the four expression roots (`1`, `2`,
+                    // the `+`, the trailing `x`) are `Source`; the `Let` images the
+                    // *assignment statement*, and a statement is not a
+                    // `Spanned<ChlExpr>`, so under the structural rule it is
+                    // `Synthetic(Lower)` carrying the `"lower.image"` label.
+                    bt(&[("Source", 4), ("Synthetic(Lower)", 1)]),
+                    bt(&[("Source", 4), ("Synthetic(Lower)", 1)]),
+                    bt(&[("Source", 4), ("Synthetic(Lower)", 1)]),
+                ],
+            ),
+            (
+                "polymorphic",
+                "dup = \\x -> (x, x)\n(dup(1), dup(2 == 2))\n",
+                [
+                    // Full lowering-projection coverage. The three
+                    // `Synthetic(Lower)` nodes are images that are not expression
+                    // *roots*: the two call-site callee `Var`s (images of the
+                    // written function names) and the `def`'s statement-level
+                    // `Let`. They keep the `"lower.image"` label.
+                    bt(&[("Source", 11), ("Synthetic(Lower)", 3)]),
+                    bt(&[
+                        ("Derived(Mono)", 10),
+                        ("Source", 7),
+                        ("Synthetic(Lower)", 2),
+                    ]),
+                    // Freshen-at-duplication: inline copies every
+                    // occurrence of a fanned-out UDF body, so the formerly
+                    // keep-first-preserved occurrence (Mono/Source) is now a
+                    // freshened `Derived(Inline)` copy too. Structural count is
+                    // unchanged (11); the attribution shifts Mono+Source → Inline.
+                    bt(&[("Derived(Inline)", 10), ("Source", 1)]),
+                ],
+            ),
+            (
+                "udf_fanout",
+                "def inc(n):\n    n + 1\na = inc(1)\nb = inc(2)\na + b\n",
+                [
+                    // Six non-root images: the `def` and two `a`/`b` assignment
+                    // `Let`s, and the three callee `Var`s.
+                    bt(&[("Source", 10), ("Synthetic(Lower)", 6)]),
+                    bt(&[("Derived(Mono)", 5), ("Source", 7), ("Synthetic(Lower)", 4)]),
+                    // See `polymorphic`: freshen-at-duplication reattributes the
+                    // formerly-preserved inlined occurrences to `Derived(Inline)`.
+                    bt(&[
+                        ("Derived(Inline)", 6),
+                        ("Source", 3),
+                        ("Synthetic(Lower)", 2),
+                    ]),
+                ],
+            ),
+            (
+                "compare_chain",
+                // Chained comparison — the keep-first duplicate-NodeId
+                // regression program. The outermost AND glue is re-tagged as the
+                // whole expression's image (`Source`); each *pair* BinOp images
+                // its own `<` but is interior, so it is `Synthetic(Lower)` under
+                // the structural rule, as are the `x = 2` assignment `Let` and the
+                // statement-sequencing `ExprStmt`. The freshened second use of the
+                // shared middle operand still mirrors its origin's attribution.
+                "x = 2\n1 < x < 3\nx\n",
+                [
+                    bt(&[("Source", 7), ("Synthetic(Lower)", 4)]),
+                    bt(&[("Source", 7), ("Synthetic(Lower)", 4)]),
+                    // Inline substitutes the single-use `x` binding and drops
+                    // the effect-free comparison statement, leaving the small
+                    // surviving spine.
+                    bt(&[("Source", 2), ("Synthetic(Lower)", 1)]),
+                ],
+            ),
+            (
+                "mutation_loop",
+                "x := 0\nfor i in [1, 2, 3]:\n    x += i\nx\n",
+                [
+                    // Lowering-manufactured plumbing (the `+=` expansion's
+                    // read/arithmetic, the loop-body chain terminal, the loop's
+                    // sequencing `ExprStmt`) is attributed `Synthetic(Lower)` by
+                    // lowering at its mint site; everything the user wrote images
+                    // as `Source`.
+                    bt(&[("Source", 7), ("Synthetic(Lower)", 8)]),
+                    bt(&[("Source", 7), ("Synthetic(Lower)", 8)]),
+                    // post-desugar: the letrec phase records its
+                    // loop→`LetRec` rewrite as honest `Derived(Letrec)`
+                    // (Expansion).
+                    //
+                    // Two movements from the pinned 38/7/3 (total 48 → 46), both
+                    // in the letrec phase:
+                    //
+                    // - **46, not 48.** The writer decision is now built by one
+                    //   `decision_record`/`disjoin_guards` pair shared with the
+                    //   conditional path, which synthesizes two fewer nodes than
+                    //   the open-coded unconditional construction it replaced.
+                    //   Count only; no attribution changed.
+                    // - **3 nodes moved `Source`(1)/`Synthetic(Lower)`(2) →
+                    //   `Derived(Letrec)`.** A write's value is inlined into the
+                    //   read-your-writes environment as a *template*, and the
+                    //   terminal takes a `fresh_copy` of it into the write set
+                    //   (`mut_elim`'s `current`), so the final value's nodes are
+                    //   now recorded `Op::Copy`s of that template rather than
+                    //   preserved originals. A pass `Copy` mirrors its origin's
+                    //   *spans* but carries the step's own nature, so `x += i`'s
+                    //   arithmetic keeps its source span while its category
+                    //   becomes phase-derived.
+                    bt(&[
+                        ("Derived(Letrec)", 39),
+                        ("Source", 6),
+                        ("Synthetic(Lower)", 1),
+                    ]),
+                ],
+            ),
+            (
+                "txn_begin",
+                "out = defer()\npool: Mut(Int, Txn) := 100\nfor r in [10, 20, 30]:\n    with begin():\n        pool := pool - r\nwith begin():\n    out << pool\nout",
+                [
+                    bt(&[("Source", 12), ("Synthetic(Lower)", 19)]),
+                    bt(&[("Source", 12), ("Synthetic(Lower)", 19)]),
+                    // post-desugar: the transaction rewrite is recorded, so
+                    // the formerly bridge-swept commit `LetRec` scaffolding is
+                    // honest `Derived(Transact)` (54 — was 59 before the per-key
+                    // commit view was retired for allocate-on-commit, dropping
+                    // the decision copy + `commit` projection per writer); the
+                    // transaction-emptied `For` retired by the mut-elim phase is
+                    // `Derived(Letrec)` (2); channelize's feed-union/cluster
+                    // steps attribute 7 nodes `Derived(Desugar)`. The 2
+                    // `Synthetic(Lower)` survivors are the standalone
+                    // transaction's singleton `[unit]` source — manufactured by
+                    // lowering and attributed at the mint site.
+                    bt(&[
+                        ("Derived(Desugar)", 7),
+                        ("Derived(Letrec)", 2),
+                        ("Derived(Transact)", 54),
+                        ("Source", 6),
+                        ("Synthetic(Lower)", 2),
+                    ]),
+                ],
+            ),
+        ];
+
+        for (name, code, expected) in cases {
+            let p = compile_ok(code);
+            let panes = p.materialize_panes();
+            let actual = [
+                provenance_census(&p.pre_inference_ir, &panes.pre_inference),
+                provenance_census(&p.post_inference_ir, &panes.post_inference),
+                provenance_census(&p.post_desugar_ir, &panes.post_desugar),
+            ];
+            let stages = ["pre_inference_ir", "post_inference_ir", "post_desugar_ir"];
+            for i in 0..3 {
+                // Structural invariant, not a per-row ratchet: with the lowering
+                // fold covering every node (an unrecorded mint would be a
+                // `Leak::Unexplained` at `collapse_lowering`) and every pane
+                // boundary fully recorded, NO census at ANY pane may contain an
+                // `unresolved` row — a node the pane projection knows nothing
+                // about no longer exists.
+                assert!(
+                    !actual[i].contains_key("unresolved"),
+                    "`{name}` at {}: census contains `unresolved` rows ({:?}) — a node \
+                     escaped the lowering projection or a pass rewrote without recording",
+                    stages[i],
+                    actual[i]
+                );
+                assert_eq!(
+                    actual[i], expected[i],
+                    "census drift for `{name}` at {}: re-bless if intended (see the \
+                     re-bless procedure on this test)",
+                    stages[i]
+                );
+            }
+        }
+    }
+
+    /// Every conditional-induction shape reaches both pane boundaries clean.
+    ///
+    /// `assert_leaks_clean` and `assert_unique_node_ids` at the post-desugar
+    /// boundary only run under [`CompiledProgram::materialize_panes`], so the
+    /// compilation-pipeline suite — which compiles but never materializes —
+    /// cannot see a leak in a rewrite it otherwise exercises heavily. The
+    /// statement-`Case` arm of the letrec phase is exactly that blind spot: it
+    /// fans the post-`Case` remainder and the entering RYW env across every
+    /// branch, so each shape below stresses a different copy/consume pairing.
+    /// Materializing is the whole assertion — a leak or a duplicate id panics
+    /// inside, naming its class and boundary.
+    #[test]
+    fn conditional_induction_panes_are_leak_free() {
+        for (name, code) in [
+            // One conditional write: guard preserved into its own arm predicate,
+            // echoed (freshened) into the carry arm's.
+            (
+                "guard_only",
+                "x := 0\nfor i in [1, 2, 3]:\n    if i > 1:\n        x := x + i\nx\n",
+            ),
+            // Unconditional write *before* the `Case`: its inlined value sits in
+            // the RYW env slot every branch clones.
+            (
+                "uncond_before",
+                "x := 0\nfor i in [1, 2, 3]:\n    x := x + 1\n    if i > 1:\n        x := x + 10\nx\n",
+            ),
+            // Unconditional write *after* the `Case`: the remainder is spliced
+            // onto every path, including the trailing carry arm.
+            (
+                "uncond_after",
+                "x := 0\nfor i in [1, 2, 3]:\n    if i > 1:\n        x := x + 10\n    x := x + 1\nx\n",
+            ),
+            // `if`/`else` writing one accumulator on both arms.
+            (
+                "if_else",
+                "t := 0\nfor x in [1, 2, 3]:\n    if x > 2:\n        t := t + x\n    else:\n        t := t + 1\nt\n",
+            ),
+            // Two accumulators, one unconditional and one conditional — the
+            // shape where a branch's write set matches the carry for *some*
+            // accumulator but not all.
+            (
+                "two_accumulators",
+                "cnt := 0\ntotal := 0\nfor i in [1, 2, 3]:\n    cnt := cnt + 1\n    if i > 1:\n        total := total + i\ncnt * 10 + total\n",
+            ),
+            // Sibling `if`s (not `elif`) on one accumulator: two guard-Cases in
+            // one body, so the second one's remainder is itself a spliced copy.
+            (
+                "sibling_ifs",
+                "a := 0\nfor i in [1, 2, 3]:\n    if i > 1:\n        a := a + i\n    if i < 3:\n        a := a + 100\na\n",
+            ),
+        ] {
+            let compiled = compile_ok(code);
+            // The gates live inside; reaching the next iteration is the pass.
+            let panes = compiled.materialize_panes();
+            assert!(
+                !provenance_census(&compiled.post_desugar_ir, &panes.post_desugar)
+                    .contains_key("unresolved"),
+                "`{name}`: post-desugar census contains `unresolved` rows — a node \
+                 escaped the projection or a pass rewrote without recording"
+            );
         }
     }
 
@@ -1361,5 +1933,493 @@ x = (1 +)
             parse_count >= 1,
             "expected at least 1 parse error: {errs:?}"
         );
+    }
+
+    /// Monomorphization end-to-end: a generalized definition used at two
+    /// distinct types is monomorphized into two specializations. Each
+    /// specialization's cloned nodes get fresh `NodeId`s (so they no longer
+    /// collide on the original definition's ids), and the folded post-inference
+    /// projection attributes them `Derived(Mono)` with spans tracing — through
+    /// the per-clone `Copy` steps and the wrapper `Transform` — back to the
+    /// original lowered node's source span (within the def's first line).
+    #[test]
+    fn monomorphization_tags_specializations_with_mono_provenance() {
+        // `dup` is bound to a polymorphic lambda and applied at Int and String,
+        // forcing two specializations. A non-trivial body (`(x, x)`) keeps the
+        // definition from being beta-reduced away before inference (a plain
+        // `\x -> x` is inlined during lowering, leaving nothing to
+        // monomorphize). The trailing tuple is the program's value.
+        let code = "\
+dup = \\x -> (x, x)
+(dup(1), dup(\"a\"))
+";
+        let compiled = compile_ok(code);
+        let panes = compiled.materialize_panes();
+
+        // The `dup = \x -> (x, x)` statement is the first line; its nodes
+        // were attributed `Source` within that span by lowering, and the mono Copy /
+        // wrapper Transform steps carry those spans onto the specialization
+        // nodes as `Derived(Mono)`.
+        let def_line_end = code.find('\n').expect("two-line program");
+
+        // Walk the post-inference pane; collect every node whose attribution is
+        // `Derived(Mono)`.
+        fn collect_mono<'a>(
+            e: &Expr,
+            proj: &'a SourceProjection,
+            out: &mut Vec<&'a SourceAttribution>,
+        ) {
+            if let Some(attr) = proj.get(&e.node_id())
+                && attr_category(attr) == "Derived(Mono)"
+            {
+                out.push(attr);
+            }
+            e.walk_children(|c| collect_mono(c, proj, out));
+        }
+        let mut mono = Vec::new();
+        collect_mono(
+            &compiled.post_inference_ir,
+            &panes.post_inference,
+            &mut mono,
+        );
+        assert!(
+            !mono.is_empty(),
+            "monomorphization must attribute specialization nodes Derived(Mono)"
+        );
+        for attr in &mono {
+            assert!(
+                !attr.spans.is_empty(),
+                "a mono specialization resolves to its original def's source span(s)"
+            );
+            for span in &attr.spans {
+                assert!(
+                    span.end <= def_line_end,
+                    "mono origin span {span:?} traces back to the `dup` definition \
+                     (within the first line, bytes 0..{def_line_end})"
+                );
+            }
+        }
+    }
+
+    /// The inline fan-out copies resolve `Derived(Inline)` with real spans.
+    ///
+    /// A scalar UDF called at two sites *at the same type* fans its body out
+    /// during inlining (one specialization from mono, N freshened copies from
+    /// inline, each recorded as a `Copy` step). Each freshened body copy mirrors
+    /// the original body node's spans — so it resolves to that body's source
+    /// span in the post-desugar projection, attributed `Derived(Inline)`.
+    #[test]
+    fn inline_fanout_copies_resolve_via_inline_copy() {
+        // `add1` is a scalar UDF (Int → Int, non-iterable domain → inlined),
+        // called at two sites both at `Int`, so mono produces ONE specialization
+        // and the two-site fan-out is inline's. The body `x + 1` is duplicated
+        // into freshened copies (recorded as `Copy` steps).
+        let code = "\
+add1 = \\x -> x + 1
+a = add1(10)
+b = add1(20)
+a + b
+";
+        let compiled = compile_ok(code);
+        let panes = compiled.materialize_panes();
+
+        fn collect(expr: &Expr, acc: &mut std::collections::HashSet<NodeId>) {
+            acc.insert(expr.node_id());
+            expr.walk_children(|c| collect(c, acc));
+        }
+        let mut pre = std::collections::HashSet::new();
+        collect(&compiled.post_inference_ir, &mut pre);
+        let mut post = std::collections::HashSet::new();
+        collect(&compiled.post_desugar_ir, &mut post);
+
+        // Candidate inline copies: ids that appear post-desugar but not
+        // post-inference (the freshened fan-out copies; on this defer-free
+        // program transact/letrec/desugar mint nothing else of note).
+        let new_ids: Vec<NodeId> = post.difference(&pre).copied().collect();
+        assert!(
+            !new_ids.is_empty(),
+            "the two-site UDF must fan out into fresh post-desugar ids"
+        );
+
+        let proj = &panes.post_desugar;
+        let derived_inline: Vec<NodeId> = new_ids
+            .iter()
+            .copied()
+            .filter(|id| {
+                proj.get(id)
+                    .is_some_and(|a| attr_category(a) == "Derived(Inline)" && !a.spans.is_empty())
+            })
+            .collect();
+        assert!(
+            !derived_inline.is_empty(),
+            "at least one inline fan-out copy must resolve Derived(Inline) \
+             with non-empty spans; new ids resolved as: {:?}",
+            new_ids
+                .iter()
+                .map(|id| (*id, proj.get(id).map(attr_category)))
+                .collect::<Vec<_>>()
+        );
+
+        // Mislabel regression guard: no inline fan-out copy is attributed
+        // `Synthetic(Desugar)` — the `Copy` steps recorded them.
+        for id in &new_ids {
+            if let Some(a) = proj.get(id) {
+                assert_ne!(
+                    attr_category(a),
+                    "Synthetic(Desugar)",
+                    "inline fan-out copy {id:?} was left to the bridge (Synthetic(Desugar))"
+                );
+            }
+        }
+    }
+
+    /// Channelize's rewrites surface as `Desugar`-attributed nodes in the
+    /// post-desugar projection: a defer program compiles end-to-end and the
+    /// folded projection carries `Pass::Desugar` attributions — the recorded
+    /// feed-union/cluster steps (`Derived(Desugar)`, blaming the fed values) and
+    /// channelize's `Machinery` steps.
+    #[test]
+    fn desugar_tags_channelized_plumbing_with_desugar_provenance() {
+        // A for-loop feed: channelize routes the feed into a channel union +
+        // companion-source fan-out, recording those rewrites as Desugar steps.
+        let code = "\
+x = defer()
+for i in [1, 2, 3]:
+  x << i
+x
+";
+        let compiled = compile_ok(code);
+        let panes = compiled.materialize_panes();
+        let proj = &panes.post_desugar;
+
+        fn count_desugar(e: &Expr, proj: &SourceProjection, n: &mut usize) {
+            if proj.get(&e.node_id()).is_some_and(|a| {
+                let l = attr_category(a);
+                l == "Synthetic(Desugar)" || l == "Derived(Desugar)"
+            }) {
+                *n += 1;
+            }
+            e.walk_children(|c| count_desugar(c, proj, n));
+        }
+        let mut desugar = 0;
+        count_desugar(&compiled.post_desugar_ir, proj, &mut desugar);
+        assert!(
+            desugar >= 1,
+            "channelize's rewrites must be attributed via Pass::Desugar"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // The construction-step logs retained on
+    // `CompiledProgram::pass_lineage`. These assert on log *structure* (labels,
+    // op shapes, channel emptiness) — never on absolute NodeId values.
+    // -----------------------------------------------------------------------
+    mod lineage_adoption {
+        use super::*;
+        use crate::ccl::lineage::{Leak, LineageLog, Op, SourceProjection, collapse};
+        use std::collections::HashSet;
+
+        fn log_for(prog: &CompiledProgram, pass: Pass) -> &LineageLog {
+            prog.pass_lineage
+                .iter()
+                .find(|(p, _)| *p == pass)
+                .map(|(_, l)| l)
+                .expect("pass has a retained lineage log")
+        }
+
+        /// Every main-tree node id of `e` (skips type-predicate interiors, the
+        /// node set the steps reason about).
+        fn tree_ids(e: &Expr) -> HashSet<NodeId> {
+            fn go(e: &Expr, s: &mut HashSet<NodeId>) {
+                s.insert(e.node_id());
+                e.walk_children(|c| go(c, s));
+            }
+            let mut s = HashSet::new();
+            go(e, &mut s);
+            s
+        }
+
+        /// A top-level two-feed defer cluster: no loop (so no companion-channel
+        /// duplication) and no mutation (so transact/letrec are inert). Exercises
+        /// the cluster step and the feed-union fan-in.
+        const DEFER_CLUSTER: &str = "x = defer()\nx << [1, 2]\nx << [3, 4]\nx\n";
+
+        #[test]
+        fn defer_cluster_logs_cluster_and_feed_union_steps() {
+            let prog = compile_ok(DEFER_CLUSTER);
+            let log = log_for(&prog, Pass::Desugar);
+
+            let cluster = log
+                .iter()
+                .find(|s| s.label == "channelize.cluster")
+                .expect("a channelize.cluster step");
+            match &cluster.op {
+                Op::Transform { consumed, produced } => {
+                    assert!(
+                        !consumed.is_empty(),
+                        "cluster consumes the defer scaffolding: {:?}",
+                        cluster.op
+                    );
+                    assert!(
+                        !produced.is_empty(),
+                        "cluster produces the carrier letrec: {:?}",
+                        cluster.op
+                    );
+                }
+                other => panic!("cluster step must be a Transform, got {other:?}"),
+            }
+
+            let feed_union = log
+                .iter()
+                .find(|s| s.label == "channelize.feed_union")
+                .expect("a channelize.feed_union step");
+            match &feed_union.op {
+                Op::Transform { consumed, .. } => assert!(
+                    consumed.is_empty(),
+                    "feed_union is a pure insertion (empty consumed): {:?}",
+                    feed_union.op
+                ),
+                other => panic!("feed_union step must be a Transform, got {other:?}"),
+            }
+            assert!(
+                !feed_union.blame.is_empty(),
+                "feed_union blames the surviving fed-value roots",
+            );
+        }
+
+        #[test]
+        fn inline_fanout_logs_copy_steps() {
+            // `inc` is called twice: its body fans out to both sites; each
+            // freshened copy (now minted at the duplication site, not by a
+            // post-hoc dedup sweep) is captured as a Copy step.
+            let prog = compile_ok("def inc(n):\n    n + 1\na = inc(1)\nb = inc(2)\na + b\n");
+            let log = log_for(&prog, Pass::Inline);
+            let copies = log
+                .iter()
+                .filter(|s| matches!(s.op, Op::Copy { .. }))
+                .count();
+            assert!(
+                copies >= 1,
+                "inline fan-out must record at least one Copy step; log: {log:?}"
+            );
+        }
+
+        #[test]
+        fn defer_free_program_has_near_empty_channelize_log() {
+            // No defers ⇒ channelize rewrites nothing; its log carries no cluster,
+            // feed-union, lift, or drop steps.
+            let prog = compile_ok("a = 1\nb = 2\na + b\n");
+            let log = log_for(&prog, Pass::Desugar);
+            assert!(
+                log.iter().all(|s| !s.label.starts_with("channelize.")),
+                "defer-free program should log no channelize rewrites; got {log:?}"
+            );
+        }
+
+        /// An unconditional loop feeding a defer: `channelize` fans the feed out
+        /// over a *cloned iteration source* (the compose-fanout companion). Its
+        /// source clones were bare `.clone()`s sharing NodeIds before
+        /// freshen-at-duplication — a genuine duplicate-id class in
+        /// `post_desugar_ir`. The transact/letrec phases are inert on a pure
+        /// defer loop (no mutation), so the pane pair is fully explained.
+        const LOOP_FED_DEFER: &str = "x = defer()\nfor i in [1, 2, 3]:\n  x << i\nx\n";
+
+        /// A guarded loop feed lowers to a `Case` with a `true → unit`
+        /// fallthrough, taking the case-fanout arm.
+        const CASE_FED_DEFER: &str =
+            "x = defer()\nfor i in [1, 2, 3]:\n  if i > 1:\n    x << i\nx\n";
+
+        #[test]
+        fn case_and_loop_fed_defer_post_desugar_ids_are_unique() {
+            // The tree-invariant tripwire (`assert_unique_node_ids`) runs inside
+            // `compile_program`; assert the same here, focused on the fan-out
+            // classes that produced genuine duplicate ids before this migration
+            // (channelize's source clones fed a loop / `Case`).
+            for code in [LOOP_FED_DEFER, CASE_FED_DEFER] {
+                let prog = compile_ok(code);
+                let dups = duplicate_node_ids(&prog.post_desugar_ir);
+                assert!(
+                    dups.is_empty(),
+                    "post_desugar_ir must carry unique ids for `{code}`; dups: {dups:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn loop_fed_defer_records_source_copies_and_has_no_leaks() {
+            let prog = compile_ok(LOOP_FED_DEFER);
+            let log = log_for(&prog, Pass::Desugar);
+
+            // The freshened iteration-source clones are recorded as Copy steps
+            // (they were invisible shared-id clones before freshen-at-source).
+            let copies = log
+                .iter()
+                .filter(|s| matches!(s.op, Op::Copy { .. }))
+                .count();
+            assert!(
+                copies >= 1,
+                "loop-fed fan-out must record source Copy steps; log: {log:?}"
+            );
+
+            let input_ids = tree_ids(&prog.post_inference_ir);
+            let output_ids = tree_ids(&prog.post_desugar_ir);
+            // The post-inference → post-desugar boundary is the Inline + Desugar
+            // logs (`pass_lineage[1..]`); the leading Mono log bridges the
+            // pre → post-inference boundary and would reference pre-inference ids
+            // absent from this input pane.
+            let (_map, _proj, leaks) = collapse(
+                &prog.pass_lineage[1..],
+                &input_ids,
+                &output_ids,
+                &SourceProjection::new(),
+            );
+            // A pure defer loop keeps transact/letrec inert (the documented
+            // tolerance would apply on a *mutation* loop), so the channelize
+            // steps — now including the source Copy steps — fully explain the
+            // pane pair with no residual leak of any kind.
+            assert!(
+                leaks.is_empty(),
+                "loop-fed defer pane pair must be fully explained; leaks: {leaks:?}"
+            );
+        }
+
+        #[test]
+        fn collapse_over_real_panes_has_no_channelize_attributable_leaks() {
+            let prog = compile_ok(DEFER_CLUSTER);
+            let input_ids = tree_ids(&prog.post_inference_ir);
+            let output_ids = tree_ids(&prog.post_desugar_ir);
+
+            // Inline + Desugar logs bridge this pane pair; the Mono log
+            // (`pass_lineage[0]`) belongs to the pre → post-inference boundary.
+            let (_map, _proj, leaks) = collapse(
+                &prog.pass_lineage[1..],
+                &input_ids,
+                &output_ids,
+                &SourceProjection::new(),
+            );
+
+            // A recording *bug* would surface as one of these structural leaks
+            // (an ordering/attribution error inside a step). Their absence is the
+            // real invariant: the channelize steps consume/produce live ids only.
+            let bug_leaks: Vec<&Leak> = leaks
+                .iter()
+                .filter(|l| {
+                    matches!(
+                        l,
+                        Leak::ConsumedUnknown { .. }
+                            | Leak::CopyOfUnknown { .. }
+                            | Leak::ProducedLive { .. }
+                            | Leak::EmptyConsumed { .. }
+                    )
+                })
+                .collect();
+            assert!(
+                bug_leaks.is_empty(),
+                "no channelize-attributable recording bug leaks; got {bug_leaks:?}"
+            );
+
+            // Unexplained/Dropped leaks that remain are NOT channelize's: the
+            // transact/letrec phases run between the two panes and mint/consume
+            // nodes without recording steps until the next increment. This
+            // program keeps them inert (no mutation, no loop), so in practice the
+            // list is empty — assert that to catch a channelize regression, while
+            // documenting why a residual would be tolerable.
+            let residual: Vec<&Leak> = leaks
+                .iter()
+                .filter(|l| matches!(l, Leak::Unexplained { .. } | Leak::Dropped { .. }))
+                .collect();
+            assert!(
+                residual.is_empty(),
+                "this program keeps transact/letrec inert, so channelize's steps \
+                 should fully explain the pane pair; residual leaks: {residual:?}"
+            );
+        }
+
+        /// A mutation loop (`x := 0; for i: x += i; x`).
+        const MUTATION_LOOP: &str = "x := 0\nfor i in [1, 2, 3]:\n    x += i\nx\n";
+        /// A transaction program: a `with begin():` writer loop + a fed-out read.
+        const TXN: &str = "out = defer()\npool: Mut(Int, Txn) := 100\n\
+             for r in [10, 20, 30]:\n    with begin():\n        pool := pool - r\n\
+             with begin():\n    out << pool\nout";
+
+        #[test]
+        fn letrec_loop_records_a_consuming_transform_step() {
+            // The induction phase records its loop → guarded `LetRec` rewrite as a
+            // `letrec.loop` Transform consuming the loop statement's spine.
+            let prog = compile_ok(MUTATION_LOOP);
+            let log = log_for(&prog, Pass::Letrec);
+            // Select the `Transform` explicitly: a frame's captured `Copy`s carry
+            // its label too, and those whose origin the frame consumes flush
+            // *ahead* of it (see `lineage`, "Flush order within a frame"), so the
+            // first `letrec.loop` record is not necessarily the Transform.
+            let loop_step = log
+                .iter()
+                .find(|s| s.label == "letrec.loop" && matches!(s.op, Op::Transform { .. }))
+                .expect("a letrec.loop Transform step");
+            match &loop_step.op {
+                Op::Transform { consumed, produced } => {
+                    assert!(
+                        !consumed.is_empty(),
+                        "the loop rewrite consumes the loop spine: {:?}",
+                        loop_step.op
+                    );
+                    assert!(
+                        !produced.is_empty(),
+                        "the loop rewrite mints the carrier LetRec scaffolding: {:?}",
+                        loop_step.op
+                    );
+                }
+                other => panic!("letrec.loop must be a Transform, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn transact_records_a_commit_transform_step() {
+            // The transaction phase records its whole rewrite as a
+            // `transact.commit` Transform consuming the `with begin():` markers.
+            let prog = compile_ok(TXN);
+            let log = log_for(&prog, Pass::Transact);
+            let commit = log
+                .iter()
+                .find(|s| s.label == "transact.commit")
+                .expect("a transact.commit step");
+            match &commit.op {
+                Op::Transform { consumed, produced } => {
+                    assert!(
+                        !consumed.is_empty(),
+                        "the transaction rewrite consumes the `with begin():` markers: {:?}",
+                        commit.op
+                    );
+                    assert!(
+                        !produced.is_empty(),
+                        "the transaction rewrite mints the commit LetRec scaffolding: {:?}",
+                        commit.op
+                    );
+                }
+                other => panic!("transact.commit must be a Transform, got {other:?}"),
+            }
+        }
+
+        /// The mutation-loop and transaction pane pairs fold with **no** leak of
+        /// any class — the whole post-inference → post-desugar boundary (Inline +
+        /// Transact + Letrec + Desugar) is fully recorded.
+        #[test]
+        fn recorded_phases_leave_the_pane_pair_leak_free() {
+            for code in [MUTATION_LOOP, TXN] {
+                let prog = compile_ok(code);
+                let input_ids = tree_ids(&prog.post_inference_ir);
+                let output_ids = tree_ids(&prog.post_desugar_ir);
+                let (_map, _proj, leaks) = collapse(
+                    &prog.pass_lineage[1..],
+                    &input_ids,
+                    &output_ids,
+                    &SourceProjection::new(),
+                );
+                assert!(
+                    leaks.is_empty(),
+                    "fully-recorded pane pair must be leak-free for `{code}`; leaks: {leaks:?}"
+                );
+            }
+        }
     }
 }

--- a/src/ccl/expr.rs
+++ b/src/ccl/expr.rs
@@ -558,8 +558,6 @@ impl TypedExprNode {
     /// invariant diagnostics (e.g. the node-id uniqueness tripwire) that name a
     /// node by kind without dumping its contents. Exhaustive on purpose so a new
     /// variant forces an entry here.
-    // Consumed by the id-uniqueness tripwires that land with pass adoption.
-    #[allow(dead_code)]
     pub(crate) fn kind_name(&self) -> &'static str {
         match self {
             TypedExprNode::Lit(_) => "Lit",

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -24,6 +24,7 @@ use crate::ccl::infer::solver::{
     CoalesceError, ConstrainCache, FreshenCache, FreshenLevel, coalesce_compact, compact_type,
     constrain_subtype, freshen_expr_type_slots, seed_chan_dom_pairings, simplify_type,
 };
+use crate::ccl::lineage::{Nature, step};
 use crate::ccl::provenance::NodeId;
 use crate::ccl::symbolic::symbolic;
 use crate::ccl::{Expr, Level, Name, Type, TypedBinding, TypedExprNode};
@@ -1227,9 +1228,21 @@ fn coalesce_type_predicates(ty: &mut Type, level: Level, ctx: &mut CoalesceCtx) 
 /// "The id domain"), and freshening them would split the predicate `Rc` sharing
 /// planning's compile memo depends on.
 fn freshen_clone_node_ids(expr: &mut Expr) {
-    // The deep walk lives on `TypedExpr::freshen_node_ids_deep`; each re-mint
-    // fires the ambient `on_copy` hook, captured by the open Mono Copy step.
+    // The deep walk lives on `TypedExpr::freshen_node_ids_deep`, shared with the
+    // transact/letrec `subst_env` copy-freshening. Every re-mint funnels through
+    // `freshen_node_id`, which fires the lineage `on_copy` hook — so a lineage
+    // `step` open around this call captures every cloned node as a per-origin
+    // `Copy` (the `via: Mono` `Copy` lineage).
     expr.freshen_node_ids_deep();
+}
+
+/// Collect every **main-tree** node id of `expr` (the `walk_children` node set —
+/// refinement-predicate interiors excluded), matching the pane node-set the
+/// lineage fold reasons over. Used to build the `consumed` set of the mono
+/// wrapper `Transform` (the original generalized-def subtree that vanishes).
+fn collect_node_ids(expr: &Expr, out: &mut Vec<NodeId>) {
+    out.push(expr.node_id());
+    expr.walk_children(|c| collect_node_ids(c, out));
 }
 
 #[allow(clippy::mutable_key_type)]
@@ -1304,8 +1317,27 @@ pub(super) fn specialize_use(use_expr: &mut Expr, frame_idx: usize, ctx: &mut Co
     // (not folded into the shared `freshen_expr_type_slots`, which also runs on
     // refinement-predicate copies outside any mono context). It covers the
     // `walk_children` domain only — predicate-embedded ids, reachable through
-    // type slots, are outside the id domain and stay aliased.
-    freshen_clone_node_ids(&mut clone);
+    // type slots, are outside the id domain and stay aliased. The coalesce below
+    // runs re-entrantly on the clone, so any nested generalized `let`'s own
+    // specializations record their own steps.
+    //
+    // Lineage: the clone consumes nothing (`frame.def` stays live) and
+    // mints nothing new — it only freshens ids. Opening a `Transform`
+    // consume-nothing frame narrowly around the freshen makes the recorder emit
+    // exactly the per-origin `Copy` steps captured from `on_copy` (an empty
+    // `consumed`+`births` `Transform` flushes to no `Transform`, only the
+    // `Copy`s), one per cloned node. The frame is scoped tightly so the
+    // re-entrant `coalesce_node` below (which opens its own steps) is not
+    // captured here.
+    {
+        let _g = step(
+            "infer.mono_specialize",
+            Vec::new(),
+            Vec::new(),
+            Nature::Expansion,
+        );
+        freshen_clone_node_ids(&mut clone);
+    }
 
     // Pin the clone to the use's live instantiation type, two-way. Inward,
     // this drives the use site's accumulated bounds into the clone's
@@ -1373,6 +1405,16 @@ pub(super) fn specialize_use(use_expr: &mut Expr, frame_idx: usize, ctx: &mut Co
 /// definition is dead code.
 pub(super) fn coalesce_generalized_let(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
     let saved_annotation = expr.user_annotation.take();
+    // The original generalized-`let`'s id, captured before the rebuild below
+    // overwrites `expr`. Only `expr.node` is consumed here; `expr.node_id()`
+    // survives as the id the wrapper `Transform` below consumes and blames, so
+    // the freshly-minted specialization-wrapper `Let`s trace back to the
+    // generalized `let`. The rewrite is encoded as two steps: a produced-empty
+    // discard of the generalized-def subtree plus a narrow `Transform`
+    // (original `let` → wrapper `Let`s); splitting them keeps the per-node
+    // `Copy` edges (def node → its clones) out of the wrapper step's bipartite
+    // consumed × produced product.
+    let original_let_id = expr.node_id();
     let node = std::mem::replace(&mut expr.node, TypedExprNode::Error);
     let TypedExprNode::Let {
         binding,
@@ -1398,26 +1440,69 @@ pub(super) fn coalesce_generalized_let(expr: &mut Expr, level: Level, ctx: &mut 
     // Wrap the body in one specialized `let` per distinct type. Built in
     // reverse so first-demanded types end up outermost; ordering is
     // immaterial since the specializations never reference one another.
+    //
+    // Lineage: this rewrite consumes the whole original generalized `let` — its
+    // node id *and* its bound-definition subtree (`frame.def`) — and mints the
+    // per-spec wrapper `Let`s. Each specialization is a freshened *clone* of
+    // `frame.def` (recorded as per-node `Copy` steps by `specialize_use`, which
+    // ran during the body walk above, so they land earlier in the log); the
+    // original def subtree itself vanishes here. Two SEPARATE steps, not one:
+    //
+    // * A produced-empty discard consumes the def-subtree ids. Keeping it apart
+    //   from the wrapper step matters because the fold emits the bipartite
+    //   product of a step's consumed × produced — folding the whole subtree
+    //   into the wrapper step would link every def node to every wrapper Let,
+    //   drowning the precise per-node `Copy` edges (each def node → its
+    //   specialization clones) in product noise. A discard produces nothing,
+    //   so the def nodes keep exactly their Copy lineage.
+    // * The wrapper step consumes only `original_let_id` and births the
+    //   wrapper `Let`s — the one construct the wrappers genuinely replace.
+    //
+    // Copy-then-consume composes correctly — the clones snapshotted the def's
+    // roots before these consumes remove them. Blaming `original_let_id`
+    // traces the wrappers to the generalized `let`'s source span (→
+    // `Derived(Mono)`). `Nature::Expansion` — the wrappers faithfully expand
+    // the user-written generalized definition.
+    let mut def_consumed = Vec::new();
+    collect_node_ids(&frame.def, &mut def_consumed);
+    def_consumed.retain(|id| *id != original_let_id);
+    {
+        let _discard = step(
+            "infer.mono_def_consumed",
+            def_consumed,
+            vec![],
+            Nature::Machinery,
+        );
+    }
     let mut result = body;
-    for spec in frame.specs.into_iter().rev() {
-        // The discharge only does work when the specialization binder is free
-        // in the body type's refinement predicates; skip cloning `spec.def`
-        // otherwise (it is still moved into the rebuilt `let` below).
-        let body_ty = if crate::ccl::subst::type_free_vars(&result.ty).contains(&spec.name) {
-            crate::ccl::subst::Subst::discharge(&spec.name, spec.def.clone()).apply_type(&result.ty)
-        } else {
-            result.ty.clone()
-        };
-        result = Expr::new(TypedExprNode::Let {
-            binding: TypedBinding {
-                name: spec.name,
-                ty: spec.def.ty.clone(),
-                user_annotation: None,
-            },
-            bound_expr: Box::new(spec.def),
-            body: Box::new(result),
-        })
-        .with_ty(body_ty);
+    {
+        let _g = step(
+            "infer.mono_wrappers",
+            vec![original_let_id],
+            vec![original_let_id],
+            Nature::Expansion,
+        );
+        for spec in frame.specs.into_iter().rev() {
+            // The discharge only does work when the specialization binder is free
+            // in the body type's refinement predicates; skip cloning `spec.def`
+            // otherwise (it is still moved into the rebuilt `let` below).
+            let body_ty = if crate::ccl::subst::type_free_vars(&result.ty).contains(&spec.name) {
+                crate::ccl::subst::Subst::discharge(&spec.name, spec.def.clone())
+                    .apply_type(&result.ty)
+            } else {
+                result.ty.clone()
+            };
+            result = Expr::new(TypedExprNode::Let {
+                binding: TypedBinding {
+                    name: spec.name,
+                    ty: spec.def.ty.clone(),
+                    user_annotation: None,
+                },
+                bound_expr: Box::new(spec.def),
+                body: Box::new(result),
+            })
+            .with_ty(body_ty);
+        }
     }
     *expr = result;
     expr.user_annotation = saved_annotation;
@@ -1563,6 +1648,7 @@ fn refresh_lambda_param_slot(expr: &mut Expr) {
 #[cfg(test)]
 mod tests {
     use super::super::test_helpers::*;
+    use super::collect_node_ids;
     use crate::ccl::infer::{int_lit_ty, str_lit_ty};
     use crate::ccl::{BaseType, Type, TypedExpr, TypedExprNode};
 
@@ -1715,6 +1801,78 @@ mod tests {
             used_names.len(),
             3,
             "a literal argument mints its own specialization, so none collapse"
+        );
+    }
+
+    /// Collect every node's `NodeId` reachable from `expr` (main tree +
+    /// type-borne refinement-predicate nodes), mirroring
+    /// `uniquify::collect_node_ids` so the multiset matches what the inspector
+    /// would index.
+    /// Monomorphization freshens every cloned node's `NodeId` and records its
+    /// lineage. Checks this directly at the inference seam: after `id` is
+    /// specialized at two distinct types, (a) every node in the inferred tree
+    /// has a *unique* id — clones never collide on the original definition's
+    /// ids — and (b) the mono lineage log carries `Copy` steps (the freshened
+    /// clones) whose produced ids are all distinct (one per cloned node).
+    #[test]
+    fn monomorphization_freshens_node_ids_and_records_lineage() {
+        use crate::ccl::infer::TypeInferenceContext;
+        use crate::ccl::lineage::{Op, RecorderSession};
+        use crate::ccl::provenance::NodeId;
+        use std::collections::HashSet;
+
+        // let id = λx. x in (id 1, id "a")  →  two specializations of `id`.
+        let id = TypedExpr::lambda("x", Type::Hole, TypedExpr::var("x"));
+        let body = TypedExpr::new(TypedExprNode::Tuple(vec![
+            TypedExpr::apply(lit_int(1), TypedExpr::var("id")),
+            TypedExpr::apply(lit_string("a"), TypedExpr::var("id")),
+        ]));
+        let mut e = TypedExpr::let_bind("id", id, body);
+
+        // Install a session so the mono steps flush into a drainable log (this
+        // is what `compile_program` does around the whole infer boundary).
+        let session = RecorderSession::new();
+        let mut ctx = TypeInferenceContext::new();
+        crate::ccl::infer::infer(&mut e, &mut ctx).expect("type-checks");
+        let log = session.into_log();
+
+        // (b) The mono lineage recorded `Copy` steps for the freshened clones,
+        // and every produced clone id is minted exactly once (no collisions).
+        let produced: Vec<NodeId> = log
+            .iter()
+            .filter_map(|s| match &s.op {
+                Op::Copy { produced, .. } => Some(produced.iter().copied()),
+                Op::Transform { .. } => None,
+            })
+            .flatten()
+            .collect();
+        assert!(
+            !produced.is_empty(),
+            "monomorphization must record clone Copy steps"
+        );
+        let produced_set: HashSet<_> = produced.iter().copied().collect();
+        assert_eq!(
+            produced.len(),
+            produced_set.len(),
+            "every fresh clone id is minted exactly once (no collisions)"
+        );
+
+        // (a) No id collides anywhere in the inferred tree: without freshening,
+        // the two `id` specializations would share the definition's ids and the
+        // multiset would have duplicates.
+        //
+        // Enumerated over the `walk_children` domain, which *is* the id domain.
+        // Predicate-embedded ids are deliberately excluded: they are outside the
+        // domain and specializations legitimately alias them, because freshening
+        // them would split the predicate `Rc` sharing planning's compile memo
+        // depends on (see `freshen_clone_node_ids`).
+        let mut ids = Vec::new();
+        collect_node_ids(&e, &mut ids);
+        let unique: HashSet<_> = ids.iter().copied().collect();
+        assert_eq!(
+            ids.len(),
+            unique.len(),
+            "every node in the specialized tree has a unique NodeId"
         );
     }
 

--- a/src/ccl/inline.rs
+++ b/src/ccl/inline.rs
@@ -64,10 +64,14 @@
 //! [`Feed`]: crate::ccl::TypedExprNode::Feed
 //! [`Define`]: crate::ccl::TypedExprNode::Define
 
+use std::collections::HashSet;
+
 use crate::ccl::{
     Expr, Lit, Name, Refinement, Type, TypedExprNode,
     ccl_utils::{PredMemo, is_free, walk_refined_predicates_mut},
     lambda_elim::substitute,
+    lineage::{self, LineageLog, Nature, RecorderSession, RewriteLabel},
+    provenance::NodeId,
 };
 
 // ---------------------------------------------------------------------------
@@ -95,6 +99,29 @@ pub fn inline_non_iterable_lambdas(expr: Expr) -> Expr {
     // each `Cast`'s `target` slot in step so the post-pass typecheck matches.
     crate::ccl::ccl_utils::sync_cast_targets(&mut expr);
     expr
+}
+
+/// Inline as [`inline_non_iterable_lambdas`], but also drain the [`LineageLog`]
+/// of the [`RewriteStep`](crate::ccl::lineage::RewriteStep)s this pass opens at
+/// its rewrite sites — the redesign's recording layer, and the only provenance
+/// surface inline exposes.
+///
+/// Inline is **id-preserving**: a rebuilt node carries its input [`NodeId`], so
+/// most of the tree is an implicit preserve (a self-edge at collapse, nothing
+/// recorded). The recorded rewrites are:
+///
+/// * a `Transform` discard per beta/alias site (the dropped scaffolding — the
+///   `Let` wrapper, beta redex, lambda wrapper, and the `Var` occurrences
+///   substitution overwrote; see [`record_drops`]), and
+/// * one `Copy` per freshened fan-out duplicate, captured from the `on_copy`
+///   hook while the substitution runs under the beta site's open step.
+///
+/// Inline neither invents source-blamed nodes nor fuses clusters (tuple-
+/// projection folding lives in `crate::ccl::simplify`).
+pub(crate) fn inline_with_lineage(expr: Expr) -> (Expr, LineageLog) {
+    let session = RecorderSession::new();
+    let expr = inline_non_iterable_lambdas(expr);
+    (expr, session.into_log())
 }
 
 // ---------------------------------------------------------------------------
@@ -281,7 +308,14 @@ fn inline_impl(expr: Expr) -> Expr {
                 && !is_let_bound(repl_name, &body)
                 && !is_mut_written(repl_name, &body)
             {
-                return substitute(body, &binding.name, &bound_expr);
+                // The `Let` wrapper and every `Var(binding.name)` occurrence
+                // vanish (each occurrence is overwritten by a copy of the
+                // `Var(x)` bound expr, whose own id survives via those copies —
+                // or is dropped when the alias is unused).
+                let consumed = consumed_subtree_ids(node_id, &bound_expr, &body);
+                let result = substitute(body, &binding.name, &bound_expr);
+                record_drops(&consumed, &result, "inline.alias");
+                return result;
             }
 
             if should_inline(&bound_expr.ty) {
@@ -293,22 +327,37 @@ fn inline_impl(expr: Expr) -> Expr {
                 // scope — no free variable in `bound_expr` can shadow a binder
                 // introduced in `body`.
                 //
-                // Re-run inline_impl after beta-reduction so that newly created
-                // Let bindings (e.g. `let y = (let x = Defer in …) in …` after
-                // expanding a defer-returning UDF) are eligible for the alias
-                // and lift rewrites on the second pass.
-                return inline_impl(inline_and_beta_reduce(
-                    body,
-                    &binding.name,
-                    &bound_expr,
+                // The `Let` wrapper, the lambda wrapper + `Apply` redex consumed
+                // at each beta-reduced site, and every `Var(binding.name)`
+                // occurrence vanish; the lambda *body*'s ids survive via
+                // substitution (fanned out to N sites, deduped later). Diffing
+                // the consumed subtree against the reduced result records
+                // exactly those drops — including the whole bound lambda when
+                // the binding is unused.
+                let consumed = consumed_subtree_ids(node_id, &bound_expr, &body);
+                let reduced = {
+                    // Open the beta site's fan-out step over the substitution +
+                    // lambda clones: each freshened duplicate is captured as a
+                    // per-origin `Copy` via the `on_copy` hook. Consuming nothing
+                    // and minting nothing of its own, this frame flushes only the
+                    // captured copies (no `Transform`).
+                    let _g =
+                        lineage::step("inline.beta", Vec::new(), Vec::new(), Nature::Expansion);
                     // One memo for the whole `[name ↦ lambda]` rewrite, so a
                     // predicate rebuilt at one node is re-pointed at (not
                     // re-derived for) its occurrences on every other node this
                     // sweep touches. Scoped to *this* rewrite, not the `inline`
                     // pass: a different binder's rewrite maps the same origin
                     // `Rc` to a different result.
-                    &PredMemo::new(),
-                ));
+                    inline_and_beta_reduce(body, &binding.name, &bound_expr, &PredMemo::new())
+                };
+                record_drops(&consumed, &reduced, "inline.beta");
+                // Re-run inline_impl after beta-reduction so that newly created
+                // Let bindings (e.g. `let y = (let x = Defer in …) in …` after
+                // expanding a defer-returning UDF) are eligible for the alias
+                // and lift rewrites on the second pass; that recursion records
+                // its own drops at the nested sites.
+                return inline_impl(reduced);
             }
             TypedExprNode::Let {
                 binding,
@@ -372,11 +421,15 @@ fn inline_impl(expr: Expr) -> Expr {
 fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr, memo: &PredMemo) -> Expr {
     // Direct occurrence: replace the variable with the Lambda value — a UDF used
     // as an unapplied value, or the function side of a call about to
-    // beta-reduce.
+    // beta-reduce. Freshen the clone unconditionally at this duplication site so
+    // N occurrences never share the source lambda's NodeIds; each freshened node
+    // fires `on_copy` into the open beta step (the fan-out `Copy` lineage).
     if let TypedExprNode::Var(ref n) = expr.node
         && n == name
     {
-        return lambda.clone();
+        let mut cloned = lambda.clone();
+        cloned.freshen_node_ids_deep();
+        return cloned;
     }
 
     // Substitute inside refinement predicates riding **every** type slot this
@@ -630,6 +683,60 @@ fn refinement_discharged_by(arg_ty: &Type, param_ty: &Type) -> bool {
     }
     let supplied = layers(arg_ty);
     demanded.iter().all(|d| supplied.contains(d))
+}
+
+// ---------------------------------------------------------------------------
+// Provenance recording: drops and fan-out
+// ---------------------------------------------------------------------------
+
+/// Collect every main-tree [`NodeId`] reachable in `expr` (itself and all
+/// descendants).
+///
+/// Walks `child_exprs` (main tree only, skipping type-refinement predicates) —
+/// the node set the drop diff reasons over.
+fn collect_ids(expr: &Expr, acc: &mut HashSet<NodeId>) {
+    acc.insert(expr.node_id());
+    expr.walk_children(|child| collect_ids(child, acc));
+}
+
+/// The ids an inlining rewrite *consumes*: the `Let` wrapper (`let_id`) plus
+/// every id in the (already-inlined) `bound_expr` and `body` it is about to
+/// rewrite away. Diffed against the produced result to find the dropped ids.
+fn consumed_subtree_ids(let_id: NodeId, bound_expr: &Expr, body: &Expr) -> HashSet<NodeId> {
+    let mut ids = HashSet::new();
+    ids.insert(let_id);
+    collect_ids(bound_expr, &mut ids);
+    collect_ids(body, &mut ids);
+    ids
+}
+
+/// Record as a lineage `Transform` discard every consumed id absent from
+/// `result` — the nodes this rewrite removed with no surviving counterpart
+/// (`Let` wrappers, beta redexes, lambda wrappers, and the `Var` occurrences
+/// overwritten by substitution).
+///
+/// This diff *is* "discard exactly the ids that vanish": a consumed id survives
+/// iff it (or its first fan-out copy) still appears in `result`.
+///
+/// The lineage `Transform` consumes *every* dropped id — including a mid-pass
+/// fresh transient a re-run inlined again and then dropped: such a transient was
+/// produced by an earlier `Copy` step in this same log, so consuming it composes
+/// cleanly at collapse. The discard is pure machinery (`Nature::Machinery`,
+/// empty blame) and mints nothing (substitution already ran, sharing ids), so
+/// the step flushes a pure discard (`produced: []`).
+fn record_drops(consumed: &HashSet<NodeId>, result: &Expr, label: RewriteLabel) {
+    let mut surviving = HashSet::new();
+    collect_ids(result, &mut surviving);
+    let mut dropped: Vec<NodeId> = Vec::new();
+    for id in consumed {
+        if !surviving.contains(id) {
+            dropped.push(*id);
+        }
+    }
+    if !dropped.is_empty() {
+        dropped.sort_unstable();
+        let _g = lineage::step(label, dropped, Vec::new(), Nature::Machinery);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1510,5 +1617,146 @@ mod tests {
         })
         .with_ty(int);
         assert_eq!(result, expected);
+    }
+
+    // -----------------------------------------------------------------------
+    // Lineage recording: the `RewriteStep`s inline opens fully explain its
+    // rewrites. Folding the drained log between the input and output panes must
+    // surface no recording-bug leak, and the fan-out (`Copy`) / discard shapes
+    // appear where expected.
+    // -----------------------------------------------------------------------
+
+    use crate::ccl::lineage::{Leak, Op, SourceProjection, collapse};
+    use crate::ccl::provenance::Pass;
+
+    /// Collect every main-tree id in `expr`.
+    fn ids(expr: &Expr) -> HashSet<NodeId> {
+        let mut acc = HashSet::new();
+        collect_ids(expr, &mut acc);
+        acc
+    }
+
+    /// Inline `input`, then fold the drained lineage log between the input and
+    /// output panes. Returns the output tree, the collapse leaks, and the number
+    /// of `Copy` steps recorded.
+    fn inline_and_collapse(input: Expr) -> (Expr, Vec<Leak>, usize) {
+        let input_ids = ids(&input);
+        let (output, log) = inline_with_lineage(input);
+        let output_ids = ids(&output);
+        let copies = log
+            .iter()
+            .filter(|s| matches!(s.op, Op::Copy { .. }))
+            .count();
+        let (_map, _proj, leaks) = collapse(
+            &[(Pass::Inline, log)],
+            &input_ids,
+            &output_ids,
+            &SourceProjection::new(),
+        );
+        (output, leaks, copies)
+    }
+
+    /// A collapse over a self-contained inline pane pair must surface no leak of
+    /// any kind: inline's steps consume/produce live ids only and account for
+    /// every input's fate (these fixtures have no unrecorded neighbour pass).
+    fn assert_clean(leaks: &[Leak]) {
+        assert!(
+            leaks.is_empty(),
+            "inline pane pair must be leak-free: {leaks:?}"
+        );
+    }
+
+    #[test]
+    fn fanout_at_single_call_site_freshens_the_inlined_copy() {
+        // let f: Int → Int = λ x → x in Apply(3, f)  — a single call site.
+        // Beta-reduces to `3`; the lambda body is freshened at the duplication
+        // site (recorded as `Copy`s) and the `Let`/redex scaffolding is dropped.
+        let int = Type::Base(BaseType::Int);
+        let lambda = TypedExpr::lambda("x", int.clone(), TypedExpr::var("x").with_ty(int.clone()))
+            .with_ty(fn_ty(int.clone(), int.clone()));
+        let call = TypedExpr::apply(
+            TypedExpr::lit(Lit::Int(3)).with_ty(int.clone()),
+            TypedExpr::var("f").with_ty(fn_ty(int.clone(), int.clone())),
+        )
+        .with_ty(int.clone());
+        let input = TypedExpr::let_bind("f", lambda, call);
+
+        let (_output, leaks, copies) = inline_and_collapse(input);
+        assert_clean(&leaks);
+        assert!(
+            copies >= 1,
+            "the inlined body must record fan-out Copy steps"
+        );
+    }
+
+    #[test]
+    fn bare_udf_used_twice_records_fanout_copies() {
+        // let f: Int → Int = λ x → x in Tuple[f, f]  — two *bare* uses, so each
+        // occurrence gets a full freshened copy of the lambda that survives into
+        // the output.
+        let int = Type::Base(BaseType::Int);
+        let fun = fn_ty(int.clone(), int.clone());
+        let lambda = TypedExpr::lambda("x", int.clone(), TypedExpr::var("x").with_ty(int.clone()))
+            .with_ty(fun.clone());
+        let body = TypedExpr::tuple(vec![
+            TypedExpr::var("f").with_ty(fun.clone()),
+            TypedExpr::var("f").with_ty(fun.clone()),
+        ])
+        .with_ty(Type::Tuple(vec![fun.clone(), fun.clone()]));
+        let input = TypedExpr::let_bind("f", lambda, body);
+
+        let (_output, leaks, copies) = inline_and_collapse(input);
+        assert_clean(&leaks);
+        assert!(
+            copies >= 1,
+            "a >=2-use inline must record fan-out Copy steps"
+        );
+    }
+
+    #[test]
+    fn alias_rewrite_is_leak_free() {
+        // let f = id in f  — pure alias α-rename; the `Let` and the `Var f`
+        // occurrence vanish, `id` survives.
+        let fun = fn_ty(Type::UIntRange(3), Type::Base(BaseType::Int));
+        let id_expr = TypedExpr::var("id").with_ty(fun.clone());
+        let body = TypedExpr::var("f").with_ty(fun);
+        let expr = TypedExpr::let_bind("f", id_expr, body);
+
+        let (_output, leaks, _copies) = inline_and_collapse(expr);
+        assert_clean(&leaks);
+    }
+
+    #[test]
+    fn unused_let_discards_everything_leak_free() {
+        // let f: Int → Int = id in Lit(42)  — f never used, so the whole
+        // binding (the `Let` and the bound `Var id`) is discarded; only Lit(42)
+        // survives.
+        let int = Type::Base(BaseType::Int);
+        let id_expr = TypedExpr::var("id").with_ty(fn_ty(int.clone(), int.clone()));
+        let body = TypedExpr::lit(Lit::Int(42)).with_ty(int);
+        let expr = TypedExpr::let_bind("f", id_expr, body);
+
+        let (output, leaks, copies) = inline_and_collapse(expr);
+        assert_clean(&leaks);
+        assert_eq!(copies, 0, "an unused binding fans nothing out");
+        // Only the `Lit(42)` survives.
+        assert!(matches!(output.node, TypedExprNode::Lit(Lit::Int(42))));
+    }
+
+    #[test]
+    fn preserves_ids_on_untouched_program() {
+        // A program with nothing to inline (scalar `let x = 2 in x + 1`) is
+        // reproduced verbatim, ids and all — id preservation is behaviour-neutral.
+        let expr = scalar_let();
+        let input_ids = ids(&expr);
+
+        let (output, log) = inline_with_lineage(expr);
+        // Nothing to rewrite ⇒ no steps recorded.
+        assert!(
+            log.is_empty(),
+            "an untouched program records no steps: {log:?}"
+        );
+        // Every input id survives with its identity intact.
+        assert_eq!(ids(&output), input_ids);
     }
 }

--- a/src/ccl/lineage.rs
+++ b/src/ccl/lineage.rs
@@ -4,34 +4,68 @@
 //! # The model
 //!
 //! Every IR node has a stable [`NodeId`]. As a pass rewrites the tree it appends
-//! [`RewriteStep`]s to a [`LineageLog`]: a [`Op::Transform`] records "these input
-//! ids vanished, these output ids appeared"; a [`Op::Copy`] records "these output
-//! ids are freshened duplicates of that origin." Each step *separately* carries a
-//! `blame` set (the upstream ids the outputs attribute to — **not** the same as
-//! what they consumed), a `nature` bit (faithful expansion vs. pure machinery),
-//! and a stable `label`. An untouched id is one no step mentions.
+//! [`RewriteStep`]s to a [`LineageLog`], each recording one hop of identity: an
+//! [`Op::Transform`] says "these ids vanished, these appeared"; an [`Op::Copy`]
+//! says "these ids are freshened duplicates of that origin". An id no step
+//! mentions is untouched and survives by default. Alongside its `op`, a step
+//! carries a `blame` set, a `nature` bit (faithful expansion vs. pure
+//! machinery), and a stable `label`.
 //!
 //! At an inspector pane boundary the intervening logs are folded once, in pass
-//! order, by [`collapse`] into a [`LineageMap`] — a bidirectional node↔node
-//! relation with an explicit self-edge for every id that survived — and, in
-//! parallel, into a [`SourceProjection`] that resolves each surviving node's
-//! blame back to source spans. The fold composes away ids born and consumed
-//! within the phase, and its two-sided leak check ([`Leak`]) guarantees no node
-//! silently loses its history.
+//! order, by [`collapse`], which yields two things: a [`LineageMap`] — the
+//! bidirectional node↔node relation, with an explicit self-edge for every id
+//! that survived — and a [`SourceProjection`] resolving each surviving node back
+//! to source spans. Ids born and consumed within the same phase compose away. A
+//! two-sided leak audit ([`Leak`]) rejects any node that loses its history: an
+//! output id with no ancestry and an input id that vanished unaccounted for are
+//! both errors.
 //!
-//! # Two independent channels (load-bearing)
+//! # Consumption and blame are separate channels
 //!
-//! `consumed` and `blame` are distinct and never mixed:
+//! A step's `consumed` and `blame` sets answer different questions and never mix:
 //!
-//! * **`consumed`** drives *fate* accounting — an id is consumed, carried, or
-//!   dropped — and the leak audit. Lineage edges resolve through the `roots`
-//!   state, which only `consumed`/`produced` move.
-//! * **`blame`** drives *span* resolution and may name ids that survive the step.
-//!   It resolves through the `attr` projection, never through `roots`.
+//! * **`consumed`** is *fate* — which ids this step destroys. It drives the leak
+//!   audit and the lineage edges, both of which resolve through the fold's
+//!   `roots` state; only `consumed`/`produced` move that state.
+//! * **`blame`** is *attribution* — which upstream ids the step's outputs take
+//!   their spans from. It may name ids that survive the step, and resolves
+//!   through the `attr` projection, never through `roots`.
 //!
-//! Welding the two would (for example) resolve a channelized feed union — whose
+//! Welding them would (for example) resolve a channelized feed union — whose
 //! step consumes the enclosing `Defer`/`Let` but blames the surviving fed-value
 //! operands — to the `defer` keyword's span rather than the operands'.
+//!
+//! # Recording is a byproduct of construction
+//!
+//! A [`RecorderSession`] installs one log for a boundary. Within it, [`step`]
+//! opens a frame and returns an RAII [`StepGuard`]; frames nest, and the
+//! innermost open frame captures. Only `consumed` is declared up front — the
+//! other two sides are captured by hooks in node construction itself:
+//! `Expr::new` reports a mint, and every freshen path reports an
+//! `(origin, fresh)` pair. A pass therefore cannot perform a rewrite without
+//! recording it, nor record one it did not perform.
+//!
+//! `StepGuard`'s `Drop` pops the frame (LIFO; an unwind still pops and flushes
+//! whatever was captured before it) and appends its records to the log.
+//!
+//! ## Flush order within a frame
+//!
+//! A frame emits its captured `Copy`s around its own `Transform`, partitioned by
+//! origin:
+//!
+//! 1. copies whose origin this frame **consumes**, which must fold while that
+//!    origin is still live;
+//! 2. the `Transform { consumed, produced: births }`;
+//! 3. copies whose origin this frame **produced**, which must fold once it is.
+//!
+//! Both orders are required, so neither can be the global one. The partition is
+//! per `(origin, fresh)` pair, so one deep freshen of a subtree mixing consumed
+//! and newly born nodes lands on both sides.
+//!
+//! The `Transform` stays whole because it carries root inheritance: the produced
+//! ids take the union of the consumed ids' roots. Splitting it into a birth half
+//! and a consume half would hand every born node an empty root set, severing it
+//! from its ancestry without tripping the audit.
 //!
 //! # Domains, not passes
 //!
@@ -58,7 +92,6 @@ pub type RewriteLabel = &'static str;
 /// the `op`'s consumed/produced/origin ids and the separate `blame` ids — are
 /// resolved independently at [`collapse`] time (see the module docs).
 #[derive(Clone, Debug, PartialEq, Eq)]
-// Consumed when the passes adopt the recorder (next commit in the stack).
 pub(crate) struct RewriteStep {
     /// The identity relation this step performs.
     pub op: Op,
@@ -387,9 +420,6 @@ pub enum Leak {
 /// `roots`. A blamed id absent from `attr` contributes no spans (it has no
 /// known source), which is legal — empty blame or all-unknown blame yields
 /// `spans: []`, the "known node, no source anchor" case.
-///
-/// A private helper of [`collapse`], so it is dead exactly while `collapse` is.
-#[allow(dead_code)]
 fn attribute(
     blame: &[NodeId],
     nature: Nature,
@@ -453,12 +483,6 @@ fn attribute(
 /// edges — the bipartite product for N:M steps and self-edges for untouched ids
 /// both fall out. Ids born and consumed within the phase never reach an output
 /// and compose away.
-///
-/// Exercised only by this module's tests until a pane boundary calls it, which
-/// needs the per-pass logs the passes do not yet record. `collapse_lowering` is
-/// the always-on sibling and shares the [`RootTracker`] core, so the fold logic
-/// here is not untested — only this entry point is uncalled.
-#[allow(dead_code)]
 pub(crate) fn collapse(
     logs: &[(Pass, LineageLog)],
     input_ids: &HashSet<NodeId>,
@@ -846,6 +870,16 @@ impl OpenStep {
     /// [`TypedExpr::freshen_node_id`](crate::ccl::expr::TypedExpr::freshen_node_id),
     /// so capture is total and a declared-origin frame kind would be redundant.
     ///
+    /// The copies straddle the `Transform`, split by whether this frame consumes
+    /// the origin (see the module docs, "Flush order within a frame"): a copy of
+    /// a node the frame is about to consume has to fold *before* the `Transform`
+    /// removes it, and a copy of a node the frame gave birth to has to fold
+    /// *after* the `Transform` makes it live. Both are real requirements, so the
+    /// split is per `(origin, fresh)` pair rather than per frame — one deep
+    /// freshen of a subtree mixing consumed and newly born nodes lands on both
+    /// sides. `group_copies` preserves first-appearance order within each side,
+    /// so a copy *of a copy* still follows the copy that produced its origin.
+    ///
     /// A `Transform` frame whose `consumed` *and* captured `births` are both
     /// empty emits no `Transform` record: it was opened purely to capture the
     /// freshen pairs of a deep clone (its only output is those per-origin `Copy`
@@ -860,6 +894,21 @@ impl OpenStep {
             births,
             copies,
         } = self;
+        let dying: HashSet<NodeId> = consumed.iter().copied().collect();
+        let (pre, post): (Vec<_>, Vec<_>) = copies
+            .into_iter()
+            .partition(|(origin, _)| dying.contains(origin));
+        let push_copies = |log: &mut LineageLog, pairs: &[(NodeId, NodeId)]| {
+            for (origin, produced) in group_copies(pairs) {
+                log.push(RewriteStep {
+                    op: Op::Copy { origin, produced },
+                    blame: Vec::new(),
+                    nature,
+                    label,
+                });
+            }
+        };
+        push_copies(log, &pre);
         if !(consumed.is_empty() && births.is_empty()) {
             log.push(RewriteStep {
                 op: Op::Transform {
@@ -871,14 +920,7 @@ impl OpenStep {
                 label,
             });
         }
-        for (origin, produced) in group_copies(&copies) {
-            log.push(RewriteStep {
-                op: Op::Copy { origin, produced },
-                blame: Vec::new(),
-                nature,
-                label,
-            });
-        }
+        push_copies(log, &post);
     }
 
     /// Finalize this frame into a [`LoweringLog`]. Lowering frames are opened
@@ -887,9 +929,16 @@ impl OpenStep {
     /// [`lowering_leaf`], so a lowering frame carries no consumed ids and no
     /// births — only the captured per-origin copies flush here, as `Copy`
     /// [`LoweringStep`]s mirroring their origins' folded entries (empty anchor).
+    ///
+    /// Consequently there is no `Transform` for copies to be ordered against,
+    /// and [`flush_into`](Self::flush_into)'s consumed/born partition has nothing
+    /// to do here. Both halves of that emptiness are asserted rather than
+    /// assumed: a lowering frame that grew a consumed set or a birth would need
+    /// the partition, and would silently lose the ordering without it.
     fn flush_into_lowering(self, log: &mut LoweringLog) {
         let OpenStep {
             label,
+            consumed,
             nature,
             births,
             copies,
@@ -899,6 +948,11 @@ impl OpenStep {
             births.is_empty(),
             "a lowering copy-frame captured a mint ({births:?}) — leaf mints must \
              append via lowering_leaf, frames capture only copies",
+        );
+        debug_assert!(
+            consumed.is_empty(),
+            "a lowering copy-frame declared a consumed set ({consumed:?}) — it emits \
+             no Transform, so its copies would have nothing to be ordered against",
         );
         for (origin, produced) in group_copies(&copies) {
             log.push(LoweringStep {
@@ -1083,11 +1137,6 @@ impl RecorderSession {
     /// Install a fresh, empty **pass** log as the active recording target for
     /// this thread. Non-reentrant: at most one session per thread
     /// (debug-asserted).
-    ///
-    /// The pass-log counterpart to [`lowering`](Self::lowering), which is
-    /// always-on. Uncalled outside this module's tests until a pass boundary
-    /// installs a session of its own.
-    #[allow(dead_code)]
     pub(crate) fn new() -> Self {
         Self::install(ActiveLog::Pass(Vec::new()))
     }
@@ -1113,9 +1162,6 @@ impl RecorderSession {
 
     /// Drain and return the recorded **pass** log, ending the session. The
     /// subsequent `Drop` is then a no-op (the slot is already empty).
-    ///
-    /// Paired with [`new`](Self::new), so it is dead exactly while that is.
-    #[allow(dead_code)]
     pub(crate) fn into_log(self) -> LineageLog {
         ACTIVE_LOG.with(|slot| match slot.borrow_mut().take() {
             Some(ActiveLog::Pass(log)) => log,
@@ -1961,10 +2007,11 @@ mod tests {
         // The `fold_induction_loop`/`build_writer` template shape (transact/letrec
         // instrumentation hazard): a single frame births a template `T`, copies
         // it per read site (`subst_env` freshens a clone at each), and discards
-        // `T` (it never reaches the output tree). Per `OpenStep::flush_into`'s
-        // refinement the frame's `Transform` (which produces `T`) flushes BEFORE
-        // the captured `Copy` steps, so `T` is live when the copies are processed —
-        // the whole shape composes in ONE frame, no split needed. `T` remains live
+        // `T` (it never reaches the output tree). `T` is a *birth*, so its copies
+        // land in `flush_into`'s post-`Transform` partition and fold once `T` is
+        // live — the whole shape composes in ONE frame, no split needed. (The
+        // mirror case, a copy of a node the frame *consumes*, is
+        // `copies_straddle_the_frame_transform_by_origin`.) `T` remains live
         // at collapse (never consumed) but is neither an input-pane nor an
         // output-pane id, so it triggers no leak (`Dropped` checks inputs only,
         // `Unexplained` checks outputs only).
@@ -2024,5 +2071,71 @@ mod tests {
             sorted(map.downstream(&origin).to_vec()),
             sorted(vec![c1, c2])
         );
+    }
+
+    /// One frame, both copy directions: a copy of a node the frame **consumes**
+    /// folds before its `Transform`, a copy of a node the frame **births** folds
+    /// after. The partition is per `(origin, fresh)` pair, so a single frame
+    /// mixing the two lands copies on both sides.
+    ///
+    /// The consumed direction is the one a single global order cannot serve: the
+    /// `Transform` removes the origin's roots, so a `Copy` folding after it would
+    /// be [`Leak::CopyOfUnknown`]. The birth direction needs the opposite order
+    /// (`born_copied_discarded_template_composes_without_leaks`), which is why
+    /// `flush_into` splits rather than picking one.
+    #[test]
+    fn copies_straddle_the_frame_transform_by_origin() {
+        // An input-pane node this frame will consume *and* copy (the
+        // `transform_chain` remainder-splice shape: one subtree fanned across
+        // several branches, the original destructured).
+        let input = Expr::lit(Lit::Int(7));
+        let src = input.node_id();
+        let (t, from_input, from_birth);
+        let session = RecorderSession::new();
+        {
+            let _g = step("test.straddle", vec![src], vec![src], Nature::Machinery);
+            let mut ci = input.clone();
+            ci.freshen_node_id();
+            from_input = ci.node_id();
+            // A template born in this same frame, then copied.
+            let template = Expr::lit(Lit::Int(0));
+            t = template.node_id();
+            let mut cb = template.clone();
+            cb.freshen_node_id();
+            from_birth = cb.node_id();
+        }
+        let log = session.into_log();
+        assert!(
+            matches!(&log[0].op, Op::Copy { origin, .. } if *origin == src),
+            "the copy of the consumed origin flushes first: {log:?}",
+        );
+        assert_eq!(
+            log[1].op,
+            Op::Transform {
+                consumed: vec![src],
+                produced: vec![t],
+            },
+            "the frame's Transform flushes between the two copy runs: {log:?}",
+        );
+        assert!(
+            matches!(&log[2].op, Op::Copy { origin, .. } if *origin == t),
+            "the copy of the birth flushes last: {log:?}",
+        );
+
+        let logs = vec![(Pass::Letrec, log)];
+        let (map, _proj, leaks) = collapse(
+            &logs,
+            &set([src]),
+            &set([from_input, from_birth]),
+            &SourceProjection::new(),
+        );
+        assert!(
+            leaks.is_empty(),
+            "both copies fold against a live origin: {leaks:?}",
+        );
+        // Both copies trace to the frame's one input root, by different paths:
+        // one mirrors `src` directly, the other through the template `t`.
+        assert_eq!(map.upstream(&from_input), &[src]);
+        assert_eq!(map.upstream(&from_birth), &[src]);
     }
 }

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -50,6 +50,7 @@ use crate::ccl::{
     TypedBinding, TypedExprNode,
     ccl_utils::{strip_refinements, synthesize_arm_predicate},
     letrec::check_letrec_causal,
+    provenance::NodeId,
     symbolic::symbolic,
 };
 
@@ -164,6 +165,20 @@ fn erase_mut_in_type(ty: &mut Type) {
 fn erase_mut(expr: &mut Expr) {
     expr.walk_type_slots_mut(erase_mut_in_type);
     expr.walk_children_mut(erase_mut);
+}
+
+/// An id-freshened copy of `e` — every node re-minted (the shared deep walk).
+///
+/// The phase splices some template expressions (the history `step` view, the
+/// loop source) into the output at several positions; a bare `clone` would stamp
+/// the *same* NodeIds at each, breaking the tree's id-uniqueness invariant. Each
+/// spliced copy is freshened so the positions carry distinct ids. When called
+/// inside an open lineage frame the deep walk's `on_copy` hook captures each
+/// re-mint as a `Copy` step (the copy mirrors the original's lineage), so these
+/// copies are attributed, not swept.
+fn fresh_copy(mut e: Expr) -> Expr {
+    e.freshen_node_ids_deep();
+    e
 }
 
 /// A `Unit` literal stamped with `Base(Unit)` — the value of a mutable write.
@@ -385,21 +400,156 @@ fn flatten_spine(mut e: Expr) -> Expr {
     e
 }
 
+/// Every node id in a subtree (main-tree node set) — for consuming a wholly
+/// vanishing source subtree.
+fn collect_all_ids(e: &Expr, out: &mut Vec<NodeId>) {
+    out.push(e.node_id());
+    e.walk_children(|c| collect_all_ids(c, out));
+}
+
+/// Collect the node ids of a loop body's statement **spine** — the nodes
+/// [`transform_chain`] destructures and drops as it rebuilds the decision chain.
+/// A spine node's *value* expression (a `Let` bound value, a `MutWrite`/`Feed`
+/// value) is **preserved** by [`subst_env`] (containers in place, substituted
+/// leaves via the read-site id-carry), so it is a self-edge and is **not**
+/// collected. This is the loop frame's `consumed` set (blame ⊥ consumption). It
+/// must mirror `transform_chain`'s spine arms: a drift surfaces at the leak gate
+/// as a `Dropped` (a vanishing node left unconsumed) or `Unexplained` (a
+/// preserved node wrongly consumed).
+fn collect_block_spine_ids(block: &Expr, out: &mut Vec<NodeId>) {
+    match &block.node {
+        TypedExprNode::Let { body, .. } => {
+            out.push(block.node_id());
+            collect_block_spine_ids(body, out);
+        }
+        TypedExprNode::ExprStmt { expr: effect, body } => {
+            out.push(block.node_id());
+            match &effect.node {
+                // A nested spliced sequence: `transform_chain` re-associates it
+                // onto the spine, so its own spine nodes vanish too.
+                TypedExprNode::ExprStmt { .. } => collect_block_spine_ids(effect, out),
+                // A statement-`Case` (conditional induction): the `Case` node
+                // itself vanishes into the writer decision, and each branch's
+                // body is spliced onto the branch chain and destructured the
+                // same way the top-level spine is. The branch *guards* are not
+                // collected — each is preserved into its arm's first-match
+                // predicate (a self-edge; see `conditional_decision`).
+                TypedExprNode::Case { branches, .. } => {
+                    out.push(effect.node_id());
+                    for br in branches {
+                        // Every guard is consumed, not preserved. Which arm
+                        // predicates survive is data-dependent — the trailing
+                        // `true` arm's is always discarded (it supplies only the
+                        // carry write set), and so is any arm whose write set
+                        // matches the carry — so a static consumed set cannot
+                        // track survival. Consuming all of them uniformly and
+                        // rebuilding each surviving predicate from a `Copy`
+                        // (see `transform_chain`'s `Case` arm) is what makes the
+                        // set data-independent.
+                        collect_all_ids(&br.guard, out);
+                        collect_block_spine_ids(&br.body, out);
+                    }
+                }
+                // A write's value is **inlined into the RYW environment**, not
+                // left on the spine, so the env slot is a *template* the reads
+                // instantiate rather than a subtree that reaches the output. The
+                // template itself never survives: `subst_env` freshens each
+                // instantiation's interior and carries the read site's id onto
+                // its root, and the terminal takes its own `fresh_copy`. So the
+                // value dies here along with the write node, and every surviving
+                // instance is an attributed `Copy` of it.
+                //
+                // (Under the older `let`-binding model the value *was* placed on
+                // the spine and only a `Var` was copied, which is why this used
+                // to be a preserve.)
+                TypedExprNode::MutWrite { value, .. } => {
+                    out.push(effect.node_id());
+                    collect_all_ids(value, out);
+                }
+                // Feed/Unit effect nodes drop; a feed's value is hoisted to a
+                // `FeedSite` and reaches the output intact, so it is preserved.
+                _ => out.push(effect.node_id()),
+            }
+            collect_block_spine_ids(body, out);
+        }
+        TypedExprNode::Lit(Lit::Unit) => out.push(block.node_id()),
+        _ => {}
+    }
+}
+
 fn rewrite(mut expr: Expr) -> Expr {
+    let stmt_id = expr.node_id();
     if let TypedExprNode::ExprStmt { expr: effect, body } = expr.node {
-        if let TypedExprNode::For {
-            target,
-            iter,
-            body: loop_body,
-        } = effect.node
-        {
+        let effect_id = effect.node_id();
+        if matches!(&effect.node, TypedExprNode::For { .. }) {
+            // The loop → causal `LetRec` rewrite. It consumes the loop
+            // statement's structural spine (the `ExprStmt` wrapper, the `For`, and
+            // the loop body's spine nodes) and mints the carrier `LetRec` plus its
+            // history/guard/decision scaffolding (captured as births in this
+            // frame). The iteration source and each value expression are
+            // preserved (self-edges), so neither is consumed. Blame is the `For`
+            // (its source span); `Nature::Expansion` — a `LetRec` faithfully
+            // expands the loop. One frame suffices: the env templates the body
+            // copies are born here, and the `Transform` flushes before its
+            // captured `Copy`s.
+            let mut consumed = vec![stmt_id, effect_id];
+            if let TypedExprNode::For {
+                body: lb, iter: it, ..
+            } = &effect.node
+            {
+                collect_block_spine_ids(lb, &mut consumed);
+                // The iteration source is preserved (bare clone) on the
+                // accumulator and feed paths — `transform_loop` /
+                // `transform_feed_only_loop` keep its ids — so it is a self-edge
+                // there and is NOT consumed. On the *drop* path (no accumulator,
+                // no feed — e.g. a transaction-emptied `For`) the whole loop
+                // vanishes, so the source is consumed. (A transaction-emptied
+                // loop's source was already `Copy`-freshened into the commit
+                // record by `transact_phase`, earlier in the log, so consuming the
+                // original here is well-ordered.)
+                let mut accs = Vec::new();
+                // Only the *emptiness* of `accs` is consulted here, and the
+                // register value types never change which names are collected
+                // — so the drop-path test needs no `reg_vtys`.
+                collect_writes(lb, &HashMap::new(), &mut accs);
+                if accs.is_empty() && !body_has_feed(lb) {
+                    collect_all_ids(it, &mut consumed);
+                }
+            }
+            let TypedExprNode::For {
+                target,
+                iter,
+                body: loop_body,
+            } = effect.node
+            else {
+                unreachable!("guarded above")
+            };
+            let _g = crate::ccl::lineage::step(
+                "letrec.loop",
+                consumed,
+                vec![effect_id],
+                crate::ccl::lineage::Nature::Expansion,
+            );
             return transform_loop(target, *iter, *loop_body, *body);
         }
         // A `MutWrite` outside any `For` is a *sequential* mutation — a
         // top-level `cnt += 1`, or an inlined pass-by-reference writer
         // (`bump(cnt)`) spliced between statements. There is no recurrence to
         // build; normalize it to a shadowing `let` (see `normalize_bare_write`).
-        if let TypedExprNode::MutWrite { name, value } = effect.node {
+        if matches!(&effect.node, TypedExprNode::MutWrite { .. }) {
+            let TypedExprNode::MutWrite { name, value } = effect.node else {
+                unreachable!("guarded above")
+            };
+            // Consumes the `ExprStmt` wrapper and the `MutWrite` marker; the
+            // shadowing `let` it mints is captured here. The write value is
+            // preserved (recursed in place). `Nature::Machinery` — a shadowing
+            // rebind is pure plumbing, not a source construct.
+            let _g = crate::ccl::lineage::step(
+                "letrec.bare_write",
+                vec![stmt_id, effect_id],
+                vec![effect_id],
+                crate::ccl::lineage::Nature::Machinery,
+            );
             return normalize_bare_write(name, *value, *body);
         }
         // Not a loop/write statement: rebuild and recurse.
@@ -644,6 +794,7 @@ fn transform_loop(target: TypedBinding, iter: Expr, loop_body: Expr, cont: Expr)
         "letrec phase emitted a non-causal group"
     );
     let ty = body_out.ty.clone();
+    // `Expr::new` so the carrier `LetRec` mint is captured by the open loop frame.
     Expr::new(TypedExprNode::LetRec {
         bindings,
         body: Box::new(body_out),
@@ -898,11 +1049,22 @@ fn transform_feed_only_loop(target: TypedBinding, iter: Expr, loop_body: Expr, c
     // Emit in reverse so the first source feed ends up outermost — desugar
     // collects feeds outermost-first into the channel union, preserving source
     // order (mirrors the accumulator path's hoist ordering).
+    let mut source_kept = false;
     for (defer, value) in feeds.into_iter().rev() {
         let value_ty = value.ty.clone();
         let mut lambda = Expr::lambda(target.name.clone(), target.ty.clone(), value);
         lambda.ty = Type::fun(target.ty.clone(), value_ty.clone());
-        let mut map = Expr::compose(vec![iter.clone(), lambda]);
+        // Each feed maps its own copy of the loop source. Keep the first copy's
+        // ids (a bare clone — a self-edge preserving the source, so the loop frame
+        // need not consume it); freshen the rest so the copies do not share ids
+        // (captured as `Copy` steps of the still-live source).
+        let src = if source_kept {
+            fresh_copy(iter.clone())
+        } else {
+            source_kept = true;
+            iter.clone()
+        };
+        let mut map = Expr::compose(vec![src, lambda]);
         map.ty = Type::fun(domain_ty.clone(), value_ty);
         let mut feed = Expr::feed(defer, map);
         feed.ty = Type::Base(BaseType::Unit);
@@ -1107,15 +1269,53 @@ fn transform_chain(
             // structurally.
             let mut priors: Vec<Expr> = Vec::new();
             let mut all: Vec<(Expr, Vec<Expr>)> = Vec::new();
-            for br in branches {
+            for (bi, br) in branches.into_iter().enumerate() {
                 // The first-match predicate, resolved through the RYW env so the
                 // loop item / accumulators read their writer-body snapshot slots
                 // (`__p.k` / `__p.i`) rather than the raw loop binder — the
                 // `commit` field must be point-free like `writes`.
-                let pi = subst_env(synthesize_arm_predicate(&br.guard, &priors), env);
+                // `synthesize_arm_predicate` splices a copy of every *earlier*
+                // guard into this arm's predicate (`gᵢ ∧ ¬g₀ ∧ … ∧ ¬gᵢ₋₁`), so a
+                // guard reaches the tree once as its own arm's `pi` and again
+                // inside each later arm. Freshen the prior copies — the arm's own
+                // `br.guard` keeps its ids (the `Case` is consumed here, so that
+                // is a self-edge) and every negated echo becomes an attributed
+                // `Copy` under the open frame.
+                // Every guard the `Case` carries is consumed by this rewrite (see
+                // `collect_block_spine_ids`), so an arm predicate is built
+                // entirely from `Copy`s: the arm's own guard once, plus a
+                // freshened echo of each earlier guard for the `¬` conjuncts.
+                let own_guard = fresh_copy(br.guard.clone());
+                let prior_copies: Vec<Expr> = priors.iter().cloned().map(fresh_copy).collect();
+                let pi = subst_env(synthesize_arm_predicate(&own_guard, &prior_copies), env);
                 priors.push(br.guard.clone());
-                let spliced = splice_after_unit(br.body, rest.clone());
-                let mut branch_env = env.clone();
+                // The post-`Case` remainder is spliced onto *every* path — each
+                // explicit branch and the trailing `true` carry arm — so it
+                // reaches the tree once per branch. Keep-first: the first path
+                // carries the original ids (a preserve; `rest` is consumed from
+                // the spine exactly once), every later path takes an attributed
+                // `Copy`.
+                let rest_here = if bi == 0 {
+                    rest.clone()
+                } else {
+                    fresh_copy(rest.clone())
+                };
+                let spliced = splice_after_unit(br.body, rest_here);
+                // Every branch starts from the entering RYW env, whose slots hold
+                // the *inlined* values of any unconditional write before the
+                // `Case`. Those slots are read straight into each branch's
+                // terminal write tuple, so a bare `env.clone()` would stamp one
+                // write's ids into every arm (visible when a branch's write set
+                // matches the carry for some accumulator). Keep-first again: the
+                // first branch inherits the originals, later branches take
+                // attributed `Copy`s.
+                let mut branch_env = if bi == 0 {
+                    env.clone()
+                } else {
+                    env.iter()
+                        .map(|(k, v)| (k.clone(), fresh_copy(v.clone())))
+                        .collect()
+                };
                 let mut branch_feeds: Vec<FeedSite> = Vec::new();
                 let dec = transform_chain(
                     spliced,
@@ -1217,10 +1417,18 @@ fn transform_chain(
             // to_<feed>*}` — always-commit, the latest value of each
             // accumulator as the positional write set (one element even for a
             // single accumulator), and each captured feed value as a tap.
+            // The env slot is a template (see `collect_block_spine_ids`), and its
+            // own ids are consumed with the write that inlined it — so the
+            // terminal takes a `fresh_copy`, not a bare clone, and the write set
+            // carries an attributed `Copy` of the final value. A bare clone here
+            // would leave the last write's ids both consumed and live, which the
+            // fold reports as an over-consumption rather than a leak.
             let current = |acc: &Name| {
-                env.get(acc)
-                    .expect("letrec phase: accumulator missing from RYW environment")
-                    .clone()
+                fresh_copy(
+                    env.get(acc)
+                        .expect("letrec phase: accumulator missing from RYW environment")
+                        .clone(),
+                )
             };
             let mut writes = Expr::tuple(accs.iter().map(|(n, _)| current(n)).collect());
             writes.ty = writes_ty.clone();
@@ -1336,11 +1544,18 @@ fn conditional_decision(
             if writing.is_empty() {
                 return carry[i].clone();
             }
+            // Each first-match guard is spliced once into `commit` and again
+            // into *every* accumulator's value-`Case`. The `commit`
+            // disjunction above holds the originals, so each per-accumulator
+            // copy is freshened — a bare clone would stamp one guard's ids at
+            // `1 + |accumulators|` positions and break the tree's
+            // id-uniqueness invariant. Inside the open `letrec.loop` frame the
+            // deep walk attributes each re-mint as a `Copy` of the guard.
             let mut case_branches: Vec<Branch> = writing
                 .iter()
                 .map(|(g, w)| Branch {
                     pattern: None,
-                    guard: g.clone(),
+                    guard: fresh_copy(g.clone()),
                     body: w[i].clone(),
                 })
                 .collect();
@@ -1423,7 +1638,27 @@ fn subst_env(mut e: Expr, env: &HashMap<Name, Expr>) -> Expr {
     if let TypedExprNode::Var(n) = &e.node
         && let Some(rep) = env.get(n)
     {
-        return rep.clone();
+        // A stored env value is substituted at every read site; a bare
+        // `rep.clone()` would stamp the *same* NodeIds into each copy, breaking
+        // the tree's id-uniqueness invariant. Freshen each copy's ids (the
+        // shared deep walk — main tree + predicate `Rc`s + `Cast` targets), then
+        // carry the read site's own id onto the copy's ROOT. That makes the read
+        // position a **preserve** (self-edge): the source span of the `Var(x)`
+        // read survives onto the snapshot projection replacing it, and the loop
+        // frame does not consume it. The copy's freshened interior is captured as
+        // per-origin `Copy` steps of the env template (born in the same open loop
+        // frame — the template flushes first, so the copies land on a live
+        // origin; the born-copied-discarded template hazard, pinned by
+        // `lineage::born_copied_discarded_template_composes_without_leaks`).
+        let read_id = e.node_id();
+        let mut copy = rep.clone();
+        // Freshen the INTERIOR only, then carry the read site's id onto the root.
+        // A deep freshen re-mints the root too, and overwriting it afterwards
+        // leaves an `Op::Copy` whose produced id no node carries — the same
+        // dead-id hazard `subst.rs`'s root-carry avoids the same way.
+        copy.freshen_interior_node_ids();
+        copy.node_id = read_id;
+        return copy;
     }
     e.map_children(|c| subst_env(c, env));
     e
@@ -1588,13 +1823,90 @@ mod tests {
         );
     }
 
-    /// RT-4b: the `flatten_spine` bare-writer arm — `Let(x, MutWrite(..), k)` (a
+    /// The typed direct-mirror tree for `x := 0; for i in [1,2,3]: x := x + x; x`
+    /// — the loop body reads the accumulator at **two** sites (`x + x`), so
+    /// [`transform_chain`]'s `subst_env` substitutes the read-your-writes value at
+    /// both. Before the freshen fix the two copies shared NodeIds.
+    fn loop_two_reads() -> Expr {
+        let int = Type::Base(BaseType::Int);
+        let list_ty = Type::fun(Type::UIntRange(3), int.clone());
+        let x = Name::fresh("x");
+        let i = Name::fresh("i");
+
+        let mut list = Expr::new(TypedExprNode::List(
+            [1, 2, 3]
+                .iter()
+                .map(|n| {
+                    let mut l = Expr::new(TypedExprNode::Lit(Lit::Int(*n)));
+                    l.ty = int.clone();
+                    l
+                })
+                .collect(),
+        ));
+        list.ty = list_ty;
+
+        // x + x — two reads of the accumulator in one write value.
+        let mut sum = Expr::new(TypedExprNode::BinOp {
+            left: Box::new(tvar(&x, int.clone())),
+            op: crate::ccl::BinOpKind::Arithmetic(crate::ccl::ArithmeticKind::Add),
+            right: Box::new(tvar(&x, int.clone())),
+        });
+        sum.ty = int.clone();
+        let mut write = Expr::mut_write(x.clone(), sum);
+        write.ty = Type::Base(BaseType::Unit);
+        let mut unit = Expr::new(TypedExprNode::Lit(Lit::Unit));
+        unit.ty = Type::Base(BaseType::Unit);
+        let mut body = Expr::expr_stmt(write, unit);
+        body.ty = Type::Base(BaseType::Unit);
+
+        let mut for_node = Expr::new(TypedExprNode::For {
+            target: TypedBinding {
+                name: i,
+                ty: int.clone(),
+                user_annotation: None,
+            },
+            iter: Box::new(list),
+            body: Box::new(body),
+        });
+        for_node.ty = Type::Base(BaseType::Unit);
+
+        let mut stmt = Expr::expr_stmt(for_node, tvar(&x, int.clone()));
+        stmt.ty = int.clone();
+        let mut init = Expr::new(TypedExprNode::Lit(Lit::Int(0)));
+        init.ty = int.clone();
+        let mut tree = Expr::let_bind(x, init, stmt);
+        tree.ty = int;
+        tree
+    }
+
+    /// Letrec-flavored sibling: the induction phase preserves
+    /// id-uniqueness when a loop body reads the accumulator at multiple sites.
+    /// `transform_chain`'s `subst_env` substitutes the read-your-writes value at
+    /// each read; before the freshen fix the copies shared NodeIds, and the
+    /// `step_view` template cloned into the guard + trailing reads shared ids too.
+    /// (Asserted at the phase boundary for the same reason as the transact
+    /// sibling: a runnable loop program's `post_desugar_ir` is defer-bearing.)
+    #[test]
+    fn subst_env_and_scaffolding_keep_ids_unique() {
+        let out = run(loop_two_reads());
+        // Through the shared checker: id uniqueness within a tree is one invariant
+        // with one implementation. A subst_env copy or a writes-view clone that was
+        // not freshened shows up here as two nodes sharing an id.
+        crate::ccl::context::assert_unique_node_ids(&out, "letrec phase");
+        // Recognition's own id-uniqueness is checked by the integration suite:
+        // it now runs *after* `lambda_elim` (which point-frees the induction
+        // binding's `λ r → let __prev = ⟨guard⟩ …` into the factored `let __prev
+        // = ⟨guard⟩ …` shape `recognize` destructures), so it can no longer
+        // consume this pass's raw `λ r → …` output directly.
+    }
+
+    /// The `flatten_spine` bare-writer arm — `Let(x, MutWrite(..), k)` (a
     /// value-position writer whose body is a bare write, e.g. an inlined
     /// `y = bump(c)`) — carries the input write's NodeId onto the repositioned
     /// write rather than minting a fresh one. This is the preserve-id fix: a mint
     /// would sever the write's source span and could duplicate the id.
     ///
-    /// Unit-test form at the letrec boundary (the plan's RT-4b fallback): the
+    /// Unit-test form at the letrec boundary: the
     /// bare-writer `MutWrite` is consumed by the loop rewrite and does not survive
     /// into `post_desugar_ir` as a span-indexable `MutWrite`, so id preservation
     /// through the phase is asserted directly here.

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -609,7 +609,12 @@ impl Subst {
     /// observed uniformly across the tree. `Compose` node types are recomputed from the
     /// rewritten elements (substituting a `Var` whose type was an unresolved
     /// placeholder can concretize the element types; the `Compose.ty ==
-    /// Fun(first_domain, last_codomain)` invariant must follow).
+    /// `Fun(first_domain, last_codomain)` invariant must follow).
+    ///
+    /// There is no freshen observer: a compound replacement's interior is
+    /// freshened by [`TypedExpr::freshen_interior_node_ids`], whose re-mints fire
+    /// the ambient `lineage::on_copy` hook directly into any open lineage step, so
+    /// the caller needs no callback.
     pub fn rewrite_expr(&self, e: &mut TypedExpr) {
         if self.is_id() {
             return;
@@ -627,7 +632,7 @@ impl Subst {
         if !is_free(binder, e) {
             return;
         }
-        Subst::discharge(binder.clone(), term.clone()).rewrite_expr(e);
+        Subst::discharge(binder.clone(), term.clone()).rewrite_expr_go(e, &PredMemo::new());
     }
 
     fn rewrite_expr_go(&self, e: &mut TypedExpr, memo: &PredMemo<Subst>) {

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -70,6 +70,7 @@ use crate::ccl::{
     ccl_utils::is_free_in_value,
     letrec::check_letrec_causal,
     mut_elim::{fold_induction_loop, hoist_feeds, register_value_tys},
+    provenance::NodeId,
 };
 
 /// Recognize a **fed-out register read** and rewrite it to an as-of join, *before*
@@ -445,6 +446,108 @@ pub fn collect_txn_registers(expr: &Expr) -> HashSet<Name> {
     out
 }
 
+/// Collect the input node ids the transaction rewrite consumes (the frame's
+/// `consumed` set — blame ⊥ consumption). These are the `with begin():` markers
+/// and their block spines that vanish, plus the transactional register `let`
+/// declarations (their inits are captured into the histories and preserved; the
+/// declaration nodes themselves are dropped by `rebind_letrec`). Everything
+/// preserved — register value expressions (`subst_env` containers + id-carried read
+/// leaves), the iteration source, the register inits, the read-only feed spine, and
+/// the enclosing `For` (retired by `mut_elim`, not here) — is a self-edge and
+/// is NOT collected.
+///
+/// Mirrors what [`strip`]/[`build_writer`]/[`build_letrec`] actually drop; a
+/// drift surfaces at the leak gate as `Dropped` (a vanishing node left
+/// unconsumed) or `Unexplained` (a preserved node wrongly consumed).
+fn collect_txn_consumed(expr: &Expr, txn_registers: &HashSet<Name>, out: &mut Vec<NodeId>) {
+    match &expr.node {
+        // A `with begin():` block on a statement spine: the `ExprStmt` wrapper and
+        // the `Begin` marker vanish. A *writing* block's inner spine is consumed
+        // by `walk_block` (the decision is freshly built); a *read-only* block's
+        // spine is spliced onto the loop (ids preserved), only its terminal `Unit`
+        // dropping.
+        TypedExprNode::ExprStmt { expr: effect, body }
+            if matches!(&effect.node, TypedExprNode::Begin { .. }) =>
+        {
+            out.push(expr.node_id());
+            out.push(effect.node_id());
+            if let TypedExprNode::Begin { body: block } = &effect.node {
+                if block_writes_txn(block, txn_registers) {
+                    collect_writing_block_spine(block, out);
+                } else {
+                    collect_readonly_block_drops(block, out);
+                }
+            }
+            collect_txn_consumed(body, txn_registers, out);
+        }
+        // A transactional register `let` declaration: the binding node drops (its init
+        // is preserved). The body is recursed.
+        TypedExprNode::Let { binding, body, .. } if txn_registers.contains(&binding.name) => {
+            out.push(expr.node_id());
+            collect_txn_consumed(body, txn_registers, out);
+        }
+        _ => expr.walk_children(|c| collect_txn_consumed(c, txn_registers, out)),
+    }
+}
+
+/// A writing `with begin():` block's spine (consumed by `walk_block`): the
+/// `Let`/`ExprStmt` structural nodes, the `MutWrite`/`Feed` markers, `if` guards
+/// (`Case` + branch bodies), and terminal `Unit`s. Value expressions are
+/// preserved (self-edges) and not collected.
+fn collect_writing_block_spine(block: &Expr, out: &mut Vec<NodeId>) {
+    match &block.node {
+        TypedExprNode::Let { body, .. } => {
+            out.push(block.node_id());
+            collect_writing_block_spine(body, out);
+        }
+        TypedExprNode::ExprStmt { expr: effect, body } => {
+            out.push(block.node_id());
+            match &effect.node {
+                TypedExprNode::Case {
+                    scrutinee: None,
+                    branches,
+                } => {
+                    out.push(effect.node_id());
+                    // `apply_guard` uses branch[0]: its guard is `subst_env`'d into
+                    // `commit` (preserved — a self-edge), its body spine consumed.
+                    // The deny branch(es) (`true → unit`) are dropped entirely.
+                    if let Some(first) = branches.first() {
+                        collect_writing_block_spine(&first.body, out);
+                    }
+                    for b in &branches[1..] {
+                        collect_all_ids_tx(&b.guard, out);
+                        collect_all_ids_tx(&b.body, out);
+                    }
+                }
+                _ => out.push(effect.node_id()),
+            }
+            collect_writing_block_spine(body, out);
+        }
+        TypedExprNode::Lit(Lit::Unit) => out.push(block.node_id()),
+        _ => {}
+    }
+}
+
+/// Every node id in a subtree (main-tree node set) — for consuming a wholly
+/// dropped fragment (e.g. a `with begin():` guard's deny branch).
+fn collect_all_ids_tx(e: &Expr, out: &mut Vec<NodeId>) {
+    out.push(e.node_id());
+    e.walk_children(|c| collect_all_ids_tx(c, out));
+}
+
+/// A read-only `with begin():` block: `splice_block` unwraps it onto the loop
+/// spine, **preserving** the `Let`/`ExprStmt`(feed) spine ids and dropping only
+/// the terminal `Unit`.
+fn collect_readonly_block_drops(block: &Expr, out: &mut Vec<NodeId>) {
+    match &block.node {
+        TypedExprNode::Lit(Lit::Unit) => out.push(block.node_id()),
+        TypedExprNode::ExprStmt { body, .. } | TypedExprNode::Let { body, .. } => {
+            collect_readonly_block_drops(body, out)
+        }
+        _ => {}
+    }
+}
+
 /// The value type `V` of a register reference. A transactional register's binding and
 /// its in-block references are `Mut(V, Txn)`-typed after inference, but the
 /// histories and commit records this phase emits — and the `final_or_default`
@@ -536,6 +639,23 @@ pub fn run(expr: Expr, txn_registers: &HashSet<Name>) -> Expr {
     if txn_registers.is_empty() && !contains_begin(&expr) {
         return expr;
     }
+    // Lineage: the whole transaction rewrite is one frame. It consumes the `with
+    // begin():` markers, store declarations, and block spine nodes that vanish
+    // (pre-walked into `consumed`), and mints the commit `LetRec` scaffolding
+    // (captured as births). Store values, sources, and inits are preserved
+    // (self-edges), so the frame's only copies are of born templates — the
+    // Transform flushes before them. Blame the program
+    // root (the rewrite's source anchor); `Nature::Expansion` — the commit
+    // `LetRec` faithfully expands the `with begin():` transaction.
+    let mut consumed: Vec<NodeId> = Vec::new();
+    collect_txn_consumed(&expr, txn_registers, &mut consumed);
+    let root_id = expr.node_id();
+    let _frame = crate::ccl::lineage::step(
+        "transact.commit",
+        consumed,
+        vec![root_id],
+        crate::ccl::lineage::Nature::Expansion,
+    );
     let mut sites: Vec<RawSite> = Vec::new();
     let stripped = strip(expr, txn_registers, None, &mut sites);
     // Post-strip invariants (release asserts, like the letrec-phase
@@ -913,7 +1033,8 @@ fn splice_block(block: Expr, rest: Expr) -> Expr {
         // any other terminal is unexpected — sequence it defensively before rest.
         other => {
             let ty = rest.ty.clone();
-            // A freshly-synthesized defensive sequencing wrapper.
+            // A freshly-synthesized defensive sequencing wrapper — `Expr::new` so
+            // the mint is captured by the open transaction frame.
             Expr::new(TypedExprNode::ExprStmt {
                 expr: Box::new(Expr {
                     node: other,
@@ -1002,6 +1123,7 @@ fn partition_spine(expr: Expr, txn_registers: &HashSet<Name>, lifted: &mut Vec<E
 fn prepend_effects(effects: Vec<Expr>, rest: Expr) -> Expr {
     effects.into_iter().rev().fold(rest, |rest, effect| {
         let ty = rest.ty.clone();
+        // `Expr::new` so the mint is captured by the open transaction frame.
         Expr::new(TypedExprNode::ExprStmt {
             expr: Box::new(effect),
             body: Box::new(rest),
@@ -1212,6 +1334,20 @@ fn tvar(name: &Name, ty: Type) -> Expr {
     e
 }
 
+/// An id-freshened copy of `e` — every node re-minted (the shared deep walk).
+///
+/// A store key's `init` is spliced at one position and preserved (kept ids) at
+/// the other; the writer `source` and `subst_env` env values land at read sites
+/// where a bare `clone` would stamp the *same* NodeIds, breaking id-uniqueness.
+/// Each such copy is freshened so the positions carry distinct ids. When called
+/// inside the open `transact.commit` frame the deep walk's `on_copy` hook
+/// captures each re-mint as a `Copy` step (mirroring the original's lineage), so
+/// these copies are attributed, not swept.
+fn fresh_copy(mut e: Expr) -> Expr {
+    e.freshen_node_ids_deep();
+    e
+}
+
 /// `p ▷ .i : elt_ty` — projection of the writer body's tuple parameter.
 fn proj_tuple(p: &Name, tuple_ty: &Type, i: usize, elt_ty: Type) -> Expr {
     let mut proj = Expr::proj_index(i);
@@ -1275,7 +1411,11 @@ fn build_writer(
     broadcasts.sort_by(|a, b| a.0.cmp(&b.0));
 
     let (source, item_ty) = if site_accs.is_empty() {
-        (site.source.clone(), orig_item_ty.clone())
+        // Freshen: the original iteration source survives (as the emptied `For`'s
+        // iter) until the letrec phase drops it, so this copy must not duplicate
+        // its ids. Captured as a `Copy` step of the still-live source by the open
+        // `transact.commit` frame.
+        (fresh_copy(site.source.clone()), orig_item_ty.clone())
     } else {
         build_zip_source(&site.source, &orig_item_ty, &site_accs)
     };
@@ -1428,13 +1568,21 @@ fn build_zip_source(source: &Expr, item_ty: &Type, accs: &[(Name, Expr, Type)]) 
     let new_item_ty = Type::Tuple(elt_tys);
 
     let x = Name::fresh("__zx");
+    // The zip re-embeds the writer's `source` and each accumulator `view`, which
+    // already live at their own tree positions; freshen each copy so the zip's
+    // clone does not duplicate their NodeIds. Captured as `Copy` steps by the open
+    // `transact.commit` frame (mirroring each origin's lineage).
     let mut elts = vec![apply_ty(
         tvar(&x, dom.clone()),
-        source.clone(),
+        fresh_copy(source.clone()),
         item_ty.clone(),
     )];
     for (_, view, vty) in accs {
-        elts.push(apply_ty(tvar(&x, dom.clone()), view.clone(), vty.clone()));
+        elts.push(apply_ty(
+            tvar(&x, dom.clone()),
+            fresh_copy(view.clone()),
+            vty.clone(),
+        ));
     }
     let mut tup = Expr::tuple(elts);
     tup.ty = new_item_ty.clone();
@@ -1587,7 +1735,26 @@ fn subst_env(e: &Expr, env: &HashMap<Name, Expr>) -> Expr {
     if let TypedExprNode::Var(n) = &e.node
         && let Some(rep) = env.get(n)
     {
-        return rep.clone();
+        // A stored env value is substituted at every read site; a bare
+        // `rep.clone()` would stamp the *same* NodeIds into each copy, breaking
+        // the tree's id-uniqueness invariant. Freshen each copy's ids (the
+        // shared deep walk — main tree + predicate `Rc`s + `Cast` targets), then
+        // carry the read site's own id onto the copy's ROOT. That makes the read
+        // position a **preserve** (self-edge): the source span of the `Var`
+        // read survives onto the snapshot projection replacing it, and the
+        // transaction frame does not consume it. The copy's freshened interior is
+        // captured as per-origin `Copy` steps of the env template (born in the
+        // open transaction frame; the `Transform` flushes before its captured
+        // `Copy`s).
+        let read_id = e.node_id();
+        let mut copy = rep.clone();
+        // Freshen the INTERIOR only, then carry the read site's id onto the root.
+        // A deep freshen re-mints the root too, and overwriting it afterwards
+        // leaves an `Op::Copy` whose produced id no node carries — the same
+        // dead-id hazard `subst.rs`'s root-carry avoids the same way.
+        copy.freshen_interior_node_ids();
+        copy.node_id = read_id;
+        return copy;
     }
     let mut out = e.clone();
     out.map_children(|c| subst_env(&c, env));
@@ -1630,6 +1797,8 @@ fn binding(name: Name, ty: Type) -> TypedBinding {
 /// `let name : name_ty = def in body`, typed as `body`.
 fn let_typed(name: Name, name_ty: Type, def: Expr, body: Expr) -> Expr {
     let ty = body.ty.clone();
+    // `Expr::new` so the mint fires `on_mint` and lands as a birth in the open
+    // transaction frame.
     Expr::new(TypedExprNode::Let {
         binding: binding(name, name_ty),
         bound_expr: Box::new(def),
@@ -1721,7 +1890,15 @@ fn per_key_view(
     let writes_ty = record_field_ty(decision_ty, F_WRITES);
     let c = Name::fresh("__c");
     let cvar = tvar(&c, rec_ty.clone());
-    let time = apply_ty(cvar.clone(), fproj(F_TIME, rec_ty, &Type::Txn), Type::Txn);
+    // `__c` and the `__c.decision` projection are each referenced at several
+    // record fields; freshen the extra copies so the shared references do not
+    // duplicate NodeIds (same name binds them, ids are metadata). Captured as
+    // `Copy` steps by the open `transact.commit` frame.
+    let time = apply_ty(
+        fresh_copy(cvar.clone()),
+        fproj(F_TIME, rec_ty, &Type::Txn),
+        Type::Txn,
+    );
     let decision = apply_ty(
         cvar,
         fproj(F_DECISION, rec_ty, decision_ty),
@@ -1965,6 +2142,11 @@ fn build_letrec(
         let v = value_ty(k);
         let reg_k = hist[k].clone();
         let t = Name::fresh("__t");
+        // The key's `init` is spliced at two positions (here, and the
+        // continuation rebind in `splice_letrec`). Keep the original ids HERE (a
+        // bare clone — a self-edge preserving the store declaration's init, since
+        // the declaration node is dropped but its init survives), and freshen the
+        // rebind copy so the two never share ids.
         let init = key_init.get(k).cloned().expect("key init present");
         // The `get_prev_txn` history slot — the design's denotation: the
         // `⧺`-merged **per-key commit views** of every site writing this key
@@ -2171,7 +2353,9 @@ fn splice_letrec(
         // it defensively. `erase_mut` sweeps any surviving `Var(x)` reference type.
         let v = register_value_ty(&key_init[k].ty);
         let stream = tvar(&hist[k], history_ty(&v));
-        let init = key_init.get(k).cloned().expect("key init present");
+        // Freshen: the same `init` is also spliced at the history binding's
+        // `get_prev_txn` default (`build_letrec`), so the copies must not share ids.
+        let init = fresh_copy(key_init.get(k).cloned().expect("key init present"));
         let bound = final_or_default_read(stream, init, v.clone());
         inner = let_typed(k.clone(), v, bound, inner);
     }
@@ -2181,6 +2365,7 @@ fn splice_letrec(
         .collect();
     let body = hoist_feeds(inner, feed_views);
     let ty = body.ty.clone();
+    // `Expr::new` so the transaction carrier `LetRec` mint is captured.
     let txn_letrec = Expr::new(TypedExprNode::LetRec {
         bindings,
         body: Box::new(body),
@@ -2204,6 +2389,7 @@ fn wrap_cross_domain(txn_letrec: Expr, cross: CrossDomain) -> Expr {
     inner = hoist_feeds(inner, cross.feeds);
     for (b, def) in cross.bindings.into_iter().rev() {
         let ty = inner.ty.clone();
+        // `Expr::new` so the cross-domain induction `LetRec` mint is captured.
         inner = Expr::new(TypedExprNode::LetRec {
             bindings: vec![(b, def)],
             body: Box::new(inner),
@@ -2317,6 +2503,102 @@ mod tests {
             check_letrec_causal(&bindings),
             Ok(()),
             "the emitted transaction letrec must be guarded"
+        );
+    }
+
+    /// The typed direct-mirror tree for a `with begin():` writer that reads the
+    /// store at **two** sites: `pool: Mut(Int, Txn) := 100; with begin(): pool :=
+    /// pool + pool`. Both `pool` reads are substituted from the read-your-writes
+    /// environment by [`subst_env`]; before the freshen fix the two copies shared
+    /// NodeIds, duplicating ids into the phase output.
+    fn txn_two_reads() -> (Expr, Name) {
+        let int = Type::Base(BaseType::Int);
+        let list_ty = Type::fun(Type::UIntRange(1), int.clone());
+        let pool = Name::fresh("pool");
+        let r = Name::fresh("r");
+
+        let mut ten = Expr::new(TypedExprNode::Lit(Lit::Int(10)));
+        ten.ty = int.clone();
+        let mut list = Expr::new(TypedExprNode::List(vec![ten]));
+        list.ty = list_ty;
+
+        // pool + pool — two reads of the store in one write value.
+        let mut add = Expr::new(TypedExprNode::BinOp {
+            left: Box::new(tvar(&pool, int.clone())),
+            op: BinOpKind::Arithmetic(ArithmeticKind::Add),
+            right: Box::new(tvar(&pool, int.clone())),
+        });
+        add.ty = int.clone();
+        let mut write = Expr::mut_write(pool.clone(), add);
+        write.ty = Type::Base(BaseType::Unit);
+        let mut unit = Expr::new(TypedExprNode::Lit(Lit::Unit));
+        unit.ty = Type::Base(BaseType::Unit);
+        let mut block = Expr::expr_stmt(write, unit);
+        block.ty = Type::Base(BaseType::Unit);
+        // A transactional store write must sit inside a `with begin():`
+        // (`Begin`) block on the loop body: `ExprStmt(Begin{block}, unit)`.
+        let mut begin = Expr::begin(block);
+        begin.ty = Type::Base(BaseType::Unit);
+        let mut body_unit = Expr::new(TypedExprNode::Lit(Lit::Unit));
+        body_unit.ty = Type::Base(BaseType::Unit);
+        let mut for_body = Expr::expr_stmt(begin, body_unit);
+        for_body.ty = Type::Base(BaseType::Unit);
+
+        let mut for_node = Expr::new(TypedExprNode::For {
+            target: binding(r, int.clone()),
+            iter: Box::new(list),
+            body: Box::new(for_body),
+        });
+        for_node.ty = Type::Base(BaseType::Unit);
+
+        let mut cont = Expr::new(TypedExprNode::Lit(Lit::Unit));
+        cont.ty = Type::Base(BaseType::Unit);
+        let mut stmt = Expr::expr_stmt(for_node, cont);
+        stmt.ty = Type::Base(BaseType::Unit);
+        let mut init = Expr::new(TypedExprNode::Lit(Lit::Int(100)));
+        init.ty = int;
+        let mut tree = Expr::let_bind(pool.clone(), init, stmt);
+        tree.ty = Type::Base(BaseType::Unit);
+        (tree, pool)
+    }
+
+    /// Every duplicated NodeId over the main tree (`walk_children` node-set), for
+    /// the id-uniqueness regression assertions.
+    fn duplicate_ids(expr: &Expr) -> Vec<NodeId> {
+        fn walk(e: &Expr, seen: &mut HashSet<NodeId>, dups: &mut Vec<NodeId>) {
+            if !seen.insert(e.node_id()) {
+                dups.push(e.node_id());
+            }
+            e.walk_children(|c| walk(c, seen, dups));
+        }
+        let mut seen = HashSet::new();
+        let mut dups = Vec::new();
+        walk(expr, &mut seen, &mut dups);
+        dups
+    }
+
+    /// The transaction phase preserves the tree's id-uniqueness invariant
+    /// even when a `with begin():` block reads the store at multiple sites.
+    ///
+    /// `subst_env` substitutes the read-your-writes snapshot at every store read;
+    /// a bare `clone` at each site stamped the *same* NodeIds into the output, so
+    /// before the freshen fix `run`'s output carried duplicate ids. The assertion
+    /// is made at the transact-phase boundary rather than `post_desugar_ir`: a
+    /// runnable txn program requires an `out << ` feed to surface output, which
+    /// makes `desugar_defers` channelize, and `desugar_substitute` legitimately
+    /// leaves duplicate ids on defer-bearing programs (the post-desugar tripwire
+    /// is gated off there). This isolates the subst_env fix at the boundary that
+    /// establishes uniqueness.
+    #[test]
+    fn subst_env_copies_keep_ids_unique() {
+        let (tree, pool) = txn_two_reads();
+        let names = HashSet::from([pool]);
+        let out = run(tree, &names);
+        let dups = duplicate_ids(&out);
+        assert!(
+            dups.is_empty(),
+            "transact phase left duplicate NodeIds after substituting a store read at \
+             multiple sites (subst_env must freshen each copy): {dups:?}"
         );
     }
 }


### PR DESCRIPTION
The five IR passes between the retained inspector panes now record their rewrites, and both pane boundaries assert leak-free.

**Start here:** `compile_program` installs the `RecorderSession`s and retains the per-pass logs on `CompiledProgram::pass_lineage` [`Mono`, `Inline`, `Transact`, `Letrec`, `Desugar`]; `materialize_panes` folds them; `src/ccl/design/provenance.md` documents the model.

Each pass records its rewrites as `RewriteStep`s:

- `mono` (`infer/solve.rs`): a consume-nothing frame around the clone freshen captures per-origin `Copy` steps; `coalesce_generalized_let` is two steps — a produced-empty discard of the def subtree plus a narrow transform (original `let` → wrapper `Let`s), keeping the per-node `Copy` edges out of the bipartite product.
- `inline`: beta/alias `Transform` discards (`record_drops` diffs the consumed subtree against the reduced result) + fan-out `Copy` capture.
- `transact_phase`: one `transact.commit` frame; consumed = the `begin()` markers, writing-block spines, and register bindings, collected by precise spine walks that mirror what `strip`/`build_writer` actually drop.
- `mut_elim` (the letrec/mutation-elimination phase): `letrec.loop` / `letrec.bare_write` frames with spine-walk consumed sets; `flatten_spine` and `hoist_writer_body` carry ids on their 1:1 reparents.
- `channelize`: cluster / lift_defer / feed_union / fan-out / drop steps, with the cluster and lift origins threaded (`ClusterDefer`, the outer-`Let` id into `try_lift_defer`).

Duplication now freshens ids at its source, unconditionally: `Subst` compound replacements, inline fan-out clones, and channelize source clones. Root-carry is the general rule in the substitution engine (`freshen_interior_node_ids` re-mints only the interior and restores the occurrence's id on the replacement root), so a transact/letrec `subst_env` read keeps its read-site `Var` id and stays a self-edge. That makes id-uniqueness a tree invariant; the tripwire that checks it (`assert_unique_node_ids`) is introduced downstack with its first call site at the lowering boundary, and this commit adds the remaining four calls at the post-inline/transact/letrec/desugar boundaries.

`materialize_panes` folds the logs at the two pane boundaries (pre→post-inference; post-inference→post-desugar) into per-pane `SourceProjection`s + dense `LineageMap`s, and `assert_leaks_clean` asserts zero leaks of every class at both.

`census_ratchet` pins per-category attribution counts per stage and asserts structurally that no pane contains an unresolved row — the lowering fold covers every node.

Every `RewriteStep` here is recorded as a byproduct of performing the rewrite — never reconstructed by diffing trees afterwards — so a pass that mints where it should preserve shows up as a leak at the boundary rather than as silently wrong attribution. That is what the zero-leak assertions buy: the recorder surface the substrate landed with is exercised for the first time, and 13 of its 15 `dead_code` allows come off here (the two that remain are `Nature::wire_str`, whose consumer is the inspector wire, and the `Copy` op's `origin` accessor).

**Conditional induction.** `transform_chain`'s statement-`Case` arm (the `if p: acc += e` shape) fans the post-`Case` remainder and the entering read-your-writes env across every branch, so several subtrees reach the tree more than once. Each fan-out site is keep-first — the first path carries the original ids, later paths take an attributed `Copy` — covering the arm predicates' negated guard echoes, the remainder splice, and the per-branch env clones. `collect_block_spine_ids` mirrors the new arm: it consumes the `Case`, every branch guard, and each branch body's spine. Guards are consumed uniformly rather than predicted, because which arm predicates survive is data-dependent (the trailing carry arm's is always discarded, as is any arm whose write set matches the carry).

A write's value is inlined into the env as a *template*, not left on the spine, so the template's own ids never reach the output — reads instantiate it with a freshened interior and the read site's id on the root. Its ids are therefore consumed with the write, and the terminal takes a `fresh_copy` into the write set. This moves `mutation_loop`'s census row: total 48 → 46 (main's shared `decision_record`/`disjoin_guards` construction mints two fewer nodes) and 3 nodes `Source`(1)/`Synthetic(Lower)`(2) → `Derived(Letrec)` (the final write value is now a recorded `Copy`, so it keeps its span but takes the step's nature). Both movements are named on the row.

**Flush order.** A frame's captured `Copy`s now straddle its own `Transform`, partitioned by origin: copies of ids the frame *consumes* fold before it (while the origin is still live), copies of ids it *births* fold after (once they are). Both orders are required, so neither can be global, and the split is per `(origin, fresh)` pair — one deep freshen of a subtree mixing consumed and newly born nodes lands on both sides. The `Transform` stays whole because it carries root inheritance; splitting it into birth and consume halves would hand every born node an empty root set and sever it from its ancestry without tripping the audit. `copies_straddle_the_frame_transform_by_origin` pins both directions.

`conditional_induction_panes_are_leak_free` materializes panes for six conditional-induction shapes. The leak and id-uniqueness assertions at the post-desugar boundary only run under `materialize_panes`, so the compilation-pipeline suite compiles these programs without ever checking them — the coverage has to be explicit.
