### PR TITLE
CLAUDE.md: author commit descriptions as Markdown (they become PR bodies)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,20 +162,17 @@ When you are using compact, focus on test output and code changes.
 
 ### Commit descriptions are PR bodies — author them as Markdown
 
-PRs here are created with `gh pr create --fill` (see `jjstack`/`jjpr`), so the
-PR body is the commit description *verbatim*, and because the repo
-squash-merges the PR body becomes the `main` commit message. GitHub renders
-that body as GitHub-Flavored Markdown, where a single newline inside a
-paragraph becomes a hard line break. So write commit descriptions as Markdown,
-not as traditional column-wrapped git prose:
+PRs here are often created with `gh pr create --fill`, so the
+PR body is the commit description *verbatim*, the PR body squashes to become
+the `main` commit message. GitHub renders that body as GitHub-Flavored Markdown,
+so write commit descriptions as Markdown,not as traditional column-wrapped git prose:
 
 - **Do not hard-wrap inside a paragraph.** Let each paragraph be one
   soft-wrapped line and separate paragraphs with a blank line — otherwise every
-  wrap point renders as a ragged `<br>` on GitHub. (This is the one deliberate
-  tradeoff: `git log`/`jj log` bodies show long lines rather than 72-col wraps.)
+  wrap point renders as a ragged `<br>` on GitHub.
 - **Backtick every code construct** — type/identifier names, file paths,
   field and flag names (`` `CompiledProgram` ``, `` `dead_code` ``,
-  `` `src/ccl/lineage.rs` ``). Bare identifiers otherwise render as prose.
+  `` `src/ccl/lineage.rs` ``).
 - Use real Markdown for structure where it helps: `-` bullet lists for
   enumerations, blank lines between paragraphs.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,25 @@ When you are using compact, focus on test output and code changes.
    1. `git fetch origin`
    2. `git log master..origin/master --pretty=format:"%h%x09%an%x09%ad%x09%s"| head -n 20`
 
+### Commit descriptions are PR bodies — author them as Markdown
+
+PRs here are created with `gh pr create --fill` (see `jjstack`/`jjpr`), so the
+PR body is the commit description *verbatim*, and because the repo
+squash-merges the PR body becomes the `main` commit message. GitHub renders
+that body as GitHub-Flavored Markdown, where a single newline inside a
+paragraph becomes a hard line break. So write commit descriptions as Markdown,
+not as traditional column-wrapped git prose:
+
+- **Do not hard-wrap inside a paragraph.** Let each paragraph be one
+  soft-wrapped line and separate paragraphs with a blank line — otherwise every
+  wrap point renders as a ragged `<br>` on GitHub. (This is the one deliberate
+  tradeoff: `git log`/`jj log` bodies show long lines rather than 72-col wraps.)
+- **Backtick every code construct** — type/identifier names, file paths,
+  field and flag names (`` `CompiledProgram` ``, `` `dead_code` ``,
+  `` `src/ccl/lineage.rs` ``). Bare identifiers otherwise render as prose.
+- Use real Markdown for structure where it helps: `-` bullet lists for
+  enumerations, blank lines between paragraphs.
+
 ### Updating PR descriptions
 
 `gh pr edit --body` fails with exit code 1 due to a Projects (classic) deprecation warning, even when the body update would otherwise succeed. Use the REST API instead:


### PR DESCRIPTION
PRs are often created with the commit description as the PR body verbatim, and since the repo squash-merges it becomes the `main` commit message. GitHub renders that body as GitHub-Flavored Markdown, where a single newline inside a paragraph becomes a hard line break — so column-wrapped git prose renders as ragged lines and bare identifiers render as plain text.

Add a Git Conventions subsection instructing that commit descriptions be authored as Markdown: no hard wraps inside a paragraph (blank line between paragraphs), backticks around every code construct, and real Markdown for structural lists.
