### PR TITLE
CHL lambdas: replace `lambda x: body` with `\x -> body`

### DIFF
--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -130,7 +130,7 @@ True   False  None
 and    or     not
 if     elif   else
 for    in
-def    lambda return yield
+def    return yield
 with
 pass
 ```
@@ -138,8 +138,10 @@ pass
 `with` is a keyword: it introduces a transaction block, `with begin():`
 (§8.2). It does **not** carry Python's general context-manager meaning.
 
+A lambda is written `\x -> body` (§3.10); `\` and `->` are punctuation
+(§1.8), not keywords, so `lambda` is an ordinary identifier — it, along with
 `while`, `class`, `import`, `try`, `except`, `as`, `global`, `nonlocal`,
-`del`, `assert`, `raise`, `is` are **not** keywords in CHL today. Some are
+`del`, `assert`, `raise`, `is`, are **not** keywords in CHL today. Some are
 reserved for future use.
 
 > **Direction.** Planned binder/keyword vocabulary, not lexed today:
@@ -167,13 +169,13 @@ surface level.
 ### 1.8 Operators and punctuation
 
 ```
-+  -  *  //  ++
++  -  *  //  ++  ->
 &  |  ^
 == != <  <= >  >=
 =  += -= *= //=
 :=
 <<  <<=
-(  )  [  ]  {  }  ,  :  .  ;
+(  )  [  ]  {  }  ,  :  .  ;  \
 ```
 
 `:=` is the **mutation** operator (§4.3, §8.1) — it introduces and writes
@@ -189,13 +191,13 @@ parsing-then-erroring.
 `++` is not a Python token at all: it is CHL's collection-union operator
 (§3.3). There is no increment operator — `++` is always binary.
 
-> **Direction.** Tokens not lexed today **[Decided]**: `\` and `->` for
-> lambdas (§3.10), and `->` doubling as the pair / map-entry arrow (§2.4).
-> CHL surface syntax is **ASCII-only**: earlier sketches used `λ`/`→`/`↦`,
-> and those are dropped — non-ASCII source is a usability hazard, and dual
-> spellings fork a corpus into two dialects. (The CCL *symbolic rendering*
-> in design docs keeps its mathematical notation; that is documentation,
-> not source.)
+`\` introduces a lambda binder and `->` separates it from the body —
+`\x -> body` (§3.10).
+
+> **Direction.** `->` additionally becomes the pair / map-entry arrow
+> (`a -> b` for a two-tuple, `[k -> v, …]` for a map literal — §2.4,
+> **[Decided]**); the token is lexed today but that *use* is not yet
+> parsed.
 
 ### 1.9 Semicolons
 
@@ -308,7 +310,7 @@ noted:
 
 | Level | Operator(s) | Notes |
 |---:|---|---|
-| 1 | `lambda`, `yield` | prefix forms; non-associative |
+| 1 | `\x -> …` (lambda), `yield` | prefix forms; non-associative |
 | 2 | `<<` | feed operator (right-associative is not meaningful — see §3.7) |
 | 3 | `e₁ if cond else e₂` | ternary; *right*-associative |
 | 4 | `or` | short-circuit; n-ary flattening |
@@ -770,34 +772,29 @@ value type — so subscript and attribute access are uniformly
 ### 3.10 Lambda
 
 ```
