### PR TITLE
inspector_model: snapshot model, indices, pane projections, wire schema 3

### DIFF
--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -61,9 +61,12 @@ use crate::{
 ///
 /// Use [`eprint_errors`] for source-context rendering: parse, lowering, and
 /// span-carrying inference errors get ariadne reports with underlines; the
-/// remaining variants render as plain `error: …` lines. Lambda-elim/conversion
-/// spans remain future work; the enum is shaped so they migrate without
-/// changing the list-of-errors return contract.
+/// remaining variants render as plain `error: …` lines. The same
+/// [`CompileError`]s feed the web [`Diagnostic`](crate::inspector_model::Diagnostic)
+/// JSON path via [`diagnostics_from_compile_errors`](crate::inspector_model::diagnostics_from_compile_errors)
+/// — one error model, two renderers. Lambda-elim/conversion spans remain
+/// future work; the enum is shaped so they migrate without changing the
+/// list-of-errors return contract.
 #[derive(Debug)]
 pub enum CompileError {
     /// The parser rejected one token / token sequence.
@@ -572,8 +575,6 @@ pub struct CompiledProgram {
     /// folds it at each pane boundary into the per-pane
     /// [`SourceProjection`](crate::ccl::lineage::SourceProjection)s and pane-pair
     /// [`LineageMap`](crate::ccl::lineage::LineageMap)s the inspector consumes.
-    // Consumed by the inspector model; unused within the compiler itself.
-    #[allow(dead_code)]
     pub(crate) pass_lineage: Vec<(Pass, LineageLog)>,
     /// The parsed CHL surface AST — the source-of-truth for source-level
     /// (lexical) inspector queries.
@@ -581,7 +582,7 @@ pub struct CompiledProgram {
     /// This is the [`Module`](crate::chl_parser::ast::Module) lowering consumed,
     /// retained verbatim. It is the anchor for *source-language* questions —
     /// name resolution (`goto-definition`, the binder half of `scope-at`) —
-    /// answered by the inspector's name-binder index.
+    /// answered by [`crate::inspector_model::NameBinderIndex`].
     ///
     /// It is deliberately **distinct from [`post_inference_ir`](Self::post_inference_ir)**
     /// (the typed IR): lowering destroys some source variables before any IR
@@ -628,8 +629,6 @@ impl CompiledProgram {
     ///   post-inference ids);
     /// * post-desugar pane = fold the concatenated Inline + Desugar logs
     ///   (post-inference → post-desugar ids). Both boundaries are fully recorded.
-    // Consumed by the inspector model (a later commit in this stack).
-    #[allow(dead_code)]
     pub(crate) fn materialize_panes(&self) -> MaterializedPanes {
         debug_assert_eq!(
             self.pass_lineage.first().map(|(p, _)| *p),
@@ -680,8 +679,6 @@ impl CompiledProgram {
 /// [`CompiledProgram::materialize_panes`]. Inspector-facing; the pane
 /// projections drive `hover`/`resolve`/`spanIndex`/`build_inspect_tree`, and the
 /// maps drive the cross-pane `paneLinks` (shipped dense, self-edges included).
-// Consumed by the inspector model; unused within the compiler itself.
-#[allow(dead_code)]
 pub(crate) struct MaterializedPanes {
     /// pre-inference pane projection (= the lowering projection).
     pub(crate) pre_inference: SourceProjection,

--- a/src/ccl/lineage.rs
+++ b/src/ccl/lineage.rs
@@ -185,10 +185,6 @@ impl Nature {
     /// `"source"` must **never** actually reach the wire — a `Source`-nature tag
     /// null-compresses at the emission sites (see [`is_source`](Self::is_source));
     /// the arm exists for the validators' guard and for completeness.
-    ///
-    /// Compiled only under the `serde` feature (the `Serialize` impl below is its
-    /// sole caller), so a default build sees it as dead.
-    #[allow(dead_code)]
     pub(crate) fn wire_str(self) -> &'static str {
         match self {
             Nature::Source => "source",

--- a/src/ccl/provenance.rs
+++ b/src/ccl/provenance.rs
@@ -65,8 +65,8 @@ impl NodeId {
     }
 
     /// The id's underlying number, for use as an opaque serialization handle
-    /// (the inspector wire shape carries a `NodeId` as a JSON number). This is
-    /// the *only* place the numeric value
+    /// (the inspector wire shape carries a `NodeId` as a JSON number; see
+    /// [`crate::inspector_model`]). This is the *only* place the numeric value
     /// is observed — internal logic compares ids by equality, never by value —
     /// so it is exposed solely so a client can round-trip a handle, not to give
     /// the value any in-compiler meaning.

--- a/src/inspector_model/index.rs
+++ b/src/inspector_model/index.rs
@@ -1,0 +1,172 @@
+//! The span→node index over the post-inference IR snapshot.
+//!
+//! This is the *backward* direction of the lineage projection: a pane's
+//! [`SourceProjection`](crate::ccl::lineage::SourceProjection) maps a
+//! [`NodeId`] forward to the source spans it traces to (node → span);
+//! [`SpanIndex`] inverts that to answer "what nodes sit at this source
+//! position" (span → node). The two are complementary projections of the same
+//! `(snapshot, projection)` pair — see the round-trip in this module's tests.
+
+use std::collections::HashMap;
+
+use crate::ccl::Expr;
+use crate::ccl::lineage::SourceProjection;
+use crate::ccl::provenance::NodeId;
+use crate::chl_parser::ast::Span;
+
+/// A node's entry in the span index: its id, the origin span it is indexed
+/// under, and its structural depth in the snapshot tree (root = 0). Depth is
+/// the coincident-span tie-break: when two nodes carry byte-identical
+/// spans, the deeper (descendant) node is the "innermost" one.
+#[derive(Clone, Copy, Debug)]
+struct Entry {
+    node: NodeId,
+    span: Span,
+    depth: u32,
+}
+
+impl Entry {
+    /// Width of the indexed origin span (the containment extent).
+    fn extent(&self) -> usize {
+        self.span.end.saturating_sub(self.span.start)
+    }
+
+    /// Does this entry's origin span contain `pos` (half-open: `[start, end)`)?
+    ///
+    /// A zero-width span (`start == end`) contains nothing under half-open
+    /// semantics, so a synthetic point span never matches a position query.
+    fn contains_pos(&self, pos: usize) -> bool {
+        self.span.start <= pos && pos < self.span.end
+    }
+
+    /// Does this entry's origin span fully contain `query` (`query ⊆ span`)?
+    /// A `query` whose width is zero is treated as the position `query.start`.
+    fn contains_span(&self, query: Span) -> bool {
+        if query.start == query.end {
+            return self.contains_pos(query.start);
+        }
+        self.span.start <= query.start && query.end <= self.span.end
+    }
+}
+
+/// Span → node containment index over the post-inference IR snapshot.
+///
+/// Built by walking the snapshot and indexing each node under *every* origin
+/// span its provenance records (so a multi-origin fan-in node — N source spans
+/// → one node — is reachable from each of those spans). Nodes with empty
+/// origins (synthetic plumbing) and nodes the table does not know are simply
+/// absent — graceful degradation, never a panic.
+///
+/// # Query model
+///
+/// The primitive is the **containment set/chain**, not a single node: span
+/// containment is a nesting stack (`let ⊃ + ⊃ literal`), so
+/// [`enclosing`](Self::enclosing) returns *all* nodes whose origin span contains
+/// the position, ordered **outermost → innermost**. Ordering is by span extent
+/// (wider = more enclosing = earlier); for coincident spans (byte-identical
+/// extent — today the `def` case, where the `let f = …` node and its inner
+/// `λ __arg_tuple_0 → …` node share the whole-statement span) the tie-break is
+/// **structural depth** in the snapshot tree, so the deepest descendant sorts
+/// last ("innermost"). [`tightest`](Self::tightest) is merely the tip of that
+/// chain; that it must pick *one* among coincident spans is the query-layer
+/// policy (innermost/deepest wins), not an index-level narrowing.
+///
+/// # Implementation: sorted-interval scan, not `intervalsets`
+///
+/// Span containment is the trivial integer test `start <= pos < end`, and the
+/// snapshot is a single program's tree (small). A flat `Vec<Entry>` scanned per
+/// query is simpler and obviously correct here; `intervalsets` is geared to
+/// numeric value-domains (and carries a known `contains` bug on half-bounded
+/// intervals, see `interpreter/tiling.rs`), so it buys nothing for this
+/// integer-offset containment and is deliberately not used. Revisit only if the
+/// snapshot grows large enough that a linear scan per query matters (it can be
+/// swapped for an interval tree behind this same API).
+#[derive(Clone, Debug, Default)]
+pub struct SpanIndex {
+    /// Every (node, origin-span, depth) triple, one per (node × origin span).
+    entries: Vec<Entry>,
+}
+
+impl SpanIndex {
+    /// Build the index from the snapshot tree and its pane [`SourceProjection`].
+    /// Each node is indexed under every span in its attribution's `spans`; nodes
+    /// with empty spans (machinery/synthetic) or absent from the projection
+    /// contribute nothing.
+    pub fn build(snapshot: &Expr, projection: &SourceProjection) -> Self {
+        let mut entries = Vec::new();
+        Self::collect(snapshot, projection, 0, &mut entries);
+        SpanIndex { entries }
+    }
+
+    fn collect(expr: &Expr, projection: &SourceProjection, depth: u32, out: &mut Vec<Entry>) {
+        let node = expr.node_id();
+        if let Some(attr) = projection.get(&node) {
+            for &span in &attr.spans {
+                out.push(Entry { node, span, depth });
+            }
+        }
+        expr.walk_children(|c| Self::collect(c, projection, depth + 1, out));
+    }
+
+    /// All nodes whose origin span contains `pos`, ordered outermost → innermost
+    /// (the containment chain). "Innermost" = narrowest span, with
+    /// structural depth as the coincident-span tie-break (deepest last).
+    ///
+    /// Duplicate node ids are removed (a node indexed under several origin spans
+    /// all containing `pos` appears once, under its tightest matching span).
+    pub fn enclosing(&self, pos: usize) -> Vec<NodeId> {
+        self.ordered_matches(|e| e.contains_pos(pos))
+    }
+
+    /// All nodes whose origin span contains the whole `query` span, ordered
+    /// outermost → innermost (see [`enclosing`](Self::enclosing)). A zero-width
+    /// `query` degenerates to a position query at `query.start`.
+    pub fn enclosing_span(&self, query: Span) -> Vec<NodeId> {
+        self.ordered_matches(|e| e.contains_span(query))
+    }
+
+    /// The tightest (innermost) node enclosing `pos`, or `None` if no origin
+    /// span contains it. The tip of [`enclosing`](Self::enclosing).
+    ///
+    /// Coincident-span policy: when the innermost span is shared by several
+    /// nodes (e.g. a `def`'s `let` and its value `λ`), the structurally deepest
+    /// (the value-carrying descendant) wins. This is a deliberate query-layer
+    /// choice, not a property of the spans themselves.
+    pub fn tightest(&self, pos: usize) -> Option<NodeId> {
+        self.enclosing(pos).into_iter().next_back()
+    }
+
+    /// Enumerate every `(span → node)` entry in the index, one per
+    /// (node × origin span) — the raw data behind the `/api/snapshot`
+    /// `spanIndex` array. Pure (no query position), order is index-build order
+    /// (snapshot pre-order × each node's origins). A node indexed under several
+    /// origin spans appears once per span, mirroring the index's internal shape.
+    pub fn entries(&self) -> impl Iterator<Item = (Span, NodeId)> + '_ {
+        self.entries.iter().map(|e| (e.span, e.node))
+    }
+
+    /// Shared matching + ordering for the `enclosing*` queries.
+    fn ordered_matches(&self, mut matches: impl FnMut(&Entry) -> bool) -> Vec<NodeId> {
+        let mut hits: Vec<&Entry> = self.entries.iter().filter(|e| matches(e)).collect();
+        // Outermost → innermost: wider extent first; ties broken by shallower
+        // structural depth first, so the deepest descendant (the true
+        // "innermost" among coincident spans) sorts last.
+        hits.sort_by(|a, b| {
+            b.extent()
+                .cmp(&a.extent())
+                .then(a.depth.cmp(&b.depth))
+                .then(a.span.start.cmp(&b.span.start))
+        });
+        // Dedup node ids while preserving the outermost→innermost order, keeping
+        // each node at its tightest (last) matching position.
+        let mut last_pos: HashMap<NodeId, usize> = HashMap::new();
+        for (i, e) in hits.iter().enumerate() {
+            last_pos.insert(e.node, i);
+        }
+        hits.iter()
+            .enumerate()
+            .filter(|(i, e)| last_pos.get(&e.node) == Some(i))
+            .map(|(_, e)| e.node)
+            .collect()
+    }
+}

--- a/src/inspector_model/mod.rs
+++ b/src/inspector_model/mod.rs
@@ -1,0 +1,386 @@
+//! The program inspector's read-only model over the post-inference IR snapshot.
+//!
+//! This module lives in the `cambra` core crate (not a separate inspector
+//! crate) because it is coupled to `ccl` internals — it walks the
+//! [`Expr`](crate::ccl::Expr) snapshot and reads the per-pane
+//! [`SourceProjection`](crate::ccl::lineage::SourceProjection)s materialized by
+//! [`CompiledProgram::materialize_panes`](crate::ccl::context::CompiledProgram::materialize_panes).
+//! It is deliberately **serde-free**: serialization lives in the
+//! `cambra-inspector` workspace crate behind the optional, default-off `serde`
+//! feature on `cambra`, so plain `ccl`/interpreter builds
+//! (`cargo build -p cambra`) never compile it.
+//!
+//! # The anchor (post-inference snapshot)
+//!
+//! Every index here is built over the **post-inference** IR retained on
+//! [`CompiledProgram::post_inference_ir`](crate::ccl::context::CompiledProgram::post_inference_ir):
+//! fully typed, but still source-shaped (lambdas intact, before
+//! inline/lambda-elim/planning). That snapshot's node ids resolve against the
+//! materialized post-inference pane
+//! [`SourceProjection`](crate::ccl::lineage::SourceProjection).
+//!
+//! # Scope
+//!
+//! Two source-side indices live here:
+//!
+//! * [`SpanIndex`] — span → typed-IR-node containment, over
+//!   [`post_inference_ir`](crate::ccl::context::CompiledProgram::post_inference_ir)
+//!   + the pane [`SourceProjection`](crate::ccl::lineage::SourceProjection).
+//! * [`NameBinderIndex`] — source-level lexical name resolution
+//!   (`goto-definition`, the binder half of `scope-at`), over the parsed CHL
+//!   surface AST retained on
+//!   [`source_ast`](crate::ccl::context::CompiledProgram::source_ast). This is
+//!   done at the *source* level, not over the lowered tree: some
+//!   source variables (multi-param `def`/`lambda` parameters) are destroyed by
+//!   lowering before any IR node exists, so only the surface AST can resolve
+//!   them.
+//!
+//! # Query handlers
+//!
+//! [`Snapshot`] bundles the two indices + the snapshot projections
+//! (source text, IR, per-pane [`SourceProjection`](crate::ccl::lineage::SourceProjection), surface AST) and exposes the
+//! transport-agnostic query handlers as methods: [`Snapshot::resolve`],
+//! [`Snapshot::hover`]/[`Snapshot::type_of`], [`Snapshot::goto_definition`],
+//! [`Snapshot::scope_at`], [`Snapshot::expand`]. These are pure reads — no
+//! serde, no I/O (serialization lives in the `cambra-inspector` crate, per the
+//! module doc above). Every value-ish result carries the
+//! always-`None` live seams (`tick`, `value_summary`).
+//!
+//! The substituted-parameter span fix (so `hover`/`type_of` on a *use* of a
+//! multi-param `def`/`lambda` parameter resolves to a type rather than `None`)
+//! is still a follow-up — see [`Snapshot::type_of`].
+
+mod index;
+mod name_binder;
+mod query;
+mod snapshot;
+mod stage;
+
+pub use index::SpanIndex;
+pub use name_binder::{Binding, Definition, NameBinderIndex, ScopeRegion};
+pub use query::{
+    GotoDefinition, Hover, Resolve, ScopeAt, ScopeBinding, Snapshot, Tick, ValueSummary,
+};
+pub use snapshot::{
+    DefinitionEntry, Diagnostic, DiagnosticLabel, Meta, SCHEMA_VERSION, ScopeBindingEntry,
+    ScopeEntry, SnapshotPayload, SourceInfo, SpanEntry, diagnostics_from_compile_errors,
+};
+pub use stage::dense_edges;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccl::context::{GlobalContext, compile_program};
+    use crate::ccl::lineage::SourceProjection;
+    use crate::interpreter::Consumer;
+
+    /// Compile a CHL program and return its post-inference snapshot tree + the
+    /// materialized post-inference pane projection.
+    fn compile_snapshot(code: &str) -> (crate::ccl::Expr, SourceProjection) {
+        let mut ctx = GlobalContext::default();
+        let consumer: Box<dyn Consumer> = Box::new(|| {});
+        let compiled = compile_program(&mut ctx, code, consumer).expect("program compiles");
+        let projection = compiled.materialize_panes().post_inference;
+        (compiled.post_inference_ir, projection)
+    }
+
+    /// Round-trip: a position resolved to a node via `SpanIndex` (span → node)
+    /// must resolve back through the pane projection (node → span) to a span
+    /// that actually contains that position. The backward and forward
+    /// directions agree.
+    #[test]
+    fn span_index_round_trips_with_projection() {
+        // A trailing arithmetic expression bound to `x`. Lowering seeds the
+        // statement-level `let x = …`, its RHS, and the operands with source
+        // spans, so the index has real entries to resolve against.
+        let code = "\
+x = 1 + 2
+x
+";
+        let (snapshot, projection) = compile_snapshot(code);
+        let index = SpanIndex::build(&snapshot, &projection);
+
+        // The `1` literal sits at byte 4 ("x = 1 + 2" → '1' at offset 4).
+        let pos = code.find('1').expect("literal 1 present");
+        let node = index
+            .tightest(pos)
+            .expect("a node encloses the literal position");
+
+        // node → span agrees with span → node: the resolved node's spans
+        // include a span that contains the position we started from.
+        let spans = &projection
+            .get(&node)
+            .expect("resolved node is known to the projection")
+            .spans;
+        assert!(
+            spans.iter().any(|s| s.start <= pos && pos < s.end),
+            "node→span must point back at a span containing pos {pos}; spans: {spans:?}"
+        );
+    }
+
+    /// Set semantics: a position inside the `1 + 2` sub-expression returns
+    /// the whole containment chain — the enclosing `BinOp` *and* the inner
+    /// operand leaf — ordered outermost → innermost (the leaf last).
+    #[test]
+    fn enclosing_returns_nested_containment_chain_innermost_last() {
+        let code = "\
+x = 1 + 2
+x
+";
+        let (snapshot, projection) = compile_snapshot(code);
+        let index = SpanIndex::build(&snapshot, &projection);
+
+        // Position on the `1` operand: inside both the operand leaf and the
+        // enclosing `+` BinOp (and the `let x = …` RHS).
+        let pos = code.find('1').expect("literal 1 present");
+        let chain = index.enclosing(pos);
+        assert!(
+            chain.len() >= 2,
+            "a nested position returns the containment set (≥2 nodes), got {}: {chain:?}",
+            chain.len()
+        );
+
+        // Outermost → innermost: each successive span is no wider than the
+        // previous one (extent monotonically non-increasing along the chain).
+        let spans: Vec<_> = chain
+            .iter()
+            .map(|&n| {
+                // Tightest matching span for this node.
+                projection
+                    .get(&n)
+                    .expect("chain node is known")
+                    .spans
+                    .iter()
+                    .filter(|s| s.start <= pos && pos < s.end)
+                    .min_by_key(|s| s.end - s.start)
+                    .copied()
+                    .expect("node was indexed under a containing span")
+            })
+            .collect();
+        for w in spans.windows(2) {
+            let outer = w[0].end - w[0].start;
+            let inner = w[1].end - w[1].start;
+            assert!(
+                inner <= outer,
+                "chain must run outermost→innermost: {:?} (extent {outer}) then {:?} (extent {inner})",
+                w[0],
+                w[1]
+            );
+        }
+
+        // The innermost (tip) is the tightest-enclosing node.
+        assert_eq!(
+            chain.last().copied(),
+            index.tightest(pos),
+            "tightest() is the tip of enclosing()"
+        );
+    }
+
+    /// A position outside every tagged span resolves to nothing — graceful, no
+    /// panic.
+    #[test]
+    fn position_outside_all_spans_resolves_to_none() {
+        let code = "\
+x = 1 + 2
+x
+";
+        let (snapshot, projection) = compile_snapshot(code);
+        let index = SpanIndex::build(&snapshot, &projection);
+        // Past the end of the source.
+        assert!(index.tightest(code.len() + 100).is_none());
+        assert!(index.enclosing(code.len() + 100).is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // NameBinderIndex (source-level lexical resolution)
+    // -----------------------------------------------------------------------
+
+    /// Compile a CHL program and return its retained source AST.
+    fn compile_source_ast(code: &str) -> crate::chl_parser::ast::Module {
+        let mut ctx = GlobalContext::default();
+        let consumer: Box<dyn Consumer> = Box::new(|| {});
+        let compiled = compile_program(&mut ctx, code, consumer).expect("program compiles");
+        compiled.source_ast
+    }
+
+    /// The span of the `n`-th (0-based) byte occurrence of `needle` in `code`.
+    fn nth_span(code: &str, needle: &str, n: usize) -> Span {
+        let start = code
+            .match_indices(needle)
+            .nth(n)
+            .unwrap_or_else(|| panic!("occurrence {n} of {needle:?} not found"))
+            .0;
+        Span::new(start, start + needle.len())
+    }
+
+    use crate::chl_parser::ast::Span;
+    use crate::inspector_model::NameBinderIndex;
+
+    /// goto-definition on an assignment variable's use resolves to the
+    /// binding-site span (the assignment target).
+    #[test]
+    fn goto_def_on_assignment_use_resolves_to_binding_site() {
+        let code = "\
+x = 1 + 2
+y = x + 3
+y
+";
+        let module = compile_source_ast(code);
+        let index = NameBinderIndex::build(&module);
+
+        // The use of `x` in `y = x + 3` (the 2nd `x`: target then use).
+        let use_x = nth_span(code, "x", 1);
+        // The binder `x` is the assignment target on line 1 (the 1st `x`).
+        let def_x = nth_span(code, "x", 0);
+
+        assert_eq!(
+            index.definition_of(use_x),
+            Some(def_x),
+            "use of x resolves to its assignment target span"
+        );
+    }
+
+    /// The motivating case for source-level resolution: goto-definition on a
+    /// **multi-param `def` parameter** use resolves to that param's `name_span`.
+    /// A lowered/uniquify
+    /// index structurally cannot do this — `uncurry_params` rewrites the
+    /// multi-param reference `Var(a)` to `__arg_tuple_N ▷ .0` before uniquify,
+    /// so `a` never survives as a renamable `Var`. Source-level resolution does.
+    #[test]
+    fn goto_def_on_multi_param_def_parameter_resolves_to_name_span() {
+        // Two params `p`, `q` (multi-param → uncurried in lowering). The function
+        // name `combine` shares no letters with the params, so byte occurrences
+        // of `p`/`q` are unambiguous. Their uses are in the body expression.
+        let code = "\
+def combine(p, q):
+  p + q
+combine(1, 2)
+";
+        let module = compile_source_ast(code);
+        let index = NameBinderIndex::build(&module);
+
+        // Param decl `p` is the 1st `p`; its use in `p + q` is the 2nd `p`.
+        let param_p = nth_span(code, "p", 0);
+        let use_p = nth_span(code, "p", 1);
+        // Likewise for `q`.
+        let param_q = nth_span(code, "q", 0);
+        let use_q = nth_span(code, "q", 1);
+
+        assert_eq!(
+            index.definition_of(use_p),
+            Some(param_p),
+            "multi-param `p` use resolves to its Param.name_span"
+        );
+        assert_eq!(
+            index.definition_of(use_q),
+            Some(param_q),
+            "multi-param `q` use resolves to its Param.name_span"
+        );
+    }
+
+    /// Shadowing: a re-bound name resolves to the innermost (most recent)
+    /// binder visible at the use, per CHL's sequential let-style scoping.
+    #[test]
+    fn shadowing_resolves_to_innermost_binder() {
+        let code = "\
+x = 1
+x = x + 1
+x
+";
+        let module = compile_source_ast(code);
+        let index = NameBinderIndex::build(&module);
+
+        // Occurrences of `x`: [0]=line1 target, [1]=line2 target, [2]=line2 RHS
+        // use, [3]=line3 use.
+        let def0 = nth_span(code, "x", 0);
+        let def1 = nth_span(code, "x", 1);
+        let rhs_use = nth_span(code, "x", 2);
+        let trailing_use = nth_span(code, "x", 3);
+
+        // The RHS use on line 2 sees only the *outer* `x` (the line-2 binder is
+        // not visible to its own RHS — sequential let-style).
+        assert_eq!(
+            index.definition_of(rhs_use),
+            Some(def0),
+            "x in `x = x + 1` RHS resolves to the prior (outer) binding"
+        );
+        // The trailing `x` sees the innermost (line-2) binder.
+        assert_eq!(
+            index.definition_of(trailing_use),
+            Some(def1),
+            "trailing x resolves to the innermost (shadowing) binder"
+        );
+    }
+
+    /// `bindings_in_scope` at a nested position (inside a `def` body) returns
+    /// the expected visible names: the params + the enclosing-scope binders.
+    #[test]
+    fn bindings_in_scope_at_nested_position_lists_visible_names() {
+        let code = "\
+g = 10
+def f(p, q):
+  p + q + g
+f(1, 2)
+";
+        let module = compile_source_ast(code);
+        let index = NameBinderIndex::build(&module);
+
+        // A position on the body use of `p` (inside the def body).
+        let body_use_p = nth_span(code, "p", 1);
+        let names: std::collections::HashSet<String> = index
+            .bindings_in_scope(body_use_p)
+            .into_iter()
+            .map(|b| b.name.to_string())
+            .collect();
+
+        // Inside f's body: params p, q and the outer g are visible. The def
+        // name `f` itself is *not* visible in its own body — CHL does not model
+        // recursion (lowering emits `let f = λ… in …`, with `f` bound only in
+        // the `in` continuation, not the lambda body).
+        assert!(names.contains("p"), "p in scope; got {names:?}");
+        assert!(names.contains("q"), "q in scope; got {names:?}");
+        assert!(names.contains("g"), "outer g in scope; got {names:?}");
+        assert!(
+            !names.contains("f"),
+            "def name f is NOT visible in its own body (no recursion); got {names:?}"
+        );
+    }
+
+    /// An unbound name resolves to `None` — graceful, no panic. Uses a raw
+    /// parse (an unbound reference fails type inference, so it can't go through
+    /// `compile_program`); name resolution is a pure function over the parsed
+    /// `Module`, exactly the point of source-level resolution.
+    #[test]
+    fn unbound_name_resolves_to_none() {
+        let code = "\
+x = 1
+z + x
+";
+        let module = crate::chl_parser::parse_module(code).value.expect("parses");
+        let index = NameBinderIndex::build(&module);
+
+        // `z` is never bound → no definition.
+        let use_z = nth_span(code, "z", 0);
+        assert_eq!(
+            index.definition_of(use_z),
+            None,
+            "unbound z resolves to None"
+        );
+
+        // A span that is not a `Name` use at all (the literal `1`) → None.
+        let lit = nth_span(code, "1", 0);
+        assert_eq!(index.definition_of(lit), None);
+
+        // An out-of-tree span matches no use → None.
+        assert_eq!(
+            index.definition_of(Span::new(code.len() + 10, code.len() + 11)),
+            None,
+            "a span matching no use resolves to None"
+        );
+
+        // But `x` *is* bound, even in this parse-only module.
+        let use_x = nth_span(code, "x", 1);
+        let def_x = nth_span(code, "x", 0);
+        assert_eq!(index.definition_of(use_x), Some(def_x));
+    }
+}

--- a/src/inspector_model/name_binder.rs
+++ b/src/inspector_model/name_binder.rs
@@ -1,0 +1,591 @@
+//! The source-level name-resolution index over the parsed CHL AST.
+//!
+//! This is the [`NameBinderIndex`] — the answer to *lexical* name questions
+//! (`goto-definition`, the binder half of `scope-at`). Unlike [`SpanIndex`],
+//! which projects the *typed IR* back onto source spans, this index resolves
+//! purely over the **surface AST** ([`Module`]).
+//!
+//! [`SpanIndex`]: crate::inspector_model::SpanIndex
+//!
+//! # Why source-level
+//!
+//! Name resolution is a *source-language* lexical question, and lowering has
+//! already destroyed some source variables by the time any IR node exists:
+//! `uncurry_params` rewrites a multi-param reference `Var(x)` to the projection
+//! `__arg_tuple_N ▷ .i` **before** uniquify runs, so a uniquify/IR-based binder
+//! table structurally cannot resolve a multi-param `def`/`lambda` parameter
+//! (there is no surviving `Var(x)` to rename, no use-span). The surface AST
+//! still has `x`/`y` with their [`Param.name_span`](crate::chl_parser::ast::Param::name_span),
+//! so resolving over it is lossless and matches the standard LSP approach.
+//!
+//! # Scoping model
+//!
+//! The walk mirrors CHL's actual scoping, which lowering realizes as nested
+//! `let`s (`x = 1; x = 2` → `let x = 1 in let x = 2 in …`), i.e. **sequential
+//! let-style**: a binder is visible only *after* its binding site within its
+//! scope, and an inner binder shadows an outer one of the same name (innermost
+//! wins). See `ccl/lower.rs`'s "Name uniqueness" note. Binder sites:
+//!
+//! * top-level + block assignments (`Assign`/`AnnAssign`/`AugAssign`/`Define`
+//!   targets, including `Tuple` destructuring),
+//! * `def` name + its [`Param`]s, `lambda` params,
+//! * `for`-loop targets, comprehension `for`-clause targets.
+//!
+//! Uses are [`Expr::Name`] occurrences.
+
+use crate::chl_parser::ast::{
+    AssignTarget, Comprehension, Expr, IfBranch, Module, Param, Span, Spanned, Stmt,
+};
+use smol_str::SmolStr;
+
+/// A name binding visible at some position: the bound name and the source span
+/// of its binding site (its definition span).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Binding {
+    /// The bound name.
+    pub name: SmolStr,
+    /// The source span of the binder — what `goto-definition` returns. For a
+    /// parameter this is its [`Param.name_span`](crate::chl_parser::ast::Param::name_span);
+    /// for an assignment it is the target's span; for a `def` it is the name's
+    /// span.
+    pub def_span: Span,
+}
+
+/// One resolved use→binder pair, the enumeration unit behind the
+/// `/api/snapshot` `definitions` array: a `Name` use, the binder it resolves
+/// to, and the bound name.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Definition {
+    /// The use-site span.
+    pub use_span: Span,
+    /// The binder's source span (goto-definition target).
+    pub def_span: Span,
+    /// The bound name.
+    pub name: SmolStr,
+}
+
+/// One scope region, the enumeration unit behind the `/api/snapshot` `scopes`
+/// array: a binder-bearing span plus the binders visible inside it. The type
+/// join (each binding's `type`) is added by the snapshot assembler, which has
+/// the [`SpanIndex`](crate::inspector_model::SpanIndex).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScopeRegion {
+    /// The source span of the region.
+    pub span: Span,
+    /// The binders visible inside it, outermost → innermost.
+    pub bindings: Vec<Binding>,
+}
+
+/// Source-level lexical name resolution over the parsed CHL [`Module`].
+///
+/// Built once over the surface AST ([`build`](Self::build)); answers
+/// [`definition_of`](Self::definition_of) (use→binder, goto-definition) and
+/// [`bindings_in_scope`](Self::bindings_in_scope) (visible binders at a
+/// position, the name half of `scope-at`).
+///
+/// # Resolution by span
+///
+/// The canonical handle is the source [`Span`] (what you click). Both queries
+/// take a span and answer by re-walking the AST with the same scope bookkeeping
+/// the build pass used; an unbound or unknown span resolves gracefully to
+/// `None`/empty, never a panic. The index keeps a reference-free owned copy of
+/// the resolution inputs — the `Module` is borrowed only during a query, so the
+/// index is built eagerly but the walks are re-run per query (a program's AST is
+/// small; this trades a tiny amount of recomputation for a far simpler, clearly
+/// correct implementation than caching a span→binder map with shadowing).
+#[derive(Clone, Debug)]
+pub struct NameBinderIndex {
+    module: Module,
+}
+
+/// One lexical binder in scope during a walk: its name, def-span, and the byte
+/// offset *after which* it becomes visible (sequential let-style — a binder is
+/// not visible to its own RHS, only to statements/expressions that follow it in
+/// its scope).
+#[derive(Clone, Copy, Debug)]
+struct Scoped<'a> {
+    name: &'a SmolStr,
+    def_span: Span,
+    /// The binder is visible at a position `pos` iff `pos >= visible_from`. For
+    /// statement bindings this is the end of the binding statement (the binder
+    /// is in scope for everything after it); for parameters and loop/comp
+    /// targets it is the start of the body the binder scopes over.
+    visible_from: usize,
+}
+
+impl NameBinderIndex {
+    /// Build the index over the parsed CHL surface AST.
+    pub fn build(module: &Module) -> Self {
+        Self {
+            module: module.clone(),
+        }
+    }
+
+    /// Resolve a `Name` use at `use_span` to the source span of its binder
+    /// (goto-definition). `None` if `use_span` is not a `Name` use, or the name
+    /// is unbound at that position.
+    ///
+    /// The innermost binder visible at `use_span` wins (shadowing); a binder is
+    /// only visible if its binding site precedes the use in lexical scope
+    /// (sequential let-style).
+    pub fn definition_of(&self, use_span: Span) -> Option<Span> {
+        let mut found: Option<Span> = None;
+        let mut scopes: Vec<Scoped> = Vec::new();
+        walk_module(&self.module, &mut scopes, &mut |ev| {
+            // Only the `Name` use exactly at `use_span` is a query hit.
+            if let Event::Use { name, span, scopes } = ev
+                && span == use_span
+            {
+                found = resolve(name, use_span, scopes);
+            }
+        });
+        found
+    }
+
+    /// Enumerate every resolved use→binder pair in the module — the data behind
+    /// the `/api/snapshot` `definitions` array. Each entry is a `Name` use that
+    /// resolves to a visible binder, paired with that binder's def-span and the
+    /// bound name; unbound uses (which would resolve to `None`) are skipped.
+    ///
+    /// Pure: re-walks the AST with the same scope bookkeeping the point queries
+    /// use, resolving each use against the binder stack live at it. Order is the
+    /// source pre-order of the uses.
+    pub fn definitions(&self) -> Vec<Definition> {
+        let mut out: Vec<Definition> = Vec::new();
+        let mut scopes: Vec<Scoped> = Vec::new();
+        walk_module(&self.module, &mut scopes, &mut |ev| {
+            if let Event::Use { name, span, scopes } = ev
+                && let Some(def_span) = resolve(name, span, scopes)
+            {
+                out.push(Definition {
+                    use_span: span,
+                    def_span,
+                    name: name.clone(),
+                });
+            }
+        });
+        out
+    }
+
+    /// Enumerate every binder-introducing scope region in the module and the
+    /// binders visible inside it — the data behind the `/api/snapshot` `scopes`
+    /// array (the type join is the caller's, since it needs the `SpanIndex`).
+    ///
+    /// A scope region is emitted for each binder-bearing span the walk surfaces
+    /// (statement sequences, function/lambda/comprehension/loop bodies) whose
+    /// visible-binder set is non-empty; regions with no binders in scope are
+    /// dropped (an empty `scopes` row carries nothing). The binders are the ones
+    /// visible at the region's start, outermost → innermost, matching
+    /// [`bindings_in_scope`](Self::bindings_in_scope)'s shape.
+    ///
+    /// Pure; re-walks the AST. Regions may nest and overlap (an inner body's
+    /// region is a sub-span of its enclosing sequence's), mirroring the lexical
+    /// structure — the schema's `scopes` is a flat list of such regions, not a
+    /// tree.
+    pub fn scopes(&self) -> Vec<ScopeRegion> {
+        let mut out: Vec<ScopeRegion> = Vec::new();
+        let mut scopes: Vec<Scoped> = Vec::new();
+        walk_module(&self.module, &mut scopes, &mut |ev| {
+            if let Event::Scope { span, scopes } = ev {
+                let bindings = visible_bindings(scopes, span.start);
+                if !bindings.is_empty() {
+                    out.push(ScopeRegion { span, bindings });
+                }
+            }
+        });
+        out
+    }
+
+    /// The binders visible at `at` (the name half of `scope-at`): every binder
+    /// in lexical scope whose binding site precedes `at`, innermost shadowing
+    /// outermost. Ordered outermost → innermost.
+    ///
+    /// Resolution is by the position `at.start`: the index walks into the
+    /// tightest AST scope containing it, capturing the binder stack there. A
+    /// position outside every scope (or inside no binding-introducing context)
+    /// returns just the top-level binders visible at that point.
+    pub fn bindings_in_scope(&self, at: Span) -> Vec<Binding> {
+        let pos = at.start;
+        let mut scopes: Vec<Scoped> = Vec::new();
+        // Capture the binder stack at the deepest scope-boundary that still
+        // contains `pos`. The use-visitor reports the *stack as of each scope's
+        // body*; we record the last (deepest) one covering `pos`.
+        let mut captured: Vec<Binding> = Vec::new();
+        let mut best_extent = usize::MAX;
+        walk_module(&self.module, &mut scopes, &mut |ev| {
+            if let Event::Scope { span, scopes } = ev
+                && span.start <= pos
+                && pos < span.end
+            {
+                let extent = span.end - span.start;
+                // `<=` so a tie (coincident span) keeps the later, deeper
+                // capture — its binder stack is a superset.
+                if extent <= best_extent {
+                    best_extent = extent;
+                    captured = visible_bindings(scopes, pos);
+                }
+            }
+        });
+        captured
+    }
+}
+
+/// An event surfaced during the AST walk. The walk fires an [`Event::Use`] at
+/// every `Name` occurrence and an [`Event::Scope`] over every region that
+/// introduces or carries binders (statement sequences, loop/function/lambda/
+/// comprehension bodies), each carrying the binder stack live at that point.
+///
+/// Both borrows are tied to the single lifetime `'s` of the in-progress walk;
+/// the visitor (a higher-ranked `FnMut`) may inspect them only for the duration
+/// of the call.
+enum Event<'s> {
+    /// A `Name` use occurrence.
+    Use {
+        name: &'s SmolStr,
+        span: Span,
+        scopes: &'s [Scoped<'s>],
+    },
+    /// A binder-bearing region and the binder stack visible inside it.
+    Scope {
+        span: Span,
+        scopes: &'s [Scoped<'s>],
+    },
+}
+
+/// Resolve `name` used at `use_span` against the visible binders: innermost
+/// (last-pushed) binder of that name whose `visible_from` precedes the use.
+fn resolve(name: &SmolStr, use_span: Span, in_scope: &[Scoped]) -> Option<Span> {
+    in_scope
+        .iter()
+        .rev()
+        .find(|b| b.name == name && use_span.start >= b.visible_from)
+        .map(|b| b.def_span)
+}
+
+/// The set of visible bindings at `pos`, innermost shadowing outermost,
+/// returned outermost → innermost with shadowed names removed.
+fn visible_bindings(in_scope: &[Scoped], pos: usize) -> Vec<Binding> {
+    use std::collections::HashSet;
+    // Walk innermost → outermost so the first occurrence of a name is the one
+    // that wins; collect into the natural (outermost→innermost) order after.
+    let mut seen: HashSet<&SmolStr> = HashSet::new();
+    let mut innermost_first: Vec<Binding> = Vec::new();
+    for b in in_scope.iter().rev() {
+        if pos < b.visible_from {
+            continue;
+        }
+        if seen.insert(b.name) {
+            innermost_first.push(Binding {
+                name: b.name.clone(),
+                def_span: b.def_span,
+            });
+        }
+    }
+    innermost_first.reverse();
+    innermost_first
+}
+
+/// Callback invoked for every [`Event`] surfaced by the walk. The higher-ranked
+/// bound lets each call hand the closure a borrow valid only for that call.
+type Visitor<'v> = dyn for<'s> FnMut(Event<'s>) + 'v;
+
+/// Walk a whole module: a top-level statement sequence is a single sequential
+/// scope.
+fn walk_module<'a>(module: &'a Module, scopes: &mut Vec<Scoped<'a>>, visit: &mut Visitor<'_>) {
+    walk_stmt_seq(&module.body, scopes, visit);
+}
+
+/// Walk a statement sequence with sequential let-style scoping: each binding
+/// statement's binders become visible to everything *after* it (their
+/// `visible_from` is the binding statement's end), while a use inside the
+/// binding's own RHS sees only the binders that preceded it.
+fn walk_stmt_seq<'a>(
+    stmts: &'a [Spanned<Stmt>],
+    scopes: &mut Vec<Scoped<'a>>,
+    visit: &mut Visitor<'_>,
+) {
+    let base = scopes.len();
+    for stmt in stmts {
+        walk_stmt(stmt, scopes, visit);
+    }
+    // Bindings introduced by this sequence go out of scope at its end.
+    scopes.truncate(base);
+}
+
+fn walk_stmt<'a>(stmt: &'a Spanned<Stmt>, scopes: &mut Vec<Scoped<'a>>, visit: &mut Visitor<'_>) {
+    let stmt_end = stmt.span.end;
+    // Surface the scope live *at* this statement (binders preceding it in the
+    // sequence), so a `bindings_in_scope` position landing on it captures them.
+    visit(Event::Scope {
+        span: stmt.span,
+        scopes,
+    });
+    match &stmt.node {
+        Stmt::Expr(e) => walk_expr(e, scopes, visit),
+
+        // Assignment family: the RHS is evaluated in the *outer* scope (binders
+        // not yet visible), then the target's names become visible from the end
+        // of the statement onward (sequential let-style; matches lowering's
+        // nested-`let` shape and shadowing semantics).
+        Stmt::Assign { target, value } => {
+            walk_expr(value, scopes, visit);
+            bind_target(target, stmt_end, scopes);
+        }
+        Stmt::AnnAssign {
+            target,
+            annotation,
+            value,
+        } => {
+            walk_expr(annotation, scopes, visit);
+            walk_expr(value, scopes, visit);
+            bind_target(target, stmt_end, scopes);
+        }
+        Stmt::AugAssign { target, value, .. } => {
+            // `x += v` reads the prior `x` in the RHS and rebinds it after.
+            walk_expr(value, scopes, visit);
+            bind_target(target, stmt_end, scopes);
+        }
+        Stmt::Define { target, value } => {
+            walk_expr(value, scopes, visit);
+            bind_target(target, stmt_end, scopes);
+        }
+
+        Stmt::If {
+            branches,
+            else_body,
+        } => {
+            for IfBranch { cond, body } in branches {
+                walk_expr(cond, scopes, visit);
+                walk_stmt_seq(body, scopes, visit);
+            }
+            if let Some(else_body) = else_body {
+                walk_stmt_seq(else_body, scopes, visit);
+            }
+        }
+
+        // `for target in iter: body` — `iter` is evaluated in the outer scope;
+        // `target` is bound across the loop body (visible from the body onward).
+        Stmt::For { target, iter, body } => {
+            walk_expr(iter, scopes, visit);
+            let base = scopes.len();
+            let body_start = body.first().map(|s| s.span.start).unwrap_or(stmt_end);
+            bind_target(target, body_start, scopes);
+            walk_stmt_seq(body, scopes, visit);
+            scopes.truncate(base);
+        }
+
+        // `def name(params): body` — `name` is visible after the def (recursion
+        // is not modeled; matches lowering's `let name = λ… in …`). `params`
+        // are visible only inside the body.
+        Stmt::FunctionDef { name, params, body } => {
+            // The def's name is bound in the enclosing scope from the statement
+            // end onward. The FunctionDef AST node carries no name span of its
+            // own, so the whole-statement span is the binder's def-span (the
+            // same span lowering tags the `let name = …`).
+            scopes.push(Scoped {
+                name,
+                def_span: stmt.span,
+                visible_from: stmt_end,
+            });
+            let base = scopes.len();
+            let body_start = body.first().map(|s| s.span.start).unwrap_or(stmt_end);
+            bind_params(params, body_start, scopes);
+            walk_stmt_seq(body, scopes, visit);
+            scopes.truncate(base);
+        }
+
+        // `target := value` (optionally annotated) — store introduction/write.
+        // Like the assignment family: the RHS (and annotation) are evaluated in
+        // the outer scope, then the target's names become visible from the end of
+        // the statement onward.
+        Stmt::MutAssign {
+            target,
+            annotation,
+            value,
+        } => {
+            if let Some(annotation) = annotation {
+                walk_expr(annotation, scopes, visit);
+            }
+            walk_expr(value, scopes, visit);
+            bind_target(target, stmt_end, scopes);
+        }
+
+        // `with [binding =] begin(): body` — a transaction block. The context
+        // (`begin()`) is evaluated in the outer scope; the body is a nested
+        // statement sequence. The optional `binding` (a commit-time handle) is
+        // reserved and not consumed by lowering, so it introduces no binder here.
+        Stmt::With {
+            binding: _,
+            context,
+            body,
+        } => {
+            walk_expr(context, scopes, visit);
+            let base = scopes.len();
+            walk_stmt_seq(body, scopes, visit);
+            scopes.truncate(base);
+        }
+
+        Stmt::Return(Some(e)) => walk_expr(e, scopes, visit),
+        Stmt::Return(None) | Stmt::Pass | Stmt::Error => {}
+    }
+}
+
+fn walk_expr<'a>(expr: &'a Spanned<Expr>, scopes: &mut Vec<Scoped<'a>>, visit: &mut Visitor<'_>) {
+    // Surface the scope live at this expression so a `bindings_in_scope`
+    // position inside a lambda/comprehension body (where the stack carries the
+    // params/targets) captures it.
+    visit(Event::Scope {
+        span: expr.span,
+        scopes,
+    });
+    match &expr.node {
+        Expr::Name(name) => visit(Event::Use {
+            name,
+            span: expr.span,
+            scopes,
+        }),
+        Expr::Lit(_) | Expr::Error => {}
+
+        Expr::BinOp { left, right, .. } => {
+            walk_expr(left, scopes, visit);
+            walk_expr(right, scopes, visit);
+        }
+        Expr::UnaryOp { operand, .. } => walk_expr(operand, scopes, visit),
+        Expr::BoolOp { operands, .. } => {
+            for o in operands {
+                walk_expr(o, scopes, visit);
+            }
+        }
+        Expr::Compare {
+            left, comparators, ..
+        } => {
+            walk_expr(left, scopes, visit);
+            for c in comparators {
+                walk_expr(c, scopes, visit);
+            }
+        }
+        Expr::Call { func, args } => {
+            walk_expr(func, scopes, visit);
+            for a in args {
+                walk_expr(a, scopes, visit);
+            }
+        }
+        Expr::List(items) | Expr::Tuple(items) => {
+            for it in items {
+                walk_expr(it, scopes, visit);
+            }
+        }
+        Expr::Record(fields) => {
+            for f in fields {
+                walk_expr(&f.value, scopes, visit);
+            }
+        }
+        // Brace forms are structural *type* syntax (a record type `{x: T}`, a
+        // tuple type `{T, U}`), reached here through an annotation — which this
+        // walk descends into like any other expression, so the type names inside
+        // surface as uses on the same footing as those in a `Mut(Int, Txn)`
+        // annotation's `Call` form.
+        Expr::BraceRecord(fields) => {
+            for f in fields {
+                walk_expr(&f.value, scopes, visit);
+            }
+        }
+        Expr::BraceGroup(items) => {
+            for it in items {
+                walk_expr(it, scopes, visit);
+            }
+        }
+        Expr::Subscript { target, index } => {
+            walk_expr(target, scopes, visit);
+            walk_expr(index, scopes, visit);
+        }
+        // `target.attr`: only `target` is a name use; `attr` is a field label,
+        // not a binding reference.
+        Expr::Attribute { target, .. } => walk_expr(target, scopes, visit),
+
+        // `\params -> body` — params visible only inside the body.
+        Expr::Lambda { params, body } => {
+            let base = scopes.len();
+            bind_params(params, body.span.start, scopes);
+            walk_expr(body, scopes, visit);
+            scopes.truncate(base);
+        }
+
+        Expr::IfExp {
+            cond,
+            then_expr,
+            else_expr,
+        } => {
+            walk_expr(cond, scopes, visit);
+            walk_expr(then_expr, scopes, visit);
+            walk_expr(else_expr, scopes, visit);
+        }
+
+        Expr::ListComp(comp) | Expr::GenExp(comp) => walk_comprehension(comp, scopes, visit),
+
+        Expr::Yield(e) => walk_expr(e, scopes, visit),
+        Expr::Feed { target, value } => {
+            walk_expr(target, scopes, visit);
+            walk_expr(value, scopes, visit);
+        }
+    }
+}
+
+/// Walk a comprehension. Each `for` clause's target is bound from that clause
+/// onward (across later clauses and the element), mirroring Python/CHL
+/// comprehension scoping; the very first clause's `iter` is evaluated in the
+/// enclosing scope.
+fn walk_comprehension<'a>(
+    comp: &'a Comprehension,
+    scopes: &mut Vec<Scoped<'a>>,
+    visit: &mut Visitor<'_>,
+) {
+    use crate::chl_parser::ast::CompClause;
+    let base = scopes.len();
+    for clause in &comp.clauses {
+        match clause {
+            CompClause::For { target, iter } => {
+                // `iter` sees bindings from prior clauses but not this clause's
+                // target; the target then binds across subsequent clauses + the
+                // element, visible from the iter's end.
+                walk_expr(iter, scopes, visit);
+                bind_target(target, iter.span.end, scopes);
+            }
+            CompClause::If(guard) => walk_expr(guard, scopes, visit),
+        }
+    }
+    walk_expr(&comp.element, scopes, visit);
+    scopes.truncate(base);
+}
+
+/// Push every name bound by an assignment/loop/comprehension target (handling
+/// nested `Tuple` destructuring), each visible from `visible_from`.
+fn bind_target<'a>(
+    target: &'a Spanned<AssignTarget>,
+    visible_from: usize,
+    scopes: &mut Vec<Scoped<'a>>,
+) {
+    match &target.node {
+        AssignTarget::Name(name) => scopes.push(Scoped {
+            name,
+            def_span: target.span,
+            visible_from,
+        }),
+        AssignTarget::Tuple(elts) => {
+            for elt in elts {
+                bind_target(elt, visible_from, scopes);
+            }
+        }
+    }
+}
+
+/// Push each parameter binder, visible from `visible_from` (the body start).
+fn bind_params<'a>(params: &'a [Param], visible_from: usize, scopes: &mut Vec<Scoped<'a>>) {
+    for p in params {
+        scopes.push(Scoped {
+            name: &p.name,
+            def_span: p.name_span,
+            visible_from,
+        });
+    }
+}

