### PR TITLE
CHL records: (name=value) values; braces are type-only; retire dict

### DIFF
--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -99,7 +99,7 @@ plus the requisite `DEDENT`s are emitted, so every `INDENT` is paired.
 ### 1.4 Implicit line continuation
 
 Inside `(...)`, `[...]`, or `{...}` (any depth, any combination), newlines
-and indentation are **ignored**. Multi-line list, tuple, dict, record,
+and indentation are **ignored**. Multi-line list, tuple, record,
 and call expressions are written naturally:
 
 ```python
@@ -341,25 +341,29 @@ atom ::= literal
        | "(" ")"                              -- empty tuple (target: the unit value, §3.1; [Open] whether it equals None today)
        | "(" expression "," ")"              -- one-tuple
        | "(" expression ( "," expression )+ [ "," ] ")"   -- tuple
+       | "(" record_field ( "," record_field )* [ "," ] ")"   -- record value
        | "[" [ expression ( "," expression )* [ "," ] ] "]"   -- list
        | "[" expression comp_for ( comp_for | comp_if )* "]"  -- collection comprehension
        | "(" expression comp_for ( comp_for | comp_if )* ")"  -- collection comprehension (paren form)
-       | "{" [ record_field ( "," record_field )* [ "," ] ] "}"   -- record (bare-identifier keys)
-       | "{" dict_entry ( "," dict_entry )* [ "," ] "}"           -- dict (expression keys)
+       | "{" typed_ident ( "," typed_ident )* [ "," ] "}"   -- record type (§6.1)
+       | "{" expression ( "," expression )+ [ "," ] "}"   -- tuple type (§6.1)
 
-record_field ::= ident ":" expression
-dict_entry   ::= expression ":" expression
+record_field ::= ident "=" expression
+typed_ident  ::= ident ":" expression
 comp_for     ::= "for" assign_target "in" expression
 comp_if      ::= "if" expression
 ```
 
-A `{...}` literal is classified by its keys: if **every** key is a bare
-identifier it is a **record** (`{x: 1, y: 2}`); otherwise (string keys,
-computed keys) it is a **dict** (`{"name": "alice"}`). `{}` is the empty
-record. Dicts currently parse but are rejected at lowering.
+A record **value** is a parenthesised list of `name=value` fields:
+`(x=1, y=2)`. The parentheses are the product constructor (§2.4 Direction),
+shared with tuples — `(1, 2)` is a tuple, `(x=1, y=2)` a record, `(e)` a
+parenthesised `e`, `(e,)` a one-tuple.
 
-`(e)` (no trailing comma) is parenthesised `e`, **not** a one-tuple. A
-one-tuple is written `(e,)`.
+A `{...}` literal is **type** syntax (§6.1), never a term-level value: bare
+identifier keys with `:` make a record type (`{x: T, y: U}`) and a colon-free
+list makes a tuple type (`{T, U}`). A `{...}` in value position is a lowering
+error pointing at the `(…)` form. (Finite maps are a collection, written
+`[k -> v, …]` — §6.3 — not a brace form.)
 
 > **Direction — term-level delimiters [Decided].** The three
 > delimiters split by role
@@ -371,9 +375,9 @@ one-tuple is written `(e,)`.
 > | `[ … ]` | **collections** — definition *and* lookup | list `[1, 2, 3]`, map `[k -> v, …]`, indexing `counts[word]`, `xs[0]` |
 > | `{ … }` | structural **types** | tuple type `{T, U}`, record type `{f: T}`, refinement `{x: T \| p(x)}` |
 >
-> Under that scheme `{…}` never appears at the term level: today's
-> `{name: e}` records become `(name=e, …)`, and dicts become map
-> literals `[k -> v, …]`.
+> Under that scheme `{…}` never appears at the term level: record values are
+> written `(name=e, …)`, and finite maps are collection literals
+> `[k -> v, …]` (**[Decided]**).
 >
 > Map entries use `->`, not `=` (**[Decided]**). `a -> b` is **pair
 > syntax** — sugar for the two-tuple `(a, b)`, valid in construction
@@ -385,9 +389,9 @@ one-tuple is written `(e,)`.
 > point `c[i]`), while the left of `->` is an *evaluated key
 > expression*. And it removes a one-character trap: `[x = 5]` (map)
 > vs `[x == 5]` (one-element list of `Bool`). Three earlier sketches