-lambda x: body
-lambda x, y, z: body
-lambda x: T, y: U: body          -- typed parameters [Planned]
-lambda: body                     -- zero-arity
+\x -> body
+\x, y, z -> body
+\x: T -> body                    -- typed parameters [Planned]
+\ -> body                        -- zero-arity
 ```
 
-A lambda denotes an anonymous function value. Applying the lambda to
-a tuple of argument values gives the value of `body` in an environment
-where each parameter is bound to its corresponding argument
-positionally.
+`\` introduces the binders and `->` separates them from the body — e.g.
+`groupby(sales, \r -> r.region)`. A lambda denotes an anonymous function
+value; applying it to a tuple of argument values gives the value of `body`
+in an environment where each parameter is bound to its corresponding
+argument positionally.
 
 Like `def`-defined functions (§4.1), lambdas are uncurried: an n-arg
 lambda consumes all n arguments at once and is invoked through an
 n-arg call.
 
-Annotated lambda parameters mirror `def` parameters (§4.1). Refinement
-annotations are not yet writable in the surface syntax; some built-ins
-(e.g. `groupby`, §7.2) produce refined lambdas internally.
-
-> **Direction — `\x -> body` [Decided].** Python's `lambda x: body`
-> is retired in favour of `\x -> body`
-> (2026-06-29 §1, ASCII
-> revision 2026-07): `\` binds the parameter, `->` separates the body
-> — e.g. `groupby(sales, \r -> r.region)` — and `:` in a lambda head
-> is freed for its annotation role (`\x: T -> body`). An earlier
-> sketch made Unicode `λ x → body` primary; CHL is ASCII-only (§1.8).
-> `\x -> x -> 1` (a lambda returning a pair, §2.4) is unusual but
-> unambiguous — the first `->` closes the binder, the rest is body.
+Parameters are bare identifiers today. Because `->` (not `:`) terminates
+the binder list, `:` is free for a per-parameter annotation `\x: T -> body`
+(**[Planned]** — not yet parsed); refinement annotations are likewise not
+writable, though some built-ins (e.g. `groupby`, §7.2) produce refined
+lambdas internally. `\x -> x -> 1` (a lambda returning a pair, §2.4) is
+unusual but unambiguous — the first `->` closes the binder, the rest is
+body.
 
 ### 3.11 List, tuple, record literals
 
@@ -2055,7 +2052,7 @@ with parser-level support that lowering rejects:
   application (`Mut(V, Txn)`, `List(T)`) and capitalized primitive names
   (`Int`, `Bool`, `String`), with record types `{name: T, …}` and tuple types
   `{T, U}` writable in annotation position (§6.1). The remaining **Direction**
-  notes are unimplemented: `\`-lambdas (§3.10), `rec` bindings (§4.3),
+  notes are unimplemented: `rec` bindings (§4.3),
   membership `in` (§3.4), the `->` pair/map-entry syntax (§2.4), the `Feed(_)`
   forward-declaration surface (§3.7, §6.2), and
   transactions-as-contextual-parameters (§8.7). The north-star programs

--- a/src/ccl/inline.rs
+++ b/src/ccl/inline.rs
@@ -9,7 +9,7 @@
 //!
 //! - **Scalar UDFs**: `Fun(non_iterable_domain, codomain)`.  These have a
 //!   non-iterable (non-enumerable) domain.  Syntactic multi-arg Python lambdas
-//!   (`lambda x, y: …`) are uncurried at lowering to `Tuple([…]) → T`, so they
+//!   (`\x, y -> …`) are uncurried at lowering to `Tuple([…]) → T`, so they
 //!   match this rule too.
 //!
 //! - **List-producing UDFs**: `Fun(Fun(iterable_domain, _), _)`.  Functions

--- a/src/ccl/lower/exprs.rs
+++ b/src/ccl/lower/exprs.rs
@@ -418,9 +418,9 @@ mod tests {
     // Lambdas — single-arg emits `λ x → body` directly; multi-arg uncurries
     // to a tupled-parameter lambda whose body binds each name to a
     // projection, keeping the tree free of nested `Lambda` chains.
-    #[case("lambda x: x + 1", "λ x → x + 1")]
+    #[case("\\x -> x + 1", "λ x → x + 1")]
     #[case(
-        "lambda x, y: x + y",
+        "\\x, y -> x + y",
         "λ __arg_tuple_0 → __arg_tuple_0.0 + __arg_tuple_0.1"
     )]
     // Nested multi-arg lambdas: the outer lambda's substitution inserts a
@@ -429,7 +429,7 @@ mod tests {
     // so the inserted reference does not collide with the inner binder.  The
     // outer takes id 1 because the inner is lowered first and consumes id 0.
     #[case(
-        "lambda x, y: lambda a, b: x + a",
+        "\\x, y -> \\a, b -> x + a",
         "λ __arg_tuple_1 → λ __arg_tuple_0 → __arg_tuple_1.0 + __arg_tuple_0.0"
     )]
     fn test_lower_expr(#[case] code: &str, #[case] expected: &str) {
@@ -474,12 +474,12 @@ mod tests {
     #[rstest]
     // Variable collection and inline key lambda
     #[case(
-        "groupby(xs, lambda x: x)",
+        "groupby(xs, \\x -> x)",
         "λ __gb_k → cast(({_ | __elem ▷ xs ▷ (λ x → x) == __gb_k} ⇒ _), λ __gb_i → __gb_i ▷ xs)"
     )]
     // List literal collection with a more complex key
     #[case(
-        "groupby([1, 2, 3], lambda x: x // 2)",
+        "groupby([1, 2, 3], \\x -> x // 2)",
         "λ __gb_k → cast(({_ | __elem ▷ [1, 2, 3] ▷ (λ x → x // 2) == __gb_k} ⇒ _), λ __gb_i → __gb_i ▷ [1, 2, 3])"
     )]
     // Key is a variable reference (pre-defined function)

--- a/src/ccl/lower/functions.rs
+++ b/src/ccl/lower/functions.rs
@@ -89,7 +89,7 @@ pub(super) fn validate_function_params(
 /// Substitution sidesteps that whole rewrite chain.
 ///
 /// Shared between [`lower_lambda`] and [`lower_function_body`] so that both
-/// `lambda x, y: …` and `def f(x, y): …` pair with [`lower_call`]'s
+/// `\x, y -> …` and `def f(x, y): …` pair with [`lower_call`]'s
 /// tupled-argument shape and never emit a curried `Expr::Lambda` chain that
 /// `lambda_elim` would fold into an unsupported `curry(body)` — the one
 /// exception being a pass-by-reference `Mut` parameter, which stays a *named*
@@ -192,7 +192,7 @@ pub(super) fn uncurry_params(
 /// [`uncurry_params`].
 ///
 /// Users who want genuine currying still write it explicitly
-/// (`lambda x: lambda y: ...` or an explicit `curry(f)` call); those nest
+/// (`\x -> \y -> ...` or an explicit `curry(f)` call); those nest
 /// through the general Lambda rule and remain unsupported past operator
 /// conversion — tracked as follow-up work.
 ///
@@ -226,7 +226,7 @@ pub(super) fn lower_lambda(
 /// engine's in-place mode ([`crate::ccl::subst::Subst::rewrite_expr`]), which
 /// traverses type slots too: a comprehension filter that references an
 /// enclosing multi-arg lambda's parameter — e.g.
-/// `lambda lo, hi: sum([x for x in data if x >= lo])` — lowers the filter
+/// `\lo, hi -> sum([x for x in data if x >= lo])` — lowers the filter
 /// into the comprehension's `Cast::target` predicate with `lo` free in it,
 /// and the engine rewrites it there along with the term spine.
 ///

--- a/src/ccl/lower/mod.rs
+++ b/src/ccl/lower/mod.rs
@@ -22,7 +22,7 @@
 //! | Assignment + expression blocks | nested [`TypedExprNode::Let`] |
 //! | Augmented assignment `x op= e` | desugared to [`TypedExprNode::Let`] via [`TypedExprNode::BinOp`] |
 //! | `sum(expr)` / `max(expr)` calls | [`TypedExprNode::Aggregate`] |
-//! | Lambda expressions `lambda x: body`, `lambda x, y: body` | single [`TypedExprNode::Lambda`] (tupled param when multi-arg) |
+//! | Lambda expressions `\x -> body`, `\x, y -> body` | single [`TypedExprNode::Lambda`] (tupled param when multi-arg) |
 //! | `groupby(collection, key)` calls | `Lambda`/`Apply` encoding with a refinement predicate |
 //! | Unary negation (`-x`) | [`TypedExprNode::UnaryOp`] with [`crate::ccl::UnaryOpKind::Neg`] |
 //! | Boolean negation (`not x`) | [`TypedExprNode::UnaryOp`] with [`crate::ccl::UnaryOpKind::Not`] |

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -378,7 +378,7 @@ impl Subst {
             // to a non-variable term has no Feed/Define shape to land in, so
             // the stale handle is kept for desugar's own
             // `UnboundDeferHandle` boundary to report (feeding a lambda
-            // parameter is user-reachable: `lambda d, v: d << v`).
+            // parameter is user-reachable: `\d, v -> d << v`).
             Feed { name, value } => {
                 let (name, value) = self.apply_handle_use(name, value);
                 Feed { name, value }

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -152,7 +152,7 @@ pub enum Type {
     /// type is an *ambiguous-type* error, reported by `collect_type_errors`
     /// as `UnresolvedInfer`. `Infer` survivals are permitted only inside
     /// sub-expressions whose output type is not exercised (e.g. a top-level
-    /// `f = lambda x: x` that is never applied).
+    /// `f = \x -> x` that is never applied).
     ///
     /// Carries the mutable [`InferVar`] (id + level + bounds) that the
     /// solver constrains in place. A *coalesced* `Infer` (one

--- a/src/chl_parser/ast.rs
+++ b/src/chl_parser/ast.rs
@@ -378,7 +378,7 @@ pub enum Expr {
         attr_span: Span,
     },
 
-    /// Lambda: `lambda params: body`.
+    /// Lambda: `\params -> body`.
     Lambda {
         params: Vec<Param>,
         body: Box<Spanned<Expr>>,

--- a/src/chl_parser/design-chl-parser.md
+++ b/src/chl_parser/design-chl-parser.md
@@ -81,7 +81,7 @@ public entry points:
 The grammar is precedence-climbed for binary operators. From lowest to
 highest precedence:
 
-1. `lambda` / `yield`
+1. `\x -> …` (lambda) / `yield`
 2. `<<` (feed)
 3. ternary `a if b else c`
 4. `or`

--- a/src/chl_parser/lexer.rs
+++ b/src/chl_parser/lexer.rs
@@ -73,8 +73,6 @@ pub enum Token {
     In,
     #[token("def", priority = 3)]
     Def,
-    #[token("lambda", priority = 3)]
-    Lambda,
     #[token("return", priority = 3)]
     Return,
     #[token("yield", priority = 3)]
@@ -103,6 +101,10 @@ pub enum Token {
     PlusEq,
     #[token("-=")]
     MinusEq,
+    /// Lambda body arrow `->` (also the planned pair / map-entry arrow, §2.4).
+    /// Two chars, so maximal munch takes it over `-` then `>`.
+    #[token("->")]
+    Arrow,
     #[token("*=")]
     StarEq,
     #[token("//=")]
@@ -156,6 +158,9 @@ pub enum Token {
     Dot,
     #[token(";")]
     Semi,
+    /// Lambda binder introducer `\` (`\x -> body`).
+    #[token("\\")]
+    Backslash,
 
     // -- Literals ---------------------------------------------------------
     /// Decimal integer literal. `_` digit separators are not supported.
@@ -205,7 +210,6 @@ impl fmt::Display for Token {
             Token::For => "for",
             Token::In => "in",
             Token::Def => "def",
-            Token::Lambda => "lambda",
             Token::Return => "return",
             Token::Yield => "yield",
             Token::Pass => "pass",
@@ -220,6 +224,7 @@ impl fmt::Display for Token {
             Token::PlusPlus => "++",
             Token::PlusEq => "+=",
             Token::MinusEq => "-=",
+            Token::Arrow => "->",
             Token::StarEq => "*=",
             Token::DoubleSlashEq => "//=",
             Token::DoubleSlash => "//",
@@ -244,6 +249,7 @@ impl fmt::Display for Token {
             Token::ColonEq => ":=",
             Token::Dot => ".",
             Token::Semi => ";",
+            Token::Backslash => "\\",
             // Value-carrying tokens — chumsky's `select!` matches the
             // variant, not a specific value, so these typically appear
             // only in "found …" positions. Descriptive names keep
@@ -432,7 +438,7 @@ mod tests {
 
     #[test]
     fn keywords_beat_idents() {
-        let toks = tokens("if elif else for in def lambda not and or True False None");
+        let toks = tokens("if elif else for in def not and or True False None");
         assert_eq!(
             toks,
             vec![
@@ -442,7 +448,6 @@ mod tests {
                 Token::For,
                 Token::In,
                 Token::Def,
-                Token::Lambda,
                 Token::Not,
                 Token::And,
                 Token::Or,
@@ -451,6 +456,27 @@ mod tests {
                 Token::None,
                 Token::Newline,
             ]
+        );
+    }
+
+    #[test]
+    fn lambda_tokens() {
+        // `\` introduces a lambda binder; `->` separates it from the body.
+        // `->` wins over `-` then `>` by maximal munch.
+        assert_eq!(
+            tokens("\\x -> x"),
+            vec![
+                Token::Backslash,
+                Token::Ident("x".into()),
+                Token::Arrow,
+                Token::Ident("x".into()),
+                Token::Newline,
+            ]
+        );
+        // `lambda` is no longer a keyword — it lexes as an ordinary identifier.
+        assert_eq!(
+            tokens("lambda"),
+            vec![Token::Ident("lambda".into()), Token::Newline]
         );
     }
 

--- a/src/chl_parser/parser.rs
+++ b/src/chl_parser/parser.rs
@@ -704,23 +704,22 @@ where
 
         // ---- Lambda / Yield (top-level expression forms) ------------
         //
-        // Lambda params do NOT allow `:` type annotations (the `:` is
-        // already taken to terminate the param list before the body), so
-        // we use a bare-ident-only param parser here. Function-def params
-        // (which use `(...)` to delimit) get the annotated form down in
-        // `statement()`.
+        // A lambda is `\params -> body`: `\` introduces the binders, `->`
+        // separates them from the body. Params are bare identifiers here;
+        // the `->` terminator (rather than `:`) leaves `:` free for a future
+        // per-param annotation (`\x: T -> body`), not yet parsed.
         let lambda_param = ident_only.map(|(name, name_span)| Param {
             name,
             name_span,
             annotation: None,
         });
-        let lambda = just(Token::Lambda)
+        let lambda = just(Token::Backslash)
             .ignore_then(
                 lambda_param
                     .separated_by(just(Token::Comma))
                     .collect::<Vec<_>>(),
             )
-            .then_ignore(just(Token::Colon))
+            .then_ignore(just(Token::Arrow))
             .then(expr.clone())
             .map_with(|(params, body), e| {
                 Spanned::new(
@@ -1275,7 +1274,9 @@ mod tests {
 
     #[test]
     fn lambda_and_ternary() {
-        let e = parse_e("lambda x: x + 1 if x > 0 else 0").node;
+        // The `->` body extends through the ternary, so the whole
+        // `x + 1 if x > 0 else 0` is the lambda body.
+        let e = parse_e("\\x -> x + 1 if x > 0 else 0").node;
         match e {
             Expr::Lambda { params, body } => {
                 assert_eq!(params.len(), 1);
@@ -1283,6 +1284,18 @@ mod tests {
             }
             other => panic!("expected Lambda, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn lambda_multi_and_zero_param() {
+        assert!(matches!(
+            parse_e("\\x, y -> x + y").node,
+            Expr::Lambda { params, .. } if params.len() == 2
+        ));
+        assert!(matches!(
+            parse_e("\\ -> 1").node,
+            Expr::Lambda { params, .. } if params.is_empty()
+        ));
     }
 
     #[test]

--- a/tests/chl_parser_roundtrip.rs
+++ b/tests/chl_parser_roundtrip.rs
@@ -206,9 +206,9 @@ fn if_elif_else_module() {
 
 #[test]
 fn lambda_in_expression_context() {
-    let e = must_parse_expr("lambda x: x + 1");
+    let e = must_parse_expr("\\x -> x + 1");
     assert!(matches!(e.node, Expr::Lambda { .. }));
-    let e = must_parse_expr("lambda x, y: x + y");
+    let e = must_parse_expr("\\x, y -> x + y");
     if let Expr::Lambda { params, .. } = e.node {
         assert_eq!(params.len(), 2);
     } else {

--- a/tests/compilation_pipeline/comprehensions.rs
+++ b/tests/compilation_pipeline/comprehensions.rs
@@ -111,7 +111,7 @@ fn test_comprehensions_filtered(#[case] code: &str, #[case] expected: Tile) {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_udf_used_inside_filter_predicate() {
-    let code = "f = lambda x: x > 1\n[x for x in [1, 2, 3] if f(x)]";
+    let code = "f = \\x -> x > 1\n[x for x in [1, 2, 3] if f(x)]";
     check_tile(
         code,
         Tile::SealedFunction {
@@ -130,7 +130,7 @@ fn test_udf_used_inside_filter_predicate() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_udf_containing_filter() {
-    let code = "f = lambda xs: [x for x in xs if x > 1]\nf([1, 2, 3])";
+    let code = "f = \\xs -> [x for x in xs if x > 1]\nf([1, 2, 3])";
     check_tile(
         code,
         Tile::SealedFunction {

--- a/tests/compilation_pipeline/generators_udf_poly.rs
+++ b/tests/compilation_pipeline/generators_udf_poly.rs
@@ -36,7 +36,7 @@ fn test_function_def_scalar(#[case] code: &str, #[case] expected: Value) {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_function_def_polymorphic_used_at_two_types() {
-    let code = "f = lambda x: x == x\nf(1) and f(\"foo\")";
+    let code = "f = \\x -> x == x\nf(1) and f(\"foo\")";
     check_scalar(code, Value::Bool(true));
 }
 
@@ -168,7 +168,7 @@ fn test_generator_polymorphic_over_element_type() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_poly_calls_poly_at_two_types() {
-    let code = "f = lambda x: x == x\ng = lambda y: f(y)\ng(1) and g(\"foo\")";
+    let code = "f = \\x -> x == x\ng = \\y -> f(y)\ng(1) and g(\"foo\")";
     check_scalar(code, Value::Bool(true));
 }
 
@@ -179,7 +179,7 @@ fn test_poly_calls_poly_at_two_types() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_poly_calls_poly_list_body() {
-    let code = "f = lambda x: [x, x]\ng = lambda y: f(y)\nsum(g(5))";
+    let code = "f = \\x -> [x, x]\ng = \\y -> f(y)\nsum(g(5))";
     check_scalar(code, Value::Int(10));
 }
 
@@ -188,7 +188,7 @@ fn test_poly_calls_poly_list_body() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_collection_udf_through_poly_wrapper() {
-    let code = "f = lambda xs: [x for x in xs]\ng = lambda ys: f(ys)\ng([1, 2, 3])";
+    let code = "f = \\xs -> [x for x in xs]\ng = \\ys -> f(ys)\ng([1, 2, 3])";
     check_tile(code, make_int_list(&[1, 2, 3]));
 }
 
@@ -197,7 +197,7 @@ fn test_collection_udf_through_poly_wrapper() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_collection_udf_through_poly_wrapper_two_element_types() {
-    let code = "f = lambda xs: [1 for x in xs]\ng = lambda ys: f(ys)\nsum(g([1, 2, 3])) + sum(g([\"a\", \"b\"]))";
+    let code = "f = \\xs -> [1 for x in xs]\ng = \\ys -> f(ys)\nsum(g([1, 2, 3])) + sum(g([\"a\", \"b\"]))";
     check_scalar(code, Value::Int(5));
 }
 
@@ -216,7 +216,7 @@ fn test_collection_udf_through_poly_wrapper_two_element_types() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_generator_def_through_poly_wrapper_two_element_types() {
-    let code = "def ones(xs):\n    for x in xs:\n        yield 1\nwrap = lambda ys: ones(ys)\nsum(wrap([1, 2, 3])) + sum(wrap([\"a\", \"b\"]))";
+    let code = "def ones(xs):\n    for x in xs:\n        yield 1\nwrap = \\ys -> ones(ys)\nsum(wrap([1, 2, 3])) + sum(wrap([\"a\", \"b\"]))";
     check_scalar(code, Value::Int(5));
 }
 
@@ -224,7 +224,8 @@ fn test_generator_def_through_poly_wrapper_two_element_types() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_triple_poly_chain_collection() {
-    let code = "f = lambda xs: [x for x in xs]\ng = lambda ys: f(ys)\nh = lambda zs: g(zs)\nsum(h([1, 2, 3]))";
+    let code =
+        "f = \\xs -> [x for x in xs]\ng = \\ys -> f(ys)\nh = \\zs -> g(zs)\nsum(h([1, 2, 3]))";
     check_scalar(code, Value::Int(6));
 }
 
@@ -232,7 +233,7 @@ fn test_triple_poly_chain_collection() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_triple_poly_chain_at_two_types() {
-    let code = "f = lambda x: x == x\ng = lambda y: f(y)\nh = lambda z: g(z)\nh(1) and h(\"foo\")";
+    let code = "f = \\x -> x == x\ng = \\y -> f(y)\nh = \\z -> g(z)\nh(1) and h(\"foo\")";
     check_scalar(code, Value::Bool(true));
 }
 
@@ -242,7 +243,7 @@ fn test_triple_poly_chain_at_two_types() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_poly_diamond() {
-    let code = "f = lambda x: x == x\ng = lambda y: f(y)\nh = lambda z: f(z)\ng(1) and h(\"foo\")";
+    let code = "f = \\x -> x == x\ng = \\y -> f(y)\nh = \\z -> f(z)\ng(1) and h(\"foo\")";
     check_scalar(code, Value::Bool(true));
 }
 
@@ -251,7 +252,7 @@ fn test_poly_diamond() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_poly_used_directly_and_through_wrapper() {
-    let code = "f = lambda x: x == x\ng = lambda y: f(y)\nf(1) and g(\"foo\")";
+    let code = "f = \\x -> x == x\ng = \\y -> f(y)\nf(1) and g(\"foo\")";
     check_scalar(code, Value::Bool(true));
 }
 
@@ -261,7 +262,7 @@ fn test_poly_used_directly_and_through_wrapper() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_poly_fanout_inside_wrapper() {
-    let code = "f = lambda x: x == x\ng = lambda y: f(y) and f(\"z\")\ng(1) and g(\"foo\")";
+    let code = "f = \\x -> x == x\ng = \\y -> f(y) and f(\"z\")\ng(1) and g(\"foo\")";
     check_scalar(code, Value::Bool(true));
 }
 
@@ -272,7 +273,7 @@ fn test_poly_fanout_inside_wrapper() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_filter_udf_through_poly_wrapper() {
-    let code = "f = lambda xs: [x for x in xs if x > 1]\ng = lambda ys: f(ys)\ng([1, 2, 3])";
+    let code = "f = \\xs -> [x for x in xs if x > 1]\ng = \\ys -> f(ys)\ng([1, 2, 3])";
     check_tile(
         code,
         Tile::SealedFunction {
@@ -291,7 +292,7 @@ fn test_filter_udf_through_poly_wrapper() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_predicate_udf_used_inside_poly_wrapper_filter() {
-    let code = "p = lambda x: x > 1\ng = lambda ys: [y for y in ys if p(y)]\ng([1, 2, 3])";
+    let code = "p = \\x -> x > 1\ng = \\ys -> [y for y in ys if p(y)]\ng([1, 2, 3])";
     check_tile(
         code,
         Tile::SealedFunction {
@@ -308,7 +309,7 @@ fn test_predicate_udf_used_inside_poly_wrapper_filter() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_poly_chain_with_extra_param() {
-    let code = "f = lambda xs: [x for x in xs]\ng = lambda ys, n: sum(f(ys)) + n\ng([1, 2], 10)";
+    let code = "f = \\xs -> [x for x in xs]\ng = \\ys, n -> sum(f(ys)) + n\ng([1, 2], 10)";
     check_scalar(code, Value::Int(13));
 }
 
@@ -320,7 +321,7 @@ fn test_poly_chain_with_extra_param() {
 fn test_unexercised_generic_definition_is_an_error_not_a_panic() {
     let mut ctx = GlobalContext::default();
     let consumer: Box<dyn Consumer> = Box::new(|| {});
-    let result = compile_program(&mut ctx, "f = lambda x: [x, x]\nf", consumer);
+    let result = compile_program(&mut ctx, "f = \\x -> [x, x]\nf", consumer);
     assert!(
         result.is_err(),
         "ambiguous (never-exercised) generic must fail with a diagnostic"

--- a/tests/compilation_pipeline/joins_aggregates_groupby.rs
+++ b/tests/compilation_pipeline/joins_aggregates_groupby.rs
@@ -132,7 +132,7 @@ fn test_aggregates(#[case] code: &str, #[case] expected: Value) {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 #[case(
-    "[sum(x) for x in groupby([2,3,4,5], lambda x: x // 2)]",
+    "[sum(x) for x in groupby([2,3,4,5], \\x -> x // 2)]",
     Tile::SealedFunction {
         domain: ColumnValue::Ints(vec![1, 2]),
         codomain: Box::new(Tile::Scalar(ColumnValue::Ints(vec![5, 9]))),
@@ -141,7 +141,7 @@ fn test_aggregates(#[case] code: &str, #[case] expected: Value) {
     }
 )]
 #[case(
-    "[sum(x) for x in groupby([y + 10 for y in [2,3,4,5,6] if y < 6], lambda x: x // 2)]",
+    "[sum(x) for x in groupby([y + 10 for y in [2,3,4,5,6] if y < 6], \\x -> x // 2)]",
     Tile::SealedFunction {
         domain: ColumnValue::Ints(vec![6, 7]),
         codomain: Box::new(Tile::Scalar(ColumnValue::Ints(vec![25, 29]))),
@@ -326,7 +326,7 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 #[case("sum([1,2,3])", "(iterate ≫ [1, 2, 3]) ▷ sum:Int", Tile::Scalar(ColumnValue::Ints(vec![6])))]
 #[case(
-    "[sum(x) for x in groupby([1,2,3,4], lambda y: y // 2)]",
+    "[sum(x) for x in groupby([1,2,3,4], \\y -> y // 2)]",
     "(iterate ≫ [1, 2, 3, 4] ≫ (id, 2 ▷ const) ▷ zip ≫ floor_div) ▷ converse ≫ [1, 2, 3, 4] ▷ map ≫ sum:(Int ⇒ Int)",
     Tile::SealedFunction {
         domain: ColumnValue::Ints(vec![0, 1, 2]),

--- a/tests/compilation_pipeline/misc.rs
+++ b/tests/compilation_pipeline/misc.rs
@@ -38,18 +38,18 @@ fn test_no_fan_outs(#[case] code: &str) {
 
 #[rstest]
 #[timeout(Duration::from_secs(10))]
-#[case("inc = lambda x: x + 1\ninc(4)", Value::Int(5))]
-#[case("double = lambda x: x * 2\ndouble(7)", Value::Int(14))]
-#[case("neg = lambda x: -x\nneg(3)", Value::Int(-3))]
-#[case("identity = lambda x: x\nidentity(42)", Value::Int(42))]
+#[case("inc = \\x -> x + 1\ninc(4)", Value::Int(5))]
+#[case("double = \\x -> x * 2\ndouble(7)", Value::Int(14))]
+#[case("neg = \\x -> -x\nneg(3)", Value::Int(-3))]
+#[case("identity = \\x -> x\nidentity(42)", Value::Int(42))]
 fn test_scalar_udf(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
 
 #[rstest]
 #[timeout(Duration::from_secs(10))]
-#[case("is_pos = lambda x: x > 0\nis_pos(5)", Value::Bool(true))]
-#[case("is_pos = lambda x: x > 0\nis_pos(-1)", Value::Bool(false))]
+#[case("is_pos = \\x -> x > 0\nis_pos(5)", Value::Bool(true))]
+#[case("is_pos = \\x -> x > 0\nis_pos(-1)", Value::Bool(false))]
 fn test_udf_bool_codomain(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
@@ -57,7 +57,7 @@ fn test_udf_bool_codomain(#[case] code: &str, #[case] expected: Value) {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 // UDF called twice: body is duplicated at each call site (acceptable trade-off).
-#[case("f = lambda x: x + 1\nf(3) + f(4)", Value::Int(9))]
+#[case("f = \\x -> x + 1\nf(3) + f(4)", Value::Int(9))]
 fn test_udf_called_multiple_times(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
@@ -65,7 +65,7 @@ fn test_udf_called_multiple_times(#[case] code: &str, #[case] expected: Value) {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 // Nested call: f(f(3)) → f(6) → 12
-#[case("f = lambda x: x * 2\nf(f(3))", Value::Int(12))]
+#[case("f = \\x -> x * 2\nf(f(3))", Value::Int(12))]
 fn test_udf_nested_calls(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
@@ -92,14 +92,14 @@ fn test_collection_let_unaffected(#[case] code: &str, #[case] expected: Tile) {
 // The n-arm zip arm in operator_conversion dispatches between `ScalarFanIn`
 // (scalar upstream) and `FanIn` (function upstream), so bodies with nested
 // BinOps also compile cleanly under scalar call sites. Explicit currying
-// (`lambda x: lambda y: ...` or explicit `curry(f)`) is still tracked as
+// (`\\x -> \\y -> ...` or explicit `curry(f)`) is still tracked as
 // follow-up work.
 #[rstest]
 #[timeout(Duration::from_secs(10))]
-#[case("add = lambda x, y: x + y\nadd(3, 4)", Value::Int(7))]
-#[case("combine = lambda a, b: a * b + 1\ncombine(3, 4)", Value::Int(13))]
-#[case("add3 = lambda x, y, z: x + y + z\nadd3(1, 2, 3)", Value::Int(6))]
-#[case("mix = lambda x, y, z: x * y - z\nmix(4, 5, 2)", Value::Int(18))]
+#[case("add = \\x, y -> x + y\nadd(3, 4)", Value::Int(7))]
+#[case("combine = \\a, b -> a * b + 1\ncombine(3, 4)", Value::Int(13))]
+#[case("add3 = \\x, y, z -> x + y + z\nadd3(1, 2, 3)", Value::Int(6))]
+#[case("mix = \\x, y, z -> x * y - z\nmix(4, 5, 2)", Value::Int(18))]
 fn test_multi_arg_udf(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
@@ -113,7 +113,7 @@ fn test_multi_arg_udf(#[case] code: &str, #[case] expected: Value) {
 #[test]
 fn test_multi_arg_param_in_filter_predicate() {
     let code = "data = [1, 2, 30]\n\
-                pick = lambda lo, hi: sum([x for x in data if x >= lo])\n\
+                pick = \\lo, hi -> sum([x for x in data if x >= lo])\n\
                 pick(8, 0)";
     check_scalar(code, Value::Int(30));
 }
@@ -124,12 +124,12 @@ fn test_multi_arg_param_in_filter_predicate() {
 // consumption filters the collection by that predicate at the iteration
 // boundary. These exercise the dependent type *through to runtime values*.
 #[rstest]
-#[case("g = groupby([1,1,2,2,3], lambda x: x)\nsum(g(1))", Value::Int(2))] // {1,1}
-#[case("g = groupby([1,1,2,2,3], lambda x: x)\nsum(g(2))", Value::Int(4))] // {2,2}
-#[case("g = groupby([1,1,2,2,3], lambda x: x)\nsum(g(3))", Value::Int(3))] // {3}
-#[case("g = groupby([1,2,3,4,5], lambda x: x // 2)\nsum(g(0))", Value::Int(1))] // {1}
-#[case("g = groupby([1,2,3,4,5], lambda x: x // 2)\nsum(g(1))", Value::Int(5))] // {2,3}
-#[case("g = groupby([1,2,3,4,5], lambda x: x // 2)\nsum(g(2))", Value::Int(9))] // {4,5}
+#[case("g = groupby([1,1,2,2,3], \\x -> x)\nsum(g(1))", Value::Int(2))] // {1,1}
+#[case("g = groupby([1,1,2,2,3], \\x -> x)\nsum(g(2))", Value::Int(4))] // {2,2}
+#[case("g = groupby([1,1,2,2,3], \\x -> x)\nsum(g(3))", Value::Int(3))] // {3}
+#[case("g = groupby([1,2,3,4,5], \\x -> x // 2)\nsum(g(0))", Value::Int(1))] // {1}
+#[case("g = groupby([1,2,3,4,5], \\x -> x // 2)\nsum(g(1))", Value::Int(5))] // {2,3}
+#[case("g = groupby([1,2,3,4,5], \\x -> x // 2)\nsum(g(2))", Value::Int(9))] // {4,5}
 fn test_dependent_groupby_lookup(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }

--- a/tests/compilation_pipeline/mutability.rs
+++ b/tests/compilation_pipeline/mutability.rs
@@ -480,7 +480,7 @@ fn rule3_unannotated_mut_alias_is_rejected() {
 /// escape where its writer set is no longer statically known.
 #[test]
 fn rule2_function_returning_mut_is_rejected() {
-    expect_mut_discipline_error("x := 0\nf = lambda z: x\nf", "inside a composite type");
+    expect_mut_discipline_error("x := 0\nf = \\z -> x\nf", "inside a composite type");
 }
 
 /// Rule 1: a `Mut` value must be a bare variable reference, so a conditional

--- a/tests/compilation_pipeline/sources_incremental.rs
+++ b/tests/compilation_pipeline/sources_incremental.rs
@@ -606,7 +606,7 @@ x";
 
 #[test_log::test]
 fn test_incremental_aggregates() {
-    let code = "[sum(x) for x in groupby(source1(), lambda x: x // 10)]";
+    let code = "[sum(x) for x in groupby(source1(), \\x -> x // 10)]";
     let mut ctx = GlobalContext::default();
 
     let test_source = Rc::new(RefCell::new(TestDataSource::new(

--- a/tests/programs/groupby_rollup/mod.rs
+++ b/tests/programs/groupby_rollup/mod.rs
@@ -2,7 +2,7 @@
 //! the canonical "group by + per-group aggregate" shape.
 //!
 //! **Currently blocked.**  The natural form
-//! `[sum([s.amount for s in g]) for g in groupby(sales, lambda r: r.region)]`
+//! `[sum([s.amount for s in g]) for g in groupby(sales, \r -> r.region)]`
 //! — i.e. groupby over records with a projecting inner comprehension —
 //! panics during operator conversion because the `curry` combinator isn't
 //! yet supported there.  Tracks completing `curry` combinator support in

--- a/tests/programs/groupby_rollup/program.cambra
+++ b/tests/programs/groupby_rollup/program.cambra
@@ -5,4 +5,4 @@ sales = [
     (region="south", amount=75),
     (region="east",  amount=150),
 ]
-[sum([s.amount for s in g]) for g in groupby(sales, lambda r: r.region)]
+[sum([s.amount for s in g]) for g in groupby(sales, \r -> r.region)]

--- a/tests/programs/ledger_balance/mod.rs
+++ b/tests/programs/ledger_balance/mod.rs
@@ -9,15 +9,15 @@
 //! This isolates the storefront's revenue view: without the `restrict`, the
 //! aggregate is only defined when the feed closes — for a server, never.
 //!
-//! **Currently blocked at lexing.**  The `\` lambda in the restrict
-//! predicate isn't a lexable token yet (same first blocker as `txn_kv`).
-//! Behind it: the `Feed(...)` annotation, feed elements carrying
-//! transaction time, `restrict`/`sum` over a feed, and structured requests.
-//! This pins the lambda lex failure.
+//! **Currently blocked at parsing.**  The `\` lambda now lexes; the next
+//! unsupported construct is the `Feed(...)` annotation-only forward
+//! declaration (an annotation with no initialiser).  Behind it: feed elements
+//! carrying transaction time, `restrict`/`sum` over a feed, and structured
+//! requests.  This pins the `Feed(...)` forward-declaration parse failure.
 
 use super::common::expect_compile_error;
 
 #[test]
-fn ledger_balance_currently_blocked_at_lexing() {
-    expect_compile_error(include_str!("program.cambra"), "invalid token");
+fn ledger_balance_currently_blocked_at_parsing() {
+    expect_compile_error(include_str!("program.cambra"), "Feed({amount: Int})");
 }

--- a/tests/programs/nonneg_inventory/mod.rs
+++ b/tests/programs/nonneg_inventory/mod.rs
@@ -23,8 +23,5 @@ use super::common::expect_compile_error;
 
 #[test]
 fn nonneg_inventory_currently_blocked_at_parsing() {
-    expect_compile_error(
-        include_str!("program.cambra"),
-        "found '>', expected expression",
-    );
+    expect_compile_error(include_str!("program.cambra"), "found '->'");
 }

--- a/tests/programs/storefront/mod.rs
+++ b/tests/programs/storefront/mod.rs
@@ -45,9 +45,11 @@
 //!
 //! ### Current limitations (what this test depends on)
 //!
-//! **Blocked at lexing today**: the `\` lambda (the restrict predicates)
-//! isn't a lexable token.  The full dependency list, each isolated by a
-//! smaller gallery program where one exists:
+//! **Blocked today**: the `\` lambda (the restrict predicates) now lexes; the
+//! next blocker is the `match` expression on the catalog lookup, which is not
+//! a keyword yet and derails the layout pass (an inconsistent-indentation lex
+//! error).  The full dependency list, each isolated by a smaller gallery
+//! program where one exists:
 //!
 //! - Boundary asserts lifted to refinement types — `discount_contract`.
 //! - Refined transactional store + guarded decrement — `nonneg_inventory`.
@@ -73,14 +75,13 @@
 //! - Version dispatch across a branch point — no isolating program yet
 //!   (deferred with the still-open versioning surface).
 //!
-//! This pins the lex failure on both files (`invalid token`, the `\`
-//! lambda); when it lexes, the test goes red and the next blocker gets
-//! pinned.
+//! This pins the `match`-block lex failure on both files; when `match` is
+//! supported, the test goes red and the next blocker gets pinned.
 
 use super::common::expect_compile_error;
 
 #[test]
 fn storefront_currently_blocked_at_lexing() {
-    expect_compile_error(include_str!("v0.cambra"), "invalid token");
-    expect_compile_error(include_str!("v1.cambra"), "invalid token");
+    expect_compile_error(include_str!("v0.cambra"), "inconsistent indentation");
+    expect_compile_error(include_str!("v1.cambra"), "inconsistent indentation");
 }

--- a/tests/programs/txn_kv/mod.rs
+++ b/tests/programs/txn_kv/mod.rs
@@ -18,15 +18,15 @@
 //! by concurrent HTTP handlers is only correct if its state is transactional)
 //! and `hit_counter` (the request-stream aggregate).
 //!
-//! **Currently blocked at lexing.**  The `\` lambda in the `/stats`
-//! aggregate isn't a lexable token yet, so lexing fails before parsing.  Behind it: the
-//! `requires` clause, `with begin()` / `abort()`, the `Mut(..., Txn)`
-//! annotation, `match`, map-index assignment, structured requests, and
-//! `restrict` / `count`.  This pins the lambda lex failure.
+//! **Currently blocked at parsing.**  The `\` lambda now lexes; the next
+//! unsupported construct is `import http` (modules) and the `requires
+//! Transaction` contextual-parameter clause.  Behind those: `with begin()` /
+//! `abort()`, `match`, map-index assignment, structured requests, and
+//! `restrict` / `count`.  This pins the `requires Transaction` parse failure.
 
 use super::common::expect_compile_error;
 
 #[test]