--- a/src/inspector_model/query.rs
+++ b/src/inspector_model/query.rs
@@ -1,0 +1,1357 @@
+//! The inspector query handlers — pure functions over the post-inference
+//! snapshot + per-pane `SourceProjection` + the two source-side indices.
+//!
+//! This is the **transport-agnostic shared core** of the inspector:
+//! `resolve`, `hover`/`type_of`, `goto_definition`, `scope_at`, and `expand`,
+//! expressed as methods on a [`Snapshot`] bundle. The HTTP server
+//! (`cambra-inspector::server`) and any future transport call *these*; no
+//! serde, no I/O lives here (serialization lives in the `cambra-inspector`
+//! crate behind a feature gate).
+//!
+//! # The bundle ([`Snapshot`])
+//!
+//! [`Snapshot`] borrows the read-only projections of a compiled program that
+//! every handler needs — the source text, the post-inference IR, the parsed
+//! surface AST — owns the materialized per-pane `SourceProjection`s, and owns
+//! the two indices built over them ([`SpanIndex`], [`NameBinderIndex`]). Every transport constructs
+//! one ([`Snapshot::new`] from a [`CompiledProgram`]) and the handlers read it
+//! without further setup; its serde wire types live in `cambra-inspector`.
+//!
+//! # The live seams (always `None`)
+//!
+//! Every value-ish result carries `tick` and `value_summary` fields that are
+//! **always `None`** here. This serves a static, value-free snapshot ("the
+//! program, no execution"); the live/operator layer (not yet built) fills these
+//! without changing the shape. They are declared now so the read model is a true
+//! subset of the live one, not a throwaway.
+//!
+//! # The type-set (`hover`)
+//!
+//! Monomorphization clones a polymorphic definition's subtree once per resolved
+//! type and tags each clone `via: Mono, nature: Expansion` with the *original
+//! def's* source span. So several distinct typed nodes share one source span.
+//! `hover`/`type_of` therefore return the **set** of those nodes' types ("used at
+//! Int and String"), not a single picked type — the general polymorphic type was
+//! consumed during coalescing and is not recoverable here.
+
+use crate::ccl::context::CompiledProgram;
+use crate::ccl::lineage::{LineageMap, SourceAttribution, SourceProjection};
+use crate::ccl::provenance::NodeId;
+use crate::ccl::{Expr, Type, TypedExprNode};
+use crate::chl_parser::ast::{Module, Span};
+
+use super::{Binding, NameBinderIndex, SpanIndex};
+use crate::pretty_tree::{InspectNode, RewriteInfo};
+
+/// One pipeline stage's read-only projection: its IR tree, its
+/// `SourceProjection`, and the span→node index built over that pair.
+///
+/// Each stage is self-contained — it resolves against its *own*
+/// `(Expr, SourceProjection)` pair, never borrowing a sibling stage's
+/// projection. The `id`/`label`/`kind` are the wire identifiers a [`StageEntry`]
+/// emits.
+///
+/// [`StageEntry`]: crate::inspector_model::StageEntry
+pub(super) struct StageProjection<'a> {
+    /// Stable machine id, e.g. `"pre-inference"`, `"post-inference"`,
+    /// `"post-desugar"`.
+    pub(super) id: &'static str,
+    /// Human-readable label for the pane header.
+    pub(super) label: &'static str,
+    /// Discriminant for the stage kind: `"holes"` for the still-hole-typed
+    /// pre-inference tree, `"typed"` for a fully-typed tree.
+    pub(super) kind: &'static str,
+    /// This stage's IR tree.
+    pub(super) ir: &'a Expr,
+    /// Node → attribution for this pane (the forward direction), materialized by
+    /// folding the lineage logs at this pane's boundary.
+    pub(super) projection: SourceProjection,
+    /// Span → node containment index (the backward direction), built over
+    /// `(ir, projection)`.
+    pub(super) span_index: SpanIndex,
+}
+
+/// The read-only inspector model bundle: all pipeline stages + the source-level
+/// name index, with the query handlers as methods.
+///
+/// Built once via [`new`](Self::new) from a [`CompiledProgram`]; every handler
+/// is a pure read over the [`anchor`](Self::anchor) stage (post-inference) and
+/// the owned name index. The bundle holds *every* stage so [`build_payload`]
+/// needs only `&self` — no second borrow of the [`CompiledProgram`].
+///
+/// [`build_payload`]: Self::build_payload
+pub struct Snapshot<'a> {
+    /// The original program source text (for `snippet` byte slicing).
+    source: &'a str,
+    /// Source-level lexical name resolution (goto-def, scope binders).
+    /// Stage-independent (built over the surface AST), so it is not per-stage.
+    name_binder: NameBinderIndex,
+    /// The pipeline stages in order (upstream → downstream): pre-inference,
+    /// post-inference, post-desugar.
+    stages: Vec<StageProjection<'a>>,
+    /// Index into [`stages`](Self::stages) of the anchor — the post-inference
+    /// stage every query handler resolves against.
+    anchor: usize,
+    /// The pane-pair lineage maps, aligned with `stages.windows(2)` — one per
+    /// adjacent stage pair, folded from the intervening passes' lineage logs
+    /// ([`CompiledProgram::materialize_panes`]). Drives the `paneLinks` payload
+    /// (shipped dense, self-edges included). Empty for a single-stage snapshot.
+    stage_maps: Vec<LineageMap<NodeId, NodeId>>,
+}
+
+/// `resolve(span)` — the bidirectional-map primitive: a source span → the IR
+/// node(s) at that position.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Resolve {
+    /// The queried span, echoed back.
+    pub span: Span,
+    /// The tightest (innermost / value-carrying) enclosing node — the primary
+    /// answer. `None` if no IR node's origin span contains the query (graceful
+    /// "source unknown").
+    ///
+    /// The index returns the whole containment *set* ([`containment`](Self::containment));
+    /// this is its tip. The coincident-span tie-break (e.g. a `def`'s `let` vs
+    /// its value `λ`, which share the whole-statement span) is **query-layer
+    /// policy**: prefer the innermost / structurally-deepest node (the
+    /// value-carrying one). That policy lives in [`SpanIndex::tightest`].
+    pub node_id: Option<NodeId>,
+    /// The full containment chain, outermost → innermost (`node_id` is its tip).
+    pub containment: Vec<NodeId>,
+    /// The dataflow-layer handle — always `None` here (the live/operator layer
+    /// is not yet built). Present so the live shape is identical.
+    pub operator_id: Option<NodeId>,
+    /// The attribution of the tightest node, or `None` if there is none.
+    /// (Serializes to the native `{ spans, rewritten }` shape — schema 3.)
+    pub attribution: Option<SourceAttribution>,
+}
+
+/// `hover(span)` — the composite core interaction, value-free (static snapshot).
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Hover {
+    /// The queried span, echoed back.
+    pub span: Span,
+    /// The tightest enclosing node (the primary handle), or `None`.
+    pub node_id: Option<NodeId>,
+    /// The **set** of types at this span: one entry per distinct typed node
+    /// sharing the queried source span — for a monomorphized polymorphic def the
+    /// specializations' types ("used at Int and String"). Deduplicated, ordered
+    /// by first appearance along the containment chain (outermost first). Empty
+    /// if the span resolves to no typed node.
+    pub types: Vec<Type>,
+    /// The source text the span covers (`source[span]`), or `None` if the span
+    /// is out of bounds.
+    pub snippet: Option<String>,
+    /// The attribution of the tightest node, or `None`.
+    pub attribution: Option<SourceAttribution>,
+    /// Live seam: the value summary at a tick — **always `None`**.
+    pub value_summary: Option<ValueSummary>,
+    /// Live seam: the tick this hover was taken at — **always `None`**.
+    pub tick: Option<Tick>,
+}
+
+/// `goto_definition(span)` — variable use → binder, over the source AST.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct GotoDefinition {
+    /// The use-site span queried.
+    pub use_span: Span,
+    /// The binder's source span.
+    pub def_span: Span,
+    /// The bound name.
+    pub name: String,
+}
+
+/// `scope_at(span)` — the visible binders at a position, each joined with its
+/// type. Value-free (static snapshot).
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct ScopeAt {
+    /// The queried span, echoed back.
+    pub span: Span,
+    /// The binders visible at the position, outermost → innermost.
+    pub bindings: Vec<ScopeBinding>,
+    /// Live seam: the tick — **always `None`**.
+    pub tick: Option<Tick>,
+}
+
+/// One binding row of [`ScopeAt`]: a visible name, its binder span, and the
+/// type joined from the SpanIndex.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct ScopeBinding {
+    /// The bound name.
+    pub name: String,
+    /// The binder's source span.
+    pub def_span: Span,
+    /// The binder's type, joined by resolving `def_span` through the SpanIndex
+    /// to a typed node. `None` when the binder's def-span maps to no typed node
+    /// — notably a substituted multi-param parameter, whose use→node span link
+    /// is the deferred substituted-parameter fix (see [`type_of`](Snapshot::type_of)).
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
+    pub ty: Option<Type>,
+    /// Live seam: the binding's value summary — **always `None`**.
+    pub value_summary: Option<ValueSummary>,
+}
+
+/// Live-seam placeholder for a value summary. Never constructed here — the field
+/// that holds it is always `None`. Declared so the seam is a real `Option<T>`,
+/// not a bare `Option<()>`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub enum ValueSummary {}
+
+/// Live-seam placeholder for an engine tick. Never constructed here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub enum Tick {}
+
+impl<'a> StageProjection<'a> {
+    /// Build a stage projection: keep the IR borrow, take ownership of the
+    /// materialized pane projection, and build the span→node index over the pair.
+    fn build(
+        id: &'static str,
+        label: &'static str,
+        kind: &'static str,
+        ir: &'a Expr,
+        projection: SourceProjection,
+    ) -> Self {
+        let span_index = SpanIndex::build(ir, &projection);
+        StageProjection {
+            id,
+            label,
+            kind,
+            ir,
+            projection,
+            span_index,
+        }
+    }
+}
+
+impl<'a> Snapshot<'a> {
+    /// Build the bundle from a compiled program: materialize the three per-pane
+    /// projections + the two pane-pair lineage maps
+    /// ([`CompiledProgram::materialize_panes`]), build each stage's span index,
+    /// build the source-level name index. The **post-inference** stage — the
+    /// middle pane — is the anchor every query resolves against.
+    pub fn new(compiled: &'a CompiledProgram) -> Self {
+        let panes = compiled.materialize_panes();
+        let stages = vec![
+            // Upstream: the pre-inference, pre-mono, hole-typed tree (its
+            // projection is the lowering seed).
+            StageProjection::build(
+                "pre-inference",
+                "IR (PRE-INFERENCE)",
+                "holes",
+                &compiled.pre_inference_ir,
+                panes.pre_inference,
+            ),
+            // Anchor: the post-inference, fully-typed, source-shaped tree.
+            StageProjection::build(
+                "post-inference",
+                "IR (POST-INFERENCE)",
+                "typed",
+                &compiled.post_inference_ir,
+                panes.post_inference,
+            ),
+            // Downstream: the post-desugar tree (channelization artifacts
+            // present); the fully-folded Inline/Desugar lineage leaves no node
+            // absent from the projection.
+            StageProjection::build(
+                "post-desugar",
+                "IR (POST-DESUGAR)",
+                "typed",
+                &compiled.post_desugar_ir,
+                panes.post_desugar,
+            ),
+        ];
+        let name_binder = NameBinderIndex::build(&compiled.source_ast);
+        // The anchor is the post-inference stage explicitly (the middle pane),
+        // not "the last stage" — post-desugar is now downstream of it.
+        let anchor = stages
+            .iter()
+            .position(|s| s.id == "post-inference")
+            .expect("the post-inference anchor stage is present");
+        Snapshot {
+            source: &compiled.source,
+            name_binder,
+            anchor,
+            stages,
+            // Aligned with `stages.windows(2)`: (pre → post-inference) then
+            // (post-inference → post-desugar).
+            stage_maps: vec![panes.mono_map, panes.desugar_map],
+        }
+    }
+
+    /// Build directly from a single materialized pane (the shape tests drive).
+    /// Equivalent to [`new`](Self::new) but for one pane, taken as the
+    /// post-inference anchor; there is no adjacent pair, so
+    /// [`build_payload`](Self::build_payload) ships a single stage with no stage
+    /// links.
+    pub fn from_parts(
+        source: &'a str,
+        ir: &'a Expr,
+        projection: SourceProjection,
+        source_ast: &Module,
+    ) -> Self {
+        let stages = vec![StageProjection::build(
+            "post-inference",
+            "IR (POST-INFERENCE)",
+            "typed",
+            ir,
+            projection,
+        )];
+        let name_binder = NameBinderIndex::build(source_ast);
+        Snapshot {
+            source,
+            name_binder,
+            anchor: stages.len() - 1,
+            stages,
+            stage_maps: Vec::new(),
+        }
+    }
+
+    /// The anchor stage (post-inference) — the one every query handler resolves
+    /// against.
+    pub(super) fn anchor(&self) -> &StageProjection<'a> {
+        &self.stages[self.anchor]
+    }
+
+    /// The pipeline stages in order (for the payload's `stages` enumeration).
+    pub(super) fn stages(&self) -> &[StageProjection<'a>] {
+        &self.stages
+    }
+
+    /// The pane-pair lineage maps, aligned with `stages.windows(2)` — for the
+    /// payload's `paneLinks` (see [`build_payload`](Self::build_payload)).
+    pub(super) fn stage_maps(&self) -> &[LineageMap<NodeId, NodeId>] {
+        &self.stage_maps
+    }
+
+    /// The program's source text (for the snapshot payload's `source.text` and
+    /// `snippet` slicing).
+    pub(super) fn source_text(&self) -> &str {
+        self.source
+    }
+
+    /// The source-level name index (for the payload's `definitions`/`scopes`).
+    pub(super) fn name_binder_ref(&self) -> &NameBinderIndex {
+        &self.name_binder
+    }
+
+    /// The whole anchor IR tree as an [`InspectNode`], rooted at the snapshot
+    /// root. Descends the full tree (ships everything), reusing
+    /// [`expand_node`](Self::expand_node) at the tree's height. Test-only: the
+    /// payload now ships per-stage trees (`build_stage_ir_and_index`), not a
+    /// single top-level `ir`; the span↔CCL coverage tests still walk it.
+    #[cfg(test)]
+    pub(super) fn expand_root(&self) -> InspectNode {
+        let ir = self.anchor().ir;
+        let depth = tree_height(ir);
+        self.expand_node(ir, depth)
+    }
+
+    /// `resolve(span)` — translate a source span to the IR node(s) at it.
+    ///
+    /// Returns the whole containment chain (outermost → innermost) plus its tip
+    /// as the primary `node_id`. The tip is chosen by [`SpanIndex::tightest`]'s
+    /// query-layer policy (innermost / value-carrying among coincident spans).
+    pub fn resolve(&self, span: Span) -> Resolve {
+        let containment = self.anchor().span_index.enclosing_span(span);
+        let node_id = containment.last().copied();
+        let attribution = node_id.and_then(|n| self.anchor().projection.get(&n).cloned());
+        Resolve {
+            span,
+            node_id,
+            containment,
+            operator_id: None,
+            attribution,
+        }
+    }
+
+    /// `type_of(span)` — the bare type at a span. The first of [`hover`](Self::hover)'s
+    /// type set (the tightest node's type), for agent/`type-of` callers that want
+    /// one type rather than the whole set.
+    ///
+    /// `None` when the span maps to no typed node. In particular a use of a
+    /// **substituted multi-param parameter** resolves to `None` for now: lowering
+    /// rewrites `Var(x)` to `__arg_tuple_N ▷ .i` before any node carries `x`'s
+    /// use-span, so the SpanIndex has no entry for it. Carrying the replaced
+    /// `Var`'s span onto the projection (with per-occurrence fresh ids) is the
+    /// deferred substituted-parameter fix; goto-def on such a param already works
+    /// via the source-level [`NameBinderIndex`].
+    ///
+    /// Perf: this builds a whole [`Hover`] (snippet, attribution, full type set)
+    /// only to take the first type, and `build_payload` calls it once per scope
+    /// binding — so payload build is ~O(bindings · chain · nodes), since
+    /// [`type_set_at`](Self::type_set_at) runs the O(nodes) [`find_node`] per
+    /// chain node. Fine at census-corpus sizes; for large trees, add a per-pane
+    /// `NodeId → Type` map and a `tip_type` that stops at the tightest node
+    /// instead of materializing the full `Hover`.
+    pub fn type_of(&self, span: Span) -> Option<Type> {
+        self.hover(span).types.into_iter().next()
+    }
+
+    /// `hover(span)` — `{ node_id, types (type set), snippet, attribution,
+    /// value_summary, tick }`, value-free (static snapshot).
+    ///
+    /// The `types` field is the **set** of types of every distinct typed node
+    /// whose origin span equals the tightest enclosing span: for a
+    /// monomorphized polymorphic def these are the specializations' types. We
+    /// take the containment chain, find the tightest node's tightest origin span,
+    /// and collect the types of every chain node indexed at that same span. The
+    /// set dedups structurally and preserves outermost-first order.
+    pub fn hover(&self, span: Span) -> Hover {
+        let containment = self.anchor().span_index.enclosing_span(span);
+        let node_id = containment.last().copied();
+        let attribution = node_id.and_then(|n| self.anchor().projection.get(&n).cloned());
+
+        // The type set is collected over every node sharing the *tightest*
+        // origin span — the mono specializations all blame that one span. We key
+        // on the narrowest origin span of the tightest node, then pull the types
+        // of all chain nodes whose origins include that span.
+        let types = self.type_set_at(&containment);
+
+        let snippet = slice_source(self.source, span);
+
+        Hover {
+            span,
+            node_id,
+            types,
+            snippet,
+            attribution,
+            value_summary: None,
+            tick: None,
+        }
+    }
+
+    /// The type set: among the containment chain, every distinct typed node
+    /// that shares the tightest node's narrowest origin span. Mono
+    /// specializations are tagged `via: Mono, nature: Expansion` with the
+    /// *original* def's span, so they all collapse onto that span and surface
+    /// here as distinct types.
+    fn type_set_at(&self, containment: &[NodeId]) -> Vec<Type> {
+        let Some(&tip) = containment.last() else {
+            return Vec::new();
+        };
+        // The tightest node's narrowest origin span is the "this position" span.
+        let Some(key_span) = self.narrowest_origin(tip) else {
+            // No origins (synthetic) — fall back to just the tip's own type.
+            return find_node(self.anchor().ir, tip)
+                .map(|e| vec![e.ty.clone()])
+                .unwrap_or_default();
+        };
+
+        // Every chain node whose origins include `key_span` contributes its type.
+        // Mono clones are distinct node ids all blaming `key_span`, so the set
+        // grows to one type per specialization. Dedup structurally, keep order.
+        let mut types: Vec<Type> = Vec::new();
+        for &n in containment {
+            let shares = self
+                .anchor()
+                .projection
+                .get(&n)
+                .map(|a| a.spans.contains(&key_span))
+                .unwrap_or(false);
+            if !shares {
+                continue;
+            }
+            if let Some(e) = find_node(self.anchor().ir, n) {
+                let ty = e.ty.clone();
+                if !types.contains(&ty) {
+                    types.push(ty);
+                }
+            }
+        }
+        types
+    }
+
+    /// The narrowest origin span of a node (the most specific "this came from
+    /// here"), or `None` if the node has no source origins.
+    fn narrowest_origin(&self, node: NodeId) -> Option<Span> {
+        self.anchor()
+            .projection
+            .get(&node)?
+            .spans
+            .iter()
+            .min_by_key(|s| s.end.saturating_sub(s.start))
+            .copied()
+    }
+
+    /// `goto_definition(span)` — resolve a `Name` use to its binder, over the
+    /// source AST. `None` if the span is not a name use or the name is
+    /// unbound.
+    pub fn goto_definition(&self, use_span: Span) -> Option<GotoDefinition> {
+        let def_span = self.name_binder.definition_of(use_span)?;
+        // Recover the name for the result by reading the use-site source text.
+        let name = slice_source(self.source, use_span).unwrap_or_default();
+        Some(GotoDefinition {
+            use_span,
+            def_span,
+            name,
+        })
+    }
+
+    /// `scope_at(span)` — the visible binders at a position, each joined with the
+    /// type read off the typed node its def-span resolves to. Value-free.
+    pub fn scope_at(&self, span: Span) -> ScopeAt {
+        let bindings = self
+            .name_binder
+            .bindings_in_scope(span)
+            .into_iter()
+            .map(|Binding { name, def_span }| ScopeBinding {
+                name: name.to_string(),
+                def_span,
+                // Join the type: resolve the binder's def-span through the
+                // SpanIndex to a typed node and read its `.ty`. A substituted
+                // multi-param parameter has no typed node at its def-span (the
+                // deferred fix), so its type is gracefully `None`.
+                ty: self.type_of(def_span),
+                value_summary: None,
+            })
+            .collect();
+        ScopeAt {
+            span,
+            bindings,
+            tick: None,
+        }
+    }
+
+    /// `expand(node_id, depth)` — the IR drill-in tree rooted at `node_id`,
+    /// depth-bounded, as an [`InspectNode`] carrying the extended source-linking
+    /// fields (`node_id`, `span`, `type`, `attribution`).
+    ///
+    /// `depth` is the number of child levels to descend (`0` = the node alone, no
+    /// children). `None` if `node_id` is not a node of the snapshot.
+    pub fn expand(&self, node_id: NodeId, depth: usize) -> Option<InspectNode> {
+        let node = find_node(self.anchor().ir, node_id)?;
+        Some(self.expand_node(node, depth))
+    }
+
+    fn expand_node(&self, expr: &Expr, depth: usize) -> InspectNode {
+        build_inspect_tree(expr, &self.anchor().projection, depth)
+    }
+}
+
+/// Build the [`InspectNode`] tree for `expr` against its pane `projection`,
+/// descending `depth` child levels (`0` = the node alone, no children). The
+/// single source-linking tree-builder: every IR-pane stage (the snapshot
+/// payload's per-stage `ir`, the `expand` query) goes through this one shape,
+/// parameterized only by its `(Expr, SourceProjection)` pair.
+pub(super) fn build_inspect_tree(
+    expr: &Expr,
+    projection: &SourceProjection,
+    depth: usize,
+) -> InspectNode {
+    let id = expr.node_id();
+    let mut node = InspectNode::leaf(node_label(&expr.node))
+        .with_type(expr.ty.to_string())
+        .with_node_id(id.as_u64());
+    if let Some(attr) = projection.get(&id) {
+        // The rewrite channel (schema 3): a direct image (`Nature::Source`)
+        // null-compresses — it carries no wire tag, byte-identical to the retired
+        // `rewritten: None` encoding; a rewritten node carries `{via, nature,
+        // label}` natively. The validators guard that `"source"` never ships.
+        let tag = &attr.rewritten;
+        if !tag.nature.is_source() {
+            node = node.with_rewritten(RewriteInfo {
+                via: format!("{:?}", tag.via),
+                nature: tag.nature.wire_str().to_string(),
+                label: tag.label.to_string(),
+            });
+        }
+        // The spans channel: the node's primary (narrowest) source span, if any.
+        if let Some(span) = attr
+            .spans
+            .iter()
+            .min_by_key(|s| s.end.saturating_sub(s.start))
+        {
+            node = node.with_node_span((span.start, span.end));
+        }
+    }
+    if depth > 0 {
+        for (idx, child) in expr.child_exprs().into_iter().enumerate() {
+            let child_node = build_inspect_tree(child, projection, depth - 1);
+            node.children.push((idx.to_string(), child_node));
+        }
+    }
+    node
+}
+
+/// Find the node with id `target` in `expr`'s tree, returning a borrow into the
+/// snapshot. A per-query walk (the program tree is small; this mirrors
+/// `NameBinderIndex`'s re-walk-per-query trade of a little recomputation for a
+/// far simpler, clearly-correct implementation than caching a borrow map, which
+/// runs into `&mut`-invariance on the lifetime).
+// O(nodes) DFS. [`type_set_at`] calls it once per containment-chain node, so
+// span queries are super-linear and the per-binding `build_payload` loop is
+// ~O(bindings · chain · nodes); a per-pane `NodeId → &Expr` map would make this
+// O(1). See [`Snapshot::type_of`]'s perf note.
+fn find_node(expr: &Expr, target: NodeId) -> Option<&Expr> {
+    if expr.node_id() == target {
+        return Some(expr);
+    }
+    expr.child_exprs()
+        .into_iter()
+        .find_map(|c| find_node(c, target))
+}
+
+/// The height of `expr`'s tree (a leaf is height 0). Used to expand the whole
+/// tree for the snapshot payload's `ir` field — `expand` takes a child-level
+/// count, and the height is exactly the count that reaches every leaf.
+pub(super) fn tree_height(expr: &Expr) -> usize {
+    expr.child_exprs()
+        .into_iter()
+        .map(|c| 1 + tree_height(c))
+        .max()
+        .unwrap_or(0)
+}
+
+/// Slice `source[span]` as an owned `String`, or `None` if the span is out of
+/// bounds or not a char boundary (graceful — never panics on a bad span).
+fn slice_source(source: &str, span: Span) -> Option<String> {
+    if span.start > span.end || span.end > source.len() {
+        return None;
+    }
+    source.get(span.start..span.end).map(str::to_owned)
+}
+
+/// A short kind label for a node, mirroring the symbolic vocabulary at a glance
+/// (`BinOp(+)`, `Lit(1)`, `Var(x)`, …). Used for `expand` tree rows.
+pub(super) fn node_label(node: &TypedExprNode) -> String {
+    use TypedExprNode::*;
+    match node {
+        Lit(l) => format!("Lit({l:?})"),
+        Var(n) => format!("Var({n})"),
+        Builtin(b) => format!("Builtin({b})"),
+        Apply { .. } => "Apply".to_string(),
+        Cast { .. } => "Cast".to_string(),
+        BinOp { op, .. } => format!("BinOp({op:?})"),
+        UnaryOp(op, _) => format!("UnaryOp({op:?})"),
+        Lambda { param, .. } => format!("Lambda({})", param.name),
+        Aggregate { kind, .. } => format!("Aggregate({kind:?})"),
+        Let { binding, .. } => format!("Let({})", binding.name),
+        List(_) => "List".to_string(),
+        Case { .. } => "Case".to_string(),
+        VariantCtor { tag, .. } => format!("VariantCtor(.{tag})"),
+        Transact { .. } => "Transact".to_string(),
+        LetRec { .. } => "LetRec".to_string(),
+        For { .. } => "For".to_string(),
+        MutWrite { name, .. } => format!("MutWrite({name})"),
+        Tuple(_) => "Tuple".to_string(),
+        Proj(k) => format!("Proj({k:?})"),
+        Record(_) => "Record".to_string(),
+        Source(s) => format!("Source({s})"),
+        Compose(_) => "Compose".to_string(),
+        CollectionUnion(_) => "CollectionUnion".to_string(),
+        ExprStmt { .. } => "ExprStmt".to_string(),
+        Feed { name, .. } => format!("Feed({name})"),
+        Define { name, .. } => format!("Define({name})"),
+        Begin { .. } => "Begin".to_string(),
+        Defer => "Defer".to_string(),
+        Error => "Error".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccl::context::{GlobalContext, compile_program};
+    use crate::ccl::lineage::Nature;
+    use crate::ccl::provenance::Pass;
+    use crate::interpreter::Consumer;
+
+    /// Compile a CHL program for inspection. Returns the whole
+    /// [`CompiledProgram`] so a [`Snapshot`] can borrow all its projections.
+    fn compile(code: &str) -> CompiledProgram {
+        let mut ctx = GlobalContext::default();
+        let consumer: Box<dyn Consumer> = Box::new(|| {});
+        compile_program(&mut ctx, code, consumer).expect("program compiles")
+    }
+
+    /// The span of the `n`-th (0-based) byte occurrence of `needle` in `code`.
+    fn nth_span(code: &str, needle: &str, n: usize) -> Span {
+        let start = code
+            .match_indices(needle)
+            .nth(n)
+            .unwrap_or_else(|| panic!("occurrence {n} of {needle:?} not found"))
+            .0;
+        Span::new(start, start + needle.len())
+    }
+
+    /// `resolve` returns the tightest enclosing node for a position, and the
+    /// live-shape `operator_id` is `None` (the live/operator layer, not yet
+    /// built).
+    #[test]
+    fn resolve_returns_tightest_node_for_span() {
+        let code = "\
+x = 1 + 2
+x
+";
+        let prog = compile(code);
+        let snap = Snapshot::new(&prog);
+
+        // The `1` literal.
+        let span = nth_span(code, "1", 0);
+        let resolved = snap.resolve(span);
+
+        assert!(
+            resolved.node_id.is_some(),
+            "a node encloses the literal span"
+        );
+        // The tip is the last element of the containment chain.
+        assert_eq!(resolved.node_id, resolved.containment.last().copied());
+        assert!(
+            resolved.containment.len() >= 2,
+            "the literal sits inside the BinOp + the let RHS: chain ≥ 2, got {:?}",
+            resolved.containment
+        );
+        // operator_id is the present-but-None live seam (the live/operator
+        // layer, not yet built).
+        assert_eq!(resolved.operator_id, None);
+        // The attribution of the tightest node is populated.
+        assert!(resolved.attribution.is_some());
+    }
+
+    /// The specialization-wrapper `Let`s that `coalesce_generalized_let`
+    /// synthesizes for a let-polymorphic definition used at multiple types
+    /// carry lineage (tagged `via: Mono, nature: Expansion`, blaming the
+    /// generalized `let`'s source span) rather than empty origins. This is the
+    /// precise post-inference lineage edge for the wrapper.
+    #[test]
+    fn generalized_let_wrappers_carry_mono_attribution() {
+        use crate::ccl::names::{Name, SyntheticKind};
+
+        // `dup` is generalized and applied at two distinct element types,
+        // forcing monomorphization to synthesize a `__mono` wrapper `Let` per
+        // use type.
+        let code = "\
+dup = \\x -> (x, x)
+a = dup(1)
+b = dup(2 == 2)
+a
+";
+        let prog = compile(code);
+        let panes = prog.materialize_panes();
+
+        fn collect_mono_lets<'a>(e: &'a Expr, out: &mut Vec<&'a Expr>) {
+            if let TypedExprNode::Let { binding, .. } = &e.node
+                && matches!(
+                    binding.name,
+                    Name::Synthetic {
+                        kind: SyntheticKind::Mono(_),
+                        ..
+                    }
+                )
+            {
+                out.push(e);
+            }
+            for c in e.child_exprs() {
+                collect_mono_lets(c, out);
+            }
+        }
+        let mut wrappers = Vec::new();
+        collect_mono_lets(&prog.post_inference_ir, &mut wrappers);
+
+        assert!(
+            !wrappers.is_empty(),
+            "a let-polymorphic def used at two types must synthesize __mono wrapper Lets"
+        );
+        for w in wrappers {
+            let attr = panes
+                .post_inference
+                .get(&w.node_id())
+                .unwrap_or_else(|| panic!("wrapper Let {:?} has no attribution", w.node_id()));
+            let tag = &attr.rewritten;
+            assert_eq!(tag.via, Pass::Mono, "wrapper is rewritten via Mono");
+            assert_eq!(
+                tag.nature,
+                Nature::Expansion,
+                "a __mono wrapper is an Expansion (Derived), not Machinery",
+            );
+            assert!(
+                !attr.spans.is_empty(),
+                "wrapper attribution must blame the generalized let's source span(s)"
+            );
+        }
+    }
+
+    /// The post-desugar pane projection is *complete* for the post-desugar tree
+    /// — every node resolves (the fully-folded Inline/Desugar lineage leaves no
+    /// node absent). The "unresolved" category is structurally impossible in the
+    /// post-desugar pane.
+    #[test]
+    fn post_desugar_projection_covers_every_post_desugar_node() {
+        // A let-polymorphic def (so the post-desugar tree still holds the
+        // pre-mono original `dup`, which the post-inference tree replaces with
+        // specialization clones).
+        let code = "\
+dup = \\x -> (x, x)
+a = dup(1)
+b = dup(2 == 2)
+a
+";
+        let prog = compile(code);
+        let panes = prog.materialize_panes();
+
+        fn check(e: &Expr, projection: &SourceProjection, missing: &mut Vec<u64>) {
+            if !projection.contains_key(&e.node_id()) {
+                missing.push(e.node_id().as_u64());
+            }
+            for c in e.child_exprs() {
+                check(c, projection, missing);
+            }
+        }
+        let mut missing = Vec::new();
+        check(&prog.post_desugar_ir, &panes.post_desugar, &mut missing);
+        assert!(
+            missing.is_empty(),
+            "post-desugar nodes left with no attribution (projection incomplete): {missing:?}"
+        );
+    }
+
+    /// `type_of`/`hover` returns the right type for a leaf (an Int literal) and
+    /// for a compound expression (the `1 + 2` BinOp). Live seams are `None`.
+    ///
+    /// The leaf's type is the literal's *singleton* refinement, which `Display`s
+    /// as the literal itself (`1`), not as `Int` — a literal is typed by which
+    /// literal it is. The compound is a plain `Int`: the singleton is consumed by
+    /// the arithmetic.
+    #[test]
+    fn hover_returns_type_for_leaf_and_compound() {
+        let code = "\
+x = 1 + 2
+x
+";
+        let prog = compile(code);
+        let snap = Snapshot::new(&prog);
+
+        // Leaf: the `1` literal hovers as its Int singleton, spelled `1`.
+        let leaf = snap.hover(nth_span(code, "1", 0));
+        assert!(
+            leaf.types.iter().any(|t| t.to_string() == "1"),
+            "leaf `1` hovers its Int singleton; got {:?}",
+            leaf.types
+        );
+        assert_eq!(leaf.snippet.as_deref(), Some("1"));
+        // Live seams.
+        assert_eq!(leaf.value_summary, None);
+        assert_eq!(leaf.tick, None);
+
+        // Compound: the `1 + 2` sub-expression. Use a span covering the operator
+        // so the tightest enclosing node is the BinOp, not an operand.
+        let plus = nth_span(code, "+", 0);
+        let compound = snap.hover(plus);
+        assert!(
+            compound.types.iter().any(|t| t.to_string().contains("Int")),
+            "`1 + 2` hovers Int; got {:?}",
+            compound.types
+        );
+
+        // type_of agrees with hover's first type.
+        assert_eq!(snap.type_of(plus), compound.types.first().cloned());
+    }
+
+    /// Hover on a monomorphized polymorphic def returns the **set** of the
+    /// specializations' types. `dup = \x -> (x, x)` applied at Int and String
+    /// produces two specialization clones sharing the def's source span; their
+    /// distinct tuple types both surface in the hover set.
+    #[test]
+    fn hover_on_monomorphized_def_returns_type_set() {
+        // Same shape as context.rs's monomorphization test: a non-trivial body
+        // so the def is not beta-reduced away before inference.
+        let code = "\
+dup = \\x -> (x, x)
+(dup(1), dup(\"a\"))
+";
+        let prog = compile(code);
+        let snap = Snapshot::new(&prog);
+
+        // Hover on the lambda body tuple `(x, x)` on line 1. Monomorphization
+        // clones the body subtree once per resolved type, tagging each clone
+        // `via: Mono, nature: Expansion` with the *original body span* — so both
+        // the Int and the String specialization's tuple node blame this one span.
+        // The hover type set therefore carries both specializations' types, not a
+        // single picked type. (Hovering the `dup` *name* span sees nothing: the
+        // clones blame the body, not the binder name — exactly the "the clones
+        // share the source span" behavior.)
+        let body_span = nth_span(code, "(x, x)", 0);
+        let hover = snap.hover(body_span);
+
+        assert!(
+            hover.types.len() >= 2,
+            "a monomorphized def hovers the SET of specialized types, \
+             expected ≥2 distinct types; got {:?}",
+            hover.types
+        );
+        // The specializations are tuple types over Int and over String — the set
+        // must contain at least one of each shape, proving it is not collapsed to
+        // one picked type.
+        let rendered: Vec<String> = hover.types.iter().map(|t| t.to_string()).collect();
+        assert!(
+            rendered.iter().any(|t| t.contains("Int")),
+            "set includes the Int specialization; got {rendered:?}"
+        );
+        assert!(
+            rendered.iter().any(|t| t.contains("String")),
+            "set includes the String specialization; got {rendered:?}"
+        );
+    }
+
+    /// `goto_definition` round-trips a variable use back to its binding site.
+    #[test]
+    fn goto_definition_round_trips_use_to_def() {
+        let code = "\
+x = 1 + 2
+y = x + 3
+y
+";
+        let prog = compile(code);
+        let snap = Snapshot::new(&prog);
+
+        // The use of `x` in `y = x + 3` (the 2nd `x`).
+        let use_x = nth_span(code, "x", 1);
+        let def_x = nth_span(code, "x", 0);
+
+        let goto = snap
+            .goto_definition(use_x)
+            .expect("x resolves to its binder");
+        assert_eq!(goto.use_span, use_x);
+        assert_eq!(goto.def_span, def_x);
+        assert_eq!(goto.name, "x");
+
+        // A non-name span resolves to None (graceful).
+        assert_eq!(snap.goto_definition(nth_span(code, "1", 0)), None);
+    }
+
+    /// `scope_at` lists the visible bindings at a position, each joined with its
+    /// type; the live `tick` seam is `None`.
+    #[test]
+    fn scope_at_lists_visible_bindings_with_types() {
+        let code = "\
+g = 10
+def f(p, q):
+  p + q + g
+f(1, 2)
+";
+        let prog = compile(code);
+        let snap = Snapshot::new(&prog);
+
+        // A position on the body use of `p`.
+        let at = nth_span(code, "p", 1);
+        let scope = snap.scope_at(at);
+        assert_eq!(scope.tick, None);
+
+        let names: std::collections::HashSet<&str> =
+            scope.bindings.iter().map(|b| b.name.as_str()).collect();
+        assert!(names.contains("p"), "p visible; got {names:?}");
+        assert!(names.contains("q"), "q visible; got {names:?}");
+        assert!(names.contains("g"), "outer g visible; got {names:?}");
+
+        // The outer `g` is a plain Int assignment, so its type joins from the
+        // SpanIndex (not a substituted param) — it must be present.
+        let g = scope
+            .bindings
+            .iter()
+            .find(|b| b.name == "g")
+            .expect("g binding present");
+        assert!(
+            g.ty.as_ref()
+                .map(|t| t.to_string().contains("Int"))
+                .unwrap_or(false),
+            "g's type joins to Int; got {:?}",
+            g.ty
+        );
+        // Live seam on each binding.
+        assert!(scope.bindings.iter().all(|b| b.value_summary.is_none()));
+    }
+
+    /// `expand` yields a tree node carrying the extended fields (`node_id`,
+    /// `span`, `type`) and its children.
+    #[test]
+    fn expand_yields_node_with_extended_fields_and_children() {
+        let code = "\
+x = 1 + 2
+x
+";
+        let prog = compile(code);
+        let snap = Snapshot::new(&prog);
+
+        // Resolve the `+` to its BinOp node, then expand it.
+        let binop_id = snap
+            .resolve(nth_span(code, "+", 0))
+            .node_id
+            .expect("the + resolves to a node");
+        let tree = snap.expand(binop_id, 1).expect("the node expands");
+
+        // Extended fields are populated.
+        assert_eq!(tree.node_id, Some(binop_id.as_u64()));
+        assert!(tree.span.is_some(), "expand carries the source span");
+        assert!(
+            tree.ty.as_deref().is_some_and(|t| t.contains("Int")),
+            "expand carries the type in the dedicated field; got {:?}",
+            tree.ty
+        );
+        // `1 + 2` is a directly-lowered source node: it has no rewrite tag (its
+        // spans channel rides the `span` field asserted above).
+        assert!(
+            tree.rewritten.is_none(),
+            "a directly-lowered source node carries no rewrite tag"
+        );
+        // A BinOp has two children (the operands) at depth 1.
+        assert_eq!(
+            tree.children.len(),
+            2,
+            "BinOp expands to its two operands; got {:?}",
+            tree.children
+        );
+
+        // Depth 0 yields the node alone (no children).
+        let shallow = snap.expand(binop_id, 0).expect("expands at depth 0");
+        assert!(shallow.children.is_empty());
+
+        // An unknown id yields None (graceful).
+        assert!(snap.expand(NodeId::fresh(), 1).is_none());
+    }
+
+    // ------------------------------------------------------------------------
+    // Span↔CCL (source↔IR) mapping: FE-independent test & debug flow.
+    //
+    // These exercise the *backend-side* of the inspector's bidirectional map —
+    // span→node resolution and the IR-coverage debug view — over two programs
+    // whose lowering produces synthetic wrapper chains: a `yield` generator and
+    // a `defer()`/`<<` feed pipeline. They mirror the manual web-validation
+    // examples (`cambra-inspector/examples/{generator_min,defer_min}.chl`) but
+    // inline the source so the flow is exercised without the front end.
+    //
+    // Part A pins the source constructs that *do* map (real correctness today).
+    // Part B is a coverage-characterization / debug view: it walks the whole IR
+    // and partitions nodes into mapped (carry a source span) vs unmapped, then
+    // asserts on both sets — a regression fixture over which nodes carry source
+    // spans.
+    // ------------------------------------------------------------------------
+
+    const GENERATOR_SRC: &str = "\
+def squared(xs):
+    for x in xs:
+        yield x * x
+
+max(squared([1, 2, 3, 4]))
+";
+
+    const DEFER_SRC: &str = "\
+readings = [1, 2, 3, 4]
+totals = defer()
+totals << sum(readings)
+for x in readings:
+    totals << x
+max(totals)
+";
+
+    /// Resolve `span`, then read the tightest node's `label` via `expand(_, 0)`.
+    /// Panics if the span resolves to no node — these are spans that must map.
+    fn resolved_label(snap: &Snapshot<'_>, span: Span) -> String {
+        let id = snap
+            .resolve(span)
+            .node_id
+            .unwrap_or_else(|| panic!("span {span:?} resolves to no IR node"));
+        snap.expand(id, 0).expect("resolved node id expands").label
+    }
+
+    /// One walked IR node, reduced to the fields the coverage view reasons over.
+    struct WalkedNode {
+        label: String,
+        /// `true` iff the node carries a source span — i.e. it is *mapped*
+        /// (equivalently: its provenance has non-empty origins / it appears in
+        /// the spanIndex).
+        mapped: bool,
+        /// The rewrite tag's label when the node was produced by a pass, or
+        /// `None` for a directly-lowered source node (a node with no source span
+        /// and no rewrite tag is read off this being `None`).
+        rewritten: Option<String>,
+    }
+
+    /// Walk the whole IR from `expand_root()` and collect every node, flattened.
+    /// The reusable substrate for the coverage view across both programs.
+    fn walk_ir(snap: &Snapshot<'_>) -> Vec<WalkedNode> {
+        fn go(node: &InspectNode, out: &mut Vec<WalkedNode>) {
+            out.push(WalkedNode {
+                label: node.label.clone(),
+                mapped: node.span.is_some(),
+                rewritten: node.rewritten.as_ref().map(|r| r.label.clone()),
+            });
+            for (_edge, child) in &node.children {
+                go(child, out);
+            }
+        }
+        let mut out = Vec::new();
+        go(&snap.expand_root(), &mut out);
+        out
+    }
+
+    /// Partition the walked IR into (mapped labels, unmapped labels). A node is
+    /// mapped iff it carries a source span. Labels repeat (e.g. several `Var`),
+    /// so the coverage assertions match on substrings/counts, not exact sets.
+    fn mapped_partition(snap: &Snapshot<'_>) -> (Vec<String>, Vec<String>) {
+        let nodes = walk_ir(snap);
+        let mapped = nodes
+            .iter()
+            .filter(|n| n.mapped)
+            .map(|n| n.label.clone())
+            .collect();
+        let unmapped = nodes
+            .iter()
+            .filter(|n| !n.mapped)
+            .map(|n| n.label.clone())
+            .collect();
+        (mapped, unmapped)
+    }
+
+    /// Count unmapped nodes carrying no source span and no rewrite tag — the
+    /// generator wrapper chain. Distinct from nodes that carry a rewrite tag
+    /// (even with empty origins), which are excluded here.
+    fn untagged_unmapped(snap: &Snapshot<'_>) -> Vec<String> {
+        walk_ir(snap)
+            .into_iter()
+            .filter(|n| !n.mapped && n.rewritten.is_none())
+            .map(|n| n.label)
+            .collect()
+    }
+
+    // === Part A: positive span→node assertions (pass today; real correctness) ===
+
+    /// GENERATOR: the source constructs that *do* map resolve to the right IR
+    /// node. `x * x` → the `Mul` BinOp; `max(...)` → `Aggregate(Max)`; the list
+    /// literals map to their `Lit` nodes.
+    #[test]
+    fn generator_mapped_spans_resolve_to_expected_nodes() {
+        let prog = compile(GENERATOR_SRC);
+        let snap = Snapshot::new(&prog);
+
+        // The `x * x` body → the arithmetic-mul BinOp (a mono clone of the
+        // generator body, which *does* carry the body span).
+        let mul = resolved_label(&snap, nth_span(GENERATOR_SRC, "x * x", 0));
+        assert!(
+            mul.contains("BinOp(Arithmetic(Mul))"),
+            "`x * x` → Mul BinOp; got {mul:?}"
+        );
+
+        // `max(squared(...))` → the Max aggregate.
+        let max = resolved_label(&snap, nth_span(GENERATOR_SRC, "max", 0));
+        assert!(max.contains("Aggregate(Max)"), "`max` → Max; got {max:?}");
+
+        // The list literals `1` and `2` map to their Lit nodes.
+        let lit1 = resolved_label(&snap, nth_span(GENERATOR_SRC, "1", 0));
+        assert!(lit1.contains("Lit(Int(1))"), "`1` → Lit; got {lit1:?}");
+        let lit2 = resolved_label(&snap, nth_span(GENERATOR_SRC, "2", 0));
+        assert!(lit2.contains("Lit(Int(2))"), "`2` → Lit; got {lit2:?}");
+
+        // The whole `[1, 2, 3, 4]` list literal (the argument of the
+        // monomorphized `squared(...)` call) maps to the `List` node. Span the
+        // elements, not the whole `[...]`: the `[` sits outside the lowered list
+        // span, so the elements' extent is what encloses to the `List`.
+        let list = resolved_label(&snap, nth_span(GENERATOR_SRC, "1, 2, 3, 4", 0));
+        assert!(list.contains("List"), "`[1, 2, 3, 4]` → List; got {list:?}");
+    }
+
+    /// DEFER: the source constructs that *do* map resolve to the right IR node.
+    /// `sum(readings)` → `Aggregate(Sum)`; `max(totals)` → `Aggregate(Max)`; the
+    /// `totals` use in `max(totals)` → `Var(totals)`; the readings list literals
+    /// map.
+    #[test]
+    fn defer_mapped_spans_resolve_to_expected_nodes() {
+        let prog = compile(DEFER_SRC);
+        let snap = Snapshot::new(&prog);
+
+        let sum = resolved_label(&snap, nth_span(DEFER_SRC, "sum", 0));
+        assert!(sum.contains("Aggregate(Sum)"), "`sum` → Sum; got {sum:?}");
+
+        let max = resolved_label(&snap, nth_span(DEFER_SRC, "max", 0));
+        assert!(max.contains("Aggregate(Max)"), "`max` → Max; got {max:?}");
+
+        // `totals` occurs 4×: the def (0), the two `<<` feeds (1, 2), and the
+        // `max(totals)` use (3). The last is the read whose span maps to Var.
+        let totals_use = resolved_label(&snap, nth_span(DEFER_SRC, "totals", 3));
+        assert!(
+            totals_use.contains("Var(totals)"),
+            "`totals` in `max(totals)` → Var(totals); got {totals_use:?}"
+        );
+
+        // The readings list literals map to Lit nodes.
+        let lit1 = resolved_label(&snap, nth_span(DEFER_SRC, "1", 0));
+        assert!(lit1.contains("Lit(Int(1))"), "`1` → Lit; got {lit1:?}");
+    }
+
+    // === Part B: coverage characterization (the debug view, regression-guarded) ===
+
+    /// GENERATOR coverage view. The mapped set includes the Part-A nodes, the
+    /// generator wrapper chain (`Lambda`/`Record`/`Compose`/`Var` from `yield`
+    /// channelization), and the `Let(__mono)` specialization wrapper.
+    ///
+    /// The wrapper chain (mono clones of the channelization plumbing) blames the
+    /// generator *body* span (`x * x`) it wraps — hovering any wrapper highlights
+    /// the body. The `Let(__mono)` specialization wrapper blames the whole `def`
+    /// via monomorphization's `(wrapper, generalized-let)` remap, since the
+    /// def-binding `Let` id is preserved through desugar.
+    ///
+    /// The DI feed chain (`Let(__floated)`, the `Apply`/`Proj`/`Var(__mono)`/
+    /// `Lit(Unit)` for *calling* the defer-mediating UDF) stays
+    /// `Synthetic(Desugar)` — internal plumbing the inspector hides, not a source
+    /// construct.
+    //
+    // IGNORED (genuine fork, not a flake): current desugar lowers this generator
+    // to a plain map whose wrapper nodes carry no source span, so the wrapper
+    // chain is not source-mapped and the assertions below no longer hold. Closing
+    // this needs the deferred desugar-lineage recording; do not touch it before.
+    #[ignore = "premise invalidated by current post-inference desugar shape (generator → plain Compose map, wrapper unmapped); needs deferred desugar-recorder provenance, out of scope"]
+    #[test]
+    fn generator_coverage_maps_wrapper_chain() {
+        let prog = compile(GENERATOR_SRC);
+        let panes = prog.materialize_panes();
+        let snap = Snapshot::from_parts(
+            &prog.source,
+            &prog.post_desugar_ir,
+            panes.post_desugar,
+            &prog.source_ast,
+        );
+        let (mapped, unmapped) = mapped_partition(&snap);
+
+        // Mapped set includes the Part-A nodes.
+        assert!(
+            mapped.iter().any(|l| l.contains("BinOp(Arithmetic(Mul))")),
+            "mapped includes the Mul BinOp; mapped={mapped:?}"
+        );
+        assert!(
+            mapped.iter().any(|l| l.contains("Aggregate(Max)")),
+            "mapped includes Max; mapped={mapped:?}"
+        );
+        assert!(
+            mapped.iter().filter(|l| l.contains("Lit(Int")).count() >= 4,
+            "mapped includes the 4 list literals; mapped={mapped:?}"
+        );
+
+        // The wrapper chain now carries spans (it inherited the generator-body
+        // blame through the Mono lineage), so the no-source-span unmapped
+        // subset is empty.
+        let untagged = untagged_unmapped(&snap);
+        assert_eq!(
+            untagged.len(),
+            0,
+            "no generator-wrapper node is left untagged; \
+             got {untagged:?}"
+        );
+        // The wrapper chain is now in the mapped set.
+        for needle in ["Lambda", "Record", "Compose"] {
+            assert!(
+                mapped.iter().any(|l| l.contains(needle)),
+                "mapped set includes the {needle} wrapper; mapped={mapped:?}"
+            );
+        }
+
+        // Positive resolve: a position inside the `def squared` body (`x * x`)
+        // resolves into the generator wrapper chain — the containment set at
+        // that span includes the synthesized `Compose`/`Lambda`/`Record`
+        // wrappers (they blame the body), tagged `via: Mono, nature: Expansion`.
+        let body = nth_span(GENERATOR_SRC, "x * x", 0);
+        let resolved = snap.resolve(body);
+        let labels: Vec<String> = resolved
+            .containment
+            .iter()
+            .map(|n| snap.expand(*n, 0).expect("node expands").label)
+            .collect();
+        assert!(
+            labels.iter().any(|l| l.contains("Compose")),
+            "the `x * x` body span resolves into the generator wrapper chain \
+             (Compose); containment labels={labels:?}"
+        );
+
+        // The `Let(__mono)` specialization wrapper maps to the whole `def`
+        // (monomorphization blames it on the preserved def-binding `Let`).
+        let mono = resolved_label(&snap, nth_span(GENERATOR_SRC, "def squared", 0));
+        assert!(
+            mono.contains("Let(__mono)"),
+            "`def squared` → the __mono specialization wrapper; got {mono:?}"
+        );
+
+        // The DI feed chain (for *calling* the defer-mediating UDF) stays
+        // unmapped by design — internal plumbing, not a source construct.
+        assert!(
+            unmapped.iter().any(|l| l.contains("Let(__floated)")),
+            "the DI feed chain stays in the unmapped set; unmapped={unmapped:?}"
+        );
+    }
+
+    /// DEFER coverage view. The mapped set includes the Part-A nodes **and** the
+    /// **`CollectionUnion` fan-in**.
+    ///
+    /// `CollectionUnion` is the node the `defer()`/`<<`/`for`-feed plumbing fans
+    /// into, tagged `via: Desugar, nature: Expansion`. Its fan-in record stores
+    /// each feed's pre-order id list and resolves to the *first* id that has a
+    /// span — the feed-value content the user wrote, as opposed to the feed
+    /// *wrapper* roots (a `λ __unused → V` lift, a `Compose` over the source)
+    /// whose own ids carry no span — so the union blames both feed sites
+    /// (`sum(readings)` and the `x` of `totals << x`) with non-empty origins.
+    ///
+    /// Distinct from the feed plumbing (`Lambda(__unused)`, the `Compose` over
+    /// the feed body), tagged `nature: Machinery`, which stays unmapped by
+    /// design.
+    // See `generator_coverage_maps_wrapper_chain`: the `CollectionUnion` fan-in is
+    // a post-desugar artifact, absent from the post-inference anchor. Retarget the
+    // walk/resolve to a snapshot anchored at the post-desugar stage.
+    #[test]
+    fn defer_coverage_maps_collection_union() {
+        let prog = compile(DEFER_SRC);
+        let panes = prog.materialize_panes();
+        let snap = Snapshot::from_parts(
+            &prog.source,
+            &prog.post_desugar_ir,
+            panes.post_desugar,
+            &prog.source_ast,
+        );
+        let (mapped, _unmapped) = mapped_partition(&snap);
+
+        // Mapped set includes the Part-A nodes.
+        assert!(
+            mapped.iter().any(|l| l.contains("Aggregate(Sum)")),
+            "mapped includes Sum; mapped={mapped:?}"
+        );
+        assert!(
+            mapped.iter().any(|l| l.contains("Aggregate(Max)")),
+            "mapped includes Max; mapped={mapped:?}"
+        );
+        assert!(
+            mapped.iter().any(|l| l.contains("Var(totals)")),
+            "mapped includes Var(totals); mapped={mapped:?}"
+        );
+        assert!(
+            mapped.iter().filter(|l| l.contains("Lit(Int")).count() >= 4,
+            "mapped includes the 4 readings literals; mapped={mapped:?}"
+        );
+
+        // Channelize's `feed_union` step blames the surviving fed-value roots
+        // (`sum(readings)` and the loop's `x`), so the `CollectionUnion` fan-in
+        // carries source spans — it is **mapped** (tagged `via: Desugar,
+        // nature: Expansion`), not left with empty origins.
+        assert!(
+            mapped.iter().any(|l| l.contains("CollectionUnion")),
+            "the CollectionUnion fan-in now carries the fed-value spans (mapped); \
+             mapped={mapped:?}"
+        );
+
+        // Invariant: every node carries *some* attribution — no node is left
+        // absent from the projection (a bare `None`). The fully-folded lineage
+        // leaves no node absent.
+        let untagged = untagged_unmapped(&snap);
+        assert_eq!(
+            untagged.len(),
+            0,
+            "no defer node is left untagged (absent from projection); got {untagged:?}"
+        );
+    }
+}

--- a/src/inspector_model/snapshot.rs
+++ b/src/inspector_model/snapshot.rs
@@ -1,0 +1,484 @@
+//! The `/api/snapshot` bulk payload — the whole read-only model in one
+//! struct, assembled by enumerating the snapshot's two indices.
+//!
+//! `/api/snapshot` is the primary read-only endpoint:
+//! source + the pipeline stages (each an IR tree + span→node index) + use→def
+//! definitions + per-scope bindings + diagnostics + meta. This module mirrors
+//! that JSON exactly as a serde-gated [`SnapshotPayload`]; the actual
+//! serialization (and `serde_json`) lives in the `cambra-inspector` crate.
+//! Building the payload is pure: it enumerates
+//! [`SpanIndex`](crate::inspector_model::SpanIndex) and
+//! [`NameBinderIndex`](crate::inspector_model::NameBinderIndex) (the enumeration
+//! methods added alongside their point queries) and builds each stage's IR tree
+//! via the shared `build_inspect_tree`.
+//!
+//! # Wire-type isolation
+//!
+//! Every type here carries `#[cfg_attr(feature = "serde", derive(Serialize))]`
+//! with camelCase field names (`spanIndex`, `useSpan`, `defSpan`,
+//! `snapshotKind`, …) to match the schema. `cambra` itself never compiles serde
+//! unless the feature is on — see the module-level note on
+//! [`inspector_model`](crate::inspector_model).
+//!
+//! # Populated vs. stubbed
+//!
+//! * `source`, `stages` (each with its own IR tree + span index),
+//!   `definitions`, `scopes`, `meta` — fully populated.
+//! * `diagnostics` — **always empty `[]`** in this payload: a `/api/snapshot`
+//!   describes a *successfully compiled* program, and there are no warnings. The
+//!   wire type ([`Diagnostic`]) drives the standalone compile-failure path
+//!   (`cambra-inspector::diagnose_json`); a failed compile instead flows
+//!   through [`SnapshotPayload::degraded`], which carries the same
+//!   diagnostics in place of a real snapshot (see `cambra-inspector::server`'s
+//!   "Transport decision" note).
+//! * `outline` — **omitted** from the payload. Rather than ship an empty stub
+//!   of an undecided shape, the field is left out until an `outline` query
+//!   exists.
+//! * `meta.tick` — `null` (the live seam); `snapshotKind` is `"post-inference"`,
+//!   `schema` is `3`.
+
+use crate::chl_parser::ast::Span;
+
+use super::name_binder::{Definition, ScopeRegion};
+use super::query::Snapshot;
+use super::stage::dense_edges;
+use crate::ccl::lineage::SourceProjection;
+use crate::ccl::{Expr, Type};
+use crate::pretty_tree::InspectNode;
+
+/// The current `/api/snapshot` wire-format version, emitted as `meta.schema` on
+/// both the success and degraded payloads. See [`Meta::schema`] for the
+/// versioning contract and the current version's field set.
+pub const SCHEMA_VERSION: u32 = 3;
+
+/// The `GET /api/snapshot` bulk payload — the whole static read-only model.
+///
+/// Field order/names mirror the schema. `outline` is intentionally absent (see
+/// the module note); `diagnostics` is always empty on the success path.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct SnapshotPayload {
+    /// The program's name + full source text.
+    pub source: SourceInfo,
+    /// Every resolved use→definition pair.
+    pub definitions: Vec<DefinitionEntry>,
+    /// Per-scope visible-binding lists.
+    pub scopes: Vec<ScopeEntry>,
+    /// Always empty on the success path (see the module doc's "Populated vs.
+    /// stubbed" section) — a failed compile carries real diagnostics through
+    /// [`SnapshotPayload::degraded`] instead.
+    pub diagnostics: Vec<Diagnostic>,
+    /// Snapshot metadata + the live-protocol seams.
+    pub meta: Meta,
+    /// The ordered pipeline stages (upstream → downstream), each carrying its
+    /// own IR tree + span index. The three stages
+    /// `["pre-inference", "post-inference", "post-desugar"]`.
+    pub stages: Vec<StageEntry>,
+    /// The dense node→node links between adjacent stages — each adjacent pane
+    /// pair's `LineageMap` shipped verbatim, self-edges included. One entry per
+    /// adjacent pair, in order: `{ from: "pre-inference", to: "post-inference" }`
+    /// (the monomorphization boundary) and `{ from: "post-inference", to:
+    /// "post-desugar" }` (the inline/desugar boundary).
+    pub pane_links: Vec<PaneLinkEntry>,
+}
+
+/// One IR pipeline stage in the multi-pane snapshot.
+///
+/// Carries its own self-contained IR tree and span index — each stage resolves
+/// against its own (`Expr`, `SourceProjection`) pair.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct StageEntry {
+    /// Stable machine id, e.g. `"pre-inference"`, `"post-inference"`,
+    /// `"post-desugar"`.
+    pub id: &'static str,
+    /// Human-readable label for the pane header.
+    pub label: &'static str,
+    /// Discriminant for the stage kind: `"holes"` for the still-hole-typed
+    /// pre-inference tree, `"typed"` for a fully-typed tree (post-inference and
+    /// post-desugar both).
+    pub kind: &'static str,
+    /// The full IR expand-tree for this stage.
+    pub ir: InspectNode,
+    /// Every `(span → nodeId)` entry of this stage's span index.
+    pub span_index: Vec<SpanEntry>,
+}
+
+/// The dense node→node links between two adjacent pipeline stages — the
+/// pane-pair [`LineageMap`](crate::ccl::lineage::LineageMap) shipped verbatim.
+///
+/// **Dense**: an id preserved unchanged across the phase appears as its own
+/// `[id, id]` self-edge, so the consumer follows edges only (no identity special
+/// case). Genuine identity changes (monomorphization / inline fan-out) are the
+/// `u != d` edges.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct PaneLinkEntry {
+    /// The upstream stage id, e.g. `"pre-inference"`.
+    pub from: &'static str,
+    /// The downstream stage id, e.g. `"post-inference"`.
+    pub to: &'static str,
+    /// Every edge as `(upstream_node_id, downstream_node_id)`, self-edges
+    /// included, sorted deterministically.
+    pub edges: Vec<(u64, u64)>,
+}
+
+/// `{ name, text }` — the program identity + source.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub struct SourceInfo {
+    /// A program name (a placeholder; the server can override it).
+    pub name: String,
+    /// The full source text.
+    pub text: String,
+}
+
+/// One `{ span, nodeId }` row of `spanIndex`.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct SpanEntry {
+    /// The origin span.
+    pub span: Span,
+    /// The node indexed under it.
+    pub node_id: crate::ccl::provenance::NodeId,
+}
+
+/// One `{ useSpan, defSpan, name }` row of `definitions`. The schema's optional
+/// `uid` is omitted — resolution is over the source AST, which keys on spans,
+/// not uniquify uids.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct DefinitionEntry {
+    /// The use-site span.
+    pub use_span: Span,
+    /// The binder's source span.
+    pub def_span: Span,
+    /// The bound name.
+    pub name: String,
+}
+
+/// One `{ span, bindings }` row of `scopes`. `nodeId` is omitted: scope regions
+/// are source-AST spans (the `NameBinderIndex` is source-level), not IR
+/// nodes, so there is no single node id to attach.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct ScopeEntry {
+    /// The region's source span.
+    pub span: Span,
+    /// The binders visible in the region, each joined with its type.
+    pub bindings: Vec<ScopeBindingEntry>,
+}
+
+/// One `{ name, defSpan, type }` binding inside a [`ScopeEntry`].
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct ScopeBindingEntry {
+    /// The bound name.
+    pub name: String,
+    /// The binder's source span.
+    pub def_span: Span,
+    /// The binder's type, joined through the `SpanIndex`. `None` (serializes as
+    /// `null`) when the def-span maps to no typed node — e.g. a substituted
+    /// multi-param parameter (the deferred substituted-parameter fix).
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
+    pub ty: Option<Type>,
+}
+
+/// A diagnostic entry.
+///
+/// The web half of the dual-use diagnostics: a [`CompileError`] rendered as
+/// structured JSON, the same error the terminal renders via ariadne. Built by
+/// [`Diagnostic::from_compile_error`] / [`diagnostics_from_compile_errors`].
+///
+/// `diagnostics` on [`SnapshotPayload`] stays `[]` for *successful* compiles
+/// (no warnings); these are produced on the compile-failure path by the
+/// standalone `diagnose_json` entry, not by `build_payload`.
+///
+/// [`CompileError`]: crate::ccl::context::CompileError
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Diagnostic {
+    /// Severity discriminant — `"error"` (no warnings).
+    pub severity: String,
+    /// The compile stage that produced it — `"parse"`, `"lower"`, `"infer"`, …
+    /// (the `CompileError` variant's stage).
+    pub stage: String,
+    /// The human-readable message (reuses the variant's rendered text).
+    pub message: String,
+    /// The primary source span, when one is known.
+    pub span: Option<Span>,
+    /// Labelled spans (one per pointed-at range). Empty when no span is known.
+    pub labels: Vec<DiagnosticLabel>,
+}
+
+/// A `{ span, message }` label inside a [`Diagnostic`].
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct DiagnosticLabel {
+    /// The source range this label points at.
+    pub span: Span,
+    /// The label text.
+    pub message: String,
+}
+
+impl Diagnostic {
+    /// Build a [`Diagnostic`] from a single [`CompileError`].
+    ///
+    /// Maps the variant to its stage string and reuses the variant's existing
+    /// rendered message. The infer path carries the span resolved at the
+    /// `compile_program` boundary (the dual-use payload); other variants
+    /// extract their span where it is cheaply reachable and otherwise degrade
+    /// to `span: None` — still a valid, renderable diagnostic.
+    ///
+    /// [`CompileError`]: crate::ccl::context::CompileError
+    pub fn from_compile_error(error: &crate::ccl::context::CompileError) -> Self {
+        use crate::ccl::context::CompileError;
+        let (stage, message, span) = match error {
+            CompileError::Parse(e) => ("parse", format!("{e:?}"), None),
+            CompileError::Lower(e) => ("lower", format!("{e:?}"), Some(e.span())),
+            CompileError::DesugarDefers(e) => ("desugarDefers", format!("{e:?}"), None),
+            CompileError::Infer { error, span } => ("infer", format!("{error:?}"), *span),
+            CompileError::LambdaElim(e) => ("lambdaElim", format!("{e:?}"), None),
+            CompileError::Conversion(e) => ("conversion", format!("{e:?}"), None),
+            CompileError::Unsupported(msg) => ("unsupported", msg.clone(), None),
+        };
+        let labels = span
+            .map(|span| {
+                vec![DiagnosticLabel {
+                    span,
+                    message: message.clone(),
+                }]
+            })
+            .unwrap_or_default();
+        Diagnostic {
+            severity: "error".to_string(),
+            stage: stage.to_string(),
+            message,
+            span,
+            labels,
+        }
+    }
+}
+
+/// Convert a slice of [`CompileError`](crate::ccl::context::CompileError)s into
+/// wire [`Diagnostic`]s — the dual-use JSON consumer of the same errors the
+/// terminal renders.
+pub fn diagnostics_from_compile_errors(
+    errors: &[crate::ccl::context::CompileError],
+) -> Vec<Diagnostic> {
+    errors.iter().map(Diagnostic::from_compile_error).collect()
+}
+
+/// `meta` — snapshot metadata + the forward-compat live seams.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Meta {
+    /// Live seam: the engine tick — **always `null`** here ("the program, no
+    /// execution"). A live snapshot carries a real tick.
+    pub tick: Option<u64>,
+    /// The snapshot kind discriminant — `"post-inference"` for a successful
+    /// compile, `"failed"` for a degraded (compile-error) payload.
+    pub snapshot_kind: String,
+    /// The wire-format version. A client reads this to detect an incompatible
+    /// payload before parsing the rest.
+    ///
+    /// **Schema 3** is the field set of [`SnapshotPayload`] documented on that
+    /// type (`source`, `definitions`, `scopes`, `diagnostics`, `meta`, `stages`,
+    /// `paneLinks`), with the live seams (`meta.tick`, value summaries) always
+    /// null. Each `stages[].ir` node carries its native attribution: the spans
+    /// channel on the `span` field plus a `rewritten` tag
+    /// (`null | { via, nature, label }`). `paneLinks` ships each adjacent pane
+    /// pair's `LineageMap` **dense** (self-edges included), so the consumer
+    /// follows edges only. There are three stages / two windows.
+    ///
+    /// **Bump the version** on any *breaking* wire change — a field removed,
+    /// renamed, or retyped, or a value-shape change an old client would
+    /// misread. Purely *additive* optional fields do **not** bump it (an old
+    /// client ignores them). The frontend pins this in its wire-shape contract
+    /// test, so a bump is a deliberate, reviewed event on both sides.
+    pub schema: u32,
+}
+
+/// Build the IR expand-tree and span-index entries for one pipeline stage.
+///
+/// Parameterized by `(Expr, SourceProjection)` so every stage goes through the same
+/// shared path: the tree via [`build_inspect_tree`] (the single source-linking
+/// tree-builder) and the index via [`SpanIndex::build`].
+fn build_stage_ir_and_index(
+    ir: &Expr,
+    projection: &SourceProjection,
+) -> (InspectNode, Vec<SpanEntry>) {
+    use super::index::SpanIndex;
+    use super::query::{build_inspect_tree, tree_height};
+
+    let span_entries = SpanIndex::build(ir, projection)
+        .entries()
+        .map(|(span, node_id)| SpanEntry { span, node_id })
+        .collect();
+
+    // Expand the full IR tree (ship-everything: descend to max depth).
+    let ir_node = build_inspect_tree(ir, projection, tree_height(ir));
+
+    (ir_node, span_entries)
+}
+
+impl Snapshot<'_> {
+    /// Assemble the `/api/snapshot` bulk payload by enumerating the indices.
+    ///
+    /// `name` is the program name for `source.name` (a placeholder; the server
+    /// picks it). Every other field is derived purely from the snapshot:
+    ///
+    /// * `stages` — the pipeline stages in upstream → downstream order:
+    ///   `"pre-inference"`, `"post-inference"`, `"post-desugar"`, each with its
+    ///   own IR tree + span index.
+    /// * `paneLinks` — per consecutive stage pair, the dense edges of the
+    ///   pane-pair `LineageMap` folded at that boundary, self-edges included (see
+    ///   [`dense_edges`](super::stage::dense_edges)).
+    /// * `definitions` — [`NameBinderIndex::definitions`](crate::inspector_model::NameBinderIndex::definitions).
+    /// * `scopes` — [`NameBinderIndex::scopes`](crate::inspector_model::NameBinderIndex::scopes),
+    ///   each binding's `type` joined via [`Snapshot::type_of`] on its def-span.
+    /// * `diagnostics` — empty.
+    /// * `meta` — `tick: None`, `snapshotKind: "post-inference"`, `schema: 3`.
+    pub fn build_payload(&self, name: impl Into<String>) -> SnapshotPayload {
+        let source = SourceInfo {
+            name: name.into(),
+            text: self.source_text().to_string(),
+        };
+
+        let definitions = self
+            .name_binder_ref()
+            .definitions()
+            .into_iter()
+            .map(
+                |Definition {
+                     use_span,
+                     def_span,
+                     name,
+                 }| DefinitionEntry {
+                    use_span,
+                    def_span,
+                    name: name.to_string(),
+                },
+            )
+            .collect();
+
+        let scopes = self
+            .name_binder_ref()
+            .scopes()
+            .into_iter()
+            .map(|ScopeRegion { span, bindings }| ScopeEntry {
+                span,
+                bindings: bindings
+                    .into_iter()
+                    .map(|b| ScopeBindingEntry {
+                        // Join the binder's type by resolving its def-span
+                        // through the SpanIndex (None for a substituted param).
+                        ty: self.type_of(b.def_span),
+                        name: b.name.to_string(),
+                        def_span: b.def_span,
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        // Build the pipeline stages (upstream → downstream) from the bundled
+        // stage projections — each ships its own IR tree + span index.
+        let stages = self
+            .stages()
+            .iter()
+            .map(|stage| {
+                let (ir, span_index) = build_stage_ir_and_index(stage.ir, &stage.projection);
+                StageEntry {
+                    id: stage.id,
+                    label: stage.label,
+                    kind: stage.kind,
+                    ir,
+                    span_index,
+                }
+            })
+            .collect();
+
+        // Dense edges between each consecutive stage pair, read off the pane-pair
+        // `LineageMap` folded at that boundary (aligned with the same
+        // `windows(2)`). `dense_edges` ships every edge — self-edges included —
+        // already sorted for a byte-reproducible payload; the frontend follows
+        // edges only, with no identity special case.
+        let stage_maps = self.stage_maps();
+        let pane_links = self
+            .stages()
+            .windows(2)
+            .zip(stage_maps)
+            .map(|(pair, map)| {
+                let (upstream, downstream) = (&pair[0], &pair[1]);
+                PaneLinkEntry {
+                    from: upstream.id,
+                    to: downstream.id,
+                    edges: dense_edges(map),
+                }
+            })
+            .collect();
+
+        SnapshotPayload {
+            source,
+            definitions,
+            scopes,
+            diagnostics: Vec::new(),
+            meta: Meta {
+                tick: None,
+                snapshot_kind: "post-inference".to_string(),
+                schema: SCHEMA_VERSION,
+            },
+            stages,
+            pane_links,
+        }
+    }
+}
+
+impl SnapshotPayload {
+    /// The degraded `/api/snapshot` payload for a program that failed to
+    /// compile: the source text + the structured diagnostics, with no typed IR.
+    ///
+    /// Built from the **same** [`SnapshotPayload`] type as the success path
+    /// (rather than a separately hand-rolled JSON object), so the two shapes
+    /// cannot silently diverge as the schema evolves — the `stages`/scope
+    /// collections are empty and `meta.snapshotKind` is `"failed"`. The frontend
+    /// still renders the editor + squiggles from this.
+    ///
+    /// TODO(degraded-stages): emit whatever pipeline stages *did* complete — if
+    /// desugaring succeeds and only inference fails, we can still ship the
+    /// post-desugar `stages[]` entry so the inspector visualizes the desugared
+    /// IR. Today every degraded payload ships empty `stages`/`paneLinks`
+    /// regardless of where the failure occurred.
+    pub fn degraded(
+        name: impl Into<String>,
+        text: impl Into<String>,
+        diagnostics: Vec<Diagnostic>,
+    ) -> SnapshotPayload {
+        SnapshotPayload {
+            source: SourceInfo {
+                name: name.into(),
+                text: text.into(),
+            },
+            definitions: Vec::new(),
+            scopes: Vec::new(),
+            diagnostics,
+            meta: Meta {
+                tick: None,
+                snapshot_kind: "failed".to_string(),
+                schema: SCHEMA_VERSION,
+            },
+            stages: Vec::new(),
+            pane_links: Vec::new(),
+        }
+    }
+}

--- a/src/inspector_model/stage.rs
+++ b/src/inspector_model/stage.rs
@@ -1,0 +1,149 @@
+//! Pane-pair node→node links (the lineage map).
+//!
+//! The multi-pane inspector shows several pipeline stages side by side (CHL
+//! source, pre-inference IR, post-inference IR, post-desugar IR, …) and links a
+//! node in one pane to the node(s) it came from / became in the adjacent panes.
+//! That link is the true lineage chain.
+//!
+//! The link is a [`LineageMap<NodeId, NodeId>`] folded at the pane boundary by
+//! [`collapse`](crate::ccl::lineage::collapse) — one per adjacent pane pair,
+//! materialized on [`CompiledProgram`](crate::ccl::context::CompiledProgram) via
+//! `materialize_panes`. The map is **dense**: every id that survived the phase
+//! is its own self-edge. Schema 3 ships the map **verbatim** — self-edges
+//! included — so the frontend follows edges only (no identity special case); a
+//! surviving node's cross-pane link is the shipped `[id, id]` self-edge, and a
+//! genuine identity *change* (monomorphization / inline fan-out, channelize's
+//! cluster/fan-in copies) is a `u != d` edge.
+
+use crate::ccl::lineage::LineageMap;
+use crate::ccl::provenance::NodeId;
+
+/// Every edge of a pane-pair [`LineageMap`], as `(upstream, downstream)` `u64`
+/// pairs — **dense**: self-edges (`u == d`, a node preserved across the phase)
+/// are kept, so the frontend needs no identity special case.
+///
+/// [`LineageMap::edges`] already yields sorted, deduplicated edges (the dense
+/// self-edges among them); this only projects the `NodeId`s to their wire `u64`.
+pub fn dense_edges(map: &LineageMap<NodeId, NodeId>) -> Vec<(u64, u64)> {
+    map.edges()
+        .into_iter()
+        .map(|(u, d)| (u.as_u64(), d.as_u64()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccl::context::{CompiledProgram, GlobalContext, compile_program};
+    use crate::interpreter::Consumer;
+
+    fn compile(code: &str) -> CompiledProgram {
+        let mut ctx = GlobalContext::default();
+        let consumer: Box<dyn Consumer> = Box::new(|| {});
+        compile_program(&mut ctx, code, consumer).expect("program compiles")
+    }
+
+    /// A let-polymorphic def used at two types fans out: the pre-inference →
+    /// post-inference map (folded from the `Pass::Mono` lineage log) is dense —
+    /// surviving nodes carry `[id, id]` self-edges — and at least one upstream
+    /// node fans out to ≥2 distinct downstream nodes (the specialization
+    /// clones), a genuine `u != d` identity change.
+    #[test]
+    fn mono_fanout_links_upstream_def_to_downstream_clones() {
+        let code = "\
+dup = \\x -> (x, x)
+a = dup(1)
+b = dup(2 == 2)
+a
+";
+        let prog = compile(code);
+        let panes = prog.materialize_panes();
+        let edges = dense_edges(&panes.mono_map);
+
+        assert!(!edges.is_empty(), "the pane-pair map has edges");
+        assert!(
+            edges.iter().any(|(u, d)| u == d),
+            "the dense map ships self-edges for nodes preserved across the phase"
+        );
+
+        // At least one upstream node fans out to ≥2 distinct downstream nodes
+        // (dup used at Int and Bool) — counting only the genuine identity
+        // changes, not the self-edges.
+        let mut fanout: std::collections::HashMap<u64, usize> = std::collections::HashMap::new();
+        for (u, d) in &edges {
+            if u != d {
+                *fanout.entry(*u).or_default() += 1;
+            }
+        }
+        assert!(
+            fanout.values().any(|&n| n >= 2),
+            "dup used at two types should fan out to ≥2 downstream nodes; edges={edges:?}"
+        );
+    }
+
+    /// A two-site inline fan-out surfaces as non-identity edges on the
+    /// post-inference → post-desugar map, each edge's upstream a post-inference
+    /// node and downstream a post-desugar node.
+    #[test]
+    fn inline_fanout_links_post_inference_to_post_desugar_copies() {
+        let code = "\
+add1 = \\x -> x + 1
+a = add1(10)
+b = add1(20)
+a + b
+";
+        let prog = compile(code);
+        let panes = prog.materialize_panes();
+        let edges = dense_edges(&panes.desugar_map);
+
+        fn ids(e: &crate::ccl::Expr) -> std::collections::HashSet<u64> {
+            let mut s = std::collections::HashSet::new();
+            fn go(e: &crate::ccl::Expr, s: &mut std::collections::HashSet<u64>) {
+                s.insert(e.node_id().as_u64());
+                e.walk_children(|c| go(c, s));
+            }
+            go(e, &mut s);
+            s
+        }
+        let up_ids = ids(&prog.post_inference_ir);
+        let down_ids = ids(&prog.post_desugar_ir);
+        assert!(
+            !edges.is_empty(),
+            "a two-site inline fan-out must produce non-identity stage edges"
+        );
+        for (u, d) in &edges {
+            assert!(
+                up_ids.contains(u),
+                "edge upstream id {u} must be a node in the post-inference tree"
+            );
+            assert!(
+                down_ids.contains(d),
+                "edge downstream id {d} must be a node in the post-desugar tree"
+            );
+        }
+    }
+
+    /// A monomorphic program's mono boundary is identity-only: the dense map has
+    /// edges (the surviving nodes' self-edges), and every one is a self-edge —
+    /// no genuine identity change.
+    #[test]
+    fn monomorphic_program_mono_map_is_identity_only() {
+        let code = "\
+x = 1 + 2
+x
+";
+        let prog = compile(code);
+        let panes = prog.materialize_panes();
+        let edges = dense_edges(&panes.mono_map);
+        assert!(
+            !edges.is_empty(),
+            "a compiled program has surviving nodes, hence dense self-edges"
+        );
+        for (u, d) in &edges {
+            assert_eq!(
+                u, d,
+                "a monomorphic program's mono map ships only self-edges"
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod ccl;
 pub mod chl_parser;
+pub mod inspector_model;
 pub mod interpreter;
 pub mod pretty_graph;
 pub mod pretty_tree;

--- a/src/pretty_tree.rs
+++ b/src/pretty_tree.rs
@@ -12,6 +12,26 @@
 //! This module has no dependencies on interpreter or domain types — it is
 //! purely a tree renderer used by [`crate::pretty_graph`].
 
+/// A node's rewrite tag — the native per-node attribution the inspector wire
+/// carries in place of the old flat provenance string. `None` on an
+/// [`InspectNode`] means the node was directly lowered (a source construct's
+/// image); `Some` means a pass rewrote it, tagged with how.
+///
+/// Stored as plain `String`s to keep `pretty_tree` free of any `ccl`/domain-type
+/// dependency (the module's standing invariant): the inspector query layer
+/// converts the `ccl::lineage::RewriteTag` (`Pass`/`Nature`/label) into these.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub struct RewriteInfo {
+    /// The pass that performed the rewrite (the `Pass` debug name, e.g. `"Mono"`).
+    pub via: String,
+    /// `"expansion"` (faithful expansion of a user construct) or `"machinery"`
+    /// (pure plumbing) — the lowercase `Nature` discriminant.
+    pub nature: String,
+    /// The rewrite's stable label, e.g. `"channelize.feed_union"`.
+    pub label: String,
+}
+
 // Box-drawing connector strings, used by render_node.
 const CONNECTOR_LAST: &str = "└── ";
 const CONNECTOR_MID: &str = "├── ";
@@ -40,6 +60,35 @@ pub struct InspectNode {
     pub intent_guard: Option<String>,
     /// Children with optional edge labels, e.g. ("left", child_desc)
     pub children: Vec<(String, InspectNode)>,
+
+    // --- Inspector source-linking fields (added for `expand`) ---
+    //
+    // These extend the tree node additively so the inspector's `expand` query
+    // can cross-link a tree row to source + types + provenance, while the CLI
+    // Unicode renderer and the existing `to_json` shape stay unaffected (all
+    // `None`/absent for the non-inspector callers in `pretty_graph` etc.).
+    //
+    // Stored as primitives — `u64` node id, `(start, end)` byte span — to keep
+    // `pretty_tree` free of any `ccl`/domain-type dependency (the module's
+    // standing invariant: it is a pure tree renderer). The inspector query layer
+    // converts its `NodeId`/`Span`/`Type` into these.
+    /// The IR node's stable id (its `NodeId` as a wire number), if this row
+    /// corresponds to an IR node.
+    pub node_id: Option<u64>,
+    /// The node's primary source span `(start, end)` (byte offsets), if known.
+    pub span: Option<(usize, usize)>,
+    /// The node's rewrite tag (`via`/`nature`/`label`) when a pass produced it;
+    /// `None` for a directly-lowered source node. The spans channel of the
+    /// node's attribution rides the `span` field above.
+    pub rewritten: Option<RewriteInfo>,
+    /// The node's type as a Display string (e.g. `"Int"`, `"(Int ⇒ Int)"`, or a
+    /// hole `"_"`/`"?N"` pre-inference), if this row corresponds to a typed IR
+    /// node. A dedicated field rather than a positional `annotations[0]` entry:
+    /// the type is a first-class wire field (`"type"`), not smuggled into the
+    /// free-form annotation list, so a consumer reads `node.type` directly. The
+    /// string is CCL's canonical type rendering (`Display for Type`), so any
+    /// change there changes this verbatim — see `crate::ccl::Type`.
+    pub ty: Option<String>,
 }
 
 impl InspectNode {
@@ -53,6 +102,10 @@ impl InspectNode {
             obsolete_guard: None,
             intent_guard: None,
             children: Vec::new(),
+            node_id: None,
+            span: None,
+            rewritten: None,
+            ty: None,
         }
     }
 
@@ -97,6 +150,30 @@ impl InspectNode {
         self
     }
 
+    /// Set the inspector node id (wire number). Additive — see the field docs.
+    pub fn with_node_id(mut self, id: u64) -> Self {
+        self.node_id = Some(id);
+        self
+    }
+
+    /// Set the inspector source span `(start, end)`. Additive.
+    pub fn with_node_span(mut self, span: (usize, usize)) -> Self {
+        self.span = Some(span);
+        self
+    }
+
+    /// Set the node's type (a CCL `Display` string). Additive — see the field docs.
+    pub fn with_type(mut self, ty: impl Into<String>) -> Self {
+        self.ty = Some(ty.into());
+        self
+    }
+
+    /// Set the inspector rewrite tag. Additive — see the field docs.
+    pub fn with_rewritten(mut self, rewritten: RewriteInfo) -> Self {
+        self.rewritten = Some(rewritten);
+        self
+    }
+
     /// Serialize this node tree to a JSON string without serde.
     ///
     /// Field names mirror the Rust struct fields. `None` guard fields are
@@ -122,6 +199,25 @@ impl InspectNode {
 
         let mut json = format!("{{\"label\":\"{}\"", escape_json(&self.label));
         json.push_str(&format!(",\"annotations\":[{}]", ann_strs.join(",")));
+        // Inspector source-linking fields: emitted only when present, so
+        // non-inspector callers' JSON is unchanged.
+        if let Some(id) = self.node_id {
+            json.push_str(&format!(",\"node_id\":{id}"));
+        }
+        if let Some((start, end)) = self.span {
+            json.push_str(&format!(",\"span\":{{\"start\":{start},\"end\":{end}}}"));
+        }
+        if let Some(ref r) = self.rewritten {
+            json.push_str(&format!(
+                ",\"rewritten\":{{\"via\":\"{}\",\"nature\":\"{}\",\"label\":\"{}\"}}",
+                escape_json(&r.via),
+                escape_json(&r.nature),
+                escape_json(&r.label),
+            ));
+        }
+        if let Some(ref t) = self.ty {
+            json.push_str(&format!(",\"type\":\"{}\"", escape_json(t)));
+        }
         if let Some(ref t) = self.tiling {
             json.push_str(&format!(",\"tiling\":\"{}\"", escape_json(t)));
         }
@@ -136,6 +232,60 @@ impl InspectNode {
         }
         json.push_str(&format!(",\"children\":[{}]}}", children_strs.join(",")));
         json
+    }
+}
+
+// Wire shape (inspector, feature `serde`): the `expand`-node / `ir`-root shape
+// the cambra-inspector `/api/snapshot` payload uses. Field names are camelCase
+// (`nodeId`) and children serialize as `{ "edge": "...", "node": { ... } }`
+// pairs. Hand-written (not derived) for that `{edge,node}` child reshaping and
+// the `nodeId` key.
+//
+// This is a DISTINCT wire from the hand-rolled [`InspectNode::to_json`] above
+// (the legacy `web_inspector` dashboard): that shape uses snake_case `node_id`,
+// omits `None` fields, and carries the tile-producer runtime fields
+// (`yield_guard`/`obsolete_guard`/`intent_guard`) that this one drops. The two
+// feed different frontends and are not kept byte-identical.
+#[cfg(feature = "serde")]
+impl serde::Serialize for InspectNode {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        /// A `{ "edge", "node" }` child pair, serialized to mirror `to_json`.
+        struct Child<'a>(&'a str, &'a InspectNode);
+        impl serde::Serialize for Child<'_> {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                let mut s = serializer.serialize_struct("Child", 2)?;
+                s.serialize_field("edge", self.0)?;
+                s.serialize_field("node", self.1)?;
+                s.end()
+            }
+        }
+
+        /// `{ "start", "end" }`, matching the `Span` wire shape.
+        #[derive(serde::Serialize)]
+        struct WireSpan {
+            start: usize,
+            end: usize,
+        }
+
+        let children: Vec<Child<'_>> = self
+            .children
+            .iter()
+            .map(|(edge, node)| Child(edge, node))
+            .collect();
+        let span = self.span.map(|(start, end)| WireSpan { start, end });
+
+        let mut s = serializer.serialize_struct("InspectNode", 8)?;
+        s.serialize_field("label", &self.label)?;
+        s.serialize_field("annotations", &self.annotations)?;
+        s.serialize_field("nodeId", &self.node_id)?;
+        s.serialize_field("span", &span)?;
+        s.serialize_field("rewritten", &self.rewritten)?;
+        s.serialize_field("type", &self.ty)?;
+        s.serialize_field("tiling", &self.tiling)?;
+        s.serialize_field("children", &children)?;
+        s.end()
     }
 }
 


### PR DESCRIPTION
The in-crate model that builds the `/api/snapshot` payload from a `CompiledProgram`, plus the wire schema (version 3) the frontend consumes.

**Start here:** `src/inspector_model/mod.rs` for the shape; `src/inspector_model/snapshot.rs` for the serializer.

The payload draws from `CompiledProgram`:

- the retained pre-inference / post-inference / post-desugar panes, and the source pane.
- per-pane `SpanIndex` — span → node point lookups for hover/resolve/scope-at.
- the `NameBinderIndex` over the surface AST — goto-definition for the source variables lowering destroys.
- `diagnostics_from_compile_errors` — one error model, two renderers.
- the snapshot serializer.

Pane provenance comes from `CompiledProgram::materialize_panes`: each pane node carries its `SourceAttribution` natively on the wire (`{spans, rewritten: null | {via, nature, label}}`), and each adjacent pane pair ships its `LineageMap` verbatim as dense `paneLinks` (self-edges included, no frontend identity special-case). `SCHEMA_VERSION = 3`; the test validator checks per-pane endpoint liveness, the `rewritten` shape, and the `ALLOWED_VIA` pass vocabulary.

`pretty_tree` renders the inspector tree labels; its `RewriteInfo` duplicates the `{via, nature, label}` tag as strings to preserve the module no-ccl-dependency invariant (`Nature::wire_str` in `lineage.rs` is the single lowercase-discriminant source).