-> are superseded: dicts as `[k: v, …]` (`:` is settling on
-> annotation/type duty), map entries as `[k=v, …]` (which read as
-> keyword arguments), and Unicode `[k ↦ v, …]` (CHL is ASCII-only —
+> are superseded: map entries as `[k: v, …]` (`:` is settling on
+> annotation/type duty), as `[k=v, …]` (which read as keyword
+> arguments), and Unicode `[k ↦ v, …]` (CHL is ASCII-only —
 > §1.8). Still **[Open]**: the spelling of an *empty* map under the
 > new scheme. The record-syntax / call-argument interaction is
 > resolved by the functions-take-one-product-argument direction
@@ -514,7 +518,7 @@ they appear on consecutive source lines.
 ### Partiality is not yet defined [Open]
 
 Some expressions are *partial*: an out-of-range list index, a missing
-dict key, division by zero, integer overflow. Where this document says
+map key, division by zero, integer overflow. Where this document says
 such an expression "is not defined", it stops there deliberately: CHL
 has **no defined divergence semantics yet**. Whether a partial
 expression traps at runtime, diverges, is statically excluded by
@@ -736,7 +740,7 @@ error.
 ### 3.9 Subscript and attribute access
 
 ```
-target[index]    -- subscript: list element or dict lookup
+target[index]    -- subscript: list element or map lookup
 target.attr      -- attribute: record field access
 ```
 
@@ -744,13 +748,13 @@ target.attr      -- attribute: record field access
   element (0-based). An out-of-range subscript is a compile-time type
   error when statically known; otherwise the expression is not
   defined (see *Partiality*, §3).
-- **Subscript** on a dict with key `k` denotes the value associated
+- **Subscript** on a map with key `k` denotes the value associated
   with `k`. Looking up a missing key is not defined (see *Partiality*,
   §3).
 - **Attribute** on a record denotes the value of the named field. The
   field must exist; missing fields are a compile-time type error.
 
-Lists, dicts, and records all denote *finite functions* from their
+Lists, maps, and records all denote *finite functions* from their
 respective index domains (`UInt`, `K`, field-name) to their element /
 value type — so subscript and attribute access are uniformly
 "evaluate the finite function at a point," just spelt differently.
@@ -795,27 +799,28 @@ annotations are not yet writable in the surface syntax; some built-ins
 > `\x -> x -> 1` (a lambda returning a pair, §2.4) is unusual but
 > unambiguous — the first `->` closes the binder, the rest is body.
 
-### 3.11 List, tuple, record, dict literals
+### 3.11 List, tuple, record literals
 
 | Form | Denotes |
 |---|---|
 | `[]`, `[e₀, e₁, …]` | A finite list — an indexed bag of elements. The element at integer index `i` is `eᵢ`, but iteration order is unspecified (§3). Element types must unify. |
 | `(e,)`, `(e₀, e₁, …)`, `e₀, e₁, …` | An anonymous heterogeneous product (tuple). Element types may differ. Tuples are positional, not unordered: `(1, 2)` and `(2, 1)` are distinct values. |
-| `{}`, `{name: e, …}` | A record (named-field product). Field names are bare identifiers; field types may differ. |
-| `{k₀: v₀, …}` (any non-identifier key) | A dict (finite map). Key types must unify; value types must unify. Parses today, but rejected at lowering. |
+| `(name=e, …)` | A record (named-field product). Field names are bare identifiers; field types may differ. The parentheses are the product constructor, shared with tuples (§2.4). |
 
 A trailing comma is allowed in every form (and required to disambiguate
 `(e,)` from `(e)`).
 
-**Record vs. dict.** The parser classifies a `{...}` literal by its
-keys (§2.4): all-bare-identifier keys make a record, anything else
-makes a dict. The two are different constructs despite sharing a
-delimiter — a record is a product with statically-known fields, a dict
-is a finite map over dynamic keys. Both the shared delimiter and the
-look-at-the-keys rule are transitional (see the Direction note below).
+**Tuple vs. record.** Both use `( … )`: a comma-list of bare expressions is
+a tuple (`(1, 2)`), a comma-list of `name=value` fields is a record
+(`(x=1, y=2)`). `(e)` (no field, no trailing comma) is a parenthesised `e`.
 
-**Empty forms.** `{}` is the empty record. `[]` is the empty list.
-There is no empty-dict literal today.
+**Records are not braces.** `{...}` is type syntax (§6.1) — a record *type*
+`{name: T}` or a tuple type `{T, U}`. A `{...}` in value position is a
+lowering error. Finite maps are a collection literal `[k -> v, …]` (§6.3,
+**[Decided]**), not a brace form.
+
+**Empty forms.** `()` is the empty product — the unit value, and equally the
+empty record (§3.1). `[]` is the empty list.
 
 > **Direction [Decided].** The literal forms migrate with the
 > delimiter split (§2.4) and the collections model (§6.3), form by
@@ -824,10 +829,10 @@ There is no empty-dict literal today.
 > | Today | Target |
 > | --- | --- |
 > | `(1, 2)` — tuple | unchanged: `( … )` is the product constructor |
-> | `{name: e, …}` — record | `(name=e, …)` — a record is a product with named fields (and a call's keyword arguments are exactly such a record — §3.8) |
-> | `{"k": v, …}` — dict | `[k -> v, …]` — a map literal of entry pairs (§2.4); `[ … ]` is the collection delimiter |
+> | `(name=e, …)` — record | a record is a product with named fields (and a call's keyword arguments are exactly such a record — §3.8) |
+> | finite map | `[k -> v, …]` — a collection of entry pairs (§2.4); `[ … ]` is the collection delimiter |
 > | `[1, 2, 3]` — list | same spelling, but shared across collection types: the literal can denote an `Array`, `List`, or `Set`, disambiguated by annotation or usage, with `list([…])` / `set([…])` constructors for explicitness (**[Tentative]** — §6.3) |
-> | `{}` — empty record | the empty product `()`: records and tuples are both products (§3.8), so the empty record, the empty tuple, and the unit value coincide (§3.1) |
+> | empty record / unit | the empty product `()`: records and tuples are both products (§3.8), so the empty record, the empty tuple, and the unit value coincide (§3.1) |
 > | `[]` — empty list | same spelling; the empty-**map** spelling is **[Open]** (§2.4) |
 >
 > `{ … }` itself moves wholesale to the type level (§2.4, §6.1); no
@@ -1358,9 +1363,9 @@ marked one carries its status per "How to read this document".)
   have the same field names with the same field types.
 - `Mut(V)` / `Mut(V, Txn)` — mutable-variable / transactional-register
   type (§6.2, §8).
-- `Dict(K, V)` — finite-map type. **[Planned]** — dict literals parse
-  but are rejected at lowering (§3.11), and `Dict(…)` is not accepted
-  as an annotation.
+- `Map(K, V)` — finite-map type. **[Planned]** — the map literal
+  `[k -> v, …]` (§3.11) and `Map(…)` as an annotation are both
+  unimplemented.
 - `{T₀, T₁, …} ⇒ U` — function type. A function takes exactly one
   argument (§3.8): an n-parameter function's domain is the
   corresponding tuple type, and a keyword-argument function's domain
@@ -2035,13 +2040,12 @@ with parser-level support that lowering rejects:
 - **Pattern matching** beyond tuple destructuring on assignment
   targets — a `match`/`case` form appears in the north-star `txn_kv`
   (**[Tentative]**, §1.6) but has no design writeup.
-- **The term-level delimiter migration** — records `(f=1, …)`, maps
-  `[k -> v, …]`, `{…}` reserved for types (**[Decided]**, §2.4). Today
-  the parser still classifies `{…}` by its keys (record vs. dict) and
-  dict lowering is `Unsupported`; earlier plans to move dicts to
-  `[k: v, …]`, `[k=v, …]`, or Unicode `[k ↦ v, …]` are superseded by
-  the map-literal decision.
-- **Map/dict comprehensions** — not in the grammar; the surface form
+- **The term-level delimiter migration** — record values are `(f=1, …)`, and
+  `{…}` no longer denotes a term-level value (it is record-type / tuple-type
+  syntax, §2.4). Finite maps as `[k -> v, …]` remain **[Decided]**; earlier
+  plans to spell them `[k: v, …]`, `[k=v, …]`, or Unicode `[k ↦ v, …]` are
+  superseded by the map-literal decision.
+- **Map comprehensions** — not in the grammar; the surface form
   follows the map-literal decision above: `[k -> v for …]`
   (**[Decided]** as surface, unimplemented; the north-star
   `storefront` `/stats` rollup uses it).

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -794,7 +794,7 @@ mod tests {
     fn rendered_errors_have_exact_format() {
         let code = "\
 x = 1 +
-y = {\"a\": 1}
+y = {a: 1}
 y
 ";
         let errs = compile_err(code);
@@ -814,9 +814,9 @@ Error: parse error
 Error: lowering error
    ╭─[<test>:2:5]
    │
- 2 │ y = {\"a\": 1}
-   │     ────┬───
-   │         ╰───── dict literals (with non-identifier keys) are not yet supported
+ 2 │ y = {a: 1}
+   │     ───┬──
+   │        ╰──── `{…}` is type syntax (a record type `{name: T}`); a record value is written `(name=value)`
 ───╯
 ";
         let normalize = |s: &str| -> String {
@@ -839,12 +839,12 @@ Error: lowering error
     #[test]
     fn parse_error_does_not_suppress_later_lowering_errors() {
         // Statement 1 has a syntax error (parser recovers at the next
-        // newline); statement 2 contains a dict literal with non-identifier
-        // keys, which lowering rejects. We must see both stages' errors in
-        // the result.
+        // newline); statement 2 is a brace record in value position, which
+        // parses but lowering rejects (braces are type syntax). We must see
+        // both stages' errors in the result.
         let code = "\
 x = (1 +)
-y = {\"a\": 1}
+y = {a: 1}
 y
 ";
         let errs = compile_err(code);
@@ -882,8 +882,8 @@ y = 2 *
     #[test]
     fn multiple_lowering_errors_all_surface() {
         let code = "\
-x = {\"a\": 1}
-y = {\"b\": 2}
+x = {a: 1}
+y = {b: 2}
 y
 ";
         let errs = compile_err(code);

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -303,7 +303,7 @@ Cambra carries features beyond plain algebraic subtyping (explicit refinements, 
 
 Cambra has **one** sum representation, the **tagged variant** — `Type::Variant(Vec<(FieldKey, Type)>)`. Since the solver works on `ccl::Type` directly, there is no second variant form to convert to: inference, coalescing, and the public AST all use this one type. (Internally, `compact_type` keys its transient `CompactType` bag by `FieldKey`, but that is an implementation detail of compaction, not a separate type.)
 
-Tags are [`FieldKey`]s — the same key type as records/tuples — so a sum can be **named** (`FieldKey::Name`, a source-level `.Tag(...)`) or **anonymous/positional** (`FieldKey::Index`, the dual of a tuple). The formerly-separate untagged `Type::Union` is gone: a positional union `A | B` is simply `Variant([(Index 0, A), (Index 1, B)])`, and the surface `++`/CollectionUnion produces exactly that (see §2's `emit_collection_union`). One constructor, one coalesce path, one width-subtyping rule (the dual of records: a subtype has *fewer* tags).
+Tags are [`FieldKey`]s — the same key type as records/tuples — so a sum can be **named** (`FieldKey::Name`, a source-level `.Tag(...)`) or **anonymous/positional** (`FieldKey::Index`, the dual of a tuple). A positional union `A | B` is simply `Variant([(Index 0, A), (Index 1, B)])`, and the surface `++`/CollectionUnion produces exactly that (see §2's `emit_collection_union`). One constructor, one coalesce path, one width-subtyping rule (the dual of records: a subtype has *fewer* tags).
 
 Two senses of "union" remain distinct:
 
@@ -326,7 +326,7 @@ A refinement `{T | p}` carries a **set** of *witnesses* (each a [`Refinement`]) 
 
 A refinement is **required**, so `constrain_subtype` is strict for *concrete* bases: an unrefined concrete value does **not** flow into a refined position (`T ⊀ {T | p}`), and `{T | q} ⊀ {T | p}`. The one subtlety is the `S₂ ⊆ S₁ ∪ witnesses(b₁)` clause: when the subtype side's base `b₁` is an **inference variable**, it can still acquire the deficit `S₂ \ S₁`, so the solver flows `b₁ <: {b₂ | S₂ \ S₁}` onto the variable rather than rejecting (the refinement analog of how the record/function arms thread structure through a variable base; it fails later iff the variable resolves to a concrete base lacking those witnesses). This is what lets a value that is *already* refined be cast to acquire a further witness — `{D | p} ⇒ V <: {?a | q} ⇒ V` records `?a <: {D | p}`, stacking `q` over `p` (nested list-comprehension filters). Acquiring a refinement on a *concrete* value is still an *explicit* operation, not subsumption: the explicit `Cast` node from [PR #218](https://github.com/cambra-dev/Cambra/pull/218) (an upcast — `value <: target` — written `cast({D | r} ⇒ V, value)`) makes refinement-acquisition explicit, and the interpreter compiles a refinement on a **collection domain** to a runtime `Restrict`/`Filter` at the iteration boundary (the `Iterate`/`Restrict` arms of `operator_conversion`, where `extent_of` strips the domain refinement into a `Restrict`). The predicate `Expr` of each witness is inferred/coalesced like any other sub-tree (annotation-borne predicates via `emit_annotation_predicates` / `coalesce_type_predicates`).
 
-**Refinements in the post-inference check.** The post-inference structural check (`infer::check`, reimplemented on the same structural rules as emission via the `Typing` trait — see §2, *The post-inference check*) is **strict and refinement-aware throughout** — it does not strip refinements before its width-subtyping checks (retiring the old blanket strip and its `strip_refinements_deep` TODO). It runs `constrain_subtype` in two places, both fully refinement-aware:
+**Refinements in the post-inference check.** The post-inference structural check (`infer::check`, reimplemented on the same structural rules as emission via the `Typing` trait — see §2, *The post-inference check*) is **strict and refinement-aware throughout** — it does not strip refinements before its width-subtyping checks. It runs `constrain_subtype` in two places, both fully refinement-aware:
 
 * **Adjacency rules** (a `Compose` link's `prev_cod <: next_dom`, an `Apply`'s argument-vs-domain) check *refinement flow*: feeding an unrefined producer into a refinement consumer is rejected (`T ⊀ {T | p}`), exactly as the solver is. There is **no cast escape** — a producer must already carry the refinement its consumer demands. A `… ≫ (id ≫ cast({D | r} ⇒ V))` chain composes because join planning surfaces the iterated / join-satisfying extent on the *producing* morphism's codomain, so the upstream genuinely supplies `{D | r}` (see the reconstructability bullets below). The producer's witness and the cast's contract are typically re-minted as distinct predicate terms, so the adjacency relies on the structural-predicate match above.
 * **The reconcile** (a node's rule-reconstructed type vs the type inference recorded on it) is the plain strict `rule <: recorded` subtype check (the recorded type may be a width-wider supertype — e.g. an annotation).
@@ -447,16 +447,16 @@ For each `Branch { guard, body }`: the guard is constrained to `Type::Base(BaseT
 
 ### Record literals and field access
 
-CHL record literals use Python dict syntax with **bare identifier keys**:
+A CHL record value is a parenthesised list of `name=value` fields:
 
 ```python
-r = {x: 1, y: "hello"}   # Record([("x", 1), ("y", "hello")])
+r = (x=1, y="hello")   # Record([("x", 1), ("y", "hello")])
 r.x                        # Apply(r, Proj(ProjKey::Field("x"))) → 1
 ```
 
 **Lowering:**
-- `{k: v, ...}` (all keys must be bare `Name` nodes) → `TypedExprNode::Record([(k, v), ...])`. Dict literals with non-identifier keys (e.g. string constants) are rejected with `LoweringError::Unsupported`.
-- `expr.field` (Python `Attribute`) → `Apply(lower(expr), Proj(ProjKey::Field("field")))`.
+- `(name=v, ...)` → `TypedExprNode::Record([(name, v), ...])`.
+- `expr.field` → `Apply(lower(expr), Proj(ProjKey::Field("field")))`.
 
 **Type inference:** `Record([(k, e), ...])` infers to `Type::Record([(k, T), ...])` where each `T` is the inferred type of the corresponding value expression — identical in structure to `Tuple` inference.
 
@@ -550,7 +550,7 @@ Consult these definitions as needed; each term is introduced in context in §1�
 | **`CompactGraph`** | Algebraic subtyping | A top-level `CompactType` plus a side-table of recursive-variable definitions; the intermediate produced by `compact_type` and consumed by `simplify_type` / `coalesce_compact`. |
 | **Coalesce** | Algebraic subtyping | Materializing a `CompactGraph` back into an immutable `ccl::Type`: positive occurrences become a union of lower bounds, negative occurrences an intersection of upper bounds. |
 | **`FieldKey`** | Algebraic subtyping | The shared key for record/tuple fields *and* variant tags: `Index(usize)` for positional (anonymous) keys, `Name(SmolStr)` for named ones. |
-| **`Variant` (tagged sum)** | Both | The single sum representation: `Type::Variant`, keyed by [`FieldKey`]. Named tags are source-level `.Tag(...)`; positional (`Index`) tags are anonymous sums (what `++` produces). Width-subtyping is the dual of records (a subtype has *fewer* tags). Subsumes the old untagged `Type::Union`. |
+| **`Variant` (tagged sum)** | Both | The single sum representation: `Type::Variant`, keyed by [`FieldKey`]. Named tags are source-level `.Tag(...)`; positional (`Index`) tags are anonymous sums (what `++` produces). Width-subtyping is the dual of records (a subtype has *fewer* tags). |
 | **`ccl::Type`** | Both | The public, immutable, user-facing AST type — and, since the unification, also the solver's working representation. Inference unknowns are `Type::Infer`; `Hole` is normalized to a fresh var, while `Refinement` is kept and rides the lattice as a refinement witness. |
 | **Refinement witness** | Both | A `Type::Refinement(T, r)` carries a refinement witness `r` (an immutable predicate `Rc<TypedExpr>`) — a refinement in its role as a black box to the subtyping lattice. A type holds a *set* of witnesses, width-subtyped like records (more refinements ⇒ subtype; `{T\|p,q} <: {T\|p}`). Witnesses compare by type-blind structural predicate equality (`Refinement`'s `PartialEq`; pointer-equal predicates short-circuit) — not implication. A refinement is *required* — `constrain_subtype` is strict (`T ⊀ {T\|p}`); acquiring one is an explicit runtime `Restrict` at the collection-iteration boundary, not subsumption. |
 | **Let Binding Resolution** | Cambra-Specific | Ensuring a `Let` binding's fully resolved type overwrites the type of any `Var` references to it within the let body. |

--- a/src/ccl/lower/mod.rs
+++ b/src/ccl/lower/mod.rs
@@ -570,9 +570,8 @@ pub fn lower_expr(
                 "only integer subscripts are supported",
             )),
         },
-        // Record literal `{field: expr, ...}` — keys are bare identifiers.
-        // Lowered to a `Record` constructor: `{x: 1, y: "foo"}` becomes
-        // `Record([("x", Lit(1)), ("y", Lit("foo"))])`.
+        // Record value `(name=expr, ...)`. Lowered to a `Record` constructor:
+        // `(x=1, y="foo")` becomes `Record([("x", Lit(1)), ("y", Lit("foo"))])`.
         ChlExpr::Record(fields) => {
             let mut out = Vec::with_capacity(fields.len());
             for RecordField {
@@ -592,11 +591,6 @@ pub fn lower_expr(
             }
             Ok(Expr::new(TypedExprNode::Record(out)))
         }
-        // Dict literal with expression keys is not supported as a record.
-        ChlExpr::Dict(_) => Err(LoweringError::unsupported(
-            expr.span,
-            "dict literals (with non-identifier keys) are not yet supported",
-        )),
         // A colon-free brace group `{T, U}` is structural *type* syntax; it
         // has no term-level value. (It is accepted in annotation position as a
         // tuple type — see `lower_type_annotation`.)
@@ -604,6 +598,14 @@ pub fn lower_expr(
             expr.span,
             "`{…}` is type syntax (a tuple type `{T, U}`); \
              use `[…]` for a collection or `(…)` for a tuple value",
+        )),
+        // A brace record `{name: T}` is structural *type* syntax (a record
+        // type); a record *value* is written with parentheses. (Accepted in
+        // annotation position — see `lower_type_annotation`.)
+        ChlExpr::BraceRecord(_) => Err(LoweringError::unsupported(
+            expr.span,
+            "`{…}` is type syntax (a record type `{name: T}`); \
+             a record value is written `(name=value)`",
         )),
         // Attribute access `r.field` → `Apply(r, Proj(Field("field")))`.
         ChlExpr::Attribute { target, attr, .. } => Ok(Expr::apply(

--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -905,7 +905,7 @@ pub(super) fn lower_type_annotation(annotation: &Spanned<ChlExpr>) -> Result<Typ
             lower_type_application(annotation.span, head, args)
         }
         // Record type `{name: T, …}`.
-        ChlExpr::Record(fields) => {
+        ChlExpr::BraceRecord(fields) => {
             let mut out = Vec::with_capacity(fields.len());
             for field in fields {
                 out.push((
@@ -1332,6 +1332,19 @@ x";
         assert!(
             message.contains("type syntax"),
             "expected a type-syntax hint, got: {message}"
+        );
+    }
+
+    /// A brace record `{name: T}` is a record *type*; a record *value* is
+    /// `(name=value)`, so the brace form is rejected in value position.
+    #[test]
+    fn test_brace_record_as_value_rejected() {
+        let stmts = parse_module("{name: 1}");
+        let err = expect_one_lowering_error(&stmts);
+        let LoweringError::Unsupported { message, .. } = &err;
+        assert!(
+            message.contains("(name=value)"),
+            "expected a paren-record hint, got: {message}"
         );
     }
 }

--- a/src/chl_parser/ast.rs
+++ b/src/chl_parser/ast.rs
@@ -17,11 +17,11 @@
 //!   [`Stmt::If`] with one `branches` entry per `if`/`elif` and one
 //!   optional `else_body`, rather than `rustpython_ast`'s nested
 //!   `else: [If(...)]` representation.
-//! - **Records vs. dicts are syntactically distinct.** `{x: 1, y: 2}` (bare
-//!   identifier keys) parses as [`Expr::Record`]; `{"name": "alice"}`
-//!   (expression keys) parses as [`Expr::Dict`]. This matches how CHL already
-//!   interprets the two forms semantically and eliminates a re-classification
-//!   pass.
+//! - **Records are parens; braces are types.** A record *value* `(x=1, y=2)`
+//!   parses as [`Expr::Record`]. A brace literal is type syntax: `{x: T}`
+//!   (bare-identifier keys) is [`Expr::BraceRecord`] (a record type) and
+//!   `{T, U}` is [`Expr::BraceGroup`] (a tuple type). Lowering reads the brace
+//!   forms as types in annotation position and rejects them in value position.
 //! - **Feed / Define get their own variants.** `x << v` is [`Expr::Feed`] and
 //!   `x <<= v` is [`Stmt::Define`], rather than being a `BinOp(LShift)` and an
 //!   `AugAssign(LShift)` that lowering has to special-case.
@@ -342,23 +342,27 @@ pub enum Expr {
     /// `(e0)` parses as parenthesised `e0`, not as a tuple.
     Tuple(Vec<Spanned<Expr>>),
 
-    /// Record literal with bare-identifier keys: `{x: 1, y: 2}`.
+    /// Record **value** with named fields: `(x=1, y=2)`.
     ///
-    /// CHL treats this as a named-field product type, distinct from
-    /// [`Expr::Dict`] (which has expression keys).
+    /// The product constructor is the parentheses (see `docs/chl-spec.md`);
+    /// a record is a product with named fields, a tuple one with anonymous
+    /// fields, both delimited by `( … )`.
     Record(Vec<RecordField>),
 
-    /// Dict literal with expression keys: `{"name": "alice", expr: value}`.
-    Dict(Vec<(Spanned<Expr>, Spanned<Expr>)>),
-
-    /// A colon-free brace group: `{e0, e1, …}` (no `key: value` entries).
+    /// A brace record: `{x: T, y: U}` (bare-identifier keys with `:` values).
     ///
-    /// Term-level braces are reserved for structural **type** syntax
-    /// (see `docs/chl-spec.md`):
-    /// a tuple type `{T, U}`. This variant captures that spelling so a type
-    /// annotation can name a tuple type; lowering interprets it as a
+    /// Term-level braces are reserved for structural **type** syntax (see
+    /// `docs/chl-spec.md`), so this is a record *type*: lowering reads it as a
+    /// [`crate::ccl::Type::Record`] in annotation position and rejects it in
+    /// value position (a record *value* is `(x=1, y=2)`, [`Expr::Record`]).
+    BraceRecord(Vec<RecordField>),
+
+    /// A colon-free brace group: `{T, U}` (no `key: value` entries).
+    ///
+    /// Term-level braces are reserved for structural **type** syntax (see
+    /// `docs/chl-spec.md`): a tuple type `{T, U}`. Lowering interprets it as a
     /// [`crate::ccl::Type::Tuple`] in annotation position and rejects it in
-    /// value position (there is no term-level brace-group value).
+    /// value position.
     BraceGroup(Vec<Spanned<Expr>>),
 
     /// Subscript: `target[index]`.
@@ -427,7 +431,8 @@ pub enum Lit {
     None,
 }
 
-/// A field in an [`Expr::Record`]: `name: value`.
+/// A named field: `name=value` in an [`Expr::Record`] value, or `name: T` in
+/// an [`Expr::BraceRecord`] record type.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RecordField {
     pub name: SmolStr,

--- a/src/chl_parser/design-chl-parser.md
+++ b/src/chl_parser/design-chl-parser.md
@@ -1,29 +1,12 @@
 # CHL Parser Design
 
 This document describes the design of the Cambra High-Level Language (CHL)
-parser introduced in `src/chl_parser/`, which replaced the
-[`rustpython_parser`](https://crates.io/crates/rustpython-parser) front end.
+parser in `src/chl_parser/`.
 
-## Motivation
-
-The historical front end used `rustpython_parser` to parse CHL source as
-Python. This was expedient but constraining:
-
-1. **Strict Python compatibility is no longer a goal.** CHL has already
-   diverged from Python at the operator level (`<<` is the feed operator,
-   `<<=` defines a deferred output, `++` is collection union) and we want
-   to add more CHL-specific syntax in future without coercing it into
-   Python's grammar.
-
-2. **Error recovery is weak.** `rustpython_parser` aborts on the first
-   syntax error, surfacing one diagnostic per parse. For an interactive UX
-   we want to recover from local errors and report *all* problems in a file.
-
-3. **Lowering is awkward.** Several `rustpython_ast` shapes don't map
-   cleanly onto CCL — e.g. `if`/`elif` chains nest in `orelse` fields, and
-   record-style `{ident: value}` and dict-style `{"key": value}` share a
-   `Dict` variant that lowering has to re-classify. A bespoke CHL AST can be
-   shaped to match what lowering actually consumes.
+Two properties shape it: **error recovery** — parsing continues past a local
+syntax error and reports *all* problems in a file, for an interactive UX — and
+an **AST shaped to match what lowering consumes**, so lowering does no
+re-classification.
 
 ## Stack: logos + chumsky
 
@@ -122,7 +105,7 @@ refuses them at the syntactic level rather than parsing-then-erroring.
 
 ### Stage 3 — AST (`ast.rs`)
 
-Designed fresh — no dependency on `rustpython_ast`. Key shape choices:
+Key shape choices:
 
 - **Every node carries a span** via `Spanned<T>`, so diagnostics for any
   sub-expression have precise location info.
@@ -132,9 +115,11 @@ Designed fresh — no dependency on `rustpython_ast`. Key shape choices:
 - **`if`/`elif` chains flatten.** `Stmt::If` carries a `Vec<IfBranch>` (one
   per `if`/`elif`) plus an optional `else_body`, rather than nesting an
   `If` inside an `Else`. This matches the `Case` shape in CCL.
-- **Records and dicts are syntactically distinct.** `{x: 1}` (bare
-  identifier keys) parses as `Expr::Record`; `{"name": "alice"}` (expression
-  keys) parses as `Expr::Dict`. Lowering no longer has to re-classify.
+- **Records are parens; braces are types.** A record *value* `(x=1)` parses
+  as `Expr::Record`; brace literals are type syntax — `{x: T}` is
+  `Expr::BraceRecord`, `{T, U}` is `Expr::BraceGroup`, `{"name": v}` is
+  `Expr::Dict`. Lowering reads the brace forms as types and rejects them as
+  values.
 - **Feed / Define have their own variants.** `Expr::Feed` and `Stmt::Define`
   capture `<<` and `<<=` directly, rather than appearing as `BinOp(LShift)`
   and `AugAssign(LShift)` that lowering must special-case.
@@ -323,21 +308,6 @@ The structured `ParseErrorInfo` preserves everything ariadne needs
 so callers building their own diagnostic UI can render without going
 through ariadne.
 
-## Phased migration plan
-
-- **Phase 1 — Foundation.** Lexer, parser, AST, tests. Produces a CHL AST
-  that nothing consumes yet; `rustpython_parser` remains the authoritative
-  input to lowering. *(Landed.)*
-
-- **Phase 2 — Cutover.** [`src/ccl/lower/`](../ccl/lower/) ported to
-  consume the CHL AST directly; `rustpython-parser` and `rustpython-ast`
-  removed from `Cargo.toml`; `pretty_ast.rs` deleted; all integration tests <!-- doc-refs-ignore: pretty_ast.rs was intentionally deleted -->
-  switched. *(Landed.)*
-
-- **Phase 3 — Diagnostics.** Future work: more `.labelled(…)` annotations
-  for richer expected-set categories, and a real diagnostic surface in the
-  compile-error path so end users see ariadne output by default.
-
 ## Gotchas
 
 Two non-obvious chumsky 1.0-alpha lifetime pitfalls — both surface as the
@@ -362,10 +332,9 @@ unhelpful `'src must outlive 'static` error — were hit during development:
 - **Unit tests** in `lexer.rs` and `parser.rs` cover individual grammar
   productions and the layout pass.
 - **Integration tests** in `tests/chl_parser_roundtrip.rs` parse
-  representative CHL programs lifted from the existing test suite (joined
-  comprehensions, defer/feed patterns, function definitions with `yield`,
-  multi-line bracketed expressions, …) and assert the AST shape only at
-  the level required to catch regressions.
+  representative CHL programs (joined comprehensions, defer/feed patterns,
+  function definitions with `yield`, multi-line bracketed expressions, …) and
+  assert the AST shape only at the level required to catch regressions.
 
 Run with `cargo test chl_parser` for the unit tests and
 `cargo test --test chl_parser_roundtrip` for the integration tests.

--- a/src/chl_parser/parser.rs
+++ b/src/chl_parser/parser.rs
@@ -250,11 +250,33 @@ where
             )
             .boxed();
 
-        // Parenthesised expression / tuple / generator expression.
+        // Record value `(name=value, …)`: the parentheses are the product
+        // constructor and `=` binds a named field (§2.4). Tried before the
+        // plain-expression tail below; `name` not followed by `=` (e.g. `(x)`,
+        // `(x, y)`, `(x == y)`) falls through to a group/tuple.
+        let record_field = ident_only
+            .then_ignore(just(Token::Eq))
+            .then(expr.clone())
+            .map(|((name, name_span), value)| RecordField {
+                name,
+                name_span,
+                value,
+            });
+        let paren_record = record_field
+            .separated_by(just(Token::Comma))
+            .at_least(1)
+            .allow_trailing()
+            .collect::<Vec<_>>()
+            .then_ignore(just(Token::RParen))
+            .map_with(|fields, e| Spanned::new(e.span(), Expr::Record(fields)));
+
+        // Parenthesised expression / tuple / record / generator expression.
         let paren_group = just(Token::LParen)
             .ignore_then(choice((
                 // Empty tuple `()`.
                 just(Token::RParen).map_with(|_, e| Spanned::new(e.span(), Expr::Tuple(vec![]))),
+                // Record value `(name=value, …)`.
+                paren_record,
                 expr.clone()
                     .then(choice((
                         // Generator expression `(expr for ...)`.
@@ -285,23 +307,24 @@ where
             )))
             .boxed();
 
-        // Brace literal `{ … }`. One production covers every brace form,
-        // classified after the fact by whether its items carry a `: value`:
+        // Brace literal `{ … }` — always **type** syntax (record values are
+        // `(x=1)`, §2.4; maps are `[k -> v]`). One production covers every
+        // brace form, classified after the fact by whether its items carry a
+        // `: value`:
         //
-        //   - every item `key: value`  → record (all bare-ident keys) or dict
-        //   - no item has a value       → colon-free brace group `{T, U}`
-        //                                 (tuple-type syntax, `Expr::BraceGroup`)
-        //   - empty `{}`                → dict (preserves existing behaviour)
-        //   - mixed                     → a parse error
+        //   - every item `field: T`, all bare-ident fields → record type
+        //     (`Expr::BraceRecord`)
+        //   - no item has a value → colon-free brace group `{T, U}`
+        //     (tuple type, `Expr::BraceGroup`)
+        //   - anything else (empty `{}`, expression keys, mixed) → error:
+        //     it is neither a record type nor a tuple type
         //
-        // Parsing items as `expr (":" expr)?` (rather than two competing
-        // `{`-starting alternatives) keeps a single committed brace parser, so
-        // classification is a total function of what was matched instead of
-        // relying on `choice` backtracking across a consumed `{`.
+        // Parsing items as `expr (":" expr)?` keeps a single committed brace
+        // parser, so classification is a total function of what was matched.
         let brace_item = expr
             .clone()
             .then(just(Token::Colon).ignore_then(expr.clone()).or_not());
-        let dict_or_record = just(Token::LBrace)
+        let brace_type = just(Token::LBrace)
             .ignore_then(
                 brace_item
                     .separated_by(just(Token::Comma))
@@ -312,45 +335,31 @@ where
             .validate(|items, e, emitter| {
                 let span = e.span();
                 let with_value = items.iter().filter(|(_, v)| v.is_some()).count();
-                if items.is_empty() {
-                    // Empty `{}` stays a (rejected-at-lowering) dict, matching
-                    // the pre-existing behaviour; the empty-record/unit meaning
-                    // is a separate, unsettled question.
-                    return Spanned::new(span, Expr::Dict(Vec::new()));
-                }
-                if with_value == items.len() {
-                    // Every item has a value: record iff all keys are bare
-                    // identifiers, else dict.
-                    let all_idents = items.iter().all(|(k, _)| matches!(k.node, Expr::Name(_)));
-                    if all_idents {
-                        let fields = items
-                            .into_iter()
-                            .map(|(k, v)| match k.node {
-                                Expr::Name(name) => RecordField {
-                                    name,
-                                    name_span: k.span,
-                                    value: v.expect("all items have a value"),
-                                },
-                                _ => unreachable!("guarded by all_idents"),
-                            })
-                            .collect();
-                        Spanned::new(span, Expr::Record(fields))
-                    } else {
-                        let entries = items
-                            .into_iter()
-                            .map(|(k, v)| (k, v.expect("all items have a value")))
-                            .collect();
-                        Spanned::new(span, Expr::Dict(entries))
-                    }
-                } else if with_value == 0 {
-                    // No `: value` anywhere: a colon-free brace group.
+                let all_idents =
+                    !items.is_empty() && items.iter().all(|(k, _)| matches!(k.node, Expr::Name(_)));
+                if !items.is_empty() && with_value == items.len() && all_idents {
+                    // Record type `{field: T, …}`.
+                    let fields = items
+                        .into_iter()
+                        .map(|(k, v)| match k.node {
+                            Expr::Name(name) => RecordField {
+                                name,
+                                name_span: k.span,
+                                value: v.expect("all items have a value"),
+                            },
+                            _ => unreachable!("guarded by all_idents"),
+                        })
+                        .collect();
+                    Spanned::new(span, Expr::BraceRecord(fields))
+                } else if !items.is_empty() && with_value == 0 {
+                    // Tuple type `{T, U}` (colon-free brace group).
                     let elts = items.into_iter().map(|(k, _)| k).collect();
                     Spanned::new(span, Expr::BraceGroup(elts))
                 } else {
                     emitter.emit(Rich::custom(
                         span,
-                        "brace items must be either all `key: value` (record or dict) \
-                         or all bare expressions (tuple type `{T, U}`), not a mix",
+                        "`{…}` is type syntax: a record type `{field: T}` or a \
+                         tuple type `{T, U}`; a map is written `[k -> v]`",
                     ));
                     Spanned::new(span, Expr::Error)
                 }
@@ -360,9 +369,9 @@ where
         // The atom is the lowest level of expression precedence — failure
         // here is the most common "expected an expression here" diagnostic.
         // We label it so error messages collapse the 5+ atom alternatives
-        // (literal, name, `(…)`, list, dict) into a single "expression"
+        // (literal, name, `(…)`, list, brace type) into a single "expression"
         // label when the failure is at the atom's start position.
-        let atom = choice((lit, list_or_listcomp, paren_group, dict_or_record, name))
+        let atom = choice((lit, list_or_listcomp, paren_group, brace_type, name))
             .labelled("expression")
             .recover_with(via_parser(nested_delimiters(
                 Token::LParen,
@@ -1207,14 +1216,21 @@ mod tests {
     }
 
     #[test]
-    fn record_vs_dict() {
-        // Bare-ident keys → Record.
-        assert!(matches!(parse_e("{x: 1, y: 2}").node, Expr::Record(_)));
-        // String keys → Dict.
+    fn record_value_and_brace_forms() {
+        // A record *value* is `(name=value, …)` (parens).
         assert!(matches!(
-            parse_e(r#"{"name": "alice"}"#).node,
-            Expr::Dict(_)
+            parse_e("(x=1, y=2)").node,
+            Expr::Record(fields) if fields.len() == 2
         ));
+        // `(name)` without `=` is a parenthesised group, not a record.
+        assert!(matches!(parse_e("(x)").node, Expr::Name(_)));
+        // Brace with bare-ident keys is a record *type* (`BraceRecord`).
+        assert!(matches!(parse_e("{x: 1, y: 2}").node, Expr::BraceRecord(_)));
+        // Expression-key braces are not a valid type — a map is `[k -> v]`.
+        assert!(
+            !parse_expression(r#"{"name": "alice"}"#).errors.is_empty(),
+            "expression-key braces should be a parse error"
+        );
     }
 
     #[test]

--- a/tests/chl_parser_roundtrip.rs
+++ b/tests/chl_parser_roundtrip.rs
@@ -95,13 +95,18 @@ fn joined_comprehension_from_survey() {
 }
 
 #[test]
-fn records_and_dicts() {
-    // Bare-ident keys → Record.
-    let r = must_parse_expr("{x: 1, y: 2}");
+fn records_and_brace_types() {
+    // A record *value* is `(name=value, …)`.
+    let r = must_parse_expr("(x=1, y=2)");
     assert!(matches!(r.node, Expr::Record(_)));
-    // String keys → Dict.
-    let d = must_parse_expr(r#"{"name": "alice", "age": 30}"#);
-    assert!(matches!(d.node, Expr::Dict(_)));
+    // Bare-ident brace keys → record *type* (`BraceRecord`).
+    let rt = must_parse_expr("{x: 1, y: 2}");
+    assert!(matches!(rt.node, Expr::BraceRecord(_)));
+    // Expression-key braces are not a valid type — a map is `[k -> v]`.
+    assert!(
+        !parse_module(r#"{"name": "alice"}"#).errors.is_empty(),
+        "expression-key braces should be a parse error"
+    );
 }
 
 #[test]

--- a/tests/compilation_pipeline/mutability.rs
+++ b/tests/compilation_pipeline/mutability.rs
@@ -32,7 +32,7 @@ x"#,
     Tile::Scalar(ColumnValue::Ints(vec![6]))
 )]
 // The accumulator's value type can be spelled concretely: `Mut(Int)`
-// annotates the binding at `int` (checked against init and updates).
+// annotates the binding at `Int` (checked against init and updates).
 #[case(
     r#"
 x: Mut(Int) := 0
@@ -580,30 +580,30 @@ fn mut_arg_must_be_a_mutable_not_a_plain_value() {
 #[test]
 fn nonmut_param_reads_mut_arg_current_value() {
     check_scalar(
-        "cnt: Mut[int] := 5\ndef g(a: int):\n    a + 1\ng(cnt)",
+        "cnt: Mut(Int) := 5\ndef g(a: Int):\n    a + 1\ng(cnt)",
         cambra::interpreter::Value::Int(6),
     );
 }
 // The enforced annotation has force even when the argument is a mutable
-// variable: a `str` parameter rejects an `int` register's value. Before
+// variable: a `String` parameter rejects an `Int` register's value. Before
 // parameter annotations were carried through lowering this compiled — the
-// annotation was silently dropped and `a` inferred `int` from the argument.
+// annotation was silently dropped and `a` inferred `Int` from the argument.
 #[test]
 fn nonmut_param_annotation_enforced_against_mut_arg() {
     expect_compile_error(
-        "cnt: Mut[int] := 0\ndef g(a: str):\n    a\ng(cnt)",
+        "cnt: Mut(Int) := 0\ndef g(a: String):\n    a\ng(cnt)",
         "mismatch",
     );
 }
-// Pass-by-reference sibling of the above: a `Mut[int]` register cannot bind a
-// `Mut[str]` parameter — the value types must agree across the `(Mut, Mut)`
+// Pass-by-reference sibling of the above: a `Mut(Int)` register cannot bind a
+// `Mut(String)` parameter — the value types must agree across the `(Mut, Mut)`
 // edge. (This path is unchanged by parameter-annotation enforcement; the `Mut`
 // annotation always seeded the binder type. Pinned here because nothing else
 // covers a `Mut` value-type clash at a call site.)
 #[test]
 fn mut_param_value_type_must_match_mut_arg() {
     expect_compile_error(
-        "cnt: Mut[int] := 0\ndef g(c: Mut[str]):\n    c := \"x\"\ng(cnt)\ncnt",
+        "cnt: Mut(Int) := 0\ndef g(c: Mut(String)):\n    c := \"x\"\ng(cnt)\ncnt",
         "mismatch",
     );
 }
@@ -691,7 +691,7 @@ fn mutable_reads_are_positional() {
 /// `y: Int = x` must compile (not trip the rule-3 "unannotated `Mut` alias"
 /// error). Regression for the deref-copy being bound at the mutable type, which
 /// made `y` a `Mut` alias in the type system and misfired the discipline on a
-/// binding the user declared `int`.
+/// binding the user declared `Int`.
 #[test]
 fn deref_copy_is_a_value_not_a_mutable_alias() {
     check_scalar(
@@ -702,7 +702,7 @@ fn deref_copy_is_a_value_not_a_mutable_alias() {
 
 /// Writing a deref-copy is rejected — `y: Int = x` is immutable, so `y += 1` is
 /// the "not a mutable variable" error, never a silent mutable write. Regression for a
-/// write-site demand coalescing the `int`-declared `y`'s `.ty` to `Mut` and the
+/// write-site demand coalescing the `Int`-declared `y`'s `.ty` to `Mut` and the
 /// write-target check trusting `.ty` over the annotation.
 #[test]
 fn write_to_deref_copy_rejected() {

--- a/tests/compilation_pipeline/records.rs
+++ b/tests/compilation_pipeline/records.rs
@@ -25,17 +25,17 @@ use crate::helpers::*;
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 #[case(
-    "{x: 1, y: 2}",
+    "(x=1, y=2)",
     make_record(&[("x", Value::Int(1)), ("y", Value::Int(2))])
 )]
 #[case(
-    r#"{name: "alice", age: 30}"#,
+    r#"(name="alice", age=30)"#,
     make_record(&[("name", Value::String("alice".into())), ("age", Value::Int(30))])
 )]
-#[case("{x: 1, y: 2}.x", Value::Int(1))]
-#[case("{x: 1, y: 2}.y", Value::Int(2))]
-#[case(r#"r = {name: "bob", score: 99}; r.score"#, Value::Int(99))]
-#[case(r#"r = {name: "bob", score: 99}; r.name"#, Value::String("bob".into()))]
+#[case("(x=1, y=2).x", Value::Int(1))]
+#[case("(x=1, y=2).y", Value::Int(2))]
+#[case(r#"r = (name="bob", score=99); r.score"#, Value::Int(99))]
+#[case(r#"r = (name="bob", score=99); r.name"#, Value::String("bob".into()))]
 fn test_records(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
@@ -46,9 +46,9 @@ fn test_records(#[case] code: &str, #[case] expected: Value) {
 
 #[rstest]
 #[timeout(Duration::from_secs(10))]
-#[case("{x: 1 + 2, y: 3 * 4}", make_record(&[("x", Value::Int(3)), ("y", Value::Int(12))]))]
-#[case(r#"r = {x: 10, y: 3}; r.x - r.y"#, Value::Int(7))]
-#[case(r#"r = {x: 10, y: 3}; r.x * r.y"#, Value::Int(30))]
+#[case("(x=1 + 2, y=3 * 4)", make_record(&[("x", Value::Int(3)), ("y", Value::Int(12))]))]
+#[case(r#"r = (x=10, y=3); r.x - r.y"#, Value::Int(7))]
+#[case(r#"r = (x=10, y=3); r.x * r.y"#, Value::Int(30))]
 fn test_records_computed(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
@@ -60,8 +60,8 @@ fn test_records_computed(#[case] code: &str, #[case] expected: Value) {
 /// Project a field from an inline record literal in a list comprehension body.
 #[rstest]
 #[timeout(Duration::from_secs(10))]
-#[case("[{n: x, doubled: x * 2}.n for x in [1, 2, 3]]", make_int_list(&[1, 2, 3]))]
-#[case("[{n: x, doubled: x * 2}.doubled for x in [1, 2, 3]]", make_int_list(&[2, 4, 6]))]
+#[case("[(n=x, doubled=x * 2).n for x in [1, 2, 3]]", make_int_list(&[1, 2, 3]))]
+#[case("[(n=x, doubled=x * 2).doubled for x in [1, 2, 3]]", make_int_list(&[2, 4, 6]))]
 fn test_record_field_in_comp_body(#[case] code: &str, #[case] expected: Tile) {
     check_tile(code, expected);
 }
@@ -71,7 +71,7 @@ fn test_record_field_in_comp_body(#[case] code: &str, #[case] expected: Tile) {
 #[timeout(Duration::from_secs(10))]
 fn test_comp_with_record_body() {
     let tile =
-        sort_sealed_function_by_domain(run_pipeline("[{n: x, doubled: x * 2} for x in [1, 2, 3]]"));
+        sort_sealed_function_by_domain(run_pipeline("[(n=x, doubled=x * 2) for x in [1, 2, 3]]"));
     assert_eq!(
         extract_record_field(tile.clone(), "n"),
         ColumnValue::Ints(vec![1, 2, 3]),
@@ -86,11 +86,11 @@ fn test_comp_with_record_body() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 #[case(
-    r#"[r.x for r in [{x: 1, y: "a"}, {x: 2, y: "b"}, {x: 3, y: "c"}]]"#,
+    r#"[r.x for r in [(x=1, y="a"), (x=2, y="b"), (x=3, y="c")]]"#,
     make_int_list(&[1, 2, 3])
 )]
 #[case(
-    r#"[r.y for r in [{x: 1, y: "a"}, {x: 2, y: "b"}, {x: 3, y: "c"}]]"#,
+    r#"[r.y for r in [(x=1, y="a"), (x=2, y="b"), (x=3, y="c")]]"#,
     Tile::SealedFunction {
         domain: ColumnValue::UInts(vec![0, 1, 2]),
         codomain: Box::new(Tile::Scalar(ColumnValue::Strings(vec![
@@ -111,7 +111,7 @@ fn test_comp_over_record_list(#[case] code: &str, #[case] expected: Tile) {
 #[timeout(Duration::from_secs(10))]
 fn test_comp_filter_on_record_field() {
     let tile = sort_sealed_function_by_domain(run_pipeline(
-        r#"[r.name for r in [{name: "alice", age: 30}, {name: "bob", age: 17}, {name: "carol", age: 25}] if r.age >= 18]"#,
+        r#"[r.name for r in [(name="alice", age=30), (name="bob", age=17), (name="carol", age=25)] if r.age >= 18]"#,
     ));
     let Tile::SealedFunction { codomain, .. } = tile else {
         panic!("expected SealedFunction");
@@ -127,7 +127,7 @@ fn test_comp_filter_on_record_field() {
 #[timeout(Duration::from_secs(10))]
 fn test_aggregate_over_record_field() {
     check_scalar(
-        r#"sum([r.score for r in [{score: 10}, {score: 20}, {score: 30}]])"#,
+        r#"sum([r.score for r in [(score=10), (score=20), (score=30)]])"#,
         Value::Int(60),
     );
 }
@@ -140,7 +140,7 @@ fn test_aggregate_over_record_field() {
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 fn test_join_with_record_body() {
-    let tile = run_pipeline("[{a: x, b: y} for x in [1, 2] for y in [3, 4] if x + y == 5]");
+    let tile = run_pipeline("[(a=x, b=y) for x in [1, 2] for y in [3, 4] if x + y == 5]");
     // (1,4) and (2,3) are the only pairs summing to 5.
     // Output order is determined by join domain — sort both fields together by "a" to compare.
     let ColumnValue::Ints(a_vals) = extract_record_field(tile.clone(), "a") else {
@@ -161,7 +161,7 @@ fn test_join_with_record_body() {
 #[timeout(Duration::from_secs(10))]
 fn test_hash_join_record_body() {
     let tile = sort_sealed_function_by_domain(run_pipeline(
-        "[{left: x, right: y} for x in [1, 2, 3] for y in [2, 3, 4] if x == y]",
+        "[(left=x, right=y) for x in [1, 2, 3] for y in [2, 3, 4] if x == y]",
     ));
     // matched pairs: (2,2) and (3,3)
     assert_eq!(

--- a/tests/compilation_pipeline/scalars_collections.rs
+++ b/tests/compilation_pipeline/scalars_collections.rs
@@ -29,8 +29,8 @@ fn test_literals(#[case] code: &str, #[case] expected: Value) {
 #[timeout(Duration::from_secs(10))]
 // Capitalized primitive.
 #[case("x: Int = 5\nx", Value::Int(5))]
-// Record type `{name: T, …}`.
-#[case("p: {a: Int, b: Int} = {a: 1, b: 2}\np.a", Value::Int(1))]
+// Record type `(name=T, …)`.
+#[case("p: {a: Int, b: Int} = (a=1, b=2)\np.a", Value::Int(1))]
 // Tuple type `{T, U}` (colon-free brace group).
 #[case("t: {Int, Bool} = (1, True)\nt[0]", Value::Int(1))]
 fn test_type_annotation_forms(#[case] code: &str, #[case] expected: Value) {

--- a/tests/programs/filter_and_aggregate/program.cambra
+++ b/tests/programs/filter_and_aggregate/program.cambra
@@ -1,7 +1,7 @@
 users = [
-    {name: "alice", age: 30, score: 85},
-    {name: "bob",   age: 17, score: 92},
-    {name: "carol", age: 25, score: 78},
-    {name: "dave",  age: 45, score: 90},
+    (name="alice", age=30, score=85),
+    (name="bob",   age=17, score=92),
+    (name="carol", age=25, score=78),
+    (name="dave",  age=45, score=90),
 ]
 sum([u.score for u in users if u.age >= 18])

--- a/tests/programs/groupby_rollup/program.cambra
+++ b/tests/programs/groupby_rollup/program.cambra
@@ -1,8 +1,8 @@
 sales = [
-    {region: "west",  amount: 100},
-    {region: "east",  amount: 50},
-    {region: "west",  amount: 200},
-    {region: "south", amount: 75},
-    {region: "east",  amount: 150},
+    (region="west",  amount=100),
+    (region="east",  amount=50),
+    (region="west",  amount=200),
+    (region="south", amount=75),
+    (region="east",  amount=150),
 ]
 [sum([s.amount for s in g]) for g in groupby(sales, lambda r: r.region)]

--- a/tests/programs/inner_join/program.cambra
+++ b/tests/programs/inner_join/program.cambra
@@ -3,20 +3,20 @@
 # no matching user (e.g. user_id=99) are dropped from the output.
 
 users = [
-    {id: 1, name: "alice"},
-    {id: 2, name: "bob"},
-    {id: 3, name: "carol"},
+    (id=1, name="alice"),
+    (id=2, name="bob"),
+    (id=3, name="carol"),
 ]
 
 orders = [
-    {user_id: 1, amount: 50},
-    {user_id: 2, amount: 75},
-    {user_id: 1, amount: 100},
-    {user_id: 99, amount: 999},
+    (user_id=1, amount=50),
+    (user_id=2, amount=75),
+    (user_id=1, amount=100),
+    (user_id=99, amount=999),
 ]
 
 [
-    {customer: u.name, total: o.amount}
+    (customer=u.name, total=o.amount)
     for u in users
     for o in orders
     if u.id == o.user_id

--- a/tests/programs/reachability/mod.rs
+++ b/tests/programs/reachability/mod.rs
@@ -6,10 +6,11 @@
 //! terminate).
 //!
 //! **Currently blocked at parsing.**  The record-term syntax `(src=1, dst=2)`
-//! isn't accepted yet — the parser stops at the `=`.  Beyond that lie the
-//! `Set(T)` type constructor and the self-referential (recursive) binding,
-//! neither of which is implemented.  This pins the first failure; when record
-//! terms parse, the test goes red and the next blocker gets pinned.
+//! now parses; the next blocker is the `rec` recursive binding — `rec` is not
+//! a keyword yet, so `rec reach_comp` reads as two identifiers.  Beyond that
+//! lie the `Set(T)` type constructor and the fixpoint semantics.  This pins
+//! the `rec` failure; when `rec` is supported, the test goes red and the next
+//! blocker gets pinned.
 //!
 //! Expected output once fully unblocked (the reachable-pair set, sorted):
 //! `{(1,2),(1,3),(1,4),(1,5),(2,3),(2,4),(2,5),(3,4)}`.
@@ -18,8 +19,5 @@ use super::common::expect_compile_error;
 
 #[test]
 fn reachability_currently_blocked_at_parsing() {
-    expect_compile_error(
-        include_str!("program.cambra"),
-        "found '=', expected binary operator",
-    );
+    expect_compile_error(include_str!("program.cambra"), "rec reach_comp");
 }

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -197,21 +197,21 @@ fn test_list_literal() {
 // A `def`/lambda parameter's type annotation is a **checking-mode declaration**
 // that lowering must carry to the lambda so inference enforces it at the call
 // site — mirroring variable ascription (`x: T = e`). Regression for a
-// long-standing lowering gap: `uncurry_params` attached only `Mut[…]`
+// long-standing lowering gap: `uncurry_params` attached only `Mut(…)`
 // annotations and dropped every other one, so a `def` param was inferred purely
 // from its body and any argument was accepted.
 #[test]
 fn test_def_param_annotation_enforced() {
     // A scalar annotation is enforced at the call site: an identity body infers
     // nothing on its own, so without the annotation any argument was accepted.
-    assert_eq!(infer_program("def g(a: int):\n    a\ng(1)"), int());
-    assert!(!infer_program_err("def g(a: int):\n    a\ng(\"x\")").is_empty());
-    // A `List[int]` annotation enforces the element type through the annotation.
+    assert_eq!(infer_program("def g(a: Int):\n    a\ng(1)"), int());
+    assert!(!infer_program_err("def g(a: Int):\n    a\ng(\"x\")").is_empty());
+    // A `List(Int)` annotation enforces the element type through the annotation.
     assert_eq!(
-        infer_program("def g(a: List[int]):\n    sum(a)\ng([1, 2, 3])"),
+        infer_program("def g(a: List(Int)):\n    sum(a)\ng([1, 2, 3])"),
         int()
     );
-    assert!(!infer_program_err("def g(a: List[int]):\n    sum(a)\ng([\"a\", \"b\"])").is_empty());
+    assert!(!infer_program_err("def g(a: List(Int)):\n    sum(a)\ng([\"a\", \"b\"])").is_empty());
     // An unannotated param still infers purely from use.
     assert_eq!(infer_program("def g(a):\n    a\ng(\"x\")"), string());
 }
@@ -220,13 +220,13 @@ fn test_def_param_annotation_enforced() {
 fn test_multiarg_def_param_annotation_enforced() {
     // Each tupled parameter's annotation is enforced independently.
     assert_eq!(
-        infer_program("def g(a: int, b: str):\n    a\ng(1, \"x\")"),
+        infer_program("def g(a: Int, b: String):\n    a\ng(1, \"x\")"),
         int()
     );
     // Wrong type on `a` is rejected.
-    assert!(!infer_program_err("def g(a: int, b: str):\n    a\ng(\"x\", \"y\")").is_empty());
+    assert!(!infer_program_err("def g(a: Int, b: String):\n    a\ng(\"x\", \"y\")").is_empty());
     // Wrong type on `b` is rejected.
-    assert!(!infer_program_err("def g(a: int, b: str):\n    a\ng(1, 2)").is_empty());
+    assert!(!infer_program_err("def g(a: Int, b: String):\n    a\ng(1, 2)").is_empty());
     // Fully unannotated params still infer from use.
     assert_eq!(infer_program("def g(a, b):\n    a + b\ng(1, 2)"), int());
 }


### PR DESCRIPTION
Record *values* are now written with parentheses and `=`: `(x=1, y=2)`. The
parentheses are the product constructor, shared with tuples (`(1, 2)`) — a
comma-list of bare expressions is a tuple, a comma-list of `name=value`
fields a record (docs/chl-spec.md, §2.4/§3.11).

Braces are now **type syntax only** at the term level: `{x: T}` is a record
type (`Expr::BraceRecord`), `{T, U}` a tuple type (`Expr::BraceGroup`); both
lower as types in annotation position and are rejected in value position. The
old brace record *value* `{x: 1}` no longer denotes a value.

Dict is retired end to end. `Dict(K, V)` is renamed to `Map(K, V)` in the
spec and design docs, with the map *literal* settled as `[k -> v, …]`
(collection syntax, [Decided]/unimplemented). The dead `Expr::Dict` node and
its brace-dict parse/lowering path are deleted — expression-key braces
(`{"k": v}`) are now a plain parse error pointing at `[k -> v]`.

Also strips rustpython/migration history from the parser design doc and a
couple of "old X" codebase-history notes from the CCL design docs.

Migrates the record-value corpus (`{k: v}` → `(k=v)`), keeping record-*type*
annotations (`{name: T}`) in braces. reachability's record-term syntax now
parses, so its pin advances to the `rec` blocker.