-fn txn_kv_currently_blocked_at_lexing() {
-    expect_compile_error(include_str!("program.cambra"), "invalid token");
+fn txn_kv_currently_blocked_at_parsing() {
+    expect_compile_error(include_str!("program.cambra"), "requires Transaction");
 }

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -469,13 +469,13 @@ fn test_collection_union_heterogeneous_rejected() {
 
 #[test]
 fn test_groupby_aggregate() {
-    // groups = groupby([1, 2, 3], lambda x: x)
+    // groups = groupby([1, 2, 3], \x -> x)
     // g = groups(1)
     // sum(g)
     // Expected: Int (sum of a group of integers)
     let ty = infer_program(
         r#"
-groups = groupby([1, 2, 3], lambda x: x)
+groups = groupby([1, 2, 3], \x -> x)
 g = groups(1)
 sum(g)
 "#
@@ -497,7 +497,7 @@ fn test_groupby_dependent_application_discharges_key() {
     // longer reference the group-by key binder `__gb_k`.
     let ty = infer_program(
         r#"
-groups = groupby([1, 2, 3], lambda x: x)
+groups = groupby([1, 2, 3], \x -> x)
 groups(0)
 "#
         .trim(),
@@ -536,8 +536,8 @@ groups(0)
 fn test_higher_order_dependent_application_discharges_key() {
     let ty = infer_program(
         r#"
-groups = groupby([1, 2, 3], lambda x: x)
-apply0 = lambda g: g(0)
+groups = groupby([1, 2, 3], \x -> x)
+apply0 = \g -> g(0)
 apply0(groups)
 "#
         .trim(),
@@ -639,13 +639,13 @@ else:
 
 #[test]
 fn test_self_application_types() {
-    // `lambda x: x(x)` is the MLsub poster child `(α ∧ (α ⇒ β)) ⇒ β`. With
+    // `\x -> x(x)` is the MLsub poster child `(α ∧ (α ⇒ β)) ⇒ β`. With
     // both Apply edges one-way there is no var⇄var cycle, so it types
     // cleanly: the unconstrained `α` leg drops and the lambda infers as
     // `(?a ⇒ ?b) ⇒ ?c`, carrying unresolved `Infer` vars like any other
     // unapplied lambda. *Misusing* a self-applicator still errors — see
     // `self_application_rejected_without_panic` in `infer/solve.rs`.
-    let ty = infer_program("lambda x: x(x)");
+    let ty = infer_program("\\x -> x(x)");
     assert!(
         matches!(&ty, Type::Fun { domain: d, .. } if matches!(&**d, Type::Fun { .. })),
         "expected a function-domained function type, got {ty:?}"
@@ -655,14 +655,14 @@ fn test_self_application_types() {
 #[rstest]
 #[case::comparison(
     r"
-f = lambda x: x > 1
+f = \x -> x > 1
 f
 ",
     Type::Fun { name: None, domain: Box::new(int()), codomain: Box::new(bool_ty()) }
 )]
 #[case::arithmetic(
     r"
-f = lambda x: x + 1
+f = \x -> x + 1
 f
 ",
     Type::Fun { name: None, domain: Box::new(int()), codomain: Box::new(int()) }
@@ -673,9 +673,9 @@ fn test_lambda_unapplied(#[case] code: &str, #[case] expected: Type) {
 
 #[test]
 fn test_generic_identity() {
-    // f = lambda x: x; f -> Fun(?a, ?b)
+    // f = \x -> x; f -> Fun(?a, ?b)
     // inference allows unconstrained parameters to remain unresolved.
-    let ty = infer_program("f = lambda x: x\nf");
+    let ty = infer_program("f = \\x -> x\nf");
     if let Type::Fun {
         domain: dom,
         codomain: cod,
@@ -707,7 +707,7 @@ fn test_tuple_index_heterogeneous() {
 fn test_unconstrained_identity_applied_resolves() {
     // bind via Let so `f(5)` is a named call (lowering doesn't yet
     // support a lambda-literal in call position).
-    let ty = infer_program("f = lambda x: x\nf(5)");
+    let ty = infer_program("f = \\x -> x\nf(5)");
     assert_eq!(ty, int());
 }
 


### PR DESCRIPTION
Retire Python's `lambda` keyword in favour of the decided target syntax
(docs/chl-spec.md, §3.10): `\` introduces the binders, `->` separates them
from the body — `\r -> r.region`. No dual dialect; `lambda` is now an
ordinary identifier.

- Lexer: new `Backslash` (`\`) and `Arrow` (`->`) tokens (`->` wins over
  `-` then `>` by maximal munch); the `lambda` keyword token is removed.
- Parser: the lambda production is `\params -> body` (bare-identifier params;
  `->` terminating the binder list frees `:` for a future per-param
  annotation). The `Expr::Lambda` AST node and all lowering are unchanged.
- Migrate the CHL test/demo corpus and internal doc comments to `\x -> body`.
- North-star pins advance past the (now-resolved) `\` lex failure to their
  next blocker: txn_kv → `requires Transaction`; storefront → the `match`
  block; ledger_balance → the `Feed(...)` forward declaration; nonneg_inventory
  now reports `found '->'` (the map-entry `->` is a single token).

Docs: §1.6 (lambda no longer a keyword), §1.8 (`\`/`->` punctuation), §2.3
precedence, §3.10 (`\x -> body` is the spec; typed params [Planned]), §12.

