### PR TITLE
build: provision rust-analyzer and rust-src via rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.97.0"
-components = ["clippy", "rustfmt"]
+components = ["clippy", "rustfmt", "rust-analyzer", "rust-src"]


### PR DESCRIPTION
## Motivation

rust-analyzer repeatedly fails to start in editors while working in this repo,
breaking go-to-definition, find-references, and the rest of the LSP surface.

`~/.cargo/bin/rust-analyzer` is a **rustup proxy**, not a real binary: it
dispatches to whichever toolchain is active for the current directory. This
repo pins `channel = "1.97.0"` in `rust-toolchain.toml`, but the
`rust-analyzer` component was only ever installed into the default `stable`
toolchain. Inside the repo the proxy therefore resolves to `1.97.0`, finds no
such component, and exits:

```
error: Unknown binary 'rust-analyzer' in official toolchain '1.97.0-x86_64-unknown-linux-gnu'.
```

The editor's LSP client then reports rust-analyzer as failed. `rust-src` shares
the same failure mode, more subtly: without it rust-analyzer cannot analyze
`std`, so lookups into standard-library types silently fail even when the server
starts.

## Change

Add `rust-analyzer` and `rust-src` to the `components` list. rustup
auto-installs the components declared here whenever it materializes the
toolchain, so a fresh clone — or a future channel bump — provisions a working
LSP automatically, instead of leaving each developer to discover the missing
component and run `rustup component add` by hand.

## Findings — no CI cost

CI is unaffected by this change:

- The GitHub workflow provisions Rust via `dtolnay/rust-toolchain` with an
  explicit `components: rustfmt, clippy` input. That action installs the
  components named in its input; it does **not** read the component list from
  `rust-toolchain.toml`.
- `Swatinem/rust-cache` caches `~/.cargo` and `target/`, but not
  `~/.rustup`, so the toolchain is reinstalled on every code-changing run —
  again, only with the components named in the workflow input.

The two added components therefore install only in local, rustup-driven
environments. CI never downloads or invokes them.
