### PR TITLE
Preserve refinement-predicate Rc sharing across inference and planning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,11 @@ jobs:
         # Read more about the "hidden ifs" and general inanity here
         # https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions
         if: steps.filter.outputs.code == 'true' && (success() || failure())
-        run: ./ci.sh test
+        # Enable the opt-in per-operation typecheck (the `deep-typecheck`
+        # feature) in automated runs so it keeps guarding against a pass that
+        # produces an ill-typed tree — it is off by default locally because it is
+        # superlinear on nested comprehensions (see `ci_test` / `debug_typecheck`).
+        run: DEEP_TYPECHECK=1 ./ci.sh test
 
         # 4. Success Signal for noops
       - name: No-op for docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,16 @@ readme = "README.md"
 # to a crate's dev-dependencies to enable.
 test-helpers = []
 
+# Run the *per-operation* post-rewrite typecheck ([`debug_typecheck`]) that
+# pass-internal helpers (lambda elimination, substitution, simplify) invoke
+# after each rewrite. It is a debugging aid that localizes *which* operation
+# first produced an ill-typed tree; `compile_program`'s pass-boundary
+# `check_pre_desugar` walls remain the always-on correctness net. Off by default
+# (even in debug): the check is O(subtree) and fires per rewrite, so on nested
+# comprehensions it was superlinear and dominated debug/test compile time.
+# Enable when bisecting a miscompile: `cargo test --features deep-typecheck`.
+deep-typecheck = []
+
 [dev-dependencies]
 microbench = "0.5.0"
 rstest = { version = "0.26.1", features = ["async-timeout"] }

--- a/ci.sh
+++ b/ci.sh
@@ -18,7 +18,11 @@ ci_clippy() { cargo clippy --all-targets -- -D warnings; }
 # (e.g. a test calling a debug-only fn) only breaks here. `-- -D warnings` is
 # scoped to our crate, not deps.
 ci_clippy_release() { cargo clippy --release --all-targets -- -D warnings; }
-ci_test() { cargo test -q; }
+# `DEEP_TYPECHECK=1` turns on the opt-in per-operation typecheck (see the
+# `deep-typecheck` feature). The GitHub workflow sets it so automated runs keep
+# exercising that check; it stays off for a bare local `./ci.sh` because it is
+# superlinear on nested comprehensions (that cost is why it is gated).
+ci_test() { cargo test -q ${DEEP_TYPECHECK:+--features deep-typecheck}; }
 ci_doc() {
   RUSTDOCFLAGS="-A warnings -D rustdoc::broken_intra_doc_links" \
     cargo doc --no-deps

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -184,9 +184,7 @@ pub fn refine_codomain(morphism: Expr, bare_predicate: &Expr) -> Expr {
     // structurally equal to the cast demand.
     let refined = Type::Refinement(
         Box::new(codomain),
-        Refinement {
-            predicate: Rc::new(bare_predicate.clone()),
-        },
+        Refinement::born(Rc::new(bare_predicate.clone())),
     );
     set_codomain(morphism, refined)
 }
@@ -300,12 +298,7 @@ pub fn cast_target_refinement(target: &Type) -> Option<Refinement> {
 /// inference fills them in by unifying against the value being cast.
 pub fn refined_fn_type(base_domain: Type, predicate: Expr, codomain: Type) -> Type {
     Type::fun(
-        Type::Refinement(
-            Box::new(base_domain),
-            Refinement {
-                predicate: Rc::new(predicate),
-            },
-        ),
+        Type::Refinement(Box::new(base_domain), Refinement::born(Rc::new(predicate))),
         codomain,
     )
 }
@@ -397,12 +390,7 @@ fn refine_with(base: Type, predicate: &Expr) -> Type {
         return base;
     }
     let bare = bare_predicate_of_fn(&base, predicate.clone());
-    Type::Refinement(
-        Box::new(base),
-        Refinement {
-            predicate: Rc::new(bare),
-        },
-    )
+    Type::Refinement(Box::new(base), Refinement::born(Rc::new(bare)))
 }
 
 /// Count free occurrences of `name` in `expr`, including occurrences in
@@ -757,46 +745,128 @@ where
     ty.walk_children(|child| walk_refined_predicates(child, visited, f));
 }
 
+/// Pass-scoped memo that **preserves refinement-predicate `Rc` sharing** across
+/// a single rebuild pass.
+///
+/// Predicates are immutable `Rc<TypedExpr>`s (see [`Refinement::predicate`]), so
+/// any pass that must "update" a predicate — resolve embedded inference vars
+/// (`coalesce`), restamp binder types (`retype`), eliminate lambdas
+/// (`lambda_elim`), simplify, or substitute — *rebuilds* it into a fresh `Rc`
+/// rather than mutating in place. When one predicate term rides several type
+/// slots as a shared `Rc` (a comprehension's filtered domain appears on its
+/// source, map, cast, and consumer-contract types), rebuilding each occurrence
+/// independently **splits** that sharing. The split is invisible to correctness
+/// — the rebuilds are value-equal (refinement equality is structural) — but it
+/// defeats every downstream `Rc`-identity dedup: `Rc::ptr_eq` fast paths and, in
+/// particular, planning's per-predicate compile memo, which then recompiles one
+/// predicate once per occurrence (superlinearly, on nested comprehensions).
+///
+/// This memo re-points every occurrence that entered a pass sharing one origin
+/// `Rc` at a *single* rebuilt `Rc`, so sharing survives the pass. It is the one
+/// mechanism every predicate-rebuilding pass threads; the alternative —
+/// reunifying afterward by structural hash/eq — would reintroduce exactly the
+/// per-predicate hashing cost the `Rc` boxing exists to avoid.
+///
+/// **The memo must be pass-scoped.** One instance threaded across the *whole*
+/// tree walk of a pass. A fresh memo per node/subtree re-shares only within that
+/// node and still splits across the tree — the exact bug this type prevents.
+/// The sharing invariant is guarded end-to-end by `tests/predicate_sharing.rs`
+/// and, per phase, by asserting [`distinct_predicate_rcs`] does not grow across
+/// a transform-only pass.
+///
+/// Keyed on [`PredicateId`] (the origin `Rc`'s address). Sound only while that
+/// address cannot be reused during the pass, which [`Self::record`] guarantees
+/// by retaining a `keepalive` clone of every origin `Rc` for the memo's
+/// lifetime: without it, overwriting a `refinement.predicate` could drop the
+/// origin `Rc`, freeing an address a later `Rc::new` in the same pass could
+/// reclaim, so an unrelated predicate landing there would collide and inherit
+/// this entry's rebuild.
+#[derive(Default)]
+pub struct PredMemo(HashMap<PredicateId, (Rc<Expr>, Rc<Expr>)>);
+
+impl PredMemo {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The rebuilt predicate for `refinement`'s origin `Rc`, if an occurrence
+    /// sharing it was already rebuilt in this pass. Clones the shared `Rc` out
+    /// so the caller holds **no** borrow of the memo across its own transform —
+    /// which is what lets a pass whose transform needs `&mut Ctx` (with the memo
+    /// living in that `Ctx`) look up, transform, then [`record`] without a
+    /// borrow conflict.
+    ///
+    /// [`record`]: Self::record
+    pub fn rebuilt_for(&self, refinement: &Refinement) -> Option<Rc<Expr>> {
+        self.0
+            .get(&refinement.predicate_id())
+            .map(|(_, rebuilt)| Rc::clone(rebuilt))
+    }
+
+    /// Record that every occurrence sharing `original` rebuilds to `rebuilt`.
+    /// Retains `original` as the keepalive pinning its address for the memo's
+    /// lifetime (see the type-level note on address reuse) — pass the origin
+    /// `Rc` you cloned *before* overwriting the slot, not the rebuilt one.
+    pub fn record(&mut self, original: Rc<Expr>, rebuilt: Rc<Expr>) {
+        let key = Rc::as_ptr(&original);
+        self.0.insert(key, (original, rebuilt));
+    }
+}
+
 /// Rebuilding analog of [`walk_refined_predicates`]: invoke `f` on a *mutable
 /// copy* of each predicate and reinstall the (possibly rewritten) result as a
-/// fresh `Rc`. `memo` maps each original predicate's identity to a
-/// `(keepalive, rebuilt)` pair, so every occurrence that shared one predicate
-/// term in `ty` is re-pointed at the *same* rebuilt term. The callback
-/// receives `memo` so it can recurse when a predicate's own subexpressions
-/// carry further refinements.
+/// fresh `Rc`, **preserving sharing** via a pass-scoped [`PredMemo`] (which the
+/// callback also receives, so it can recurse when a predicate's own
+/// subexpressions carry further refinements). Every occurrence that shared one
+/// predicate term is re-pointed at the same rebuilt term.
 ///
-/// The dedup itself is a **performance / structural-sharing optimization, not
-/// a correctness requirement**: `f` is a deterministic rewrite, so rebuilding
-/// each occurrence independently would yield *value-equal* predicates (refinement
-/// equality is structural) — the memo only makes them the *same* `Rc` rather
-/// than *equal* `Rc`s, saving the recompute and keeping `ptr_eq` fast paths and
-/// any downstream `Rc`-keyed dedup effective. It keys on [`PredicateId`]
-/// (`Rc::as_ptr`), the one residual pointer-identity dependency, sound only as
-/// long as that address cannot be reused for the rest of the walk — which is
-/// exactly what the `keepalive` clone guarantees. Without it, overwriting
-/// `refinement.predicate` below would drop the original `Rc` (if this was its
-/// only strong reference), freeing an address that a later, unrelated
-/// `Rc::new` in the same walk could reclaim; a subsequent predicate landing on
-/// that address would then collide with this entry and wrongly inherit its
-/// `rebuilt` value. (Planning's predicate-compilation memo has the identical
-/// shape — see [`crate::ccl::planning`]'s `PredMemo`.)
-pub fn walk_refined_predicates_mut<F>(
-    ty: &mut Type,
-    memo: &mut HashMap<PredicateId, (Rc<Expr>, Rc<Expr>)>,
-    f: &mut F,
-) where
-    F: FnMut(&mut Expr, &mut HashMap<PredicateId, (Rc<Expr>, Rc<Expr>)>),
+/// The caller **must** pass one memo for the whole pass, not a fresh one per
+/// call — see [`PredMemo`] for why.
+/// Count the **distinct** refinement-predicate `Rc`s reachable from `expr`'s
+/// type slots (every node's `.ty`, `user_annotation`, and binder-slot types).
+/// Pure address-set arithmetic — no structural hashing — so it is cheap enough
+/// for a `debug_assert!` guard.
+///
+/// This is the per-phase sharing check: a *sharing-preserving* transform maps N
+/// distinct origin predicate `Rc`s to ≤ N distinct rebuilt `Rc`s, so this count
+/// is **non-increasing** across a transform-only pass (one that rewrites but
+/// does not introduce predicates). A pass that splits sharing strictly
+/// increases it, tripping the guard at the exact phase that regressed.
+pub fn distinct_predicate_rcs(expr: &Expr) -> usize {
+    fn in_type(ty: &Type, seen: &mut HashSet<PredicateId>) {
+        if let Type::Refinement(_, r) = ty
+            && seen.insert(r.predicate_id())
+        {
+            // A predicate's own subexpressions carry further refinements.
+            in_expr(&r.predicate, seen);
+        }
+        ty.walk_children(|c| in_type(c, seen));
+    }
+    fn in_expr(e: &Expr, seen: &mut HashSet<PredicateId>) {
+        in_type(&e.ty, seen);
+        if let Some(a) = &e.user_annotation {
+            in_type(a, seen);
+        }
+        e.walk_children(|c| in_expr(c, seen));
+    }
+    let mut seen = HashSet::new();
+    in_expr(expr, &mut seen);
+    seen.len()
+}
+
+pub fn walk_refined_predicates_mut<F>(ty: &mut Type, memo: &mut PredMemo, f: &mut F)
+where
+    F: FnMut(&mut Expr, &mut PredMemo),
 {
     if let Type::Refinement(_, refinement) = ty {
-        let original_rc = Rc::clone(&refinement.predicate);
-        let original = Rc::as_ptr(&original_rc);
-        if let Some((_, rebuilt)) = memo.get(&original) {
-            refinement.predicate = Rc::clone(rebuilt);
+        if let Some(rebuilt) = memo.rebuilt_for(refinement) {
+            refinement.predicate = rebuilt;
         } else {
+            let original = Rc::clone(&refinement.predicate);
             let mut pred = (*refinement.predicate).clone();
             f(&mut pred, memo);
             let rebuilt = Rc::new(pred);
-            memo.insert(original, (original_rc, Rc::clone(&rebuilt)));
+            memo.record(original, Rc::clone(&rebuilt));
             refinement.predicate = rebuilt;
         }
     }

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -429,21 +429,22 @@ pub fn count_free(name: &Name, expr: &Expr) -> usize {
 /// its free-var count is collected on first encounter and short-circuited on
 /// subsequent encounters.
 fn count_free_with_visited(name: &Name, expr: &Expr, visited: &mut HashSet<PredicateId>) -> usize {
-    // Every type slot of the node counts: `ty`, the user annotation, and a
-    // `Cast`'s target (where its refinement is written syntactically —
-    // pre-inference no `ty` slot carries the same refinement, so it must be
-    // walked explicitly or a predicate-only occurrence goes unseen).
-    let in_type = count_free_in_type_with_visited(name, &expr.ty, visited)
-        + expr
-            .user_annotation
-            .as_ref()
-            .map_or(0, |t| count_free_in_type_with_visited(name, t, visited))
-        + match &expr.node {
-            TypedExprNode::Cast { target, .. } => {
-                count_free_in_type_with_visited(name, target, visited)
-            }
-            _ => 0,
-        };
+    // Every type slot the node carries counts, via the same
+    // [`Expr::walk_type_slots`] the rewriting passes use. Getting this set wrong
+    // is not a cosmetic under-count: several passes *skip work* when `is_free`
+    // says no (`inline_in_type_predicates`' early return, `subst`'s inert-subtree
+    // and vacuous-predicate checks), so a slot this walk cannot see is a slot
+    // those passes silently decline to rewrite. Enumerating it here by hand is how
+    // it fell out of step with `walk_type_slots` in the first place.
+    //
+    // A binder's declared type is in the *enclosing* scope — a binder does not
+    // bind in its own type — so occurrences there are unshadowed and count, which
+    // is why this runs before the shadowing logic below. Occurrences are
+    // deduplicated by `visited`, so a predicate riding both a binder slot and the
+    // matching position of `expr.ty` (the usual case, and increasingly so as
+    // sharing improves) is still counted once.
+    let mut in_type = 0;
+    expr.walk_type_slots(|ty| in_type += count_free_in_type_with_visited(name, ty, visited));
     let in_node = match &expr.node {
         TypedExprNode::Var(n) => (n == name) as usize,
 
@@ -782,16 +783,54 @@ where
 /// an unrelated predicate landing there would collide and inherit this entry's
 /// rebuild. This is why a pass uses `PredMemo` rather than a bare map — the
 /// keepalive is not optional bookkeeping.
+///
+/// # Key-determined vs context-determined transforms
+///
+/// The key is the predicate `Rc`'s address **and nothing else**, so *reusing* an
+/// earlier occurrence's result is only sound for a transform that is a function
+/// of the predicate term. Passes divide on this, and the division decides which
+/// protocol below they use:
+///
+/// - **Key-determined** — [`begin`](Self::begin) + [`finish`](Self::finish). The
+///   result depends on the term plus context that is invariant across the
+///   occurrences sharing it: `uniquify`, `coalesce` (whose predicates resolve out
+///   of one live constraint graph, so two occurrences of one term resolve
+///   identically), `retype`, `simplify`, `inline` and `subst` *within one active
+///   substitution*. A hit skips the transform.
+/// - **Context-determined** — [`begin_always`](Self::begin_always) +
+///   [`finish_shared`](Self::finish_shared). The result depends on something the
+///   key does not name, so the transform **must run at every occurrence**; only
+///   the resulting *term* is unified. Constraint emission is the case: it binds
+///   `REFINEMENT_BINDER` to a domain supplied per occurrence, and skipping it
+///   would leave that occurrence's domain without the constraints the predicate
+///   imposes on it.
+///
+/// A third shape is neither: when the context is *part of the transform's
+/// identity* rather than a parameter of it — `subst`'s active substitution, which
+/// by design acts differently in different scopes — the fix is to scope the memo
+/// so the context is constant within it, rather than to widen the key. See
+/// `subst::rewrite_type_go`.
+///
+/// Mixing them up is a silent wrong answer, not a compile error, which is why the
+/// two protocols are named rather than left as one.
 #[derive(Default)]
-pub struct PredMemo(HashMap<PredicateId, (Rc<Expr>, Rc<Expr>)>);
+pub struct PredMemo {
+    entries: HashMap<PredicateId, (Rc<Expr>, Rc<Expr>)>,
+    /// Bumped whenever a predicate slot is pointed at a *different* `Rc`. Lets
+    /// [`walk_refined_predicates_mut`] observe re-pointings performed inside a
+    /// callback's own recursion — which the callback's `changed` bit cannot
+    /// report, because a nested memo *hit* mutates the callback's copy without
+    /// the callback doing anything. See [`Self::revision`].
+    revision: u64,
+}
 
 /// A predicate's **origin** `Rc`, captured before its slot was overwritten —
 /// the memo key, and the keepalive pinning that key's address.
 ///
-/// Only [`PredMemo::begin`] mints one and only [`PredMemo::finish`] /
-/// [`PredMemo::finish_unchanged`] consume one, so it cannot be confused with a
-/// rebuild: the "did you pass the origin or the rebuild?" mistake the raw
-/// `record(Rc, Rc)` shape invited is not expressible.
+/// Only [`PredMemo::begin`] / [`PredMemo::begin_always`] mint one, and only the
+/// `finish*` methods consume one, so it cannot be confused with a rebuild: the
+/// "did you pass the origin or the rebuild?" mistake the raw `record(Rc, Rc)`
+/// shape invited is not expressible.
 pub struct Origin(Rc<Expr>);
 
 impl PredMemo {
@@ -812,14 +851,22 @@ impl PredMemo {
     /// its own transform — which is what lets a pass whose transform needs
     /// `&mut Ctx` (with the memo living in that `Ctx`) drive this protocol
     /// without a borrow conflict.
-    pub fn begin(&self, refinement: &mut Refinement) -> Option<(Origin, Expr)> {
-        if let Some((_, rebuilt)) = self.0.get(&refinement.predicate_id()) {
-            refinement.predicate = Rc::clone(rebuilt);
+    pub fn begin(&mut self, refinement: &mut Refinement) -> Option<(Origin, Expr)> {
+        if let Some((_, rebuilt)) = self.entries.get(&refinement.predicate_id()) {
+            let rebuilt = Rc::clone(rebuilt);
+            self.point_at(refinement, rebuilt);
             return None;
         }
-        let origin = Origin(Rc::clone(&refinement.predicate));
-        let copy = (*refinement.predicate).clone();
-        Some((origin, copy))
+        Some(self.open(refinement))
+    }
+
+    /// Open a rebuild for a **context-determined** transform: one whose result
+    /// depends on something the memo key does not name, so it must run at *every*
+    /// occurrence. Always returns the [`Origin`] token and a copy — there is no
+    /// skip — to be closed with [`finish_shared`](Self::finish_shared), which
+    /// unifies the term while leaving the per-occurrence work already done.
+    pub fn begin_always(&self, refinement: &Refinement) -> (Origin, Expr) {
+        self.open(refinement)
     }
 
     /// Close a rebuild: install `rebuilt` into `refinement` and record
@@ -827,8 +874,27 @@ impl PredMemo {
     /// re-pointed at this same term.
     pub fn finish(&mut self, refinement: &mut Refinement, origin: Origin, rebuilt: Expr) {
         let rebuilt = Rc::new(rebuilt);
-        refinement.predicate = Rc::clone(&rebuilt);
+        self.point_at(refinement, Rc::clone(&rebuilt));
         self.insert(origin, rebuilt);
+    }
+
+    /// Close a [`begin_always`](Self::begin_always) rebuild: point the slot at the
+    /// term an earlier occurrence produced if there is one, otherwise record this
+    /// occurrence's `rebuilt` as that shared term.
+    ///
+    /// The caller's transform has already run — that is the whole point — so this
+    /// only decides *which* term the occurrences share. Discarding `rebuilt` on a
+    /// hit is safe precisely because refinement identity is type-blind: the
+    /// occurrences denote one refinement, and the winning term's embedded type
+    /// slots are as good as the discarded one's.
+    pub fn finish_shared(&mut self, refinement: &mut Refinement, origin: Origin, rebuilt: Expr) {
+        match self.entries.get(&Rc::as_ptr(&origin.0)) {
+            Some((_, shared)) => {
+                let shared = Rc::clone(shared);
+                self.point_at(refinement, shared);
+            }
+            None => self.finish(refinement, origin, rebuilt),
+        }
     }
 
     /// Close a rebuild the transform left **untouched**: keep the origin `Rc` in
@@ -842,8 +908,37 @@ impl PredMemo {
     /// from once per *occurrence* into once per distinct predicate.
     pub fn finish_unchanged(&mut self, refinement: &mut Refinement, origin: Origin) {
         let kept = Rc::clone(&origin.0);
-        refinement.predicate = Rc::clone(&kept);
+        self.point_at(refinement, Rc::clone(&kept));
         self.insert(origin, kept);
+    }
+
+    /// A counter that advances every time this memo points some predicate slot at
+    /// a *different* `Rc`.
+    ///
+    /// [`walk_refined_predicates_mut`] brackets its callback with this to learn
+    /// whether the copy it handed over was mutated by the memo itself — a nested
+    /// memo *hit* re-points a slot inside that copy without the callback doing
+    /// anything, so the callback's own `changed` bit cannot report it. Comparing
+    /// revisions is exact for that question and costs one integer.
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    /// Point `refinement` at `to`, counting it as a re-pointing when the `Rc`
+    /// actually changes (see [`revision`](Self::revision)).
+    fn point_at(&mut self, refinement: &mut Refinement, to: Rc<Expr>) {
+        if !Rc::ptr_eq(&refinement.predicate, &to) {
+            self.revision += 1;
+        }
+        refinement.predicate = to;
+    }
+
+    /// Mint the [`Origin`] token and the working copy for a miss.
+    fn open(&self, refinement: &Refinement) -> (Origin, Expr) {
+        (
+            Origin(Rc::clone(&refinement.predicate)),
+            (*refinement.predicate).clone(),
+        )
     }
 
     /// Retain `origin` as the keepalive pinning its address for the memo's
@@ -851,7 +946,7 @@ impl PredMemo {
     /// `rebuilt`.
     fn insert(&mut self, origin: Origin, rebuilt: Rc<Expr>) {
         let key = Rc::as_ptr(&origin.0);
-        self.0.insert(key, (origin.0, rebuilt));
+        self.entries.insert(key, (origin.0, rebuilt));
     }
 }
 
@@ -915,20 +1010,37 @@ pub fn distinct_predicate_rcs(expr: &Expr) -> usize {
 /// walks past a predicate does not reallocate it — which is what lets sharing
 /// survive across the nodes such a caller visits, not just within one type.
 ///
+/// `f`'s bit is *not* the whole answer, and this does not trust it as such. A
+/// callback that recurses back through the memo — which is why it is handed one —
+/// can have its copy mutated underneath it by a nested memo **hit** re-pointing a
+/// slot, with nothing of its own to report. Discarding the copy would then throw
+/// that re-pointing away *and* memoize the staleness for every later occurrence.
+/// So the copy is kept when `f` reports a change **or** the memo's
+/// [`revision`](PredMemo::revision) advanced during the call: the memo is what
+/// knows about its own re-pointings, so it is asked.
+///
+/// Returns whether this walk changed anything reachable from `ty`, so a caller
+/// driving its own fixpoint (`simplify`) can fold it in.
+///
 /// The caller **must** pass one memo for the whole pass, not a fresh one per
 /// call — see [`PredMemo`] for why.
-pub fn walk_refined_predicates_mut<F>(ty: &mut Type, memo: &mut PredMemo, f: &mut F)
+pub fn walk_refined_predicates_mut<F>(ty: &mut Type, memo: &mut PredMemo, f: &mut F) -> bool
 where
     F: FnMut(&mut Expr, &mut PredMemo) -> bool,
 {
+    let mut changed = false;
     if let Type::Refinement(_, refinement) = ty
         && let Some((origin, mut pred)) = memo.begin(refinement)
     {
-        if f(&mut pred, memo) {
+        let before = memo.revision();
+        let reported = f(&mut pred, memo);
+        if reported || memo.revision() != before {
             memo.finish(refinement, origin, pred);
+            changed = true;
         } else {
             memo.finish_unchanged(refinement, origin);
         }
     }
-    ty.walk_children_mut(|child| walk_refined_predicates_mut(child, memo, f));
+    ty.walk_children_mut(|child| changed |= walk_refined_predicates_mut(child, memo, f));
+    changed
 }

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -831,7 +831,45 @@ pub struct PredMemo {
 /// `finish*` methods consume one, so it cannot be confused with a rebuild: the
 /// "did you pass the origin or the rebuild?" mistake the raw `record(Rc, Rc)`
 /// shape invited is not expressible.
-pub struct Origin(Rc<Expr>);
+///
+/// **An opened rebuild must be closed.** Dropping the token instead of passing it
+/// to a `finish*` is silent and lossy, not merely wasteful: the caller's transform
+/// result is discarded, the slot keeps its origin `Rc`, and nothing is memoized —
+/// so a pass that opened a rebuild and then returned early (a `?` between the two
+/// halves) leaves that occurrence un-rewritten while its siblings are rewritten.
+/// The `#[must_use]` on the opening methods catches ignoring the token; this
+/// type's `Drop` catches losing it on an early return.
+pub struct Origin(Option<Rc<Expr>>);
+
+impl Origin {
+    /// The retained origin `Rc`, defusing the drop check — the `finish*` methods'
+    /// single exit.
+    fn consume(mut self) -> Rc<Expr> {
+        self.0.take().expect("an Origin is consumed exactly once")
+    }
+
+    /// The origin `Rc` without consuming the token.
+    fn peek(&self) -> &Rc<Expr> {
+        self.0.as_ref().expect("an Origin is consumed exactly once")
+    }
+}
+
+impl Drop for Origin {
+    fn drop(&mut self) {
+        // Unwinding already: a second panic from a destructor aborts the process,
+        // which would bury the original failure.
+        if std::thread::panicking() {
+            return;
+        }
+        debug_assert!(
+            self.0.is_none(),
+            "a `PredMemo` rebuild was opened and never finished: the transform's result is \
+             discarded, the occurrence silently keeps its origin `Rc`, and nothing is \
+             memoized. Every `begin`/`begin_always` must reach a `finish`, \
+             `finish_shared`, or `finish_unchanged` — including on error paths."
+        );
+    }
+}
 
 impl PredMemo {
     pub fn new() -> Self {
@@ -851,6 +889,7 @@ impl PredMemo {
     /// its own transform — which is what lets a pass whose transform needs
     /// `&mut Ctx` (with the memo living in that `Ctx`) drive this protocol
     /// without a borrow conflict.
+    #[must_use = "an opened rebuild must be closed with a `finish*` — see `Origin`"]
     pub fn begin(&mut self, refinement: &mut Refinement) -> Option<(Origin, Expr)> {
         if let Some((_, rebuilt)) = self.entries.get(&refinement.predicate_id()) {
             let rebuilt = Rc::clone(rebuilt);
@@ -865,6 +904,7 @@ impl PredMemo {
     /// occurrence. Always returns the [`Origin`] token and a copy — there is no
     /// skip — to be closed with [`finish_shared`](Self::finish_shared), which
     /// unifies the term while leaving the per-occurrence work already done.
+    #[must_use = "an opened rebuild must be closed with a `finish*` — see `Origin`"]
     pub fn begin_always(&self, refinement: &Refinement) -> (Origin, Expr) {
         self.open(refinement)
     }
@@ -888,10 +928,14 @@ impl PredMemo {
     /// occurrences denote one refinement, and the winning term's embedded type
     /// slots are as good as the discarded one's.
     pub fn finish_shared(&mut self, refinement: &mut Refinement, origin: Origin, rebuilt: Expr) {
-        match self.entries.get(&Rc::as_ptr(&origin.0)) {
+        match self.entries.get(&Rc::as_ptr(origin.peek())) {
             Some((_, shared)) => {
                 let shared = Rc::clone(shared);
                 self.point_at(refinement, shared);
+                // The entry already retains its own keepalive for this key, so
+                // this token has nothing left to record — but it still has to be
+                // consumed rather than dropped (see `Origin`).
+                drop(origin.consume());
             }
             None => self.finish(refinement, origin, rebuilt),
         }
@@ -907,7 +951,7 @@ impl PredMemo {
     /// "would this transform do anything?" test — `subst`'s `is_free` scan, say —
     /// from once per *occurrence* into once per distinct predicate.
     pub fn finish_unchanged(&mut self, refinement: &mut Refinement, origin: Origin) {
-        let kept = Rc::clone(&origin.0);
+        let kept = Rc::clone(origin.peek());
         self.point_at(refinement, Rc::clone(&kept));
         self.insert(origin, kept);
     }
@@ -936,7 +980,7 @@ impl PredMemo {
     /// Mint the [`Origin`] token and the working copy for a miss.
     fn open(&self, refinement: &Refinement) -> (Origin, Expr) {
         (
-            Origin(Rc::clone(&refinement.predicate)),
+            Origin(Some(Rc::clone(&refinement.predicate))),
             (*refinement.predicate).clone(),
         )
     }
@@ -945,8 +989,8 @@ impl PredMemo {
     /// lifetime (see the type-level note on address reuse) while mapping it to
     /// `rebuilt`.
     fn insert(&mut self, origin: Origin, rebuilt: Rc<Expr>) {
-        let key = Rc::as_ptr(&origin.0);
-        self.entries.insert(key, (origin.0, rebuilt));
+        let origin = origin.consume();
+        self.entries.insert(Rc::as_ptr(&origin), (origin, rebuilt));
     }
 }
 

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -775,99 +775,159 @@ where
 /// a transform-only pass.
 ///
 /// Keyed on [`PredicateId`] (the origin `Rc`'s address). Sound only while that
-/// address cannot be reused during the pass, which [`Self::record`] guarantees
-/// by retaining a `keepalive` clone of every origin `Rc` for the memo's
-/// lifetime: without it, overwriting a `refinement.predicate` could drop the
-/// origin `Rc`, freeing an address a later `Rc::new` in the same pass could
-/// reclaim, so an unrelated predicate landing there would collide and inherit
-/// this entry's rebuild.
+/// address cannot be reused during the pass, which the [`Origin`] token
+/// guarantees: every entry retains its origin `Rc` for the memo's lifetime.
+/// Without that, overwriting a `refinement.predicate` could drop the origin
+/// `Rc`, freeing an address a later `Rc::new` in the same pass could reclaim, so
+/// an unrelated predicate landing there would collide and inherit this entry's
+/// rebuild. This is why a pass uses `PredMemo` rather than a bare map — the
+/// keepalive is not optional bookkeeping.
 #[derive(Default)]
 pub struct PredMemo(HashMap<PredicateId, (Rc<Expr>, Rc<Expr>)>);
+
+/// A predicate's **origin** `Rc`, captured before its slot was overwritten —
+/// the memo key, and the keepalive pinning that key's address.
+///
+/// Only [`PredMemo::begin`] mints one and only [`PredMemo::finish`] /
+/// [`PredMemo::finish_unchanged`] consume one, so it cannot be confused with a
+/// rebuild: the "did you pass the origin or the rebuild?" mistake the raw
+/// `record(Rc, Rc)` shape invited is not expressible.
+pub struct Origin(Rc<Expr>);
 
 impl PredMemo {
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// The rebuilt predicate for `refinement`'s origin `Rc`, if an occurrence
-    /// sharing it was already rebuilt in this pass. Clones the shared `Rc` out
-    /// so the caller holds **no** borrow of the memo across its own transform —
-    /// which is what lets a pass whose transform needs `&mut Ctx` (with the memo
-    /// living in that `Ctx`) look up, transform, then [`record`] without a
-    /// borrow conflict.
+    /// Open a rebuild of `refinement`'s predicate.
     ///
-    /// [`record`]: Self::record
-    pub fn rebuilt_for(&self, refinement: &Refinement) -> Option<Rc<Expr>> {
-        self.0
-            .get(&refinement.predicate_id())
-            .map(|(_, rebuilt)| Rc::clone(rebuilt))
+    /// On a **hit** — an occurrence sharing this origin `Rc` was already rebuilt
+    /// in this pass — re-points `refinement` at that single rebuild and returns
+    /// `None`: sharing preserved, transform skipped. On a **miss**, returns the
+    /// [`Origin`] token together with a mutable copy for the caller to transform,
+    /// to be handed back to [`finish`](Self::finish) (or
+    /// [`finish_unchanged`](Self::finish_unchanged)).
+    ///
+    /// The copy is owned, so the caller holds **no** borrow of the memo across
+    /// its own transform — which is what lets a pass whose transform needs
+    /// `&mut Ctx` (with the memo living in that `Ctx`) drive this protocol
+    /// without a borrow conflict.
+    pub fn begin(&self, refinement: &mut Refinement) -> Option<(Origin, Expr)> {
+        if let Some((_, rebuilt)) = self.0.get(&refinement.predicate_id()) {
+            refinement.predicate = Rc::clone(rebuilt);
+            return None;
+        }
+        let origin = Origin(Rc::clone(&refinement.predicate));
+        let copy = (*refinement.predicate).clone();
+        Some((origin, copy))
     }
 
-    /// Record that every occurrence sharing `original` rebuilds to `rebuilt`.
-    /// Retains `original` as the keepalive pinning its address for the memo's
-    /// lifetime (see the type-level note on address reuse) — pass the origin
-    /// `Rc` you cloned *before* overwriting the slot, not the rebuilt one.
-    pub fn record(&mut self, original: Rc<Expr>, rebuilt: Rc<Expr>) {
-        let key = Rc::as_ptr(&original);
-        self.0.insert(key, (original, rebuilt));
+    /// Close a rebuild: install `rebuilt` into `refinement` and record
+    /// `origin ↦ rebuilt`, so every later occurrence sharing `origin` is
+    /// re-pointed at this same term.
+    pub fn finish(&mut self, refinement: &mut Refinement, origin: Origin, rebuilt: Expr) {
+        let rebuilt = Rc::new(rebuilt);
+        refinement.predicate = Rc::clone(&rebuilt);
+        self.insert(origin, rebuilt);
+    }
+
+    /// Close a rebuild the transform left **untouched**: keep the origin `Rc` in
+    /// the slot and record `origin ↦ origin`.
+    ///
+    /// This is strictly better than rebuilding an identical term. It preserves
+    /// sharing a pass *already* had rather than re-establishing it (a predicate a
+    /// pass merely walks past is never reallocated, so occurrences it never
+    /// visits stay pointer-equal to ones it did), and it turns the caller's
+    /// "would this transform do anything?" test — `subst`'s `is_free` scan, say —
+    /// from once per *occurrence* into once per distinct predicate.
+    pub fn finish_unchanged(&mut self, refinement: &mut Refinement, origin: Origin) {
+        let kept = Rc::clone(&origin.0);
+        refinement.predicate = Rc::clone(&kept);
+        self.insert(origin, kept);
+    }
+
+    /// Retain `origin` as the keepalive pinning its address for the memo's
+    /// lifetime (see the type-level note on address reuse) while mapping it to
+    /// `rebuilt`.
+    fn insert(&mut self, origin: Origin, rebuilt: Rc<Expr>) {
+        let key = Rc::as_ptr(&origin.0);
+        self.0.insert(key, (origin.0, rebuilt));
     }
 }
 
-/// Rebuilding analog of [`walk_refined_predicates`]: invoke `f` on a *mutable
-/// copy* of each predicate and reinstall the (possibly rewritten) result as a
-/// fresh `Rc`, **preserving sharing** via a pass-scoped [`PredMemo`] (which the
-/// callback also receives, so it can recurse when a predicate's own
-/// subexpressions carry further refinements). Every occurrence that shared one
-/// predicate term is re-pointed at the same rebuilt term.
+/// Every refinement reachable from `expr`'s type slots, one entry per distinct
+/// predicate `Rc`, in walk order. Coverage is [`Expr::walk_type_slots`]' — every
+/// node's `ty`, `user_annotation`, `Cast` target, and binder-declared types — so
+/// a refinement riding *only* a binder slot or a cast target (where a
+/// comprehension filter's predicate lives) is reached.
 ///
-/// The caller **must** pass one memo for the whole pass, not a fresh one per
-/// call — see [`PredMemo`] for why.
+/// Deduplicated by [`PredicateId`], so occurrences sharing one `Rc` yield one
+/// entry: the result's length is the sharing metric ([`distinct_predicate_rcs`]),
+/// while [`Refinement`]'s own structural `PartialEq` lets a caller ask the
+/// sharper question — whether two of those *distinct* `Rc`s denote the same
+/// refinement, i.e. whether sharing was split (see `tests/predicate_sharing.rs`).
+pub fn reachable_refinements(expr: &Expr) -> Vec<Refinement> {
+    fn in_type(ty: &Type, out: &mut Vec<Refinement>, seen: &mut HashSet<PredicateId>) {
+        if let Type::Refinement(_, r) = ty
+            && seen.insert(r.predicate_id())
+        {
+            out.push(r.clone());
+            // A predicate's own subexpressions carry further refinements.
+            in_expr(&r.predicate, out, seen);
+        }
+        ty.walk_children(|c| in_type(c, out, seen));
+    }
+    fn in_expr(e: &Expr, out: &mut Vec<Refinement>, seen: &mut HashSet<PredicateId>) {
+        e.walk_type_slots(|ty| in_type(ty, out, seen));
+        e.walk_children(|c| in_expr(c, out, seen));
+    }
+    let mut out = Vec::new();
+    in_expr(expr, &mut out, &mut HashSet::new());
+    out
+}
+
 /// Count the **distinct** refinement-predicate `Rc`s reachable from `expr`'s
-/// type slots (every node's `.ty`, `user_annotation`, and binder-slot types).
-/// Pure address-set arithmetic — no structural hashing — so it is cheap enough
-/// for a `debug_assert!` guard.
+/// type slots ([`reachable_refinements`]). Pure address-set arithmetic — no
+/// structural hashing — so it is cheap enough for a `debug_assert!` guard.
 ///
 /// This is the per-phase sharing check: a *sharing-preserving* transform maps N
 /// distinct origin predicate `Rc`s to ≤ N distinct rebuilt `Rc`s, so this count
 /// is **non-increasing** across a transform-only pass (one that rewrites but
 /// does not introduce predicates). A pass that splits sharing strictly
 /// increases it, tripping the guard at the exact phase that regressed.
+///
+/// A count is a *necessary* check, not a sufficient one — it cannot see a split
+/// that a pass pairs with an equal-sized collapse elsewhere. The end-to-end
+/// guard in `tests/predicate_sharing.rs` closes that by asserting no two
+/// distinct `Rc`s are structurally equal, which names the defect directly.
 pub fn distinct_predicate_rcs(expr: &Expr) -> usize {
-    fn in_type(ty: &Type, seen: &mut HashSet<PredicateId>) {
-        if let Type::Refinement(_, r) = ty
-            && seen.insert(r.predicate_id())
-        {
-            // A predicate's own subexpressions carry further refinements.
-            in_expr(&r.predicate, seen);
-        }
-        ty.walk_children(|c| in_type(c, seen));
-    }
-    fn in_expr(e: &Expr, seen: &mut HashSet<PredicateId>) {
-        in_type(&e.ty, seen);
-        if let Some(a) = &e.user_annotation {
-            in_type(a, seen);
-        }
-        e.walk_children(|c| in_expr(c, seen));
-    }
-    let mut seen = HashSet::new();
-    in_expr(expr, &mut seen);
-    seen.len()
+    reachable_refinements(expr).len()
 }
 
+/// Rebuilding analog of [`walk_refined_predicates`]: invoke `f` on a *mutable
+/// copy* of each predicate and reinstall the result, **preserving sharing** via a
+/// pass-scoped [`PredMemo`] (which the callback also receives, so it can recurse
+/// when a predicate's own subexpressions carry further refinements). Every
+/// occurrence that shared one predicate term is re-pointed at the same term.
+///
+/// `f` returns whether it **changed** the copy. Returning `false` keeps the
+/// origin `Rc` in place ([`PredMemo::finish_unchanged`]), so a caller that merely
+/// walks past a predicate does not reallocate it — which is what lets sharing
+/// survive across the nodes such a caller visits, not just within one type.
+///
+/// The caller **must** pass one memo for the whole pass, not a fresh one per
+/// call — see [`PredMemo`] for why.
 pub fn walk_refined_predicates_mut<F>(ty: &mut Type, memo: &mut PredMemo, f: &mut F)
 where
-    F: FnMut(&mut Expr, &mut PredMemo),
+    F: FnMut(&mut Expr, &mut PredMemo) -> bool,
 {
-    if let Type::Refinement(_, refinement) = ty {
-        if let Some(rebuilt) = memo.rebuilt_for(refinement) {
-            refinement.predicate = rebuilt;
+    if let Type::Refinement(_, refinement) = ty
+        && let Some((origin, mut pred)) = memo.begin(refinement)
+    {
+        if f(&mut pred, memo) {
+            memo.finish(refinement, origin, pred);
         } else {
-            let original = Rc::clone(&refinement.predicate);
-            let mut pred = (*refinement.predicate).clone();
-            f(&mut pred, memo);
-            let rebuilt = Rc::new(pred);
-            memo.record(original, Rc::clone(&rebuilt));
-            refinement.predicate = rebuilt;
+            memo.finish_unchanged(refinement, origin);
         }
     }
     ty.walk_children_mut(|child| walk_refined_predicates_mut(child, memo, f));

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -1,5 +1,6 @@
 //! Miscellaneous utilities for working with CCL.
 
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
@@ -746,251 +747,249 @@ where
     ty.walk_children(|child| walk_refined_predicates(child, visited, f));
 }
 
-/// Pass-scoped memo that **preserves refinement-predicate `Rc` sharing** across
-/// a single rebuild pass.
+/// Pass-scoped memo that **preserves refinement-predicate `Rc` sharing** across a
+/// single rebuild pass — a cheap clonable handle, so reaching it never requires an
+/// exclusive borrow of whatever owns it.
 ///
 /// Predicates are immutable `Rc<TypedExpr>`s (see [`Refinement::predicate`]), so
 /// any pass that must "update" a predicate — resolve embedded inference vars
-/// (`coalesce`), restamp binder types (`retype`), eliminate lambdas
-/// (`lambda_elim`), simplify, or substitute — *rebuilds* it into a fresh `Rc`
-/// rather than mutating in place. When one predicate term rides several type
-/// slots as a shared `Rc` (a comprehension's filtered domain appears on its
+/// (`coalesce`), restamp binder types (`retype`), α-uniquify, eliminate lambdas,
+/// simplify, substitute, or compile to point-free form — *rebuilds* it into a
+/// fresh `Rc` rather than mutating in place. When one predicate term rides several
+/// type slots as a shared `Rc` (a comprehension's filtered domain appears on its
 /// source, map, cast, and consumer-contract types), rebuilding each occurrence
-/// independently **splits** that sharing. The split is invisible to correctness
-/// — the rebuilds are value-equal (refinement equality is structural) — but it
-/// defeats every downstream `Rc`-identity dedup: `Rc::ptr_eq` fast paths and, in
-/// particular, planning's per-predicate compile memo, which then recompiles one
-/// predicate once per occurrence (superlinearly, on nested comprehensions).
+/// independently **splits** that sharing. The split is invisible to correctness —
+/// the rebuilds are value-equal, since refinement equality is structural — but it
+/// defeats every downstream `Rc`-identity dedup, in particular planning's
+/// per-predicate compile memo, which then recompiles one predicate once per
+/// occurrence (superlinearly, on nested comprehensions).
 ///
-/// This memo re-points every occurrence that entered a pass sharing one origin
-/// `Rc` at a *single* rebuilt `Rc`, so sharing survives the pass. It is the one
-/// mechanism every predicate-rebuilding pass threads; the alternative —
-/// reunifying afterward by structural hash/eq — would reintroduce exactly the
-/// per-predicate hashing cost the `Rc` boxing exists to avoid.
+/// # `C` is what the rebuild depends on besides the term
 ///
-/// **The memo must be pass-scoped.** One instance threaded across the *whole*
-/// tree walk of a pass. A fresh memo per node/subtree re-shares only within that
-/// node and still splits across the tree — the exact bug this type prevents.
-/// The sharing invariant is guarded end-to-end by `tests/predicate_sharing.rs`
-/// and, per phase, by asserting [`distinct_predicate_rcs`] does not grow across
-/// a transform-only pass.
+/// The obvious key for such a memo is the predicate `Rc`'s address. That is only
+/// half a key: it answers "have I rebuilt this term?", while every pass needs
+/// "have I rebuilt this term **under the conditions I am rebuilding it under
+/// now**?". `C` is those conditions, and an entry is reused only when it was
+/// recorded under a `C` equal to the current one. Passing the wrong `C` is then a
+/// *lost sharing opportunity* rather than a wrong answer, which is the property
+/// worth having: the previous key-only design made `subst` discharge a binder its
+/// inner scope owned, and made constraint emission skip the emission that bounds
+/// an occurrence's own domain.
 ///
-/// Keyed on [`PredicateId`] (the origin `Rc`'s address). Sound only while that
-/// address cannot be reused during the pass, which the [`Origin`] token
-/// guarantees: every entry retains its origin `Rc` for the memo's lifetime.
-/// Without that, overwriting a `refinement.predicate` could drop the origin
-/// `Rc`, freeing an address a later `Rc::new` in the same pass could reclaim, so
-/// an unrelated predicate landing there would collide and inherit this entry's
-/// rebuild. This is why a pass uses `PredMemo` rather than a bare map — the
-/// keepalive is not optional bookkeeping.
+/// What each pass supplies:
 ///
-/// # Key-determined vs context-determined transforms
+/// - `()` — the rebuild is a function of the term alone, or of context that is
+///   provably invariant across the occurrences sharing an `Rc`. `simplify`
+///   (nothing at all), and `uniquify` / `coalesce` / `retype` / `inline`, each with
+///   the argument written at its call site. `()` is a *claim*, and the place to
+///   check it.
+/// - [`crate::ccl::subst::Subst`] — the active substitution. Acting differently in
+///   different scopes is the point of a substitution, so this is the case the
+///   key-only design got wrong.
+/// - [`Type`] — planning's refinement base, which its compilation reads.
 ///
-/// The key is the predicate `Rc`'s address **and nothing else**, so *reusing* an
-/// earlier occurrence's result is only sound for a transform that is a function
-/// of the predicate term. Passes divide on this, and the division decides which
-/// protocol below they use:
+/// A pass that needs to share *allocations* without sharing *results* wants
+/// [`TermMemo`] instead: constraint emission binds `REFINEMENT_BINDER` to a domain
+/// minted per occurrence, so no two occurrences may reuse an answer, yet they
+/// should still end up on one term.
 ///
-/// - **Key-determined** — [`begin`](Self::begin) + [`finish`](Self::finish). The
-///   result depends on the term plus context that is invariant across the
-///   occurrences sharing it: `uniquify`, `coalesce` (whose predicates resolve out
-///   of one live constraint graph, so two occurrences of one term resolve
-///   identically), `retype`, `simplify`, `inline` and `subst` *within one active
-///   substitution*. A hit skips the transform.
-/// - **Context-determined** — [`begin_always`](Self::begin_always) +
-///   [`finish_shared`](Self::finish_shared). The result depends on something the
-///   key does not name, so the transform **must run at every occurrence**; only
-///   the resulting *term* is unified. Constraint emission is the case: it binds
-///   `REFINEMENT_BINDER` to a domain supplied per occurrence, and skipping it
-///   would leave that occurrence's domain without the constraints the predicate
-///   imposes on it.
+/// # Keepalive
 ///
-/// A third shape is neither: when the context is *part of the transform's
-/// identity* rather than a parameter of it — `subst`'s active substitution, which
-/// by design acts differently in different scopes — the fix is to scope the memo
-/// so the context is constant within it, rather than to widen the key. See
-/// `subst::rewrite_type_go`.
+/// Keyed on [`PredicateId`] (the origin `Rc`'s address), which is sound only while
+/// that address cannot be reused: overwriting a `refinement.predicate` can drop
+/// the last reference to the origin, freeing an address a later `Rc::new` in the
+/// same pass reclaims, so an unrelated predicate landing there would collide and
+/// inherit this entry's rebuild. Every entry therefore retains its origin `Rc` for
+/// the memo's lifetime. This is why passes use `PredMemo` rather than a bare map.
 ///
-/// Mixing them up is a silent wrong answer, not a compile error, which is why the
-/// two protocols are named rather than left as one.
-#[derive(Default)]
-pub struct PredMemo {
-    entries: HashMap<PredicateId, (Rc<Expr>, Rc<Expr>)>,
-    /// Bumped whenever a predicate slot is pointed at a *different* `Rc`. Lets
-    /// [`walk_refined_predicates_mut`] observe re-pointings performed inside a
-    /// callback's own recursion — which the callback's `changed` bit cannot
-    /// report, because a nested memo *hit* mutates the callback's copy without
-    /// the callback doing anything. See [`Self::revision`].
+/// # One memo per pass
+///
+/// One handle (or clones of it, which are the same memo) across the *whole* tree
+/// walk. A fresh memo per node re-shares only within that node and splits across
+/// the tree — the bug this type exists to prevent. Guarded end-to-end by
+/// `tests/predicate_sharing.rs` and, per phase, by asserting
+/// [`distinct_predicate_rcs`] does not grow across a rewrite-only pass.
+pub struct PredMemo<C = ()>(Rc<RefCell<MemoStore<C>>>);
+
+impl<C> Clone for PredMemo<C> {
+    /// Another handle on the *same* memo — not a copy of it.
+    fn clone(&self) -> Self {
+        PredMemo(Rc::clone(&self.0))
+    }
+}
+
+impl<C> Default for PredMemo<C> {
+    fn default() -> Self {
+        PredMemo(Rc::new(RefCell::new(MemoStore {
+            entries: HashMap::new(),
+            revision: 0,
+        })))
+    }
+}
+
+/// Shares predicate *terms* without sharing rebuild *results*: the transform runs
+/// at every occurrence, and occurrences that entered sharing one `Rc` leave
+/// sharing one `Rc`.
+///
+/// For a pass whose rebuild depends on something that never repeats across
+/// occurrences, so [`PredMemo`]'s reuse could never fire and must not: constraint
+/// emission types the predicate with `REFINEMENT_BINDER` bound to a domain
+/// `emit_cast` mints fresh per cast node. Each occurrence has to discharge its own
+/// typing obligation; only the resulting allocation is unified. Discarding the
+/// loser's term is sound because refinement identity is type-blind — the
+/// occurrences denote one refinement, so the winner's embedded type slots are as
+/// good as the discarded one's.
+///
+/// A separate type from [`PredMemo`] on purpose: "reuse the answer" and "reuse only
+/// the allocation" are different operations, and which one a pass is entitled to
+/// should be visible in its type rather than argued in a comment.
+#[derive(Clone, Default)]
+pub struct TermMemo(PredMemo<()>);
+
+/// The memo's actual storage, reached only through a handle.
+struct MemoStore<C> {
+    /// One key can be rebuilt under several contexts (`subst` inside and outside a
+    /// scope that shadows a substituted binder), so entries are a list. It is
+    /// almost always length 1, and a linear scan of it beats hashing a `C`.
+    entries: HashMap<PredicateId, Vec<Entry<C>>>,
+    /// Advances whenever a predicate slot is pointed at a *different* `Rc`. Lets
+    /// [`PredMemo::rebuild`] observe re-pointings performed inside its callback's
+    /// own recursion, which the callback cannot report: a nested reuse mutates the
+    /// callback's copy without the callback doing anything.
     revision: u64,
 }
 
-/// A predicate's **origin** `Rc`, captured before its slot was overwritten —
-/// the memo key, and the keepalive pinning that key's address.
-///
-/// Only [`PredMemo::begin`] / [`PredMemo::begin_always`] mint one, and only the
-/// `finish*` methods consume one, so it cannot be confused with a rebuild: the
-/// "did you pass the origin or the rebuild?" mistake the raw `record(Rc, Rc)`
-/// shape invited is not expressible.
-///
-/// **An opened rebuild must be closed.** Dropping the token instead of passing it
-/// to a `finish*` is silent and lossy, not merely wasteful: the caller's transform
-/// result is discarded, the slot keeps its origin `Rc`, and nothing is memoized —
-/// so a pass that opened a rebuild and then returned early (a `?` between the two
-/// halves) leaves that occurrence un-rewritten while its siblings are rewritten.
-/// The `#[must_use]` on the opening methods catches ignoring the token; this
-/// type's `Drop` catches losing it on an early return.
-pub struct Origin(Option<Rc<Expr>>);
-
-impl Origin {
-    /// The retained origin `Rc`, defusing the drop check — the `finish*` methods'
-    /// single exit.
-    fn consume(mut self) -> Rc<Expr> {
-        self.0.take().expect("an Origin is consumed exactly once")
-    }
-
-    /// The origin `Rc` without consuming the token.
-    fn peek(&self) -> &Rc<Expr> {
-        self.0.as_ref().expect("an Origin is consumed exactly once")
-    }
+struct Entry<C> {
+    /// Pins the key's address for the memo's lifetime (see the keepalive note on
+    /// [`PredMemo`]). Deliberately never read: *holding* the `Rc` is the entire
+    /// job, and dropping this field would make the address reusable and the key
+    /// unsound.
+    #[allow(dead_code)]
+    keepalive: Rc<Expr>,
+    rebuilt: Rc<Expr>,
+    context: C,
 }
 
-impl Drop for Origin {
-    fn drop(&mut self) {
-        // Unwinding already: a second panic from a destructor aborts the process,
-        // which would bury the original failure.
-        if std::thread::panicking() {
-            return;
-        }
-        debug_assert!(
-            self.0.is_none(),
-            "a `PredMemo` rebuild was opened and never finished: the transform's result is \
-             discarded, the occurrence silently keeps its origin `Rc`, and nothing is \
-             memoized. Every `begin`/`begin_always` must reach a `finish`, \
-             `finish_shared`, or `finish_unchanged` — including on error paths."
-        );
-    }
-}
-
-impl PredMemo {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Open a rebuild of `refinement`'s predicate.
-    ///
-    /// On a **hit** — an occurrence sharing this origin `Rc` was already rebuilt
-    /// in this pass — re-points `refinement` at that single rebuild and returns
-    /// `None`: sharing preserved, transform skipped. On a **miss**, returns the
-    /// [`Origin`] token together with a mutable copy for the caller to transform,
-    /// to be handed back to [`finish`](Self::finish) (or
-    /// [`finish_unchanged`](Self::finish_unchanged)).
-    ///
-    /// The copy is owned, so the caller holds **no** borrow of the memo across
-    /// its own transform — which is what lets a pass whose transform needs
-    /// `&mut Ctx` (with the memo living in that `Ctx`) drive this protocol
-    /// without a borrow conflict.
-    #[must_use = "an opened rebuild must be closed with a `finish*` — see `Origin`"]
-    pub fn begin(&mut self, refinement: &mut Refinement) -> Option<(Origin, Expr)> {
-        if let Some((_, rebuilt)) = self.entries.get(&refinement.predicate_id()) {
-            let rebuilt = Rc::clone(rebuilt);
-            self.point_at(refinement, rebuilt);
-            return None;
-        }
-        Some(self.open(refinement))
-    }
-
-    /// Open a rebuild for a **context-determined** transform: one whose result
-    /// depends on something the memo key does not name, so it must run at *every*
-    /// occurrence. Always returns the [`Origin`] token and a copy — there is no
-    /// skip — to be closed with [`finish_shared`](Self::finish_shared), which
-    /// unifies the term while leaving the per-occurrence work already done.
-    #[must_use = "an opened rebuild must be closed with a `finish*` — see `Origin`"]
-    pub fn begin_always(&self, refinement: &Refinement) -> (Origin, Expr) {
-        self.open(refinement)
-    }
-
-    /// Close a rebuild: install `rebuilt` into `refinement` and record
-    /// `origin ↦ rebuilt`, so every later occurrence sharing `origin` is
-    /// re-pointed at this same term.
-    pub fn finish(&mut self, refinement: &mut Refinement, origin: Origin, rebuilt: Expr) {
-        let rebuilt = Rc::new(rebuilt);
-        self.point_at(refinement, Rc::clone(&rebuilt));
-        self.insert(origin, rebuilt);
-    }
-
-    /// Close a [`begin_always`](Self::begin_always) rebuild: point the slot at the
-    /// term an earlier occurrence produced if there is one, otherwise record this
-    /// occurrence's `rebuilt` as that shared term.
-    ///
-    /// The caller's transform has already run — that is the whole point — so this
-    /// only decides *which* term the occurrences share. Discarding `rebuilt` on a
-    /// hit is safe precisely because refinement identity is type-blind: the
-    /// occurrences denote one refinement, and the winning term's embedded type
-    /// slots are as good as the discarded one's.
-    pub fn finish_shared(&mut self, refinement: &mut Refinement, origin: Origin, rebuilt: Expr) {
-        match self.entries.get(&Rc::as_ptr(origin.peek())) {
-            Some((_, shared)) => {
-                let shared = Rc::clone(shared);
-                self.point_at(refinement, shared);
-                // The entry already retains its own keepalive for this key, so
-                // this token has nothing left to record — but it still has to be
-                // consumed rather than dropped (see `Origin`).
-                drop(origin.consume());
-            }
-            None => self.finish(refinement, origin, rebuilt),
-        }
-    }
-
-    /// Close a rebuild the transform left **untouched**: keep the origin `Rc` in
-    /// the slot and record `origin ↦ origin`.
-    ///
-    /// This is strictly better than rebuilding an identical term. It preserves
-    /// sharing a pass *already* had rather than re-establishing it (a predicate a
-    /// pass merely walks past is never reallocated, so occurrences it never
-    /// visits stay pointer-equal to ones it did), and it turns the caller's
-    /// "would this transform do anything?" test — `subst`'s `is_free` scan, say —
-    /// from once per *occurrence* into once per distinct predicate.
-    pub fn finish_unchanged(&mut self, refinement: &mut Refinement, origin: Origin) {
-        let kept = Rc::clone(origin.peek());
-        self.point_at(refinement, Rc::clone(&kept));
-        self.insert(origin, kept);
-    }
-
-    /// A counter that advances every time this memo points some predicate slot at
-    /// a *different* `Rc`.
-    ///
-    /// [`walk_refined_predicates_mut`] brackets its callback with this to learn
-    /// whether the copy it handed over was mutated by the memo itself — a nested
-    /// memo *hit* re-points a slot inside that copy without the callback doing
-    /// anything, so the callback's own `changed` bit cannot report it. Comparing
-    /// revisions is exact for that question and costs one integer.
-    pub fn revision(&self) -> u64 {
-        self.revision
-    }
-
-    /// Point `refinement` at `to`, counting it as a re-pointing when the `Rc`
-    /// actually changes (see [`revision`](Self::revision)).
+impl<C> MemoStore<C> {
+    /// Point `refinement` at `to`, counting it when the `Rc` actually changes.
     fn point_at(&mut self, refinement: &mut Refinement, to: Rc<Expr>) {
         if !Rc::ptr_eq(&refinement.predicate, &to) {
             self.revision += 1;
         }
         refinement.predicate = to;
     }
+}
 
-    /// Mint the [`Origin`] token and the working copy for a miss.
-    fn open(&self, refinement: &Refinement) -> (Origin, Expr) {
-        (
-            Origin(Some(Rc::clone(&refinement.predicate))),
-            (*refinement.predicate).clone(),
-        )
+impl<C: PartialEq + Clone> PredMemo<C> {
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    /// Retain `origin` as the keepalive pinning its address for the memo's
-    /// lifetime (see the type-level note on address reuse) while mapping it to
-    /// `rebuilt`.
-    fn insert(&mut self, origin: Origin, rebuilt: Rc<Expr>) {
-        let origin = origin.consume();
-        self.entries.insert(Rc::as_ptr(&origin), (origin, rebuilt));
+    /// Rebuild `refinement`'s predicate under `context`, or reuse the rebuild an
+    /// earlier occurrence made under an **equal** context.
+    ///
+    /// `f` receives a mutable copy of the predicate and reports whether it changed
+    /// it. It may re-enter this memo freely — including through the pass's own
+    /// recursion, which is the usual case — because no borrow of the store is held
+    /// across the call. That re-entrancy is why this is a closure rather than a
+    /// begin/finish token pair: the token could be dropped on an early return,
+    /// silently discarding the rebuild and leaving the occurrence on its origin.
+    ///
+    /// Reporting `false` keeps the origin `Rc` in the slot, so a predicate the pass
+    /// merely walks past is never reallocated and stays pointer-shared with
+    /// occurrences the pass never visits.
+    ///
+    /// Returns whether the slot ended up pointing somewhere new — which is *not*
+    /// just `f`'s answer. A nested reuse inside `f` can re-point a slot in the copy
+    /// with `f` having nothing of its own to report; discarding the copy would then
+    /// throw that away and memoize the staleness. The store's revision counter is
+    /// consulted for exactly that.
+    pub fn rebuild(
+        &self,
+        refinement: &mut Refinement,
+        context: &C,
+        f: impl FnOnce(&mut Expr) -> bool,
+    ) -> bool {
+        let (mut pred, keepalive, before) = {
+            let mut store = self.0.borrow_mut();
+            let hit = store
+                .entries
+                .get(&refinement.predicate_id())
+                .and_then(|es| es.iter().find(|e| e.context == *context))
+                .map(|e| Rc::clone(&e.rebuilt));
+            match hit {
+                Some(rebuilt) => {
+                    store.point_at(refinement, rebuilt);
+                    return false;
+                }
+                None => {
+                    let keepalive = Rc::clone(&refinement.predicate);
+                    let copy = (*refinement.predicate).clone();
+                    let rev = store.revision;
+                    (copy, keepalive, rev)
+                }
+            }
+        };
+        let reported = f(&mut pred);
+        let mut store = self.0.borrow_mut();
+        let changed = reported || store.revision != before;
+        let installed = if changed {
+            Rc::new(pred)
+        } else {
+            Rc::clone(&keepalive)
+        };
+        store.point_at(refinement, Rc::clone(&installed));
+        store
+            .entries
+            .entry(Rc::as_ptr(&keepalive))
+            .or_default()
+            .push(Entry {
+                keepalive,
+                rebuilt: installed,
+                context: context.clone(),
+            });
+        changed
+    }
+}
+
+impl TermMemo {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Run `f` on a copy of `refinement`'s predicate — **always**, never skipped —
+    /// then point the slot at the term an earlier occurrence produced, or record
+    /// this one as that term if it is the first.
+    ///
+    /// The closure cannot leak the rebuild: there is no token to drop, so an early
+    /// return inside `f` (a `?` on the pass's own error type, captured by the
+    /// caller) still leaves the occurrence rebuilt and recorded.
+    pub fn rebuild_always(&self, refinement: &mut Refinement, f: impl FnOnce(&mut Expr)) {
+        let keepalive = Rc::clone(&refinement.predicate);
+        let mut pred = (*refinement.predicate).clone();
+        f(&mut pred);
+        let mut store = self.0.0.borrow_mut();
+        let shared = store
+            .entries
+            .get(&Rc::as_ptr(&keepalive))
+            .and_then(|es| es.first())
+            .map(|e| Rc::clone(&e.rebuilt));
+        match shared {
+            Some(term) => store.point_at(refinement, term),
+            None => {
+                let installed = Rc::new(pred);
+                store.point_at(refinement, Rc::clone(&installed));
+                store
+                    .entries
+                    .entry(Rc::as_ptr(&keepalive))
+                    .or_default()
+                    .push(Entry {
+                        keepalive,
+                        rebuilt: installed,
+                        context: (),
+                    });
+            }
+        }
     }
 }
 
@@ -1049,42 +1048,29 @@ pub fn distinct_predicate_rcs(expr: &Expr) -> usize {
 /// when a predicate's own subexpressions carry further refinements). Every
 /// occurrence that shared one predicate term is re-pointed at the same term.
 ///
-/// `f` returns whether it **changed** the copy. Returning `false` keeps the
-/// origin `Rc` in place ([`PredMemo::finish_unchanged`]), so a caller that merely
-/// walks past a predicate does not reallocate it — which is what lets sharing
-/// survive across the nodes such a caller visits, not just within one type.
-///
-/// `f`'s bit is *not* the whole answer, and this does not trust it as such. A
-/// callback that recurses back through the memo — which is why it is handed one —
-/// can have its copy mutated underneath it by a nested memo **hit** re-pointing a
-/// slot, with nothing of its own to report. Discarding the copy would then throw
-/// that re-pointing away *and* memoize the staleness for every later occurrence.
-/// So the copy is kept when `f` reports a change **or** the memo's
-/// [`revision`](PredMemo::revision) advanced during the call: the memo is what
-/// knows about its own re-pointings, so it is asked.
+/// `f` returns whether it **changed** the copy; see [`PredMemo::rebuild`] for what
+/// that bit does and does not decide, and for why `f` may re-enter the memo.
 ///
 /// Returns whether this walk changed anything reachable from `ty`, so a caller
 /// driving its own fixpoint (`simplify`) can fold it in.
 ///
 /// The caller **must** pass one memo for the whole pass, not a fresh one per
-/// call — see [`PredMemo`] for why.
-pub fn walk_refined_predicates_mut<F>(ty: &mut Type, memo: &mut PredMemo, f: &mut F) -> bool
+/// call — see [`PredMemo`] for why. `context` is that pass's `C` (see `PredMemo`);
+/// a pass whose rebuild is a function of the term alone passes `&()`.
+pub fn walk_refined_predicates_mut<C, F>(
+    ty: &mut Type,
+    memo: &PredMemo<C>,
+    context: &C,
+    f: &mut F,
+) -> bool
 where
-    F: FnMut(&mut Expr, &mut PredMemo) -> bool,
+    C: PartialEq + Clone,
+    F: FnMut(&mut Expr, &PredMemo<C>) -> bool,
 {
     let mut changed = false;
-    if let Type::Refinement(_, refinement) = ty
-        && let Some((origin, mut pred)) = memo.begin(refinement)
-    {
-        let before = memo.revision();
-        let reported = f(&mut pred, memo);
-        if reported || memo.revision() != before {
-            memo.finish(refinement, origin, pred);
-            changed = true;
-        } else {
-            memo.finish_unchanged(refinement, origin);
-        }
+    if let Type::Refinement(_, refinement) = ty {
+        changed |= memo.rebuild(refinement, context, |pred| f(pred, memo));
     }
-    ty.walk_children_mut(|child| changed |= walk_refined_predicates_mut(child, memo, f));
+    ty.walk_children_mut(|child| changed |= walk_refined_predicates_mut(child, memo, context, f));
     changed
 }

--- a/src/ccl/channelize.rs
+++ b/src/ccl/channelize.rs
@@ -2148,9 +2148,7 @@ fn extract_for_defer(
                             let pred_lambda = Expr::lambda(&param.name, param.ty.clone(), pred);
                             let pred_on_source = Expr::apply(source_at_elem, pred_lambda)
                                 .with_ty(Type::Base(BaseType::Bool));
-                            let refinement_struct = Refinement {
-                                predicate: Rc::new(pred_on_source),
-                            };
+                            let refinement_struct = Refinement::born(Rc::new(pred_on_source));
                             let mut refined_argument = new_argument.clone();
                             refine_source_domain(&mut refined_argument, refinement_struct, ctx);
                             // stamp the channel at
@@ -2363,9 +2361,8 @@ fn extract_for_defer(
                                         Expr::lambda(&param.name, param.ty.clone(), pred);
                                     let pred_on_source = Expr::apply(source_at_elem, pred_lambda)
                                         .with_ty(Type::Base(BaseType::Bool));
-                                    let refinement_struct = Refinement {
-                                        predicate: Rc::new(pred_on_source),
-                                    };
+                                    let refinement_struct =
+                                        Refinement::born(Rc::new(pred_on_source));
                                     let mut refined_prefix = source_prefix.clone();
                                     refine_source_domain(
                                         &mut refined_prefix,

--- a/src/ccl/channelize.rs
+++ b/src/ccl/channelize.rs
@@ -2854,9 +2854,7 @@ mod tests {
         // predicate referencing `outer_n`:
         //   `Var("__chan")` with user_annotation = Fun(Refinement(Hole, pred(outer_n)), Hole)
         let pred = var("outer_n");
-        let refinement = Refinement {
-            predicate: Rc::new(pred),
-        };
+        let refinement = Refinement::born(Rc::new(pred));
         let annotated = TypedExpr {
             node: TypedExprNode::Var(Name::raw("__chan")),
             ty: Type::Hole,
@@ -2884,9 +2882,7 @@ mod tests {
     #[test]
     fn collect_free_vars_descends_into_ty_refinement_predicates() {
         let pred = var("inner_k");
-        let refinement = Refinement {
-            predicate: Rc::new(pred),
-        };
+        let refinement = Refinement::born(Rc::new(pred));
         let typed = TypedExpr {
             node: TypedExprNode::Lit(Lit::Unit),
             ty: Type::Fun {

--- a/src/ccl/channelize.rs
+++ b/src/ccl/channelize.rs
@@ -719,8 +719,12 @@ fn erase_chan_domains_in_type(ty: &mut Type, map: &HashMap<Name, Type>) {
 /// substitution *above* the binder injects the closed form the strict checker
 /// derives. Still derivation-free — a discharge transport, not re-inference.
 fn erase_chan_domains(expr: &mut Expr, map: &mut HashMap<Name, Type>) {
-    // Erase this node's binder-declared type slots (shared coverage with
-    // `mut_elim::erase_mut` via `walk_binders_mut`). This is order-invariant
+    // Erase this node's binder-declared type slots — both the declared type and
+    // the annotation, since a handle can ride either. Deliberately *not*
+    // `walk_type_slots_mut` (which `mut_elim::erase_mut` uses): the slots here are
+    // visited in three separate phases — binders, then children, then this node's
+    // own `ty`/annotation *after* the `Let`-discharge below has updated `map` —
+    // and one combined call would collapse that ordering. This is order-invariant
     // w.r.t. the `Let`-discharge below: a binder's type resolves against `map` as
     // it stands, and a child's discharge only closes variables bound *inside*
     // that child — never in scope at this binder — so erasing binders before the

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -318,47 +318,64 @@ lives, is the one that costs most. `count_free`/`is_free` are on it too, and tha
 is not cosmetic: several passes *skip work* when `is_free` says no, so a slot the
 free-variable walk cannot see is a slot those passes decline to rewrite.
 
-#### Reusing an entry is only sound for a key-determined transform
+#### The memo key is the predicate *and the conditions it was rebuilt under*
 
-The memo's key is the predicate `Rc`'s address **and nothing else**. Serving one
-occurrence's result to another is therefore only valid when the transform is a
-function of the predicate term. Passes divide on this, and the division decides
-which protocol they use:
+Keying such a memo on the predicate `Rc`'s address alone is half a key: it answers
+"have I rebuilt this term?", while every pass needs "have I rebuilt this term
+**under the conditions I am rebuilding it under now**?". `PredMemo<C>` carries those
+conditions as `C`, and reuses an entry only when it was recorded under an equal
+`C`. Supplying the wrong `C` costs a sharing opportunity; it cannot produce a wrong
+answer — which is the point, because the key-only design did produce wrong answers
+(`subst` discharging a binder its inner scope owned; constraint emission skipping
+the emission that bounds an occurrence's own domain).
 
-- **Key-determined** — `begin`/`finish`, where a hit *skips* the transform.
-  `uniquify`, `coalesce`, `retype`, `simplify`, `inline`, and `subst` within one
-  active substitution. Each depends on the term plus context invariant across the
-  occurrences sharing it: coalesce's predicates resolve out of one live constraint
-  graph, so two occurrences of one term resolve identically.
-- **Context-determined** — `begin_always`/`finish_shared`, where the transform
-  runs at *every* occurrence and only the resulting term is unified. Constraint
-  emission is the case: it binds `REFINEMENT_BINDER` to a domain supplied per
-  occurrence (`emit_cast` mints a fresh one per cast node), so skipping it would
-  leave that occurrence's domain without the constraints the predicate imposes on
-  it. Discarding the loser's term is sound because refinement identity is
-  type-blind.
+What each pass supplies:
 
-A third shape is neither, and wants the memo *scoped* rather than the key widened:
-when the context is part of the transform's identity instead of a parameter of it.
-`subst` is that case — acting differently in different scopes is the point of a
-substitution, so a memo carried across a binder crossing that shadows a
-substituted variable is wrong in both directions (an outer rebuild served inside,
-or an inner vacuity decision served outside). `subst::recurse_shrunk` gives the
-inner scope a fresh memo whenever the substitution actually shrinks, which keeps
-each memo key-determined and costs nothing in the common unshadowed case.
+| pass | `C` | why |
+|---|---|---|
+| `simplify` | `()` | a function of the term, full stop |
+| `uniquify` | `()` | resolves against `env`, but lowering shares an `Rc` only by copying one refinement, and pre-uniquifies a subtree before cloning it |
+| `coalesce` | `()` | resolution reads one live constraint graph, so occurrences of one term resolve identically |
+| `retype` | `()` | stamps by `Name`; uids are minted once, and a monomorphization clone rebuilds its predicates while freshening |
+| `inline` | `()` | the rewrite is fixed per sweep, and a shadowed subtree is *skipped*, never descended into |
+| `subst` | `Subst` | acting differently in different scopes is the point of a substitution |
+| planning | `Type` | compilation reads the refinement's base |
 
-Planning's predicate compilation is the borderline: it reads the refinement's
-`base`, which the key does not name, but only into the compiled term's *type*
-slots — so type-blind identity makes reuse sound *provided the bases agree*.
-Debug builds check exactly that on the hit path (`predicates::CompileMemo`) rather
-than leaving it argued.
+The `()` rows are *claims*, and each one's justification lives at its call site —
+that is where to check it. Two are load-bearing in a way worth flagging: `inline`'s
+depends on its binder arms skipping rather than descending-with-a-guard, and
+`retype`'s on freshening giving clones distinct predicate `Rc`s.
 
-One consequence of the protocol worth stating: the `changed` bit a callback
-returns is not the whole answer. A callback that recurses back through the memo
-can have its copy mutated underneath it by a nested memo hit, with nothing of its
-own to report; discarding the copy would throw that re-pointing away and memoize
-the staleness. `walk_refined_predicates_mut` therefore also consults the memo's
-own revision counter, and returns a `changed` bit of its own for callers running a
+A pass that must share *allocations* without sharing *results* uses `TermMemo`
+instead. Constraint emission is the case: it binds `REFINEMENT_BINDER` to a domain
+`emit_cast` mints fresh per cast node, so no occurrence may reuse another's answer,
+yet all should still land on one term. `TermMemo` is a separate type rather than a
+flag, so which of the two a pass is entitled to is visible in its signature.
+
+#### The protocol is a closure, so a rebuild cannot be half-done
+
+`PredMemo::rebuild` and `TermMemo::rebuild_always` take the transform as a closure.
+An earlier token-based shape (`begin` handing out a token that a `finish` consumed)
+could be left open: dropping the token discarded the rebuild, left the occurrence
+on its origin `Rc`, and memoized nothing — so a pass that returned early between
+the halves rewrote every occurrence *but one*. Two such leaks existed; the closure
+form makes them unrepresentable.
+
+The closure is also what lets the memo be a cheap clonable handle
+(`Rc<RefCell<_>>`), which matters because three passes own their memo inside the
+very context their transform needs mutably — `uniquify`'s `self.expr` → `self.ty`,
+`coalesce_node` → `coalesce_type_predicates`, `subexpr` → `emit_node` →
+`emit_cast`. Reaching a handle needs only `&ctx`, and no borrow of the store is held
+across the callback, so those transforms re-enter the memo freely. Threading the
+memo as a plain parameter instead would mean changing `Typing::subexpr` and every
+emit rule.
+
+One consequence worth stating: the `changed` bit a callback returns is not the
+whole answer. A callback that re-enters the memo can have its copy mutated
+underneath it by a nested reuse, with nothing of its own to report; discarding the
+copy would throw that re-pointing away and memoize the staleness. `rebuild`
+therefore also consults the store's revision counter, and
+`walk_refined_predicates_mut` returns a `changed` bit for callers running a
 fixpoint.
 
 The invariant is guarded two ways: a debug-only tripwire around `retype` asserts

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -314,7 +314,52 @@ each binder's declared type all hold independent predicate `Rc`s.
 `Expr::walk_type_slots{,_mut}` is the single source of truth for that set,
 precisely because hand-rolling it per pass is how a pass silently acquires a
 blind spot — `Cast.target`, where a comprehension filter's predicate actually
-lives, is the one that costs most.
+lives, is the one that costs most. `count_free`/`is_free` are on it too, and that
+is not cosmetic: several passes *skip work* when `is_free` says no, so a slot the
+free-variable walk cannot see is a slot those passes decline to rewrite.
+
+#### Reusing an entry is only sound for a key-determined transform
+
+The memo's key is the predicate `Rc`'s address **and nothing else**. Serving one
+occurrence's result to another is therefore only valid when the transform is a
+function of the predicate term. Passes divide on this, and the division decides
+which protocol they use:
+
+- **Key-determined** — `begin`/`finish`, where a hit *skips* the transform.
+  `uniquify`, `coalesce`, `retype`, `simplify`, `inline`, and `subst` within one
+  active substitution. Each depends on the term plus context invariant across the
+  occurrences sharing it: coalesce's predicates resolve out of one live constraint
+  graph, so two occurrences of one term resolve identically.
+- **Context-determined** — `begin_always`/`finish_shared`, where the transform
+  runs at *every* occurrence and only the resulting term is unified. Constraint
+  emission is the case: it binds `REFINEMENT_BINDER` to a domain supplied per
+  occurrence (`emit_cast` mints a fresh one per cast node), so skipping it would
+  leave that occurrence's domain without the constraints the predicate imposes on
+  it. Discarding the loser's term is sound because refinement identity is
+  type-blind.
+
+A third shape is neither, and wants the memo *scoped* rather than the key widened:
+when the context is part of the transform's identity instead of a parameter of it.
+`subst` is that case — acting differently in different scopes is the point of a
+substitution, so a memo carried across a binder crossing that shadows a
+substituted variable is wrong in both directions (an outer rebuild served inside,
+or an inner vacuity decision served outside). `subst::recurse_shrunk` gives the
+inner scope a fresh memo whenever the substitution actually shrinks, which keeps
+each memo key-determined and costs nothing in the common unshadowed case.
+
+Planning's predicate compilation is the borderline: it reads the refinement's
+`base`, which the key does not name, but only into the compiled term's *type*
+slots — so type-blind identity makes reuse sound *provided the bases agree*.
+Debug builds check exactly that on the hit path (`predicates::CompileMemo`) rather
+than leaving it argued.
+
+One consequence of the protocol worth stating: the `changed` bit a callback
+returns is not the whole answer. A callback that recurses back through the memo
+can have its copy mutated underneath it by a nested memo hit, with nothing of its
+own to report; discarding the copy would throw that re-pointing away and memoize
+the staleness. `walk_refined_predicates_mut` therefore also consults the memo's
+own revision counter, and returns a `changed` bit of its own for callers running a
+fixpoint.
 
 The invariant is guarded two ways: a debug-only tripwire around `retype` asserts
 the distinct-`Rc` count (`ccl_utils::distinct_predicate_rcs`) never *grows*

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -309,14 +309,30 @@ Two things make this load-bearing rather than housekeeping:
   than a bare map.
 
 A pass reaches predicates through **every type slot a node carries**, not just
-`expr.ty`: the node's own type, its `user_annotation`, a `Cast`'s `target`, and
-each binder's declared type all hold independent predicate `Rc`s.
-`Expr::walk_type_slots{,_mut}` is the single source of truth for that set,
-precisely because hand-rolling it per pass is how a pass silently acquires a
-blind spot — `Cast.target`, where a comprehension filter's predicate actually
-lives, is the one that costs most. `count_free`/`is_free` are on it too, and that
-is not cosmetic: several passes *skip work* when `is_free` says no, so a slot the
-free-variable walk cannot see is a slot those passes decline to rewrite.
+`expr.ty`: the node's own type, its `user_annotation`, a `Cast`'s `target`, and —
+per binder — both the binder's declared type *and* its annotation. Each holds an
+independent predicate `Rc`. `Expr::walk_type_slots{,_mut}` is the single source of
+truth for that set, precisely because hand-rolling it per pass is how a pass
+silently acquires a blind spot — `Cast.target`, where a comprehension filter's
+predicate actually lives, is the one that costs most. `count_free`/`is_free` are on
+it too, and that is not cosmetic: several passes *skip work* when `is_free` says
+no, so a slot the free-variable walk cannot see is a slot those passes decline to
+rewrite.
+
+A binder's **annotation** is the subtle member of that set: it is where lowering
+writes a mutable variable's `Mut(V, D)` history (`x := e` lowers via
+`let_bind_annotated`), and `infer::api::binder_is_mut` reads it as authoritative
+over the binder's `ty`. A walk covering only `b.ty` skips every mutable binder in
+the program, and — because an erasure and its own post-condition would share that
+walk — the check could not report what the erasure missed.
+
+The claim is *checked*, not asserted: `walk_type_slots_covers_every_carried_type_slot`
+stamps a distinct marker into every directly-carried `Type` in the AST and pins
+which ones the walk reaches. One is deliberately excluded — `Transact`'s `domain` —
+because that node is born by `plan_loops` after every pass on the walk, so covering
+it would newly expose the sequencing extent to planning's predicate compilation.
+That is a behavioural change in the recurrence engine, and the test pins the
+exclusion so it stays a decision rather than drift.
 
 #### The memo key is the predicate *and the conditions it was rebuilt under*
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -281,6 +281,49 @@ that rebuild a predicate on `expr.ty` re-sync the `target` to it
 (`ccl_utils::sync_cast_targets`) — the post-inference check reconstructs a cast
 from its `target`.
 
+#### Sharing is an invariant, not an optimization detail
+
+One structural predicate should be **one `Rc`** for the whole pipeline. Lowering
+establishes that (`Refinement::sharing` puts a single filter predicate on the
+source, the map, the cast target, and the consumer contract); every pass that
+rebuilds predicates must then *preserve* it, and "every pass" is the whole list —
+`uniquify`, constraint emission (`emit_bare_predicate`), `coalesce`, `retype`,
+`subst`'s both modes, `inline`, `simplify`, and planning's compilation. Each
+threads one **pass-scoped** `ccl_utils::PredMemo`, whose `begin`/`finish`
+protocol maps an origin `Rc` to a single rebuild; `finish_unchanged` is the
+stronger case, where a pass that has nothing to say about a predicate keeps the
+origin `Rc` rather than reallocating an equal one.
+
+Two things make this load-bearing rather than housekeeping:
+
+- **Downstream cost.** Planning's predicate-compilation memo is `Rc`-keyed, so a
+  predicate split into 𝑛 occurrences is compiled 𝑛 times. With nested
+  comprehensions 𝑛 grows with depth, which is how a split turns into superlinear
+  compile time.
+- **The keepalive.** The memo keys on the `Rc`'s *address*
+  (`PredicateId`), which is sound only while that address cannot be reused.
+  Overwriting a slot can drop the last reference to the origin and free an
+  address a later `Rc::new` in the same walk reclaims, at which point an
+  unrelated predicate collides with the entry and inherits its rebuild. `PredMemo`
+  retains every origin for its own lifetime; that is why passes use it rather
+  than a bare map.
+
+A pass reaches predicates through **every type slot a node carries**, not just
+`expr.ty`: the node's own type, its `user_annotation`, a `Cast`'s `target`, and
+each binder's declared type all hold independent predicate `Rc`s.
+`Expr::walk_type_slots{,_mut}` is the single source of truth for that set,
+precisely because hand-rolling it per pass is how a pass silently acquires a
+blind spot — `Cast.target`, where a comprehension filter's predicate actually
+lives, is the one that costs most.
+
+The invariant is guarded two ways: a debug-only tripwire around `retype` asserts
+the distinct-`Rc` count (`ccl_utils::distinct_predicate_rcs`) never *grows*
+across a rewrite-only pass, and `tests/predicate_sharing.rs` asserts end-to-end
+that no two `Rc`-distinct refinements reachable from an inferred tree are
+structurally equal — the exact shape a split leaves. The count is a necessary
+check; the equal-but-distinct assertion is the sufficient one, and it needs no
+magic number.
+
 A predicate *function* `p : 𝐷 ⇒ Bool` never lives in a refinement type — only in
 a *term* (an `Apply(p, Iterate/Restrict)` argument). In a type it is represented
 bare as `__elem ▷ p` (`ccl_utils::bare_predicate_of_fn`; its inverse
@@ -408,7 +451,7 @@ Some refinement predicates **close over an outer binder**. The motivating case i
 
 **Pi types.** `Type::Fun` carries an optional binder: `Fun { name: Option<Name>, domain, codomain }`. `name: Some(𝑥)` is the dependent type `(𝑥: domain) ⇒ codomain`, with `𝑥` bound in `codomain`; `name: None` is the ordinary arrow. `emit_lambda` always names the binder from the lambda parameter, so a predicate that closes over the parameter stays bound. The binder is **cosmetic for ordinary functions** — `coalesce_compact_go` keeps it only when the codomain's refinement predicates actually reference it (queried via `subst::type_free_vars`) and strips it otherwise, so monomorphic output is unchanged and equality/printing don't churn.
 
-**Substitutions and contexts (`ccl::subst`).** A `Subst` is a context morphism that maps *term* binders (`Var` names) to replacement `TypedExpr`s. It never relabels a type variable — that is freshening's job. Two flavours: a **rename** `[𝑘 ↦ 𝑥]` (invertible) and a **discharge** `[𝑥 ↦ arg]` (one-way). The traversal is uniform over terms and types: `apply_expr` rewrites each node's type slots via `apply_type` in the same pass, so a substituted binder occurring inside a type-borne refinement predicate is discharged where it sits (no value-only contract, no dangling residual for §6.2 to catch in release builds). It is a true no-op when no substituted binder occurs free in the term — value or type slots — so a vacuous discharge from a non-dependent application changes nothing and shares the predicate `Rc`. Capture is impossible under the Barendregt convention (binder uids are minted once at lowering; copies preserve them) and the engine *asserts* it instead of α-renaming. Predicates are immutable, so a substitution always *rebuilds* a changed predicate (a fresh `Rc`); the engine drives two modes that differ only in what else they touch: **transport** (`apply_expr`/`apply_type`, builds new terms — the constraint-edge flavour) and **in-place rewrite** (`rewrite_expr`, mutates the term tree the caller owns but still rebuilds each predicate, re-pointing occurrences that shared one term via a memo — the pass-level flavour that `lambda_elim::substitute`, `channelize::desugar_substitute`, inlining's beta step, and lowering's uncurrying all wrap). A **context** (`well_formed` / `type_free_vars`) is the dual *checking* device: a type is well-formed iff its predicates' free term-vars are in scope.
+**Substitutions and contexts (`ccl::subst`).** A `Subst` is a context morphism that maps *term* binders (`Var` names) to replacement `TypedExpr`s. It never relabels a type variable — that is freshening's job. Two flavours: a **rename** `[𝑘 ↦ 𝑥]` (invertible) and a **discharge** `[𝑥 ↦ arg]` (one-way). The traversal is uniform over terms and types: `apply_expr` rewrites each node's type slots via `apply_type` in the same pass, so a substituted binder occurring inside a type-borne refinement predicate is discharged where it sits (no value-only contract, no dangling residual for §6.2 to catch in release builds). It is a true no-op when no substituted binder occurs free in the term — value or type slots — so a vacuous discharge from a non-dependent application changes nothing and shares the predicate `Rc`. Capture is impossible under the Barendregt convention (binder uids are minted once at lowering; copies preserve them) and the engine *asserts* it instead of α-renaming. Predicates are immutable, so a substitution always *rebuilds* a changed predicate (a fresh `Rc`); the engine drives two modes that differ only in what else they touch: **transport** (`apply_expr`/`apply_type`, builds new terms — the constraint-edge flavour) and **in-place rewrite** (`rewrite_expr`, mutates the term tree the caller owns; a predicate the substitution actually touches is rebuilt, one it merely walks past keeps its `Rc` — the pass-level flavour that `lambda_elim::substitute`, `channelize::desugar_substitute`, inlining's beta step, and lowering's uncurrying all wrap). Both modes thread the same `PredMemo`, so occurrences that shared one term are re-pointed at the same result. A **context** (`well_formed` / `type_free_vars`) is the dual *checking* device: a type is well-formed iff its predicates' free term-vars are in scope.
 
 **Edges carry substitutions, stored two-sided in their native direction.** Each entry of a variable's bound lists is a `Bound { self_subst, ty, ty_subst }`: an upper entry on `𝑉` reads `𝑉‹self_subst› <: ty‹ty_subst›`, a lower entry `ty‹ty_subst› <: 𝑉‹self_subst›` (both identity for ordinary bounds). `constrain_subtype` delegates to `constrain_go(lhs, rhs, sl, sr, cache)` — each side under its own morphism. The **Fun/Fun arm derives the binder correspondence** `[𝑘 ↦ 𝑥]` onto the lhs side of the codomain edge, and the contravariant domain edge **swaps the two sides** rather than inverting anything. The var arms record edges verbatim — *nothing is inverted at record time*. A **discharge has no inverse**, so edges are recorded in their native direction rather than pre-inverted and re-inverted during closure (which would degrade a discharge to the identity, silently destroying it whenever a consumer edge is recorded before the producer's concrete codomain arrives — the opaque/higher-order application order, O3). Under identity morphisms every arm reduces exactly to the substitution-free solver, so all monomorphic inference is byte-identical.
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -289,10 +289,10 @@ source, the map, the cast target, and the consumer contract); every pass that
 rebuilds predicates must then *preserve* it, and "every pass" is the whole list —
 `uniquify`, constraint emission (`emit_bare_predicate`), `coalesce`, `retype`,
 `subst`'s both modes, `inline`, `simplify`, and planning's compilation. Each
-threads one **pass-scoped** `ccl_utils::PredMemo`, whose `begin`/`finish`
-protocol maps an origin `Rc` to a single rebuild; `finish_unchanged` is the
-stronger case, where a pass that has nothing to say about a predicate keeps the
-origin `Rc` rather than reallocating an equal one.
+threads one **pass-scoped** `ccl_utils::PredMemo`, whose `rebuild` maps an origin
+`Rc` to a single result. A pass that has nothing to say about a predicate reports
+no change and keeps the origin `Rc` rather than reallocating an equal one, so
+sharing survives even the passes that merely walk past.
 
 Two things make this load-bearing rather than housekeeping:
 

--- a/src/ccl/expr.rs
+++ b/src/ccl/expr.rs
@@ -1202,10 +1202,10 @@ impl TypedExpr {
     }
 
     /// Invoke `f` on every [`Type`] slot this node carries **directly**: its own
-    /// `ty`, its `user_annotation`, a [`TypedExprNode::Cast`]'s `target`, and the
-    /// declared type of every binder it introduces
-    /// ([`walk_binders`](Self::walk_binders)). Does not recurse into child
-    /// expressions.
+    /// `ty`, its `user_annotation`, a [`TypedExprNode::Cast`]'s `target`, and — for
+    /// every binder it introduces ([`walk_binders`](Self::walk_binders)) — both
+    /// that binder's `ty` **and** its `user_annotation`. Does not recurse into
+    /// child expressions.
     ///
     /// This is the single source of truth for "which type slots a node carries",
     /// and it exists because those slots are **independent** values: a refinement
@@ -1219,6 +1219,22 @@ impl TypedExpr {
     /// one place instead of every such pass, and a pass cannot acquire a blind
     /// spot by omission.
     ///
+    /// **A binder's annotation is a slot, not decoration.** Lowering writes a
+    /// mutable variable's `Mut(V, D)` history *there* rather than on `b.ty`
+    /// (`x := e` lowers via `let_bind_annotated`), and `infer::api::binder_is_mut`
+    /// reads it as authoritative over `b.ty`. A walk that visits only `b.ty` will
+    /// silently skip every mutable binder in the program.
+    ///
+    /// **Coverage is exact for every variant except
+    /// [`TypedExprNode::Transact`]**, whose `domain` — the sequencing extent, or
+    /// `Txn` — is the one directly-carried `Type` this does not visit. `Transact`
+    /// is born by `planning::plan_loops`, *after* every pass that uses this walk,
+    /// so no caller can observe the omission today; covering it would newly expose
+    /// the domain to `planning::compile_refinement_predicates`, which runs later.
+    /// That is a real behavioural change in the recurrence engine and wants its
+    /// own change rather than riding along here. The exhaustiveness this claims is
+    /// checked, not asserted: `walk_type_slots_covers_every_carried_type_slot`.
+    ///
     /// Callers that also need slots reachable *through* a type (a `Fun` domain, a
     /// refinement predicate's own type slots) compose this with
     /// [`Type::walk_children`] — see
@@ -1231,7 +1247,12 @@ impl TypedExpr {
         if let TypedExprNode::Cast { target, .. } = &self.node {
             f(target);
         }
-        self.walk_binders(|b| f(&b.ty));
+        self.walk_binders(|b| {
+            f(&b.ty);
+            if let Some(annotation) = &b.user_annotation {
+                f(annotation);
+            }
+        });
     }
 
     /// Mutable analog of [`walk_type_slots`](Self::walk_type_slots), for passes
@@ -1245,7 +1266,12 @@ impl TypedExpr {
         if let TypedExprNode::Cast { target, .. } = &mut self.node {
             f(target);
         }
-        self.walk_binders_mut(|b| f(&mut b.ty));
+        self.walk_binders_mut(|b| {
+            f(&mut b.ty);
+            if let Some(annotation) = &mut b.user_annotation {
+                f(annotation);
+            }
+        });
     }
 
     /// Mutable analog of [`fold_children`](Self::fold_children).
@@ -1479,6 +1505,73 @@ mod tests {
         assert!(
             !ops.iter()
                 .any(|e| matches!(&e.node, TypedExprNode::CollectionUnion(_))),
+        );
+    }
+
+    /// Every `Type` a node carries *directly* is reached by
+    /// [`TypedExpr::walk_type_slots`] — or is a named, justified exception.
+    ///
+    /// Stamps a distinct `Type::DataSource` marker into each slot and asserts the
+    /// walk reports exactly the expected set. A marker is used rather than a real
+    /// type because the point is slot *reachability*, not type content.
+    ///
+    /// The full inventory of directly-carried `Type`s in the AST: `TypedExpr.ty`,
+    /// `TypedExpr.user_annotation`, `TypedBinding.ty`, `TypedBinding.user_annotation`,
+    /// `TypedExprNode::Cast.target`, and `TypedExprNode::Transact.domain`. The walk
+    /// covers the first five; `Transact.domain` is excluded for the reason on
+    /// `walk_type_slots`, and this pins that exclusion so it cannot become silent.
+    #[test]
+    fn walk_type_slots_covers_every_carried_type_slot() {
+        fn marker(name: &str) -> Type {
+            Type::DataSource(name.into())
+        }
+        fn reached(e: &TypedExpr) -> Vec<String> {
+            let mut seen = Vec::new();
+            e.walk_type_slots(|ty| {
+                if let Type::DataSource(n) = ty {
+                    seen.push(n.to_string());
+                }
+            });
+            seen.sort();
+            seen
+        }
+
+        // A binder-bearing node: node type + annotation, binder type + annotation.
+        let mut lam = TypedExpr::new(TypedExprNode::Lambda {
+            param: TypedBinding {
+                name: "x".into(),
+                ty: marker("param_ty"),
+                user_annotation: Some(marker("param_annotation")),
+            },
+            body: Box::new(TypedExpr::lit(Lit::Unit)),
+        });
+        lam.ty = marker("node_ty");
+        lam.user_annotation = Some(marker("node_annotation"));
+        assert_eq!(
+            reached(&lam),
+            vec!["node_annotation", "node_ty", "param_annotation", "param_ty"],
+            "a binder's annotation carries a mutable variable's history — see \
+             `walk_type_slots`"
+        );
+
+        // `Cast` carries a target beyond its own type.
+        let mut cast = TypedExpr::cast(TypedExpr::lit(Lit::Unit), marker("cast_target"));
+        cast.ty = marker("node_ty");
+        assert_eq!(reached(&cast), vec!["cast_target", "node_ty"]);
+
+        // `Transact.domain` is the one directly-carried `Type` deliberately not
+        // covered. Asserted so the exclusion stays a decision rather than drift:
+        // if this starts failing, the walk grew to cover it and the doc must too.
+        let mut txn = TypedExpr::new(TypedExprNode::Transact {
+            keys: Vec::new(),
+            writers: Vec::new(),
+            domain: marker("transact_domain"),
+        });
+        txn.ty = marker("node_ty");
+        assert_eq!(
+            reached(&txn),
+            vec!["node_ty"],
+            "`Transact.domain` is excluded on purpose; see `walk_type_slots`"
         );
     }
 }

--- a/src/ccl/expr.rs
+++ b/src/ccl/expr.rs
@@ -1201,6 +1201,53 @@ impl TypedExpr {
         }
     }
 
+    /// Invoke `f` on every [`Type`] slot this node carries **directly**: its own
+    /// `ty`, its `user_annotation`, a [`TypedExprNode::Cast`]'s `target`, and the
+    /// declared type of every binder it introduces
+    /// ([`walk_binders`](Self::walk_binders)). Does not recurse into child
+    /// expressions.
+    ///
+    /// This is the single source of truth for "which type slots a node carries",
+    /// and it exists because those slots are **independent** values: a refinement
+    /// riding a lambda's domain also rides `param.ty`, and a cast's refinement
+    /// rides both `ty` and `target`, but each slot holds its *own* immutable
+    /// predicate `Rc`. So a pass that rewrites or measures predicates must reach
+    /// all of them — `ty` alone silently misses the slot a comprehension filter's
+    /// predicate actually lives in (`Cast.target`, which downstream
+    /// `lambda_elim` and operator conversion read). Enumerate here rather than
+    /// re-deriving the set per pass: a new type-slot-bearing variant then updates
+    /// one place instead of every such pass, and a pass cannot acquire a blind
+    /// spot by omission.
+    ///
+    /// Callers that also need slots reachable *through* a type (a `Fun` domain, a
+    /// refinement predicate's own type slots) compose this with
+    /// [`Type::walk_children`] — see
+    /// [`crate::ccl::ccl_utils::distinct_predicate_rcs`].
+    pub fn walk_type_slots(&self, mut f: impl FnMut(&Type)) {
+        f(&self.ty);
+        if let Some(annotation) = &self.user_annotation {
+            f(annotation);
+        }
+        if let TypedExprNode::Cast { target, .. } = &self.node {
+            f(target);
+        }
+        self.walk_binders(|b| f(&b.ty));
+    }
+
+    /// Mutable analog of [`walk_type_slots`](Self::walk_type_slots), for passes
+    /// that rewrite type slots in place. Kept in lockstep with it — any new
+    /// type-slot-bearing variant must appear in both.
+    pub fn walk_type_slots_mut(&mut self, mut f: impl FnMut(&mut Type)) {
+        f(&mut self.ty);
+        if let Some(annotation) = &mut self.user_annotation {
+            f(annotation);
+        }
+        if let TypedExprNode::Cast { target, .. } = &mut self.node {
+            f(target);
+        }
+        self.walk_binders_mut(|b| f(&mut b.ty));
+    }
+
     /// Mutable analog of [`fold_children`](Self::fold_children).
     ///
     /// Threads `init` through `f` while visiting each direct child by mutable

--- a/src/ccl/infer/api.rs
+++ b/src/ccl/infer/api.rs
@@ -26,7 +26,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
 
-use crate::ccl::symbolic::{symbolic, symbolic_typed};
+use crate::ccl::symbolic::symbolic;
 use crate::ccl::{Expr, HistoryKind, InferVarId, Name, Type, TypedBinding, TypedExprNode};
 use crate::util::ScopeStack;
 
@@ -1165,20 +1165,33 @@ fn check_mut_write_targets_go(
     expr.walk_children(|c| check_mut_write_targets_go(c, muts, errors));
 }
 
-/// In debug mode only, typecheck the expression and panic if any errors are found.
+/// Per-operation post-rewrite typecheck — a **debugging aid**, off by default.
 ///
-/// Routes through [`check_pre_desugar`], which self-selects strictness: a
+/// Pass-internal helpers (lambda elimination, substitution, simplify) call this
+/// after each rewrite to localize *which* operation first produced an ill-typed
+/// tree. Routes through [`check_pre_desugar`], which self-selects strictness: a
 /// (sub)tree carrying defer artifacts (a `Feed`/`Infer` channel type — which
 /// `substitute` now sees, since inline runs before desugar) is checked at the
 /// relaxed `PreDesugar` level; a fully-desugared tree is checked strictly (the
 /// `typecheck` bar).
+///
+/// Gated behind the opt-in `deep-typecheck` feature. `compile_program` already
+/// runs [`check_pre_desugar`] at every *pass boundary* — those walls are the
+/// always-on correctness net — so this per-op version only adds localization.
+/// It is O(subtree) and fires once per rewrite, so on nested comprehensions it
+/// is superlinear (O(rewrites) × O(subtree)) and dominated debug/test compile
+/// time; release built it out entirely. Enable it (`cargo test --features
+/// deep-typecheck`) to bisect a miscompile to its introducing operation.
 pub fn debug_typecheck(expr: &Expr) {
-    debug_assert_eq!(
+    #[cfg(feature = "deep-typecheck")]
+    assert_eq!(
         check_pre_desugar(expr),
         Ok(()),
         "Failed post-transform typecheck: {}",
-        symbolic_typed(expr)
+        crate::ccl::symbolic::symbolic_typed(expr)
     );
+    #[cfg(not(feature = "deep-typecheck"))]
+    let _ = expr;
 }
 
 // Helper to run typechecking inline when building an Expr

--- a/src/ccl/infer/check.rs
+++ b/src/ccl/infer/check.rs
@@ -2,7 +2,7 @@
 // Check pass: post-inference structural re-validation
 // ---------------------------------------------------------------------------
 
-use crate::ccl::ccl_utils::strip_refinements;
+use crate::ccl::ccl_utils::{PredMemo, strip_refinements};
 use crate::ccl::infer::InferError;
 use crate::ccl::infer::solver::{ConstrainCache, PolyScheme, constrain_subtype, fresh_var, prim};
 use crate::ccl::symbolic::symbolic;
@@ -54,6 +54,7 @@ pub(super) struct CheckCtx {
     schemes: OperatorSchemes,
     level: Level,
     errors: Vec<InferError>,
+    pred_memo: PredMemo,
 }
 
 impl CheckCtx {
@@ -65,11 +66,16 @@ impl CheckCtx {
             schemes: OperatorSchemes::new(),
             level: 0,
             errors: Vec::new(),
+            pred_memo: Default::default(),
         }
     }
 }
 
 impl Typing for CheckCtx {
+    fn pred_memo(&mut self) -> &mut PredMemo {
+        &mut self.pred_memo
+    }
+
     fn subexpr(&mut self, child: &mut Expr) -> Result<Type, InferError> {
         // Recurse to collect the child's own errors, then hand back its
         // *recorded* type (not the rule-derived, throwaway-laden one) so the

--- a/src/ccl/infer/check.rs
+++ b/src/ccl/infer/check.rs
@@ -2,7 +2,7 @@
 // Check pass: post-inference structural re-validation
 // ---------------------------------------------------------------------------
 
-use crate::ccl::ccl_utils::{PredMemo, strip_refinements};
+use crate::ccl::ccl_utils::{TermMemo, strip_refinements};
 use crate::ccl::infer::InferError;
 use crate::ccl::infer::solver::{ConstrainCache, PolyScheme, constrain_subtype, fresh_var, prim};
 use crate::ccl::symbolic::symbolic;
@@ -54,7 +54,7 @@ pub(super) struct CheckCtx {
     schemes: OperatorSchemes,
     level: Level,
     errors: Vec<InferError>,
-    pred_memo: PredMemo,
+    pred_memo: TermMemo,
 }
 
 impl CheckCtx {
@@ -72,8 +72,8 @@ impl CheckCtx {
 }
 
 impl Typing for CheckCtx {
-    fn pred_memo(&mut self) -> &mut PredMemo {
-        &mut self.pred_memo
+    fn pred_memo(&self) -> TermMemo {
+        self.pred_memo.clone()
     }
 
     fn subexpr(&mut self, child: &mut Expr) -> Result<Type, InferError> {

--- a/src/ccl/infer/context.rs
+++ b/src/ccl/infer/context.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use crate::ccl::ccl_utils::PredMemo;
+use crate::ccl::ccl_utils::TermMemo;
 use crate::ccl::infer::InferError;
 use crate::ccl::infer::solver::{
     ConstrainCache, PolyScheme, constrain_subtype, fresh_var, fun, type_level,
@@ -81,7 +81,7 @@ pub(super) struct InferCtx {
     /// `in_let_rhs`) so RHS-local variables are minted deeper than the
     /// defining scope and become generalizable at the binding site.
     pub(super) level: Level,
-    pred_memo: PredMemo,
+    pred_memo: TermMemo,
 }
 
 impl InferCtx {
@@ -160,8 +160,8 @@ impl InferCtx {
 }
 
 impl Typing for InferCtx {
-    fn pred_memo(&mut self) -> &mut PredMemo {
-        &mut self.pred_memo
+    fn pred_memo(&self) -> TermMemo {
+        self.pred_memo.clone()
     }
 
     fn subexpr(&mut self, child: &mut Expr) -> Result<Type, InferError> {

--- a/src/ccl/infer/context.rs
+++ b/src/ccl/infer/context.rs
@@ -9,7 +9,9 @@ use crate::ccl::infer::InferError;
 use crate::ccl::infer::solver::{
     ConstrainCache, PolyScheme, constrain_subtype, fresh_var, fun, type_level,
 };
-use crate::ccl::{Expr, Level, Name, Type, TypedExprNode};
+use std::rc::Rc;
+
+use crate::ccl::{Expr, Level, Lit, Name, Refinement, Type, TypedExpr, TypedExprNode};
 use crate::util::ScopeStack;
 
 use super::emit::emit_node;
@@ -82,6 +84,18 @@ pub(super) struct InferCtx {
     /// defining scope and become generalizable at the binding site.
     pub(super) level: Level,
     pred_memo: TermMemo,
+    /// One predicate `Rc` per distinct literal *value*, for the singleton
+    /// refinements `emit_node` stamps on `Lit` nodes.
+    ///
+    /// Without this every literal *occurrence* mints its own `{Int | __elem == 5}`,
+    /// so a program's literals become a large family of structurally-equal but
+    /// `Rc`-distinct predicates — exactly the shape that defeats planning's
+    /// `Rc`-keyed compile memo and makes it compile one trivial predicate once per
+    /// occurrence. Interning at birth is the cheapest place to prevent it: the
+    /// term is ground (see [`singleton_predicate`](super::singleton_predicate)), so
+    /// sharing it carries none of the context-dependence that makes sharing
+    /// delicate elsewhere.
+    lit_singletons: HashMap<Lit, Rc<TypedExpr>>,
 }
 
 impl InferCtx {
@@ -93,6 +107,7 @@ impl InferCtx {
             schemes: OperatorSchemes::new(),
             level: 0,
             pred_memo: Default::default(),
+            lit_singletons: HashMap::new(),
         }
     }
 
@@ -156,6 +171,23 @@ impl InferCtx {
             | Type::Txn
             | Type::Infer(_) => ty.clone(),
         }
+    }
+}
+
+impl InferCtx {
+    /// `lit`'s singleton type, with its predicate shared across every occurrence
+    /// of the same literal value in this pass (see [`Self::lit_singletons`]).
+    pub(super) fn lit_singleton(&mut self, lit: &Lit) -> Type {
+        let base = super::lit_base(lit);
+        let Some(predicate) = self.lit_singletons.get(lit).cloned().or_else(|| {
+            let p = super::singleton_predicate(lit)?;
+            self.lit_singletons.insert(lit.clone(), Rc::clone(&p));
+            Some(p)
+        }) else {
+            // `unit`: a singleton adds nothing to a one-inhabitant base.
+            return base;
+        };
+        Type::Refinement(Box::new(base), Refinement::sharing(&predicate))
     }
 }
 

--- a/src/ccl/infer/context.rs
+++ b/src/ccl/infer/context.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 
+use crate::ccl::ccl_utils::PredMemo;
 use crate::ccl::infer::InferError;
 use crate::ccl::infer::solver::{
     ConstrainCache, PolyScheme, constrain_subtype, fresh_var, fun, type_level,
@@ -80,6 +81,7 @@ pub(super) struct InferCtx {
     /// `in_let_rhs`) so RHS-local variables are minted deeper than the
     /// defining scope and become generalizable at the binding site.
     pub(super) level: Level,
+    pred_memo: PredMemo,
 }
 
 impl InferCtx {
@@ -90,6 +92,7 @@ impl InferCtx {
             cache: ConstrainCache::new(),
             schemes: OperatorSchemes::new(),
             level: 0,
+            pred_memo: Default::default(),
         }
     }
 
@@ -157,6 +160,10 @@ impl InferCtx {
 }
 
 impl Typing for InferCtx {
+    fn pred_memo(&mut self) -> &mut PredMemo {
+        &mut self.pred_memo
+    }
+
     fn subexpr(&mut self, child: &mut Expr) -> Result<Type, InferError> {
         emit_node(child, self)
     }

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -1347,3 +1347,52 @@ pub(super) fn emit_transact<C: Typing>(
     }
     Ok(Type::Record(fields))
 }
+
+#[cfg(test)]
+mod review_tests {
+    use super::*;
+    use crate::ccl::{BinOpKind, CompareKind, Lit, TypedExpr};
+    use std::rc::Rc;
+
+    /// Finding 2: [`emit_bare_predicate`]'s transform is parameterized by
+    /// `domain`, which is not part of the memo key. `emit_cast` passes a *fresh*
+    /// inference variable per cast node, so two occurrences of one shared
+    /// predicate `Rc` are typed against two different domains — and the memo
+    /// makes the second one emit nothing at all, leaving its domain with none of
+    /// the constraints the predicate imposes on `REFINEMENT_BINDER`.
+    #[test]
+    fn each_occurrence_constrains_its_own_domain() {
+        // `__elem > 0` — using the element binder is what makes the predicate
+        // constrain the domain it is typed against.
+        let shared = Rc::new(TypedExpr::binop(
+            TypedExpr::var(Name::elem()),
+            BinOpKind::Compare(CompareKind::Greater),
+            TypedExpr::lit(Lit::Int(0)),
+        ));
+        let mut r1 = Refinement::sharing(&shared);
+        let mut r2 = Refinement::sharing(&shared);
+
+        let mut ctx = InferCtx::new(std::collections::HashMap::new());
+        let d1 = ctx.fresh();
+        let d2 = ctx.fresh();
+        emit_bare_predicate(&mut r1, &d1, &mut ctx).expect("first occurrence types");
+        emit_bare_predicate(&mut r2, &d2, &mut ctx).expect("second occurrence types");
+
+        let bound_count = |t: &Type| {
+            let Type::Infer(v) = t else {
+                panic!("fresh() yields a variable");
+            };
+            let b = v.bounds.borrow();
+            b.lower.len() + b.upper.len()
+        };
+        assert!(
+            bound_count(&d1) > 0,
+            "sanity: typing `__elem > 0` at `d1` constrains `d1`",
+        );
+        assert!(
+            bound_count(&d2) > 0,
+            "the second occurrence's domain must be constrained by the predicate \
+             too — the memo hit skipped emission and left `d2` unbounded",
+        );
+    }
+}

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -3,7 +3,6 @@
 // ---------------------------------------------------------------------------
 
 use std::collections::BTreeMap;
-use std::rc::Rc;
 
 use smol_str::SmolStr;
 
@@ -299,17 +298,36 @@ fn emit_annotation_predicates(ty: &mut Type, ctx: &mut InferCtx) -> Result<(), I
 /// it as a fresh `Rc` on `r`. The caller holds `&mut Refinement` so the typed
 /// predicate lands on the syntactic node; the cast/annotation result type then
 /// clones the typed refinement, carrying the same slots.
+///
+/// **Emission is therefore a predicate-rebuilding pass**, and threads the
+/// pass-scoped [`PredMemo`](crate::ccl::ccl_utils::PredMemo) like every other
+/// one: the occurrences that enter it sharing one `Rc` leave sharing one `Rc`.
+/// Without the memo, the *first* pass over the tree splits sharing before any of
+/// the later ones can preserve it — a nested comprehension's inner filter
+/// predicate is reached twice (once on the term-level `Cast`'s `target`, once on
+/// the copy of that `Cast` inside the enclosing comprehension's own filter
+/// predicate), so it emerges from emit as two `Rc`s.
+///
+/// Sharing the memoized copy across occurrences also makes them share inference
+/// variables, which is exactly right: a bare predicate is closed but for
+/// `REFINEMENT_BINDER`, so two occurrences of *one* refinement `Rc` denote the
+/// same refinement over the same base and their slots have one solution. (This
+/// is the same precondition the resolution passes rely on — see
+/// `coalesce_type_predicates` — with sharing meaning literally the same term, so
+/// merging the constraint sets adds no information.)
 fn emit_bare_predicate<C: Typing>(
     r: &mut Refinement,
     domain: &Type,
     ctx: &mut C,
 ) -> Result<(), InferError> {
-    let mut pred = (*r.predicate).clone();
+    let Some((origin, mut pred)) = ctx.pred_memo().begin(r) else {
+        return Ok(());
+    };
     let pred_ty = ctx.scoped(&Name::elem(), domain, |ctx| ctx.subexpr(&mut pred))?;
     ctx.require_sub(&pred_ty, &prim(BaseType::Bool), &|| {
         "refinement predicate".to_string()
     })?;
-    r.predicate = Rc::new(pred);
+    ctx.pred_memo().finish(r, origin, pred);
     Ok(())
 }
 

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -300,9 +300,10 @@ fn emit_annotation_predicates(ty: &mut Type, ctx: &mut InferCtx) -> Result<(), I
 /// clones the typed refinement, carrying the same slots.
 ///
 /// **Emission is therefore a predicate-rebuilding pass**, and it preserves
-/// predicate `Rc` sharing — but as a *context-determined* one, so it uses
-/// [`PredMemo`](crate::ccl::ccl_utils::PredMemo)'s `begin_always` /
-/// `finish_shared` protocol rather than the skipping one.
+/// predicate `Rc` sharing — but it shares *terms* rather than *results*, so it
+/// uses [`TermMemo::rebuild_always`](crate::ccl::ccl_utils::TermMemo) rather than
+/// [`PredMemo::rebuild`](crate::ccl::ccl_utils::PredMemo), which would reuse an
+/// earlier occurrence's answer.
 ///
 /// The distinction is load-bearing here. This function's result depends on
 /// `domain`, which is **not** part of the memo key: the element binder is bound to

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -327,19 +327,20 @@ fn emit_bare_predicate<C: Typing>(
     domain: &Type,
     ctx: &mut C,
 ) -> Result<(), InferError> {
-    let (origin, mut pred) = ctx.pred_memo().begin_always(r);
-    // No `?` between opening and closing the rebuild: an early return would drop
-    // the `Origin`, discarding the typed copy and leaving this occurrence pointing
-    // at its un-emitted origin while its siblings are rebuilt (see `Origin`). The
-    // result is closed first, then propagated.
-    let typed = ctx
-        .scoped(&Name::elem(), domain, |ctx| ctx.subexpr(&mut pred))
-        .and_then(|pred_ty| {
-            ctx.require_sub(&pred_ty, &prim(BaseType::Bool), &|| {
-                "refinement predicate".to_string()
-            })
-        });
-    ctx.pred_memo().finish_shared(r, origin, pred);
+    let memo = ctx.pred_memo();
+    // The closure cannot leave the rebuild half-done: there is no token to drop on
+    // an early return, so the error is captured and propagated after the term is
+    // installed rather than skipping the install.
+    let mut typed = Ok(());
+    memo.rebuild_always(r, |pred| {
+        typed = ctx
+            .scoped(&Name::elem(), domain, |ctx| ctx.subexpr(pred))
+            .and_then(|pred_ty| {
+                ctx.require_sub(&pred_ty, &prim(BaseType::Bool), &|| {
+                    "refinement predicate".to_string()
+                })
+            });
+    });
     typed
 }
 

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -18,7 +18,7 @@ use crate::ccl::{
 
 use super::context::InferCtx;
 use super::typing::{Typing, peel_refinements_outer};
-use super::{lit_singleton, product, variant_type};
+use super::{product, variant_type};
 
 /// Walk one expression node, emit constraints for it, write its inferred
 /// `Type` onto `expr.ty`, and return that `Type`. Sub-expressions recurse;
@@ -27,7 +27,7 @@ pub(super) fn emit_node(expr: &mut Expr, ctx: &mut InferCtx) -> Result<Type, Inf
     // Compute the label before the mutable borrow so Case can pass it to emit_case.
     let label = symbolic(expr);
     let ty = match &mut expr.node {
-        TypedExprNode::Lit(lit) => lit_singleton(lit),
+        TypedExprNode::Lit(lit) => ctx.lit_singleton(lit),
 
         // Resolve a variable through its bound scheme. A monomorphic binder
         // freshens nothing and returns its type verbatim. A *polymorphic* `let`

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -299,35 +299,40 @@ fn emit_annotation_predicates(ty: &mut Type, ctx: &mut InferCtx) -> Result<(), I
 /// predicate lands on the syntactic node; the cast/annotation result type then
 /// clones the typed refinement, carrying the same slots.
 ///
-/// **Emission is therefore a predicate-rebuilding pass**, and threads the
-/// pass-scoped [`PredMemo`](crate::ccl::ccl_utils::PredMemo) like every other
-/// one: the occurrences that enter it sharing one `Rc` leave sharing one `Rc`.
-/// Without the memo, the *first* pass over the tree splits sharing before any of
-/// the later ones can preserve it — a nested comprehension's inner filter
-/// predicate is reached twice (once on the term-level `Cast`'s `target`, once on
-/// the copy of that `Cast` inside the enclosing comprehension's own filter
-/// predicate), so it emerges from emit as two `Rc`s.
+/// **Emission is therefore a predicate-rebuilding pass**, and it preserves
+/// predicate `Rc` sharing — but as a *context-determined* one, so it uses
+/// [`PredMemo`](crate::ccl::ccl_utils::PredMemo)'s `begin_always` /
+/// `finish_shared` protocol rather than the skipping one.
 ///
-/// Sharing the memoized copy across occurrences also makes them share inference
-/// variables, which is exactly right: a bare predicate is closed but for
-/// `REFINEMENT_BINDER`, so two occurrences of *one* refinement `Rc` denote the
-/// same refinement over the same base and their slots have one solution. (This
-/// is the same precondition the resolution passes rely on — see
-/// `coalesce_type_predicates` — with sharing meaning literally the same term, so
-/// merging the constraint sets adds no information.)
+/// The distinction is load-bearing here. This function's result depends on
+/// `domain`, which is **not** part of the memo key: the element binder is bound to
+/// it, so the predicate's constraints land on *that* domain. `emit_cast` mints a
+/// fresh domain variable per cast node, so two occurrences of one shared
+/// predicate `Rc` are two genuinely different typing problems. Skipping emission
+/// on a memo hit would leave the second occurrence's domain carrying none of the
+/// constraints the predicate imposes on `REFINEMENT_BINDER` — silently
+/// under-determined rather than wrong-looking.
+///
+/// So emission runs at **every** occurrence, and only the resulting *term* is
+/// unified. That keeps sharing without borrowing an answer: without it the first
+/// pass over the tree splits sharing before any later pass can preserve it — a
+/// nested comprehension's inner filter is reached twice (once on the term-level
+/// `Cast`'s `target`, once on the copy of that `Cast` inside the enclosing
+/// comprehension's own filter predicate), so it would emerge from emit as two
+/// `Rc`s. Discarding this occurrence's copy in favour of the first's is sound
+/// because refinement identity is type-blind: the occurrences denote one
+/// refinement, and each has already discharged its own typing obligation.
 fn emit_bare_predicate<C: Typing>(
     r: &mut Refinement,
     domain: &Type,
     ctx: &mut C,
 ) -> Result<(), InferError> {
-    let Some((origin, mut pred)) = ctx.pred_memo().begin(r) else {
-        return Ok(());
-    };
+    let (origin, mut pred) = ctx.pred_memo().begin_always(r);
     let pred_ty = ctx.scoped(&Name::elem(), domain, |ctx| ctx.subexpr(&mut pred))?;
     ctx.require_sub(&pred_ty, &prim(BaseType::Bool), &|| {
         "refinement predicate".to_string()
     })?;
-    ctx.pred_memo().finish(r, origin, pred);
+    ctx.pred_memo().finish_shared(r, origin, pred);
     Ok(())
 }
 

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -328,12 +328,19 @@ fn emit_bare_predicate<C: Typing>(
     ctx: &mut C,
 ) -> Result<(), InferError> {
     let (origin, mut pred) = ctx.pred_memo().begin_always(r);
-    let pred_ty = ctx.scoped(&Name::elem(), domain, |ctx| ctx.subexpr(&mut pred))?;
-    ctx.require_sub(&pred_ty, &prim(BaseType::Bool), &|| {
-        "refinement predicate".to_string()
-    })?;
+    // No `?` between opening and closing the rebuild: an early return would drop
+    // the `Origin`, discarding the typed copy and leaving this occurrence pointing
+    // at its un-emitted origin while its siblings are rebuilt (see `Origin`). The
+    // result is closed first, then propagated.
+    let typed = ctx
+        .scoped(&Name::elem(), domain, |ctx| ctx.subexpr(&mut pred))
+        .and_then(|pred_ty| {
+            ctx.require_sub(&pred_ty, &prim(BaseType::Bool), &|| {
+                "refinement predicate".to_string()
+            })
+        });
     ctx.pred_memo().finish_shared(r, origin, pred);
-    Ok(())
+    typed
 }
 
 /// Apply a binary scheme: instantiate, build the expected call shape,

--- a/src/ccl/infer/mod.rs
+++ b/src/ccl/infer/mod.rs
@@ -323,7 +323,7 @@ pub(crate) fn run(
     // end-to-end guard is `tests/predicate_sharing.rs`.)
     #[cfg(debug_assertions)]
     let pred_rcs_before_retype = crate::ccl::ccl_utils::distinct_predicate_rcs(expr);
-    retype_predicate_slots(expr, &HashMap::new(), &mut PredMemo::new());
+    retype_predicate_slots(expr, &HashMap::new(), &PredMemo::new());
     #[cfg(debug_assertions)]
     debug_assert!(
         crate::ccl::ccl_utils::distinct_predicate_rcs(expr) <= pred_rcs_before_retype,

--- a/src/ccl/infer/mod.rs
+++ b/src/ccl/infer/mod.rs
@@ -236,23 +236,34 @@ pub(super) fn lit_base(lit: &Lit) -> Type {
 /// involved is known: both sides are the base and the comparison is `Bool`. The inner
 /// literal takes [`lit_base`] — refining *it* too would not terminate.
 pub fn lit_singleton(lit: &Lit) -> Type {
-    let base = lit_base(lit);
-    // `unit` has a single inhabitant, so a singleton adds nothing to its base.
-    if matches!(lit, Lit::Unit) {
-        return base;
+    match singleton_predicate(lit) {
+        Some(predicate) => Type::Refinement(Box::new(lit_base(lit)), Refinement::born(predicate)),
+        None => lit_base(lit),
     }
-    let predicate = TypedExpr::binop(
-        TypedExpr::var(Name::elem()).with_ty(base.clone()),
-        BinOpKind::Compare(CompareKind::Equals),
-        TypedExpr::lit(lit.clone()).with_ty(base.clone()),
-    )
-    .with_ty(prim(BaseType::Bool));
-    Type::Refinement(
-        Box::new(base),
-        Refinement {
-            predicate: Rc::new(predicate),
-        },
-    )
+}
+
+/// The bare predicate of `lit`'s singleton — `__elem == lit` — or `None` for
+/// `unit`, whose single inhabitant makes a singleton add nothing to its base.
+///
+/// Split out from [`lit_singleton`] because the term is **ground**: fully typed at
+/// construction, closed but for [`crate::ccl::REFINEMENT_BINDER`], and a pure
+/// function of `lit`. That is what lets one `Rc` serve every occurrence of a
+/// literal value (`InferCtx::lit_singleton`) — nothing about an occurrence can
+/// make its singleton resolve differently, because there is nothing left to
+/// resolve.
+pub(crate) fn singleton_predicate(lit: &Lit) -> Option<Rc<TypedExpr>> {
+    if matches!(lit, Lit::Unit) {
+        return None;
+    }
+    let base = lit_base(lit);
+    Some(Rc::new(
+        TypedExpr::binop(
+            TypedExpr::var(Name::elem()).with_ty(base.clone()),
+            BinOpKind::Compare(CompareKind::Equals),
+            TypedExpr::lit(lit.clone()).with_ty(base.clone()),
+        )
+        .with_ty(prim(BaseType::Bool)),
+    ))
 }
 
 /// Test shorthand for an integer literal's *type* — its singleton, `{Int | __elem == n}`.

--- a/src/ccl/infer/mod.rs
+++ b/src/ccl/infer/mod.rs
@@ -91,6 +91,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 
 use crate::ccl::FieldKey;
+use crate::ccl::ccl_utils::PredMemo;
 use crate::ccl::infer::solver::{CoalesceError, ConstrainError, prim};
 use crate::ccl::{BaseType, BinOpKind, CompareKind, Lit, Refinement, Type, TypedExpr};
 
@@ -312,7 +313,23 @@ pub(crate) fn run(
     }
     // Stamp the resolved binder types onto free `Var` references a discharge
     // substituted into refinement predicates (see `retype_predicate_slots`).
-    retype_predicate_slots(expr, &HashMap::new());
+    //
+    // Sharing tripwire: `retype` is a *rewrite-only* pass (it restamps existing
+    // predicates, never introduces new refinement types), so the distinct
+    // predicate-`Rc` count is non-increasing across it. A regression that
+    // restamps each occurrence independently — instead of threading its
+    // `PredMemo` — would split the sharing and grow this count, tripping here at
+    // the exact phase. (Cheap: address-set arithmetic, debug builds only. The
+    // end-to-end guard is `tests/predicate_sharing.rs`.)
+    #[cfg(debug_assertions)]
+    let pred_rcs_before_retype = crate::ccl::ccl_utils::distinct_predicate_rcs(expr);
+    retype_predicate_slots(expr, &HashMap::new(), &mut PredMemo::new());
+    #[cfg(debug_assertions)]
+    debug_assert!(
+        crate::ccl::ccl_utils::distinct_predicate_rcs(expr) <= pred_rcs_before_retype,
+        "retype split refinement-predicate `Rc` sharing (a rewrite-only pass must not \
+         increase the distinct-predicate count) — see `ccl_utils::PredMemo`",
+    );
     // Scope-validity check (design §6.2): every coalesced node's type is
     // well-formed in the lexical scope at that node — every free term-variable
     // of its refinement predicates is bound by an enclosing Pi binder
@@ -373,9 +390,7 @@ pub(crate) mod test_helpers {
         );
         Type::Refinement(
             Box::new(Type::Base(BaseType::Int)),
-            Refinement {
-                predicate: Rc::new(pred),
-            },
+            Refinement::born(Rc::new(pred)),
         )
     }
 

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -1576,6 +1576,15 @@ pub(super) fn retype_predicate_slots(
 /// combinator's job — this only supplies the per-predicate transform, so a new
 /// `Type` variant can never be silently missed and the `PredMemo` discipline is
 /// inherited rather than re-hand-rolled.
+/// **Why reusing an entry is sound here**, given that the stamp reads `scope` —
+/// context the memo key does not name (see [`PredMemo`]'s note on key-determined
+/// transforms). The stamp looks a binder up *by `Name`*, and binder names carry
+/// uids minted once at lowering, so a name denotes one binder with one resolved
+/// type. Copies preserve uids, so two copies of a subtree agree; and the one place
+/// copies get *different* types — a monomorphization clone — rebuilds its
+/// predicates as fresh `Rc`s while freshening (`freshen_refinement_predicate`), so
+/// clones never share an `Rc` to collapse. Occurrences sharing one `Rc` therefore
+/// stamp identically.
 fn retype_in_type(ty: &mut Type, scope: &HashMap<Name, Type>, memo: &mut PredMemo) {
     walk_refined_predicates_mut(ty, memo, &mut |pred, memo| {
         // Always reported as changed: retyping rewrites *type slots* inside the

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -19,7 +19,6 @@
 // live in a single module.
 
 use std::collections::HashMap;
-use std::rc::Rc;
 
 use crate::ccl::ccl_utils::{PredMemo, walk_refined_predicates_mut};
 use crate::ccl::infer::InferError;
@@ -1027,25 +1026,30 @@ fn coalesce_node(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
 /// that ctx, so the combinator's `&mut PredMemo` and the transform's `&mut ctx`
 /// would alias. Pulling the memo out would force it through `coalesce_node`'s
 /// whole recursion (far more threading than the ctx field). So the sharing is
-/// preserved inline here via the same [`PredMemo`] API (`rebuilt_for` /
-/// `record`) the combinator uses.
+/// preserved inline here via the same [`PredMemo`] protocol (`begin` / `finish`)
+/// the combinator uses.
+///
+/// **Precondition the memo relies on.** `coalesce_node` is level- and
+/// scope-dependent, while the memo is keyed on the predicate `Rc` alone — so for
+/// two occurrences of one shared `Rc` reached under different scopes, whichever
+/// the walk hits first would win. That is sound because sharing means *literally
+/// the same term with the same inference variables*: resolution reads those
+/// variables out of the one live constraint graph, so both occurrences would
+/// resolve identically and the first result is the only result. It is the
+/// converse that must not happen — two refinements that should resolve
+/// differently must not share an `Rc` — which holds because a shared `Rc` is only
+/// ever created by copying one occurrence of one refinement.
 fn coalesce_type_predicates(ty: &mut Type, level: Level, ctx: &mut CoalesceCtx) {
     match ty {
         Type::Refinement(inner, r) => {
-            // Preserve sharing: if another occurrence of this predicate `Rc` was
-            // already coalesced in this pass, reuse its rebuild rather than
-            // coalescing an independent copy (which would split the sharing —
-            // see [`PredMemo`]). `rebuilt_for` clones the shared `Rc` out and
-            // drops its borrow, so `coalesce_node` can take `&mut ctx` below.
-            if let Some(rebuilt) = ctx.pred_memo.rebuilt_for(r) {
-                r.predicate = rebuilt;
-            } else {
-                let original = Rc::clone(&r.predicate);
-                let mut pred = (*r.predicate).clone();
+            // Preserve sharing: an occurrence of this predicate `Rc` already
+            // coalesced in this pass re-points at that rebuild rather than
+            // coalescing an independent copy (which would split the sharing — see
+            // [`PredMemo`]). `begin` hands back an owned copy and drops its
+            // borrow, so `coalesce_node` can take `&mut ctx` below.
+            if let Some((origin, mut pred)) = ctx.pred_memo.begin(r) {
                 coalesce_node(&mut pred, level, ctx);
-                let rebuilt = Rc::new(pred);
-                ctx.pred_memo.record(original, Rc::clone(&rebuilt));
-                r.predicate = rebuilt;
+                ctx.pred_memo.finish(r, origin, pred);
             }
             coalesce_type_predicates(inner, level, ctx);
         }
@@ -1467,27 +1471,56 @@ fn refresh_lambda_param_slot(expr: &mut Expr) {
 /// its correct type is exactly that binder's resolved type. Look it up by name
 /// and stamp it. (O2/O7 for the monomorphic-direct case: the binders predicates
 /// close over are ordinary in-scope binders, each with a single solution.)
+///
+/// A predicate is itself a term, so this is **one** walk, not a term walk plus a
+/// parallel predicate walk: [`retype_in_type`] hands each predicate back to this
+/// function. That is load-bearing rather than tidy — the slot a comprehension
+/// filter's predicate lives in (`Cast.target`) is reached only through the
+/// predicate side, so a hand-rolled predicate walk that omits an arm leaves a
+/// predicate un-restamped *and* splits its `Rc` sharing against the occurrence
+/// the term walk did reach.
 pub(super) fn retype_predicate_slots(
     expr: &mut Expr,
     scope: &HashMap<Name, Type>,
     memo: &mut PredMemo,
 ) {
-    retype_in_type(&mut expr.ty, scope, memo);
-    // Retype the **binder type slots** (and a `Cast`'s `target`), not just
-    // `expr.ty`. A binder's type (`param.ty`, a `let` binding's `ty`, a `Cast`
-    // `target`) is a copy of the same refinement that also rides `expr.ty`, but
-    // an independent immutable `Rc`: rebuilding the predicate on `expr.ty` above
-    // leaves that copy stale, and [`crate::ccl::infer::check_fully_typed`] walks
-    // these slots (a lambda's `param.ty`, etc.), so an unresolved predicate slot
-    // there is a hard error. (Under the retired shared predicate cells one
-    // rewrite fixed every alias at once; immutable terms must restamp each slot.)
-    // Each binder's *own* type is in the enclosing `scope` — the binder does not
-    // bind in its own type — so it is retyped before the binder enters `scope`.
+    // Every type slot the node carries, retyped in the *enclosing* scope — a
+    // binder does not bind in its own type. Each slot (`ty`, the annotation, a
+    // binder's declared type, a `Cast`'s `target`) is a copy of the same
+    // refinement holding an independent immutable `Rc`, so rebuilding one leaves
+    // the others stale; [`crate::ccl::infer::check_fully_typed`] walks them all,
+    // and an unresolved predicate slot there is a hard error.
+    // [`Expr::walk_type_slots_mut`] is the single source of truth for that set.
+    expr.walk_type_slots_mut(|ty| retype_in_type(ty, scope, memo));
+
+    // The stamp itself: a free `Var` whose slot coalesce left unresolved takes
+    // its type from the binder in scope. (Fires inside predicates — a dependent
+    // discharge's substituted argument copy is invisible to the per-node
+    // coalesce — and is a no-op on the term side, where coalesce resolved every
+    // slot.)
+    if let TypedExprNode::Var(n) = &expr.node
+        && matches!(expr.ty, Type::Infer(_) | Type::Hole)
+        && let Some(t) = scope.get(n)
+    {
+        expr.ty = t.clone();
+    }
+
+    // Recurse, extending `scope` over exactly the children each binder scopes.
+    // (The shape "walk children, each under the binders that scope it" recurs —
+    // `subst::rewrite_expr_go` and `infer::api`'s scope walks spell it out too;
+    // it is a candidate for a `walk_children_scoped` combinator alongside
+    // [`Expr::walk_binders`], which would make the scoping non-uniformity —
+    // `Let` binds only `body`, `LetRec` binds everything — declared once.)
     match &mut expr.node {
         TypedExprNode::Lambda { param, body, .. } => {
-            retype_in_type(&mut param.ty, scope, memo);
             let mut s = scope.clone();
             s.insert(param.name.clone(), param.ty.clone());
+            retype_predicate_slots(body, &s, memo);
+        }
+        TypedExprNode::For { target, iter, body } => {
+            retype_predicate_slots(iter, scope, memo);
+            let mut s = scope.clone();
+            s.insert(target.name.clone(), target.ty.clone());
             retype_predicate_slots(body, &s, memo);
         }
         TypedExprNode::Let {
@@ -1495,10 +1528,21 @@ pub(super) fn retype_predicate_slots(
             bound_expr,
             body,
         } => {
-            retype_in_type(&mut binding.ty, scope, memo);
             retype_predicate_slots(bound_expr, scope, memo);
             let mut s = scope.clone();
             s.insert(binding.name.clone(), binding.ty.clone());
+            retype_predicate_slots(body, &s, memo);
+        }
+        // Mutual recursion: every group binder scopes every definition and the
+        // body.
+        TypedExprNode::LetRec { bindings, body } => {
+            let mut s = scope.clone();
+            for (b, _) in bindings.iter() {
+                s.insert(b.name.clone(), b.ty.clone());
+            }
+            for (_, def) in bindings.iter_mut() {
+                retype_predicate_slots(def, &s, memo);
+            }
             retype_predicate_slots(body, &s, memo);
         }
         TypedExprNode::Case {
@@ -1510,65 +1554,31 @@ pub(super) fn retype_predicate_slots(
             }
             for b in branches.iter_mut() {
                 let mut s = scope.clone();
-                if let Some(p) = &mut b.pattern {
-                    retype_in_type(&mut p.binding.ty, scope, memo);
+                if let Some(p) = &b.pattern {
                     s.insert(p.binding.name.clone(), p.binding.ty.clone());
                 }
                 retype_predicate_slots(&mut b.guard, &s, memo);
                 retype_predicate_slots(&mut b.body, &s, memo);
             }
         }
-        TypedExprNode::Cast { value, target } => {
-            retype_in_type(target, scope, memo);
-            retype_predicate_slots(value, scope, memo);
-        }
         _ => expr.walk_children_mut(|c| retype_predicate_slots(c, scope, memo)),
     }
 }
 
-/// Recurse into `ty`'s refinement predicates, stamping each free `Var`'s
-/// resolved type from `scope`. The type recursion and sharing-preserving
+/// Recurse into `ty`'s refinement predicates, retyping each as a term
+/// ([`retype_predicate_slots`]). The type recursion and the sharing-preserving
 /// predicate rebuild are both the shared [`walk_refined_predicates_mut`]
-/// combinator's job — this only supplies the per-predicate transform
-/// ([`retype_pred_expr`]), so a new `Type` variant can never be silently
-/// missed and the `PredMemo` discipline is inherited rather than re-hand-rolled.
+/// combinator's job — this only supplies the per-predicate transform, so a new
+/// `Type` variant can never be silently missed and the `PredMemo` discipline is
+/// inherited rather than re-hand-rolled.
 fn retype_in_type(ty: &mut Type, scope: &HashMap<Name, Type>, memo: &mut PredMemo) {
     walk_refined_predicates_mut(ty, memo, &mut |pred, memo| {
-        retype_pred_expr(pred, scope, memo);
+        // Always reported as changed: retyping rewrites *type slots* inside the
+        // predicate, and `Refinement`'s equality is type-blind — so a "did it
+        // change?" test at the refinement level cannot see this pass's work.
+        retype_predicate_slots(pred, scope, memo);
+        true
     });
-}
-
-/// Stamp free `Var` types inside a predicate expression from `scope`, tracking
-/// the predicate's own binders (so they shadow outer names rather than being
-/// rewritten). Only an unresolved (`Infer`/`Hole`) slot is overwritten — a slot
-/// coalesce already resolved is left intact.
-fn retype_pred_expr(e: &mut Expr, scope: &HashMap<Name, Type>, memo: &mut PredMemo) {
-    retype_in_type(&mut e.ty, scope, memo);
-    match &mut e.node {
-        TypedExprNode::Var(n) => {
-            if matches!(e.ty, Type::Infer(_) | Type::Hole)
-                && let Some(t) = scope.get(n)
-            {
-                e.ty = t.clone();
-            }
-        }
-        TypedExprNode::Lambda { param, body, .. } => {
-            let mut s = scope.clone();
-            s.insert(param.name.clone(), param.ty.clone());
-            retype_pred_expr(body, &s, memo);
-        }
-        TypedExprNode::Let {
-            binding,
-            bound_expr,
-            body,
-        } => {
-            retype_pred_expr(bound_expr, scope, memo);
-            let mut s = scope.clone();
-            s.insert(binding.name.clone(), binding.ty.clone());
-            retype_pred_expr(body, &s, memo);
-        }
-        _ => e.walk_children_mut(|c| retype_pred_expr(c, scope, memo)),
-    }
 }
 
 #[cfg(test)]

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -1047,11 +1047,6 @@ fn coalesce_node(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
 fn coalesce_type_predicates(ty: &mut Type, level: Level, ctx: &mut CoalesceCtx) {
     match ty {
         Type::Refinement(inner, r) => {
-            // Preserve sharing: an occurrence of this predicate `Rc` already
-            // coalesced in this pass re-points at that rebuild rather than
-            // coalescing an independent copy (which would split the sharing — see
-            // [`PredMemo`]). `begin` hands back an owned copy and drops its
-            // borrow, so `coalesce_node` can take `&mut ctx` below.
             // A handle clone, so `ctx` stays freely borrowable for the rebuild —
             // which re-enters this same memo through `coalesce_node` →
             // `coalesce_type_predicates`.

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -1029,16 +1029,21 @@ fn coalesce_node(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
 /// preserved inline here via the same [`PredMemo`] protocol (`begin` / `finish`)
 /// the combinator uses.
 ///
-/// **Precondition the memo relies on.** `coalesce_node` is level- and
-/// scope-dependent, while the memo is keyed on the predicate `Rc` alone — so for
-/// two occurrences of one shared `Rc` reached under different scopes, whichever
-/// the walk hits first would win. That is sound because sharing means *literally
-/// the same term with the same inference variables*: resolution reads those
-/// variables out of the one live constraint graph, so both occurrences would
-/// resolve identically and the first result is the only result. It is the
-/// converse that must not happen — two refinements that should resolve
-/// differently must not share an `Rc` — which holds because a shared `Rc` is only
-/// ever created by copying one occurrence of one refinement.
+/// **Why this is a key-determined transform** (see [`PredMemo`]'s note on the
+/// distinction, which decides whether a pass may skip its transform on a memo
+/// hit). `coalesce_node` is level- and scope-dependent, and the memo is keyed on
+/// the predicate `Rc` alone — so for two occurrences of one shared `Rc` reached
+/// under different scopes, whichever the walk hits first wins. That is sound here
+/// because sharing means *literally the same term with the same inference
+/// variables*: resolution reads those variables out of the one live constraint
+/// graph, so both occurrences would resolve identically and the first result is
+/// the only result. It is the converse that must not happen — two refinements
+/// that should resolve differently must not share an `Rc` — which holds because a
+/// shared `Rc` is only ever created by copying one occurrence of one refinement.
+///
+/// Contrast constraint *emission*, where the same reasoning fails: it is
+/// parameterized by a domain minted per occurrence, so it must run at each one
+/// (`emit_bare_predicate`).
 fn coalesce_type_predicates(ty: &mut Type, level: Level, ctx: &mut CoalesceCtx) {
     match ty {
         Type::Refinement(inner, r) => {

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -1026,14 +1026,14 @@ fn coalesce_node(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
 /// that ctx, so the combinator's `&mut PredMemo` and the transform's `&mut ctx`
 /// would alias. Pulling the memo out would force it through `coalesce_node`'s
 /// whole recursion (far more threading than the ctx field). So the sharing is
-/// preserved inline here via the same [`PredMemo`] protocol (`begin` / `finish`)
-/// the combinator uses.
+/// preserved inline here via the same [`PredMemo::rebuild`] the combinator uses —
+/// which is possible because the memo is a handle, so reaching it needs only
+/// `&ctx` and the callback can re-enter it through `coalesce_node`'s own recursion.
 ///
-/// **Why this is a key-determined transform** (see [`PredMemo`]'s note on the
-/// distinction, which decides whether a pass may skip its transform on a memo
-/// hit). `coalesce_node` is level- and scope-dependent, and the memo is keyed on
-/// the predicate `Rc` alone — so for two occurrences of one shared `Rc` reached
-/// under different scopes, whichever the walk hits first wins. That is sound here
+/// **Why `C = ()`** (see [`PredMemo`]'s note on what `C` is). `coalesce_node` is
+/// level- and scope-dependent, so declaring no context means: for two occurrences
+/// of one shared `Rc` reached under different scopes, whichever the walk reaches
+/// first wins. That is sound here
 /// because sharing means *literally the same term with the same inference
 /// variables*: resolution reads those variables out of the one live constraint
 /// graph, so both occurrences would resolve identically and the first result is
@@ -1042,8 +1042,8 @@ fn coalesce_node(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
 /// shared `Rc` is only ever created by copying one occurrence of one refinement.
 ///
 /// Contrast constraint *emission*, where the same reasoning fails: it is
-/// parameterized by a domain minted per occurrence, so it must run at each one
-/// (`emit_bare_predicate`).
+/// parameterized by a domain minted per occurrence, so it must run at each one and
+/// uses `TermMemo` instead (`emit_bare_predicate`).
 fn coalesce_type_predicates(ty: &mut Type, level: Level, ctx: &mut CoalesceCtx) {
     match ty {
         Type::Refinement(inner, r) => {
@@ -1052,10 +1052,14 @@ fn coalesce_type_predicates(ty: &mut Type, level: Level, ctx: &mut CoalesceCtx) 
             // coalescing an independent copy (which would split the sharing — see
             // [`PredMemo`]). `begin` hands back an owned copy and drops its
             // borrow, so `coalesce_node` can take `&mut ctx` below.
-            if let Some((origin, mut pred)) = ctx.pred_memo.begin(r) {
-                coalesce_node(&mut pred, level, ctx);
-                ctx.pred_memo.finish(r, origin, pred);
-            }
+            // A handle clone, so `ctx` stays freely borrowable for the rebuild —
+            // which re-enters this same memo through `coalesce_node` →
+            // `coalesce_type_predicates`.
+            let memo = ctx.pred_memo.clone();
+            memo.rebuild(r, &(), |pred| {
+                coalesce_node(pred, level, ctx);
+                true
+            });
             coalesce_type_predicates(inner, level, ctx);
         }
         Type::Fun {
@@ -1487,7 +1491,7 @@ fn refresh_lambda_param_slot(expr: &mut Expr) {
 pub(super) fn retype_predicate_slots(
     expr: &mut Expr,
     scope: &HashMap<Name, Type>,
-    memo: &mut PredMemo,
+    memo: &PredMemo,
 ) {
     // Every type slot the node carries, retyped in the *enclosing* scope — a
     // binder does not bind in its own type. Each slot (`ty`, the annotation, a
@@ -1585,8 +1589,8 @@ pub(super) fn retype_predicate_slots(
 /// predicates as fresh `Rc`s while freshening (`freshen_refinement_predicate`), so
 /// clones never share an `Rc` to collapse. Occurrences sharing one `Rc` therefore
 /// stamp identically.
-fn retype_in_type(ty: &mut Type, scope: &HashMap<Name, Type>, memo: &mut PredMemo) {
-    walk_refined_predicates_mut(ty, memo, &mut |pred, memo| {
+fn retype_in_type(ty: &mut Type, scope: &HashMap<Name, Type>, memo: &PredMemo) {
+    walk_refined_predicates_mut(ty, memo, &(), &mut |pred, memo| {
         // Always reported as changed: retyping rewrites *type slots* inside the
         // predicate, and `Refinement`'s equality is type-blind — so a "did it
         // change?" test at the refinement level cannot see this pass's work.

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -21,6 +21,7 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use crate::ccl::ccl_utils::{PredMemo, walk_refined_predicates_mut};
 use crate::ccl::infer::InferError;
 use crate::ccl::infer::solver::{
     CoalesceError, ConstrainCache, FreshenCache, FreshenLevel, coalesce_compact, compact_type,
@@ -103,6 +104,11 @@ pub(super) struct CoalesceCtx {
     /// applies).
     scope: Vec<ScopeEntry>,
     errors: Vec<InferError>,
+    /// Pass-scoped predicate-rewrite memo: keeps every refinement occurrence
+    /// that entered the coalesce walk sharing one predicate `Rc` sharing a
+    /// single coalesced `Rc` on the way out, instead of splitting into one
+    /// independently-coalesced copy per node. See [`PredMemo`].
+    pred_memo: PredMemo,
     /// Every read the walk performed, for the end-of-pass ordering-invariant
     /// check ([`assert_reads_stable`]). Debug builds only.
     #[cfg(debug_assertions)]
@@ -470,6 +476,7 @@ pub(super) fn coalesce_pass(expr: &mut Expr) -> Vec<InferError> {
     let mut ctx = CoalesceCtx {
         scope: Vec::new(),
         errors: Vec::new(),
+        pred_memo: PredMemo::new(),
         #[cfg(debug_assertions)]
         reads: Vec::new(),
     };
@@ -1013,12 +1020,33 @@ fn coalesce_node(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
 /// is emitted in the enclosing scope), and the walk's scope travels with
 /// `ctx`, so a generalized-binding use living only inside a predicate
 /// specializes here.
+///
+/// Unlike [`retype_in_type`], this can't delegate the type-walk to
+/// [`walk_refined_predicates_mut`]: its per-predicate transform is
+/// `coalesce_node`, which needs `&mut CoalesceCtx` — and the memo lives *in*
+/// that ctx, so the combinator's `&mut PredMemo` and the transform's `&mut ctx`
+/// would alias. Pulling the memo out would force it through `coalesce_node`'s
+/// whole recursion (far more threading than the ctx field). So the sharing is
+/// preserved inline here via the same [`PredMemo`] API (`rebuilt_for` /
+/// `record`) the combinator uses.
 fn coalesce_type_predicates(ty: &mut Type, level: Level, ctx: &mut CoalesceCtx) {
     match ty {
         Type::Refinement(inner, r) => {
-            let mut pred = (*r.predicate).clone();
-            coalesce_node(&mut pred, level, ctx);
-            r.predicate = Rc::new(pred);
+            // Preserve sharing: if another occurrence of this predicate `Rc` was
+            // already coalesced in this pass, reuse its rebuild rather than
+            // coalescing an independent copy (which would split the sharing —
+            // see [`PredMemo`]). `rebuilt_for` clones the shared `Rc` out and
+            // drops its borrow, so `coalesce_node` can take `&mut ctx` below.
+            if let Some(rebuilt) = ctx.pred_memo.rebuilt_for(r) {
+                r.predicate = rebuilt;
+            } else {
+                let original = Rc::clone(&r.predicate);
+                let mut pred = (*r.predicate).clone();
+                coalesce_node(&mut pred, level, ctx);
+                let rebuilt = Rc::new(pred);
+                ctx.pred_memo.record(original, Rc::clone(&rebuilt));
+                r.predicate = rebuilt;
+            }
             coalesce_type_predicates(inner, level, ctx);
         }
         Type::Fun {
@@ -1439,8 +1467,12 @@ fn refresh_lambda_param_slot(expr: &mut Expr) {
 /// its correct type is exactly that binder's resolved type. Look it up by name
 /// and stamp it. (O2/O7 for the monomorphic-direct case: the binders predicates
 /// close over are ordinary in-scope binders, each with a single solution.)
-pub(super) fn retype_predicate_slots(expr: &mut Expr, scope: &HashMap<Name, Type>) {
-    retype_in_type(&mut expr.ty, scope);
+pub(super) fn retype_predicate_slots(
+    expr: &mut Expr,
+    scope: &HashMap<Name, Type>,
+    memo: &mut PredMemo,
+) {
+    retype_in_type(&mut expr.ty, scope, memo);
     // Retype the **binder type slots** (and a `Cast`'s `target`), not just
     // `expr.ty`. A binder's type (`param.ty`, a `let` binding's `ty`, a `Cast`
     // `target`) is a copy of the same refinement that also rides `expr.ty`, but
@@ -1453,86 +1485,65 @@ pub(super) fn retype_predicate_slots(expr: &mut Expr, scope: &HashMap<Name, Type
     // bind in its own type — so it is retyped before the binder enters `scope`.
     match &mut expr.node {
         TypedExprNode::Lambda { param, body, .. } => {
-            retype_in_type(&mut param.ty, scope);
+            retype_in_type(&mut param.ty, scope, memo);
             let mut s = scope.clone();
             s.insert(param.name.clone(), param.ty.clone());
-            retype_predicate_slots(body, &s);
+            retype_predicate_slots(body, &s, memo);
         }
         TypedExprNode::Let {
             binding,
             bound_expr,
             body,
         } => {
-            retype_in_type(&mut binding.ty, scope);
-            retype_predicate_slots(bound_expr, scope);
+            retype_in_type(&mut binding.ty, scope, memo);
+            retype_predicate_slots(bound_expr, scope, memo);
             let mut s = scope.clone();
             s.insert(binding.name.clone(), binding.ty.clone());
-            retype_predicate_slots(body, &s);
+            retype_predicate_slots(body, &s, memo);
         }
         TypedExprNode::Case {
             scrutinee,
             branches,
         } => {
             if let Some(sc) = scrutinee {
-                retype_predicate_slots(sc, scope);
+                retype_predicate_slots(sc, scope, memo);
             }
             for b in branches.iter_mut() {
                 let mut s = scope.clone();
                 if let Some(p) = &mut b.pattern {
-                    retype_in_type(&mut p.binding.ty, scope);
+                    retype_in_type(&mut p.binding.ty, scope, memo);
                     s.insert(p.binding.name.clone(), p.binding.ty.clone());
                 }
-                retype_predicate_slots(&mut b.guard, &s);
-                retype_predicate_slots(&mut b.body, &s);
+                retype_predicate_slots(&mut b.guard, &s, memo);
+                retype_predicate_slots(&mut b.body, &s, memo);
             }
         }
         TypedExprNode::Cast { value, target } => {
-            retype_in_type(target, scope);
-            retype_predicate_slots(value, scope);
+            retype_in_type(target, scope, memo);
+            retype_predicate_slots(value, scope, memo);
         }
-        _ => expr.walk_children_mut(|c| retype_predicate_slots(c, scope)),
+        _ => expr.walk_children_mut(|c| retype_predicate_slots(c, scope, memo)),
     }
 }
 
 /// Recurse into `ty`'s refinement predicates, stamping each free `Var`'s
-/// resolved type from `scope`.
-fn retype_in_type(ty: &mut Type, scope: &HashMap<Name, Type>) {
-    match ty {
-        Type::Fun {
-            domain, codomain, ..
-        } => {
-            retype_in_type(domain, scope);
-            retype_in_type(codomain, scope);
-        }
-        Type::Tuple(ts) => ts.iter_mut().for_each(|t| retype_in_type(t, scope)),
-        Type::Record(fs) => fs.iter_mut().for_each(|(_, t)| retype_in_type(t, scope)),
-        Type::Variant(tags) => tags.iter_mut().for_each(|(_, t)| retype_in_type(t, scope)),
-        Type::Refinement(base, r) => {
-            retype_in_type(base, scope);
-            let mut pred = (*r.predicate).clone();
-            retype_pred_expr(&mut pred, scope);
-            r.predicate = Rc::new(pred);
-        }
-        Type::History { value, domain, .. } => {
-            retype_in_type(value, scope);
-            retype_in_type(domain, scope);
-        }
-        Type::Base(_)
-        | Type::UIntRange(_)
-        | Type::DataSource(_)
-        | Type::ChanDom(..)
-        | Type::Txn
-        | Type::Hole
-        | Type::Infer(_) => {}
-    }
+/// resolved type from `scope`. The type recursion and sharing-preserving
+/// predicate rebuild are both the shared [`walk_refined_predicates_mut`]
+/// combinator's job — this only supplies the per-predicate transform
+/// ([`retype_pred_expr`]), so a new `Type` variant can never be silently
+/// missed and the `PredMemo` discipline is inherited rather than re-hand-rolled.
+fn retype_in_type(ty: &mut Type, scope: &HashMap<Name, Type>, memo: &mut PredMemo) {
+    walk_refined_predicates_mut(ty, memo, &mut |pred, memo| {
+        retype_pred_expr(pred, scope, memo);
+    });
 }
 
 /// Stamp free `Var` types inside a predicate expression from `scope`, tracking
 /// the predicate's own binders (so they shadow outer names rather than being
 /// rewritten). Only an unresolved (`Infer`/`Hole`) slot is overwritten — a slot
 /// coalesce already resolved is left intact.
-fn retype_pred_expr(e: &mut Expr, scope: &HashMap<Name, Type>) {
-    retype_in_type(&mut e.ty, scope);
+fn retype_pred_expr(e: &mut Expr, scope: &HashMap<Name, Type>, memo: &mut PredMemo) {
+    retype_in_type(&mut e.ty, scope, memo);
     match &mut e.node {
         TypedExprNode::Var(n) => {
             if matches!(e.ty, Type::Infer(_) | Type::Hole)
@@ -1544,19 +1555,19 @@ fn retype_pred_expr(e: &mut Expr, scope: &HashMap<Name, Type>) {
         TypedExprNode::Lambda { param, body, .. } => {
             let mut s = scope.clone();
             s.insert(param.name.clone(), param.ty.clone());
-            retype_pred_expr(body, &s);
+            retype_pred_expr(body, &s, memo);
         }
         TypedExprNode::Let {
             binding,
             bound_expr,
             body,
         } => {
-            retype_pred_expr(bound_expr, scope);
+            retype_pred_expr(bound_expr, scope, memo);
             let mut s = scope.clone();
             s.insert(binding.name.clone(), binding.ty.clone());
-            retype_pred_expr(body, &s);
+            retype_pred_expr(body, &s, memo);
         }
-        _ => e.walk_children_mut(|c| retype_pred_expr(c, scope)),
+        _ => e.walk_children_mut(|c| retype_pred_expr(c, scope, memo)),
     }
 }
 

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -979,9 +979,7 @@ mod tests {
         let mk = || {
             Type::Refinement(
                 Box::new(prim(BaseType::Int)),
-                Refinement {
-                    predicate: Rc::new(TypedExpr::lit(Lit::Bool(true))),
-                },
+                Refinement::born(Rc::new(TypedExpr::lit(Lit::Bool(true)))),
             )
         };
         let lhs = mk();
@@ -1002,9 +1000,7 @@ mod tests {
         let mk = || {
             Type::Refinement(
                 Box::new(prim(BaseType::Int)),
-                Refinement {
-                    predicate: Rc::new(TypedExpr::lit(Lit::Bool(true))),
-                },
+                Refinement::born(Rc::new(TypedExpr::lit(Lit::Bool(true)))),
             )
         };
         let a = mk();
@@ -1035,9 +1031,7 @@ mod tests {
         // A structurally *different* predicate must not collapse into it.
         let c = Type::Refinement(
             Box::new(prim(BaseType::Int)),
-            Refinement {
-                predicate: Rc::new(TypedExpr::lit(Lit::Bool(false))),
-            },
+            Refinement::born(Rc::new(TypedExpr::lit(Lit::Bool(false)))),
         );
         assert_ne!(a, c, "distinct predicates must stay distinct");
     }
@@ -1623,9 +1617,7 @@ mod tests {
             BinOpKind::Compare(CompareKind::Greater),
             rhs,
         );
-        Refinement {
-            predicate: Rc::new(pred),
-        }
+        Refinement::born(Rc::new(pred))
     }
 
     fn coalesce(ty: &Type) -> Type {

--- a/src/ccl/infer/solver/mod.rs
+++ b/src/ccl/infer/solver/mod.rs
@@ -148,9 +148,7 @@ pub(crate) mod test_helpers {
     /// equal markers match and distinct markers stay distinct.
     pub(crate) fn refined(base: Type, marker: i64) -> Type {
         use crate::ccl::{Lit, TypedExpr};
-        let r = Refinement {
-            predicate: Rc::new(TypedExpr::lit(Lit::Int(marker))),
-        };
+        let r = Refinement::born(Rc::new(TypedExpr::lit(Lit::Int(marker))));
         Type::Refinement(Box::new(base), r)
     }
 

--- a/src/ccl/infer/solver/scheme.rs
+++ b/src/ccl/infer/solver/scheme.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::ccl::subst::Subst;
-use crate::ccl::{Bound, InferVar, InferVarId, Level, Refinement, Type, TypedExpr, TypedExprNode};
+use crate::ccl::{Bound, InferVar, InferVarId, Level, Refinement, Type, TypedExpr};
 
 use super::type_level;
 
@@ -270,9 +270,12 @@ fn freshen_refinement_predicate(
     Refinement::born(Rc::new(pred))
 }
 
-/// Freshen every type slot reachable from an expression — `expr.ty`, the user
-/// annotation, each binder's declared type, a `Cast`'s target — through one
-/// shared [`FreshenCache`], recursing into child terms. Used to freshen a
+/// Freshen every type slot reachable from an expression, through one shared
+/// [`FreshenCache`], recursing into child terms. Slot coverage is
+/// [`TypedExpr::walk_type_slots_mut`]'s — `expr.ty`, the user annotation, each
+/// binder's declared type, a `Cast`'s target — rather than enumerated here, so a
+/// new type-slot-bearing variant cannot leave a clone with a mix of fresh and
+/// original variables. Used to freshen a
 /// specialization clone's whole subtree (`infer::solve::specialize_use`)
 /// and, via [`freshen_refinement_predicate`], a refinement predicate's slots.
 ///
@@ -287,40 +290,7 @@ pub fn freshen_expr_type_slots(
     target: FreshenLevel,
     cache: &mut FreshenCache,
 ) {
-    expr.ty = freshen_above(lim, &expr.ty, target, cache);
-    if let Some(annotation) = &mut expr.user_annotation {
-        *annotation = freshen_above(lim, annotation, target, cache);
-    }
-    match &mut expr.node {
-        TypedExprNode::Lambda { param, .. } => {
-            param.ty = freshen_above(lim, &param.ty, target, cache);
-        }
-        TypedExprNode::Cast {
-            target: cast_target,
-            ..
-        } => {
-            *cast_target = freshen_above(lim, cast_target, target, cache);
-        }
-        TypedExprNode::Let { binding, .. } => {
-            binding.ty = freshen_above(lim, &binding.ty, target, cache);
-        }
-        TypedExprNode::Case { branches, .. } => {
-            for b in branches.iter_mut() {
-                if let Some(p) = &mut b.pattern {
-                    p.binding.ty = freshen_above(lim, &p.binding.ty, target, cache);
-                }
-            }
-        }
-        TypedExprNode::LetRec { bindings, .. } => {
-            for (b, _) in bindings.iter_mut() {
-                b.ty = freshen_above(lim, &b.ty, target, cache);
-            }
-        }
-        TypedExprNode::For { target: t, .. } => {
-            t.ty = freshen_above(lim, &t.ty, target, cache);
-        }
-        _ => {}
-    }
+    expr.walk_type_slots_mut(|ty| *ty = freshen_above(lim, ty, target, cache));
     expr.walk_children_mut(|c| freshen_expr_type_slots(c, lim, target, cache));
 }
 

--- a/src/ccl/infer/solver/scheme.rs
+++ b/src/ccl/infer/solver/scheme.rs
@@ -267,9 +267,7 @@ fn freshen_refinement_predicate(
 ) -> Refinement {
     let mut pred = (*r.predicate).clone();
     freshen_expr_type_slots(&mut pred, lim, target, cache);
-    Refinement {
-        predicate: Rc::new(pred),
-    }
+    Refinement::born(Rc::new(pred))
 }
 
 /// Freshen every type slot reachable from an expression — `expr.ty`, the user

--- a/src/ccl/infer/typing.rs
+++ b/src/ccl/infer/typing.rs
@@ -2,7 +2,7 @@
 // Typing: the structural typing-rule interface
 // ---------------------------------------------------------------------------
 
-use crate::ccl::ccl_utils::PredMemo;
+use crate::ccl::ccl_utils::TermMemo;
 use crate::ccl::infer::InferError;
 use crate::ccl::infer::solver::PolyScheme;
 use crate::ccl::{Expr, Name, Type};
@@ -32,7 +32,7 @@ pub(super) trait Typing {
     /// emit/check walk. Both modes rebuild every predicate they type
     /// ([`emit_bare_predicate`](super::emit)), so both need it; it lives on the
     /// ctx because that is the only thing scoped to the pass rather than a node.
-    fn pred_memo(&mut self) -> &mut PredMemo;
+    fn pred_memo(&self) -> TermMemo;
 
     /// Instantiate a polymorphic operator scheme at the current level.
     fn instantiate(&mut self, scheme: &PolyScheme) -> Type;

--- a/src/ccl/infer/typing.rs
+++ b/src/ccl/infer/typing.rs
@@ -2,6 +2,7 @@
 // Typing: the structural typing-rule interface
 // ---------------------------------------------------------------------------
 
+use crate::ccl::ccl_utils::PredMemo;
 use crate::ccl::infer::InferError;
 use crate::ccl::infer::solver::PolyScheme;
 use crate::ccl::{Expr, Name, Type};
@@ -26,6 +27,12 @@ pub(super) trait Typing {
 
     /// A fresh existential type variable at the current level.
     fn fresh(&mut self) -> Type;
+
+    /// The memo that keeps refinement-predicate `Rc` sharing across this whole
+    /// emit/check walk. Both modes rebuild every predicate they type
+    /// ([`emit_bare_predicate`](super::emit)), so both need it; it lives on the
+    /// ctx because that is the only thing scoped to the pass rather than a node.
+    fn pred_memo(&mut self) -> &mut PredMemo;
 
     /// Instantiate a polymorphic operator scheme at the current level.
     fn instantiate(&mut self, scheme: &PolyScheme) -> Type;

--- a/src/ccl/inline.rs
+++ b/src/ccl/inline.rs
@@ -65,7 +65,8 @@
 //! [`Define`]: crate::ccl::TypedExprNode::Define
 
 use crate::ccl::{
-    Expr, Lit, Name, Refinement, Type, TypedExprNode, ccl_utils::walk_refined_predicates_mut,
+    Expr, Lit, Name, Refinement, Type, TypedExprNode,
+    ccl_utils::{PredMemo, walk_refined_predicates_mut},
     lambda_elim::substitute,
 };
 
@@ -550,7 +551,11 @@ fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr) -> Expr {
 /// substitution proper is the engine's job and runs inside
 /// [`inline_and_beta_reduce`] via `lambda_elim::substitute`.
 fn inline_in_type_predicates(ty: &mut Type, name: &Name, lambda: &Expr) {
-    walk_refined_predicates_mut(ty, &mut std::collections::HashMap::new(), &mut |pred, _| {
+    // Per-call memo: `inline_in_type_predicates` runs on one node's type at a
+    // time, and only rebuilds predicates that actually contain the inlined
+    // binder, so it shares within a type but does not (need to) span the pass.
+    // A cross-node re-split here would be caught by `distinct_predicate_rcs`.
+    walk_refined_predicates_mut(ty, &mut PredMemo::new(), &mut |pred, _| {
         let old = std::mem::replace(pred, Expr::lit(Lit::Unit));
         *pred = inline_and_beta_reduce(old, name, lambda);
     });
@@ -681,7 +686,7 @@ mod tests {
         use crate::ccl::Refinement;
         use std::rc::Rc;
         let pred = Rc::new(TypedExpr::lit(Lit::Bool(true)));
-        let refinement = Refinement { predicate: pred };
+        let refinement = Refinement::born(pred);
         let ty = Type::Refinement(Box::new(Type::Base(BaseType::Int)), refinement);
         assert!(!is_iterable_domain(&ty));
     }
@@ -691,7 +696,7 @@ mod tests {
         use crate::ccl::Refinement;
         use std::rc::Rc;
         let pred = Rc::new(TypedExpr::lit(Lit::Bool(true)));
-        let refinement = Refinement { predicate: pred };
+        let refinement = Refinement::born(pred);
         let ty = Type::Refinement(Box::new(Type::UIntRange(3)), refinement);
         assert!(is_iterable_domain(&ty));
     }
@@ -746,7 +751,7 @@ mod tests {
         use crate::ccl::Refinement;
         use std::rc::Rc;
         let pred = Rc::new(TypedExpr::lit(Lit::Bool(true)));
-        let refinement = Refinement { predicate: pred };
+        let refinement = Refinement::born(pred);
         let inner_fun = Type::Fun {
             name: None,
             domain: Box::new(Type::Base(BaseType::Int)),

--- a/src/ccl/inline.rs
+++ b/src/ccl/inline.rs
@@ -303,7 +303,7 @@ fn inline_impl(expr: Expr) -> Expr {
                     // sweep touches. Scoped to *this* rewrite, not the `inline`
                     // pass: a different binder's rewrite maps the same origin
                     // `Rc` to a different result.
-                    &mut PredMemo::new(),
+                    &PredMemo::new(),
                 ));
             }
             TypedExprNode::Let {
@@ -363,7 +363,7 @@ fn inline_impl(expr: Expr) -> Expr {
 /// perturbs CCC simplify's input shape for list comprehensions, scalar UDFs,
 /// and BinOp paths in ways that need test-suite triage first.  Revisit if a
 /// case surfaces where the surviving anon-lambda blocks downstream work.
-fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr, memo: &mut PredMemo) -> Expr {
+fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr, memo: &PredMemo) -> Expr {
     // Direct occurrence: replace the variable with the Lambda value.
     if let TypedExprNode::Var(ref n) = expr.node
         && n == name
@@ -551,19 +551,18 @@ fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr, memo: &mut Pre
 /// inside a predicate must also *beta-reduce* the call sites it creates —
 /// substitution proper is the engine's job and runs inside
 /// [`inline_and_beta_reduce`] via `lambda_elim::substitute`.
-/// **Why one memo may span the whole sweep** even though the rewrite is
-/// scope-sensitive (see [`PredMemo`]'s note on key-determined transforms).
-/// `[name ↦ lambda]` must not fire under a binder that shadows `name`, and unlike
-/// `subst` — which descends into such a scope with a *restricted* substitution,
-/// and therefore needs a fresh memo per shrink — [`inline_and_beta_reduce`] does
-/// not descend at all: every binder arm that matches `name` returns its node with
-/// the body untouched. An occurrence inside a shadowed scope is thus never
-/// *visited*, so there is no hit to serve it the outer rebuild. That is a real
-/// dependency of this memo's scope on that skipping behaviour: an arm rewritten to
-/// descend-with-a-guard instead of skip would silently reintroduce the leak, and
-/// would need `Subst::recurse_shrunk`'s treatment.
-fn inline_in_type_predicates(ty: &mut Type, name: &Name, lambda: &Expr, memo: &mut PredMemo) {
-    walk_refined_predicates_mut(ty, memo, &mut |pred, memo| {
+/// **Why `C = ()` is honest here** even though the rewrite is scope-sensitive (see
+/// [`PredMemo`]'s note on what `C` is). `[name ↦ lambda]` must not fire under a
+/// binder that shadows `name`, and unlike `subst` — which descends into such a
+/// scope with a *restricted* substitution, and so carries that substitution as its
+/// `C` — [`inline_and_beta_reduce`] does not descend at all: every binder arm that
+/// matches `name` returns its node with the body untouched. An occurrence inside a
+/// shadowed scope is therefore never *visited*, so there is nothing for the memo to
+/// serve it. This claim depends on that skipping: an arm rewritten to
+/// descend-with-a-guard would need the rewrite's scope in `C`, exactly as `subst`
+/// carries its `Subst`.
+fn inline_in_type_predicates(ty: &mut Type, name: &Name, lambda: &Expr, memo: &PredMemo) {
+    walk_refined_predicates_mut(ty, memo, &(), &mut |pred, memo| {
         // A predicate the inlined binder does not occur in is reported
         // *unchanged*, so it keeps its origin `Rc` and stays pointer-shared with
         // its occurrences on other nodes rather than being reallocated at each
@@ -1093,7 +1092,7 @@ mod tests {
         let lambda = TypedExpr::lambda("x", int.clone(), TypedExpr::var("x").with_ty(int.clone()))
             .with_ty(fn_ty(int.clone(), int.clone()));
         let body = TypedExpr::var("f").with_ty(fn_ty(int.clone(), int));
-        let result = inline_and_beta_reduce(body, &Name::raw("f"), &lambda, &mut PredMemo::new());
+        let result = inline_and_beta_reduce(body, &Name::raw("f"), &lambda, &PredMemo::new());
         assert_eq!(result, lambda);
     }
 
@@ -1106,7 +1105,7 @@ mod tests {
         let arg = TypedExpr::lit(Lit::Int(3)).with_ty(int.clone());
         let call = TypedExpr::apply(arg.clone(), TypedExpr::var("f").with_ty(lambda.ty.clone()))
             .with_ty(int);
-        let result = inline_and_beta_reduce(call, &Name::raw("f"), &lambda, &mut PredMemo::new());
+        let result = inline_and_beta_reduce(call, &Name::raw("f"), &lambda, &PredMemo::new());
         assert_eq!(result, arg);
     }
 
@@ -1129,7 +1128,7 @@ mod tests {
             .with_ty(fn_ty(int.clone(), int.clone())),
         )
         .with_ty(int.clone());
-        let result = inline_and_beta_reduce(call, &Name::raw("f"), &lambda, &mut PredMemo::new());
+        let result = inline_and_beta_reduce(call, &Name::raw("f"), &lambda, &PredMemo::new());
         assert_eq!(result, TypedExpr::lit(Lit::Int(1)).with_ty(int));
     }
 
@@ -1153,7 +1152,7 @@ mod tests {
             shadowed.clone(),
             &Name::raw("f"),
             &replacement,
-            &mut PredMemo::new(),
+            &PredMemo::new(),
         );
         assert_eq!(result, shadowed);
     }

--- a/src/ccl/inline.rs
+++ b/src/ccl/inline.rs
@@ -66,7 +66,7 @@
 
 use crate::ccl::{
     Expr, Lit, Name, Refinement, Type, TypedExprNode,
-    ccl_utils::{PredMemo, walk_refined_predicates_mut},
+    ccl_utils::{PredMemo, is_free, walk_refined_predicates_mut},
     lambda_elim::substitute,
 };
 
@@ -293,7 +293,18 @@ fn inline_impl(expr: Expr) -> Expr {
                 // Let bindings (e.g. `let y = (let x = Defer in …) in …` after
                 // expanding a defer-returning UDF) are eligible for the alias
                 // and lift rewrites on the second pass.
-                return inline_impl(inline_and_beta_reduce(body, &binding.name, &bound_expr));
+                return inline_impl(inline_and_beta_reduce(
+                    body,
+                    &binding.name,
+                    &bound_expr,
+                    // One memo for the whole `[name ↦ lambda]` rewrite, so a
+                    // predicate rebuilt at one node is re-pointed at (not
+                    // re-derived for) its occurrences on every other node this
+                    // sweep touches. Scoped to *this* rewrite, not the `inline`
+                    // pass: a different binder's rewrite maps the same origin
+                    // `Rc` to a different result.
+                    &mut PredMemo::new(),
+                ));
             }
             TypedExprNode::Let {
                 binding,
@@ -352,7 +363,7 @@ fn inline_impl(expr: Expr) -> Expr {
 /// perturbs CCC simplify's input shape for list comprehensions, scalar UDFs,
 /// and BinOp paths in ways that need test-suite triage first.  Revisit if a
 /// case surfaces where the surviving anon-lambda blocks downstream work.
-fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr) -> Expr {
+fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr, memo: &mut PredMemo) -> Expr {
     // Direct occurrence: replace the variable with the Lambda value.
     if let TypedExprNode::Var(ref n) = expr.node
         && n == name
@@ -360,16 +371,18 @@ fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr) -> Expr {
         return lambda.clone();
     }
 
-    // Substitute inside refinement predicates riding this node's types. A
-    // predicate is an expression tree the children-walk below never reaches
-    // (e.g. a list-comprehension filter `f(x)` lives only in the cast-target
-    // refinement), so a UDF use inside one would survive as a dangling `Var`
-    // once the enclosing `Let` is dropped.
+    // Substitute inside refinement predicates riding **every** type slot this
+    // node carries — its `ty`, its annotation, a `Cast`'s `target`, and each
+    // binder's declared type. A predicate is an expression tree the
+    // children-walk below never reaches (e.g. a list-comprehension filter
+    // `f(x)` lives only in the cast-target refinement, which is also where
+    // `lambda_elim` and operator conversion read it from), so a UDF use inside
+    // one would survive as a dangling `Var` once the enclosing `Let` is
+    // dropped — and enumerating the slots by hand here is how one gets missed.
+    // A binder's own type is in the enclosing scope (a binder does not bind in
+    // its own type), so the shadowing checks further down do not apply to it.
     let mut expr = expr;
-    inline_in_type_predicates(&mut expr.ty, name, lambda);
-    if let Some(annotation) = &mut expr.user_annotation {
-        inline_in_type_predicates(annotation, name, lambda);
-    }
+    expr.walk_type_slots_mut(|ty| inline_in_type_predicates(ty, name, lambda, memo));
 
     // Apply chain ending in `Var(name)` — beta-reduce after recursively
     // substituting the argument and collapsing the function side.
@@ -385,8 +398,8 @@ fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr) -> Expr {
             TypedExprNode::Apply { function, argument } => (function, argument),
             _ => unreachable!(),
         };
-        let argument = inline_and_beta_reduce(*argument, name, lambda);
-        let function = inline_and_beta_reduce(*function, name, lambda);
+        let argument = inline_and_beta_reduce(*argument, name, lambda, memo);
+        let function = inline_and_beta_reduce(*function, name, lambda, memo);
         match function.node {
             TypedExprNode::Lambda { param, body } => {
                 // A domain refinement on this outer lambda encodes a precondition
@@ -452,7 +465,7 @@ fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr) -> Expr {
             } else {
                 TypedExprNode::Lambda {
                     param,
-                    body: Box::new(inline_and_beta_reduce(*body, name, lambda)),
+                    body: Box::new(inline_and_beta_reduce(*body, name, lambda, memo)),
                 }
             }
         }
@@ -462,11 +475,11 @@ fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr) -> Expr {
             bound_expr,
             body,
         } => {
-            let new_bound = inline_and_beta_reduce(*bound_expr, name, lambda);
+            let new_bound = inline_and_beta_reduce(*bound_expr, name, lambda, memo);
             let new_body = if &binding.name == name {
                 *body
             } else {
-                inline_and_beta_reduce(*body, name, lambda)
+                inline_and_beta_reduce(*body, name, lambda, memo)
             };
             TypedExprNode::Let {
                 binding,
@@ -485,22 +498,10 @@ fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr) -> Expr {
                 TypedExprNode::LetRec {
                     bindings: bindings
                         .into_iter()
-                        .map(|(b, def)| (b, inline_and_beta_reduce(def, name, lambda)))
+                        .map(|(b, def)| (b, inline_and_beta_reduce(def, name, lambda, memo)))
                         .collect(),
-                    body: Box::new(inline_and_beta_reduce(*body, name, lambda)),
+                    body: Box::new(inline_and_beta_reduce(*body, name, lambda, memo)),
                 }
-            }
-        }
-
-        // The cast target is where its refinement predicate is written —
-        // `lambda_elim` and operator conversion read the predicate off the
-        // target, not off `ty` — so walk it explicitly; `target` carries its
-        // own predicate `Rc`, independent of the one on `ty`.
-        TypedExprNode::Cast { value, mut target } => {
-            inline_in_type_predicates(&mut target, name, lambda);
-            TypedExprNode::Cast {
-                value: Box::new(inline_and_beta_reduce(*value, name, lambda)),
-                target,
             }
         }
 
@@ -509,11 +510,11 @@ fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr) -> Expr {
         // The loop target shadows `name` inside the body only; the source
         // still substitutes.
         TypedExprNode::For { target, iter, body } => {
-            let iter = Box::new(inline_and_beta_reduce(*iter, name, lambda));
+            let iter = Box::new(inline_and_beta_reduce(*iter, name, lambda, memo));
             let body = if &target.name == name {
                 body
             } else {
-                Box::new(inline_and_beta_reduce(*body, name, lambda))
+                Box::new(inline_and_beta_reduce(*body, name, lambda, memo))
             };
             TypedExprNode::For { target, iter, body }
         }
@@ -528,7 +529,7 @@ fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr) -> Expr {
                 ty,
                 user_annotation,
             };
-            expr.map_children(|child| inline_and_beta_reduce(child, name, lambda));
+            expr.map_children(|child| inline_and_beta_reduce(child, name, lambda, memo));
             return expr;
         }
     };
@@ -541,23 +542,27 @@ fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr) -> Expr {
 }
 
 /// Run [`inline_and_beta_reduce`] on every refinement predicate embedded in
-/// `ty`, rebuilding each predicate as a fresh immutable `Rc`. Every occurrence
-/// that shared one predicate term in `ty` is re-pointed at the same rebuilt
-/// term (the memo in [`walk_refined_predicates_mut`]), so the rewrite is
-/// observed uniformly across them.
+/// `ty` that mentions the inlined binder, rebuilding each as a fresh immutable
+/// `Rc`. `memo` spans the whole `[name ↦ lambda]` sweep, so every occurrence
+/// sharing one predicate term — across nodes, not just within one type — is
+/// re-pointed at the same rebuilt term and the rewrite is observed uniformly.
 ///
 /// This stays a pass-level walk rather than a `Subst` call because inlining
 /// inside a predicate must also *beta-reduce* the call sites it creates —
 /// substitution proper is the engine's job and runs inside
 /// [`inline_and_beta_reduce`] via `lambda_elim::substitute`.
-fn inline_in_type_predicates(ty: &mut Type, name: &Name, lambda: &Expr) {
-    // Per-call memo: `inline_in_type_predicates` runs on one node's type at a
-    // time, and only rebuilds predicates that actually contain the inlined
-    // binder, so it shares within a type but does not (need to) span the pass.
-    // A cross-node re-split here would be caught by `distinct_predicate_rcs`.
-    walk_refined_predicates_mut(ty, &mut PredMemo::new(), &mut |pred, _| {
+fn inline_in_type_predicates(ty: &mut Type, name: &Name, lambda: &Expr, memo: &mut PredMemo) {
+    walk_refined_predicates_mut(ty, memo, &mut |pred, memo| {
+        // A predicate the inlined binder does not occur in is reported
+        // *unchanged*, so it keeps its origin `Rc` and stays pointer-shared with
+        // its occurrences on other nodes rather than being reallocated at each
+        // one the sweep walks past.
+        if !is_free(name, pred) {
+            return false;
+        }
         let old = std::mem::replace(pred, Expr::lit(Lit::Unit));
-        *pred = inline_and_beta_reduce(old, name, lambda);
+        *pred = inline_and_beta_reduce(old, name, lambda, memo);
+        true
     });
 }
 
@@ -1077,7 +1082,7 @@ mod tests {
         let lambda = TypedExpr::lambda("x", int.clone(), TypedExpr::var("x").with_ty(int.clone()))
             .with_ty(fn_ty(int.clone(), int.clone()));
         let body = TypedExpr::var("f").with_ty(fn_ty(int.clone(), int));
-        let result = inline_and_beta_reduce(body, &Name::raw("f"), &lambda);
+        let result = inline_and_beta_reduce(body, &Name::raw("f"), &lambda, &mut PredMemo::new());
         assert_eq!(result, lambda);
     }
 
@@ -1090,7 +1095,7 @@ mod tests {
         let arg = TypedExpr::lit(Lit::Int(3)).with_ty(int.clone());
         let call = TypedExpr::apply(arg.clone(), TypedExpr::var("f").with_ty(lambda.ty.clone()))
             .with_ty(int);
-        let result = inline_and_beta_reduce(call, &Name::raw("f"), &lambda);
+        let result = inline_and_beta_reduce(call, &Name::raw("f"), &lambda, &mut PredMemo::new());
         assert_eq!(result, arg);
     }
 
@@ -1113,7 +1118,7 @@ mod tests {
             .with_ty(fn_ty(int.clone(), int.clone())),
         )
         .with_ty(int.clone());
-        let result = inline_and_beta_reduce(call, &Name::raw("f"), &lambda);
+        let result = inline_and_beta_reduce(call, &Name::raw("f"), &lambda, &mut PredMemo::new());
         assert_eq!(result, TypedExpr::lit(Lit::Int(1)).with_ty(int));
     }
 
@@ -1133,7 +1138,12 @@ mod tests {
             TypedExpr::lit(Lit::Int(42)).with_ty(int.clone()),
         )
         .with_ty(fn_ty(int.clone(), int));
-        let result = inline_and_beta_reduce(shadowed.clone(), &Name::raw("f"), &replacement);
+        let result = inline_and_beta_reduce(
+            shadowed.clone(),
+            &Name::raw("f"),
+            &replacement,
+            &mut PredMemo::new(),
+        );
         assert_eq!(result, shadowed);
     }
 

--- a/src/ccl/inline.rs
+++ b/src/ccl/inline.rs
@@ -551,6 +551,17 @@ fn inline_and_beta_reduce(expr: Expr, name: &Name, lambda: &Expr, memo: &mut Pre
 /// inside a predicate must also *beta-reduce* the call sites it creates —
 /// substitution proper is the engine's job and runs inside
 /// [`inline_and_beta_reduce`] via `lambda_elim::substitute`.
+/// **Why one memo may span the whole sweep** even though the rewrite is
+/// scope-sensitive (see [`PredMemo`]'s note on key-determined transforms).
+/// `[name ↦ lambda]` must not fire under a binder that shadows `name`, and unlike
+/// `subst` — which descends into such a scope with a *restricted* substitution,
+/// and therefore needs a fresh memo per shrink — [`inline_and_beta_reduce`] does
+/// not descend at all: every binder arm that matches `name` returns its node with
+/// the body untouched. An occurrence inside a shadowed scope is thus never
+/// *visited*, so there is no hit to serve it the outer rebuild. That is a real
+/// dependency of this memo's scope on that skipping behaviour: an arm rewritten to
+/// descend-with-a-guard instead of skip would silently reintroduce the leak, and
+/// would need `Subst::recurse_shrunk`'s treatment.
 fn inline_in_type_predicates(ty: &mut Type, name: &Name, lambda: &Expr, memo: &mut PredMemo) {
     walk_refined_predicates_mut(ty, memo, &mut |pred, memo| {
         // A predicate the inlined binder does not occur in is reported

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -791,9 +791,7 @@ fn elim_lambdas_impl(ctx: &mut ElimContext, expr: Expr) -> Result<Expr, LambdaEl
             let pred_on_source = typed_compose(vec![target_elim.clone(), pred_elem]);
             let source_domain = target_elim.ty.domain().unwrap();
             let source_codomain = target_elim.ty.codomain().unwrap();
-            let refinement = Refinement {
-                predicate: Rc::new(pred_on_source),
-            };
+            let refinement = Refinement::born(Rc::new(pred_on_source));
             let refined_domain = Type::Refinement(Box::new(source_domain), refinement);
             let refined_source = target_elim.with_ty(Type::fun(refined_domain, source_codomain));
             let body_elim = elim_lambda(ctx, &param.name, &param.ty, true_body)?;
@@ -1303,7 +1301,8 @@ mod tests {
             BinOpKind::Compare(CompareKind::Greater),
             Expr::var("x"),
         ));
-        let refinement = Refinement { predicate: pred };
+        // A predicate this call site is creating, so `born` — see `Refinement`.
+        let refinement = Refinement::born(pred);
 
         // Tuple([Int, {Int | __elem > x}]): the predicate rides only the second
         // component, so `any`-vs-`all` is observable.

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -1114,9 +1114,7 @@ mod tests {
         // predicate lives in the lambda's *domain type* `{Int | y > 0}`, not on
         // a dedicated AST field. `substitute` must descend through the type
         // (via `substitute_in_type`) into the predicate body.
-        let refinement = Refinement {
-            predicate: Rc::new(refinement_pred),
-        };
+        let refinement = Refinement::born(Rc::new(refinement_pred));
         let refined_param = Type::Refinement(Box::new(int_ty()), refinement);
         let expr = Expr::lambda("x", int_ty(), Expr::var("x").with_ty(int_ty()))
             .with_ty(fun_ty(refined_param, int_ty()));
@@ -1248,9 +1246,7 @@ mod tests {
         let bool_ty = Type::Base(BaseType::Bool);
 
         // Uncorrelated refinement (a Bool constant predicate) on the param.
-        let refinement = Refinement {
-            predicate: Rc::new(Expr::lit(Lit::Bool(true)).with_ty(bool_ty)),
-        };
+        let refinement = Refinement::born(Rc::new(Expr::lit(Lit::Bool(true)).with_ty(bool_ty)));
         let refined_y_ty = Type::Refinement(Box::new(int_ty()), refinement);
         let body = var("y").with_ty(int_ty());
 

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -108,11 +108,11 @@ fn contains_marker(expr: &Expr) -> bool {
     found
 }
 
-/// Whether any reachable type slot (node type, binder slot, or user
-/// annotation) still carries a mutable `Type::History` — the
-/// post-condition [`erase_mut`] establishes. A `Feed` history is *not* the
-/// phase's concern (it is erased later by `channelize`), so only
-/// [`HistoryKind::Overwrite`] counts here.
+/// Whether any type slot still carries a mutable `Type::History` — the
+/// post-condition [`erase_mut`] establishes, checked over the *same*
+/// [`Expr::walk_type_slots`] set the erasure uses so the two cannot disagree about
+/// which slots exist. A `Feed` history is *not* the phase's concern (it is erased
+/// later by `channelize`), so only [`HistoryKind::Overwrite`] counts here.
 fn contains_mut_type(expr: &Expr) -> bool {
     fn ty_has_mut(ty: &Type) -> bool {
         matches!(
@@ -123,24 +123,9 @@ fn contains_mut_type(expr: &Expr) -> bool {
             }
         ) || ty.fold_children(false, |acc, t| acc || ty_has_mut(t))
     }
-    let binder_has_mut =
-        |b: &TypedBinding| ty_has_mut(&b.ty) || b.user_annotation.as_ref().is_some_and(ty_has_mut);
-    let node_binders = match &expr.node {
-        TypedExprNode::Lambda { param, .. }
-        | TypedExprNode::Let { binding: param, .. }
-        | TypedExprNode::For { target: param, .. } => binder_has_mut(param),
-        TypedExprNode::LetRec { bindings, .. } => bindings.iter().any(|(b, _)| binder_has_mut(b)),
-        TypedExprNode::Case { branches, .. } => branches.iter().any(|b| {
-            b.pattern
-                .as_ref()
-                .is_some_and(|p| binder_has_mut(&p.binding))
-        }),
-        _ => false,
-    };
-    ty_has_mut(&expr.ty)
-        || expr.user_annotation.as_ref().is_some_and(ty_has_mut)
-        || node_binders
-        || expr.any_child(contains_mut_type)
+    let mut here = false;
+    expr.walk_type_slots(|t| here |= ty_has_mut(t));
+    here || expr.any_child(contains_mut_type)
 }
 
 /// Replace every transient mutable `Type::History { value, .. }` in
@@ -163,24 +148,18 @@ fn erase_mut_in_type(ty: &mut Type) {
     ty.walk_children_mut(erase_mut_in_type);
 }
 
-/// Erase `Type::History` on a binder slot (its declared type and any annotation).
-fn erase_mut_in_binding(b: &mut TypedBinding) {
-    erase_mut_in_type(&mut b.ty);
-    if let Some(ann) = &mut b.user_annotation {
-        erase_mut_in_type(ann);
-    }
-}
-
-/// Erase every `Type::History` throughout `expr`: node types, user annotations, and
-/// the binder slots `walk_children_mut` does not reach (`walk_binders_mut`,
-/// mirroring the binder coverage of `infer::collect_expr_errors`, the
-/// strict-wall checker this keeps happy).
+/// Erase every `Type::History` throughout `expr`, over **every** type slot each
+/// node carries ([`Expr::walk_type_slots_mut`]) rather than an enumeration written
+/// out here.
+///
+/// The enumeration matters because [`contains_mut_type`] — the release-mode
+/// post-condition asserting this pass left no history behind — has to cover the
+/// same set. Writing the set twice is how an eraser and its own checker come to
+/// share a blind spot, at which point the check cannot observe what the erasure
+/// missed. Sharing one walk makes that impossible: a slot either both erase and
+/// check, or neither.
 fn erase_mut(expr: &mut Expr) {
-    erase_mut_in_type(&mut expr.ty);
-    if let Some(ann) = &mut expr.user_annotation {
-        erase_mut_in_type(ann);
-    }
-    expr.walk_binders_mut(erase_mut_in_binding);
+    expr.walk_type_slots_mut(erase_mut_in_type);
     expr.walk_children_mut(erase_mut);
 }
 

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -1093,6 +1093,57 @@ mod tests {
     use super::*;
     use crate::ccl::BaseType;
 
+    /// Whether any *binder annotation* still carries a mutable history.
+    ///
+    /// Deliberately independent of [`contains_mut_type`]: the post-condition and
+    /// the erasure share one walk, so a slot that walk misses is a slot the
+    /// post-condition cannot report. A guard has to enumerate the slot itself or
+    /// it inherits the same blind spot.
+    fn binder_annotation_has_mut(expr: &Expr) -> bool {
+        fn ty_has_mut(ty: &Type) -> bool {
+            matches!(
+                ty,
+                Type::History {
+                    kind: HistoryKind::Overwrite,
+                    ..
+                }
+            ) || ty.fold_children(false, |acc, t| acc || ty_has_mut(t))
+        }
+        let mut found = false;
+        expr.walk_binders(|b| {
+            if let Some(ann) = &b.user_annotation {
+                found |= ty_has_mut(ann);
+            }
+        });
+        found || expr.any_child(binder_annotation_has_mut)
+    }
+
+    /// A mutable variable's history rides the binder's **annotation**, not its
+    /// `ty`: `x := e` lowers to `let_bind_annotated(.., Mut(V, _))`, and
+    /// `infer::api::binder_is_mut` reads the annotation as authoritative. So the
+    /// phase's erasure has to reach that slot.
+    #[test]
+    fn phase_erases_mut_from_a_binder_annotation() {
+        let (mut tree, _, _) = direct_mirror_sum();
+        let TypedExprNode::Let { binding, .. } = &mut tree.node else {
+            panic!("fixture is a let");
+        };
+        binding.user_annotation = Some(Type::History {
+            value: Box::new(Type::Base(BaseType::Int)),
+            domain: Box::new(Type::Hole),
+            kind: HistoryKind::Overwrite,
+        });
+        assert!(binder_annotation_has_mut(&tree), "sanity: fixture has one");
+
+        let out = run(tree);
+
+        assert!(
+            !binder_annotation_has_mut(&out),
+            "a history survived on a binder annotation: {}",
+            symbolic(&out)
+        );
+    }
+
     /// Build the typed direct-mirror tree for
     /// `x := 0; for i in [1,2,3]: x += i; x` as lowering + inference
     /// leave it: `let x = 0 in ExprStmt(For{i, [1,2,3], x := x+i}, x)`.

--- a/src/ccl/ops.rs
+++ b/src/ccl/ops.rs
@@ -69,7 +69,7 @@ pub enum TypeError {
 ///
 /// Named `Lit` to avoid shadowing `crate::interpreter::Literal`, which is
 /// an unrelated operator struct.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Lit {
     /// An integer constant.
     Int(i64),

--- a/src/ccl/planning/iterate.rs
+++ b/src/ccl/planning/iterate.rs
@@ -8,7 +8,9 @@
 use std::mem::take;
 
 use super::join::try_hash_join_rewrite;
-use super::predicates::{CompileMemo, compile_refinement_predicates, fn_of_bare_predicate};
+use crate::ccl::ccl_utils::PredMemo;
+
+use super::predicates::{compile_refinement_predicates, fn_of_bare_predicate};
 use super::*;
 
 /// Walks `expr` and materializes every iteration site, choosing the best
@@ -345,7 +347,7 @@ pub(super) fn wrap_with_iterate(expr: &mut Expr) {
     // two sibling sites may be compiled again; that is safe because
     // `lambda_elim::run` is idempotent on an already-point-free predicate
     // (re-running finds no lambdas to eliminate).
-    compile_refinement_predicates(expr, &mut CompileMemo::new());
+    compile_refinement_predicates(expr, &PredMemo::new());
     let Some(domain_ty) = expr.ty.domain() else {
         return;
     };

--- a/src/ccl/planning/iterate.rs
+++ b/src/ccl/planning/iterate.rs
@@ -8,7 +8,9 @@
 use std::mem::take;
 
 use super::join::try_hash_join_rewrite;
-use super::predicates::{PredMemo, compile_refinement_predicates, fn_of_bare_predicate};
+use crate::ccl::ccl_utils::PredMemo;
+
+use super::predicates::{compile_refinement_predicates, fn_of_bare_predicate};
 use super::*;
 
 /// Walks `expr` and materializes every iteration site, choosing the best

--- a/src/ccl/planning/iterate.rs
+++ b/src/ccl/planning/iterate.rs
@@ -8,9 +8,7 @@
 use std::mem::take;
 
 use super::join::try_hash_join_rewrite;
-use crate::ccl::ccl_utils::PredMemo;
-
-use super::predicates::{compile_refinement_predicates, fn_of_bare_predicate};
+use super::predicates::{CompileMemo, compile_refinement_predicates, fn_of_bare_predicate};
 use super::*;
 
 /// Walks `expr` and materializes every iteration site, choosing the best
@@ -347,7 +345,7 @@ pub(super) fn wrap_with_iterate(expr: &mut Expr) {
     // two sibling sites may be compiled again; that is safe because
     // `lambda_elim::run` is idempotent on an already-point-free predicate
     // (re-running finds no lambdas to eliminate).
-    compile_refinement_predicates(expr, &mut PredMemo::new());
+    compile_refinement_predicates(expr, &mut CompileMemo::new());
     let Some(domain_ty) = expr.ty.domain() else {
         return;
     };

--- a/src/ccl/planning/mod.rs
+++ b/src/ccl/planning/mod.rs
@@ -107,7 +107,7 @@ pub fn run(mut expr: Expr) -> Expr {
     // post-planning typecheck's structural refinement match holds. It runs
     // after the recognizers (which already consumed the bare shapes they
     // match) and is idempotent on already-compiled predicates.
-    compile_refinement_predicates(&mut expr, &mut predicates::CompileMemo::new());
+    compile_refinement_predicates(&mut expr, &PredMemo::new());
     // Re-run `simplify` to absorb the `id` leaves and nested `Compose`
     // boilerplate that [`join::try_hash_join_rewrite`] emits via
     // [`replace_tuple_project_with_id`].  `simplify` is marker-aware: its

--- a/src/ccl/planning/mod.rs
+++ b/src/ccl/planning/mod.rs
@@ -295,12 +295,7 @@ pub(crate) mod test_helpers {
     /// predicate.  The predicate must have type `base ⇒ Bool` so the
     /// refinement is well-formed.
     pub(crate) fn refined_ty(base: Type, predicate: Expr) -> Type {
-        Type::Refinement(
-            Box::new(base),
-            Refinement {
-                predicate: Rc::new(predicate),
-            },
-        )
+        Type::Refinement(Box::new(base), Refinement::born(Rc::new(predicate)))
     }
 
     /// Build an `Apply { argument, function: <builtin> }` whose function

--- a/src/ccl/planning/mod.rs
+++ b/src/ccl/planning/mod.rs
@@ -107,7 +107,7 @@ pub fn run(mut expr: Expr) -> Expr {
     // post-planning typecheck's structural refinement match holds. It runs
     // after the recognizers (which already consumed the bare shapes they
     // match) and is idempotent on already-compiled predicates.
-    compile_refinement_predicates(&mut expr, &mut PredMemo::new());
+    compile_refinement_predicates(&mut expr, &mut predicates::CompileMemo::new());
     // Re-run `simplify` to absorb the `id` leaves and nested `Compose`
     // boilerplate that [`join::try_hash_join_rewrite`] emits via
     // [`replace_tuple_project_with_id`].  `simplify` is marker-aware: its

--- a/src/ccl/planning/mod.rs
+++ b/src/ccl/planning/mod.rs
@@ -18,7 +18,7 @@
 use log::trace;
 
 use crate::ccl::ccl_utils::{
-    self, apply_function, make_iterate, make_restrict, refine_codomain, set_codomain,
+    self, PredMemo, apply_function, make_iterate, make_restrict, refine_codomain, set_codomain,
     trivially_true_predicate, typed_compose,
 };
 // Re-exported so the `planning` submodules (`groupby`, `join`) can keep calling
@@ -107,7 +107,7 @@ pub fn run(mut expr: Expr) -> Expr {
     // post-planning typecheck's structural refinement match holds. It runs
     // after the recognizers (which already consumed the bare shapes they
     // match) and is idempotent on already-compiled predicates.
-    compile_refinement_predicates(&mut expr, &mut predicates::PredMemo::new());
+    compile_refinement_predicates(&mut expr, &mut PredMemo::new());
     // Re-run `simplify` to absorb the `id` leaves and nested `Compose`
     // boilerplate that [`join::try_hash_join_rewrite`] emits via
     // [`replace_tuple_project_with_id`].  `simplify` is marker-aware: its

--- a/src/ccl/planning/predicates.rs
+++ b/src/ccl/planning/predicates.rs
@@ -38,63 +38,13 @@ use super::*;
 // rebuilt predicate that must be compiled on its own, so keying by id would skip
 // it and leave it in lambda form.
 
-/// The predicate-compilation memo, plus the precondition that makes reusing an
-/// entry sound.
-///
-/// Compilation reads the refinement's **base** (`fn_of_bare_predicate` eta-expands
-/// `λ __elem : base → bare`; `bare_predicate_of_fn` stamps `base` on the element
-/// var), and the base is *not* part of [`PredMemo`]'s key. That puts this pass in
-/// the same position as constraint emission — see [`PredMemo`]'s note on
-/// context-determined transforms — with one difference that lets it keep the
-/// skipping protocol: `base` only reaches the compiled term's **type slots**, and
-/// refinement identity is type-blind, so two occurrences of one predicate `Rc`
-/// compile to terms that compare equal regardless. Reusing one is therefore sound
-/// *provided the bases actually agree*, which holds because a shared `Rc` is only
-/// ever created by copying one refinement — but nothing in the types enforces it,
-/// and if it ever failed the symptom would be an element type quietly borrowed
-/// from another occurrence.
-///
-/// So debug builds record each entry's base and check it on the hit path. That is
-/// the whole reason this wrapper exists; release builds are exactly a `PredMemo`.
-pub(crate) struct CompileMemo {
-    preds: PredMemo,
-    #[cfg(debug_assertions)]
-    bases: std::collections::HashMap<crate::ccl::PredicateId, Type>,
-}
-
-impl CompileMemo {
-    pub(crate) fn new() -> Self {
-        Self {
-            preds: PredMemo::new(),
-            #[cfg(debug_assertions)]
-            bases: std::collections::HashMap::new(),
-        }
-    }
-
-    /// Record the base this predicate was compiled against.
-    fn record_base(&mut self, id: crate::ccl::PredicateId, base: &Type) {
-        #[cfg(debug_assertions)]
-        self.bases.insert(id, base.clone());
-        let _ = (id, base);
-    }
-
-    /// On a memo hit, check that this occurrence's base matches the one the
-    /// entry was compiled against (see the type-level note).
-    fn assert_base_agrees(&self, id: crate::ccl::PredicateId, base: &Type) {
-        #[cfg(debug_assertions)]
-        if let Some(compiled_against) = self.bases.get(&id) {
-            debug_assert!(
-                ccl_utils::strip_refinements(compiled_against)
-                    == ccl_utils::strip_refinements(base),
-                "predicate-compilation memo hit across differing refinement bases: this \
-                 occurrence is over `{base}` but the entry was compiled against \
-                 `{compiled_against}`. Compilation reads the base, so the reused term \
-                 carries the other occurrence's element type — see `CompileMemo`."
-            );
-        }
-        let _ = (id, base);
-    }
-}
+// The refinement's **base** is the memo's context (`PredMemo<Type>`), because
+// compilation reads it: `fn_of_bare_predicate` eta-expands `λ __elem : base →
+// bare`, and `bare_predicate_of_fn` stamps it on the element var. An entry is
+// therefore reused only for an occurrence over an equal base. That holds in
+// practice — a shared `Rc` is only ever created by copying one refinement — but
+// nothing enforces it, and keying on the base means a mismatch *recompiles*
+// rather than silently borrowing another occurrence's element type.
 
 /// True if a `__pair` binder ([`Name::is_synthetic_pair`]) appears anywhere in
 /// the **term** `e` — its node and child *expressions*, never its type slots.
@@ -148,7 +98,7 @@ fn term_mentions_pair_binder(e: &Expr) -> bool {
 /// predicates and still match under refinement equality; for the nested-lambda
 /// case the per-`Rc` memo keeps shared occurrences equal despite `lambda_elim`'s
 /// `__pair` minting (see [`PredMemo`]).
-pub(crate) fn compile_refinement_predicates(expr: &mut Expr, memo: &mut CompileMemo) {
+pub(crate) fn compile_refinement_predicates(expr: &mut Expr, memo: &PredMemo<Type>) {
     expr.walk_type_slots_mut(|ty| compile_predicates_in_type(ty, memo));
     expr.walk_children_mut(|child| compile_refinement_predicates(child, memo));
 }
@@ -167,47 +117,42 @@ pub(crate) fn fn_of_bare_predicate(base: &Type, bare: &Expr) -> Expr {
         .expect("lambda-elim of refinement predicate")
 }
 
-fn compile_predicates_in_type(ty: &mut Type, memo: &mut CompileMemo) {
+fn compile_predicates_in_type(ty: &mut Type, memo: &PredMemo<Type>) {
     if let Type::Refinement(base, refinement) = ty {
-        let id = refinement.predicate_id();
-        let Some((origin, bare)) = memo.preds.begin(refinement) else {
-            // Hit: the entry's compiled term is reused, which is only sound while
-            // the bases agree.
-            memo.assert_base_agrees(id, base);
-            ty.walk_children_mut(|child| compile_predicates_in_type(child, memo));
-            return;
-        };
-        // Normalize the bare predicate to `__elem ▷ p` with `p` point-free:
-        // recover the predicate function and re-wrap it. This keeps the stored
-        // predicate in the single bare form while pinning a point-free core, so
-        // the iterate/restrict producers (built from the same `p`) carry a
-        // structurally-identical refinement to the cast demand they satisfy.
-        let p = fn_of_bare_predicate(base, &bare);
-        let mut compiled = ccl_utils::bare_predicate_of_fn(base, p);
-        // The compiled predicate's own sub-expressions can carry *nested*
-        // refinements (a filter over an already-filtered source: the inner
-        // refinement rides a sub-expression's type slot inside this predicate).
-        // `Type::walk_children_mut` below does not descend into a predicate term,
-        // so compile those here, sharing the memo.
-        compile_refinement_predicates(&mut compiled, memo);
-        // The producer/consumer refinement match (`sum`'s domain vs. its feed, a
-        // compose adjacency) compares *distinct* predicate `Rc`s — the memo only
-        // dedups occurrences sharing one `Rc`. That match rests on compilation
-        // being a deterministic value function, which requires that lambda
-        // elimination's freshly-minted `__pair` (`Uid::fresh()`) never survive
-        // into the compared *term*. It legitimately survives as a `Fun.name` Pi
-        // binder in a type slot (which `eq_refinement_predicate` is type-blind
-        // to), so the check is term-only. Assert that load-bearing invariant
-        // rather than leaving it argued.
-        debug_assert!(
-            !term_mentions_pair_binder(&compiled),
-            "a `__pair` binder survived into a compiled predicate term, \
-             breaking the value-function property the structural \
-             producer/consumer match relies on: {}",
-            symbolic(&compiled)
-        );
-        memo.record_base(id, base);
-        memo.preds.finish(refinement, origin, compiled);
+        let base_ctx = (**base).clone();
+        memo.rebuild(refinement, &base_ctx, |bare| {
+            // Normalize the bare predicate to `__elem ▷ p` with `p` point-free:
+            // recover the predicate function and re-wrap it. This keeps the stored
+            // predicate in the single bare form while pinning a point-free core, so
+            // the iterate/restrict producers (built from the same `p`) carry a
+            // structurally-identical refinement to the cast demand they satisfy.
+            let p = fn_of_bare_predicate(&base_ctx, bare);
+            let mut compiled = ccl_utils::bare_predicate_of_fn(&base_ctx, p);
+            // The compiled predicate's own sub-expressions can carry *nested*
+            // refinements (a filter over an already-filtered source: the inner
+            // refinement rides a sub-expression's type slot inside this predicate).
+            // `Type::walk_children_mut` below does not descend into a predicate term,
+            // so compile those here, sharing the memo.
+            compile_refinement_predicates(&mut compiled, memo);
+            // The producer/consumer refinement match (`sum`'s domain vs. its feed, a
+            // compose adjacency) compares *distinct* predicate `Rc`s — the memo only
+            // dedups occurrences sharing one `Rc`. That match rests on compilation
+            // being a deterministic value function, which requires that lambda
+            // elimination's freshly-minted `__pair` (`Uid::fresh()`) never survive
+            // into the compared *term*. It legitimately survives as a `Fun.name` Pi
+            // binder in a type slot (which `eq_refinement_predicate` is type-blind
+            // to), so the check is term-only. Assert that load-bearing invariant
+            // rather than leaving it argued.
+            debug_assert!(
+                !term_mentions_pair_binder(&compiled),
+                "a `__pair` binder survived into a compiled predicate term, \
+                 breaking the value-function property the structural \
+                 producer/consumer match relies on: {}",
+                symbolic(&compiled)
+            );
+            *bare = compiled;
+            true
+        });
     }
     // Recurse into structural type children (refinement base, function
     // domain/codomain, tuple/record/variant elements).

--- a/src/ccl/planning/predicates.rs
+++ b/src/ccl/planning/predicates.rs
@@ -45,6 +45,16 @@ use super::*;
 // practice — a shared `Rc` is only ever created by copying one refinement — but
 // nothing enforces it, and keying on the base means a mismatch *recompiles*
 // rather than silently borrowing another occurrence's element type.
+//
+// Cost of a `Type` context: a lookup compares bases structurally, and `PartialEq`
+// for a refined `Type` descends into predicate terms. Two things keep that cheap.
+// The base is the type being *refined*, so it sits below the refinement rather
+// than containing it — comparing `{Int | p}`'s base compares `Int`, never `p` —
+// and the entry list for one key is a singleton in every shape measured, so a hit
+// is one compare of a small type. The clone per refinement node is the same
+// shallow value. Measured against the pre-context memo the difference is in the
+// noise; a base that ever became large enough to matter would be a signal about
+// the types, not about this key.
 
 /// True if a `__pair` binder ([`Name::is_synthetic_pair`]) appears anywhere in
 /// the **term** `e` — its node and child *expressions*, never its type slots.

--- a/src/ccl/planning/predicates.rs
+++ b/src/ccl/planning/predicates.rs
@@ -7,46 +7,36 @@
 //! [`crate::ccl::ccl_utils::bare_predicate_of_fn`] that the iterate/restrict and
 //! op-conversion lowering consume.
 
-use std::collections::HashMap;
-use std::rc::Rc;
-
 use super::*;
 
-/// Identity key for a refinement predicate — the `Rc<Expr>` address. Keyed on
-/// object identity, not [`crate::ccl::RefinementId`]: a substituted/discharged
-/// refinement keeps its id but holds an independently rebuilt predicate that
-/// must be compiled on its own (keying by id would skip it and leave it in
-/// lambda form). Maps each original predicate to a `(keepalive, compiled)`
-/// pair so every occurrence that shared one term is re-pointed at the same
-/// compiled `Rc` (and compiled exactly once).
-///
-/// The `keepalive` clone is load-bearing, not incidental: [`compile_predicates_in_type`]
-/// overwrites `refinement.predicate` with the compiled result, which drops the
-/// *original* `Rc` if this was its only strong reference. Without a clone held
-/// here, that free can hand the address straight back to an unrelated `Rc::new`
-/// later in the *same* tree walk — including one of `compile_predicates_in_type`'s
-/// own allocations — so a subsequent, unrelated predicate that happens to start
-/// life at that address collides with this entry and gets served this entry's
-/// `compiled` value instead of its own. Confirmed in practice: two structurally
-/// unrelated join predicates from different call sites landed on the same freed
-/// address and the second silently inherited the first's compiled form.
-///
-/// Like the value-rewrite memo in [`ccl_utils::walk_refined_predicates_mut`],
-/// dedup itself is a **performance / structural-sharing optimization, not a
-/// correctness requirement** — verified: the full suite passes with dedup
-/// disabled (i.e. recompiling every occurrence independently). Compilation is
-/// effectively a value function for comparison purposes: `lambda_elim` mints a
-/// fresh `__pair` `Uid` in its nested-lambda rule, but that binder is
-/// *eliminated* within the same run, so the compiled output is point-free and
-/// carries no minted binder — two independent compilations of one predicate
-/// yield structurally-equal terms. (The convention this rests on — no pass
-/// leaves a re-minted bound binder in a term that equality later compares — is
-/// what keeps by-name equality coincide with α-equivalence; `lambda_elim`
-/// upholds it by eliminating `__pair` rather than the equality having to be
-/// α-aware.) The *keying*, however — using the original `Rc`'s address as a
-/// stand-in for its identity — is only sound while that address cannot be
-/// reused, which is exactly what the keepalive guarantees.
-pub(super) type PredMemo = HashMap<*const Expr, (Rc<Expr>, Rc<Expr>)>;
+// Predicate compilation is a predicate-*rebuilding* pass like any other, so it
+// memoizes with the shared [`ccl_utils::PredMemo`] — including its keepalive
+// discipline, which is load-bearing rather than incidental here: overwriting
+// `refinement.predicate` with the compiled result drops the *original* `Rc` if
+// that was its last strong reference, and the freed address can be handed
+// straight back to an unrelated `Rc::new` later in the same walk — including one
+// of `compile_predicates_in_type`'s own allocations — so an unrelated predicate
+// starting life at that address would collide and inherit this entry's compiled
+// form. Observed in practice: two structurally unrelated join predicates from
+// different call sites landed on the same freed address and the second silently
+// inherited the first's compiled form.
+//
+// Dedup itself is a **performance / structural-sharing optimization, not a
+// correctness requirement** — verified: the full suite passes with dedup
+// disabled (i.e. recompiling every occurrence independently). Compilation is
+// effectively a value function for comparison purposes: `lambda_elim` mints a
+// fresh `__pair` `Uid` in its nested-lambda rule, but that binder is
+// *eliminated* within the same run, so the compiled output is point-free and
+// carries no minted binder — two independent compilations of one predicate yield
+// structurally-equal terms. (The convention this rests on — no pass leaves a
+// re-minted bound binder in a term that equality later compares — is what makes
+// by-name equality coincide with α-equivalence; `lambda_elim` upholds it by
+// eliminating `__pair` rather than the equality having to be α-aware.)
+//
+// Keying on the `Rc` address rather than a refinement id is deliberate: a
+// substituted/discharged refinement keeps its id but holds an independently
+// rebuilt predicate that must be compiled on its own, so keying by id would skip
+// it and leave it in lambda form.
 
 /// True if a `__pair` binder ([`Name::is_synthetic_pair`]) appears anywhere in
 /// the **term** `e` — its node and child *expressions*, never its type slots.
@@ -91,41 +81,17 @@ fn term_mentions_pair_binder(e: &Expr) -> bool {
 /// recovers `p` via `fn_of_bare_predicate` and re-wraps). Each distinct predicate
 /// `Rc` is compiled once.
 ///
-/// Every type slot a node carries is compiled, not just `expr.ty`: a `Cast`'s
-/// `target` and the binder-declared types (lambda param, `let` binding, etc.)
-/// carry their own predicate `Rc`s. They are independent (immutable) terms, so
-/// each must be normalized. For the common predicate (no nested lambdas)
-/// compilation is deterministic, so a `target` and its parallel `expr.ty`
-/// normalize to structurally-equal point-free predicates and still
-/// match under refinement equality; for the nested-lambda case the per-`Rc`
-/// memo keeps shared occurrences equal despite `lambda_elim`'s `__pair` minting
-/// (see [`PredMemo`]).
+/// Every type slot a node carries is compiled, not just `expr.ty`
+/// ([`Expr::walk_type_slots_mut`]): a `Cast`'s `target` and the binder-declared
+/// types (lambda param, `let` binding, etc.) carry their own predicate `Rc`s.
+/// They are independent (immutable) terms, so each must be normalized. For the
+/// common predicate (no nested lambdas) compilation is deterministic, so a
+/// `target` and its parallel `expr.ty` normalize to structurally-equal point-free
+/// predicates and still match under refinement equality; for the nested-lambda
+/// case the per-`Rc` memo keeps shared occurrences equal despite `lambda_elim`'s
+/// `__pair` minting (see [`PredMemo`]).
 pub(crate) fn compile_refinement_predicates(expr: &mut Expr, memo: &mut PredMemo) {
-    compile_predicates_in_type(&mut expr.ty, memo);
-    if let Some(annotation) = &mut expr.user_annotation {
-        compile_predicates_in_type(annotation, memo);
-    }
-    match &mut expr.node {
-        TypedExprNode::Lambda { param, .. } => compile_predicates_in_type(&mut param.ty, memo),
-        TypedExprNode::Cast { target, .. } => compile_predicates_in_type(target, memo),
-        TypedExprNode::Let { binding, .. } => compile_predicates_in_type(&mut binding.ty, memo),
-        TypedExprNode::Case { branches, .. } => {
-            for b in branches.iter_mut() {
-                if let Some(p) = &mut b.pattern {
-                    compile_predicates_in_type(&mut p.binding.ty, memo);
-                }
-            }
-        }
-        TypedExprNode::LetRec { bindings, .. } => {
-            for (b, _) in bindings.iter_mut() {
-                compile_predicates_in_type(&mut b.ty, memo);
-            }
-        }
-        TypedExprNode::For { target, .. } => {
-            compile_predicates_in_type(&mut target.ty, memo);
-        }
-        _ => {}
-    }
+    expr.walk_type_slots_mut(|ty| compile_predicates_in_type(ty, memo));
     expr.walk_children_mut(|child| compile_refinement_predicates(child, memo));
 }
 
@@ -144,52 +110,39 @@ pub(crate) fn fn_of_bare_predicate(base: &Type, bare: &Expr) -> Expr {
 }
 
 fn compile_predicates_in_type(ty: &mut Type, memo: &mut PredMemo) {
-    if let Type::Refinement(base, refinement) = ty {
-        // Clone before computing the pointer: the clone is the keepalive that
-        // keeps this address from being freed and reused for the rest of the
-        // walk (see [`PredMemo`]). Reading the pointer off `refinement.predicate`
-        // directly would still be correct today, but pairing the clone with the
-        // pointer it backs makes the dependency obvious at the call site.
-        let original_rc = Rc::clone(&refinement.predicate);
-        let original = Rc::as_ptr(&original_rc);
-        if let Some((_, compiled)) = memo.get(&original) {
-            refinement.predicate = Rc::clone(compiled);
-        } else {
-            // Normalize the bare predicate to `__elem ▷ p` with `p` point-free:
-            // recover the predicate function and re-wrap it. This keeps the
-            // stored predicate in the single bare form while pinning a
-            // point-free core, so the iterate/restrict producers (built from
-            // the same `p`) carry a structurally-identical refinement to the
-            // cast demand they satisfy.
-            let p = fn_of_bare_predicate(base, &refinement.predicate);
-            let mut compiled = ccl_utils::bare_predicate_of_fn(base, p);
-            // The compiled predicate's own sub-expressions can carry *nested*
-            // refinements (a filter over an already-filtered source: the inner
-            // refinement rides a sub-expression's type slot inside this
-            // predicate). `Type::walk_children_mut` below does not descend into
-            // a predicate term, so compile those here, sharing the memo.
-            compile_refinement_predicates(&mut compiled, memo);
-            // The producer/consumer refinement match (`sum`'s domain vs. its
-            // feed, a compose adjacency) compares *distinct* predicate `Rc`s —
-            // the memo only dedups occurrences sharing one `Rc`. That match
-            // rests on compilation being a deterministic value function, which
-            // requires that lambda elimination's freshly-minted `__pair`
-            // (`Uid::fresh()`) never survive into the compared *term*. It
-            // legitimately survives as a `Fun.name` Pi binder in a type slot
-            // (which `eq_refinement_predicate` is type-blind to), so the check
-            // is term-only. Assert that load-bearing invariant rather than
-            // leaving it argued.
-            debug_assert!(
-                !term_mentions_pair_binder(&compiled),
-                "a `__pair` binder survived into a compiled predicate term, \
-                 breaking the value-function property the structural \
-                 producer/consumer match relies on: {}",
-                symbolic(&compiled)
-            );
-            let compiled = Rc::new(compiled);
-            memo.insert(original, (original_rc, Rc::clone(&compiled)));
-            refinement.predicate = compiled;
-        }
+    if let Type::Refinement(base, refinement) = ty
+        && let Some((origin, bare)) = memo.begin(refinement)
+    {
+        // Normalize the bare predicate to `__elem ▷ p` with `p` point-free:
+        // recover the predicate function and re-wrap it. This keeps the stored
+        // predicate in the single bare form while pinning a point-free core, so
+        // the iterate/restrict producers (built from the same `p`) carry a
+        // structurally-identical refinement to the cast demand they satisfy.
+        let p = fn_of_bare_predicate(base, &bare);
+        let mut compiled = ccl_utils::bare_predicate_of_fn(base, p);
+        // The compiled predicate's own sub-expressions can carry *nested*
+        // refinements (a filter over an already-filtered source: the inner
+        // refinement rides a sub-expression's type slot inside this predicate).
+        // `Type::walk_children_mut` below does not descend into a predicate term,
+        // so compile those here, sharing the memo.
+        compile_refinement_predicates(&mut compiled, memo);
+        // The producer/consumer refinement match (`sum`'s domain vs. its feed, a
+        // compose adjacency) compares *distinct* predicate `Rc`s — the memo only
+        // dedups occurrences sharing one `Rc`. That match rests on compilation
+        // being a deterministic value function, which requires that lambda
+        // elimination's freshly-minted `__pair` (`Uid::fresh()`) never survive
+        // into the compared *term*. It legitimately survives as a `Fun.name` Pi
+        // binder in a type slot (which `eq_refinement_predicate` is type-blind
+        // to), so the check is term-only. Assert that load-bearing invariant
+        // rather than leaving it argued.
+        debug_assert!(
+            !term_mentions_pair_binder(&compiled),
+            "a `__pair` binder survived into a compiled predicate term, \
+             breaking the value-function property the structural \
+             producer/consumer match relies on: {}",
+            symbolic(&compiled)
+        );
+        memo.finish(refinement, origin, compiled);
     }
     // Recurse into structural type children (refinement base, function
     // domain/codomain, tuple/record/variant elements).

--- a/src/ccl/planning/predicates.rs
+++ b/src/ccl/planning/predicates.rs
@@ -38,6 +38,64 @@ use super::*;
 // rebuilt predicate that must be compiled on its own, so keying by id would skip
 // it and leave it in lambda form.
 
+/// The predicate-compilation memo, plus the precondition that makes reusing an
+/// entry sound.
+///
+/// Compilation reads the refinement's **base** (`fn_of_bare_predicate` eta-expands
+/// `λ __elem : base → bare`; `bare_predicate_of_fn` stamps `base` on the element
+/// var), and the base is *not* part of [`PredMemo`]'s key. That puts this pass in
+/// the same position as constraint emission — see [`PredMemo`]'s note on
+/// context-determined transforms — with one difference that lets it keep the
+/// skipping protocol: `base` only reaches the compiled term's **type slots**, and
+/// refinement identity is type-blind, so two occurrences of one predicate `Rc`
+/// compile to terms that compare equal regardless. Reusing one is therefore sound
+/// *provided the bases actually agree*, which holds because a shared `Rc` is only
+/// ever created by copying one refinement — but nothing in the types enforces it,
+/// and if it ever failed the symptom would be an element type quietly borrowed
+/// from another occurrence.
+///
+/// So debug builds record each entry's base and check it on the hit path. That is
+/// the whole reason this wrapper exists; release builds are exactly a `PredMemo`.
+pub(crate) struct CompileMemo {
+    preds: PredMemo,
+    #[cfg(debug_assertions)]
+    bases: std::collections::HashMap<crate::ccl::PredicateId, Type>,
+}
+
+impl CompileMemo {
+    pub(crate) fn new() -> Self {
+        Self {
+            preds: PredMemo::new(),
+            #[cfg(debug_assertions)]
+            bases: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Record the base this predicate was compiled against.
+    fn record_base(&mut self, id: crate::ccl::PredicateId, base: &Type) {
+        #[cfg(debug_assertions)]
+        self.bases.insert(id, base.clone());
+        let _ = (id, base);
+    }
+
+    /// On a memo hit, check that this occurrence's base matches the one the
+    /// entry was compiled against (see the type-level note).
+    fn assert_base_agrees(&self, id: crate::ccl::PredicateId, base: &Type) {
+        #[cfg(debug_assertions)]
+        if let Some(compiled_against) = self.bases.get(&id) {
+            debug_assert!(
+                ccl_utils::strip_refinements(compiled_against)
+                    == ccl_utils::strip_refinements(base),
+                "predicate-compilation memo hit across differing refinement bases: this \
+                 occurrence is over `{base}` but the entry was compiled against \
+                 `{compiled_against}`. Compilation reads the base, so the reused term \
+                 carries the other occurrence's element type — see `CompileMemo`."
+            );
+        }
+        let _ = (id, base);
+    }
+}
+
 /// True if a `__pair` binder ([`Name::is_synthetic_pair`]) appears anywhere in
 /// the **term** `e` — its node and child *expressions*, never its type slots.
 ///
@@ -90,7 +148,7 @@ fn term_mentions_pair_binder(e: &Expr) -> bool {
 /// predicates and still match under refinement equality; for the nested-lambda
 /// case the per-`Rc` memo keeps shared occurrences equal despite `lambda_elim`'s
 /// `__pair` minting (see [`PredMemo`]).
-pub(crate) fn compile_refinement_predicates(expr: &mut Expr, memo: &mut PredMemo) {
+pub(crate) fn compile_refinement_predicates(expr: &mut Expr, memo: &mut CompileMemo) {
     expr.walk_type_slots_mut(|ty| compile_predicates_in_type(ty, memo));
     expr.walk_children_mut(|child| compile_refinement_predicates(child, memo));
 }
@@ -109,10 +167,16 @@ pub(crate) fn fn_of_bare_predicate(base: &Type, bare: &Expr) -> Expr {
         .expect("lambda-elim of refinement predicate")
 }
 
-fn compile_predicates_in_type(ty: &mut Type, memo: &mut PredMemo) {
-    if let Type::Refinement(base, refinement) = ty
-        && let Some((origin, bare)) = memo.begin(refinement)
-    {
+fn compile_predicates_in_type(ty: &mut Type, memo: &mut CompileMemo) {
+    if let Type::Refinement(base, refinement) = ty {
+        let id = refinement.predicate_id();
+        let Some((origin, bare)) = memo.preds.begin(refinement) else {
+            // Hit: the entry's compiled term is reused, which is only sound while
+            // the bases agree.
+            memo.assert_base_agrees(id, base);
+            ty.walk_children_mut(|child| compile_predicates_in_type(child, memo));
+            return;
+        };
         // Normalize the bare predicate to `__elem ▷ p` with `p` point-free:
         // recover the predicate function and re-wrap it. This keeps the stored
         // predicate in the single bare form while pinning a point-free core, so
@@ -142,7 +206,8 @@ fn compile_predicates_in_type(ty: &mut Type, memo: &mut PredMemo) {
              producer/consumer match relies on: {}",
             symbolic(&compiled)
         );
-        memo.finish(refinement, origin, compiled);
+        memo.record_base(id, base);
+        memo.preds.finish(refinement, origin, compiled);
     }
     // Recurse into structural type children (refinement base, function
     // domain/codomain, tuple/record/variant elements).

--- a/src/ccl/simplify.rs
+++ b/src/ccl/simplify.rs
@@ -156,13 +156,16 @@ fn simplify_once(expr: &mut Expr, memo: &mut PredMemo) -> (bool, bool) {
     // occurrences that shared a predicate term. A predicate's own iteration-containment is
     // irrelevant to the term-tree guard (`iterate` sources live in the term
     // tree, never inside predicates), so the iteration bit is discarded here.
-    walk_refined_predicates_mut(&mut expr.ty, memo, &mut |pred, memo| {
-        let pred_changed = simplify_once(pred, memo).0;
-        changed |= pred_changed;
+    // Take the *combinator's* answer, not just the callback's: a rule firing
+    // inside a predicate is one way this changed something, and the memo
+    // re-pointing a slot is another that the callback cannot observe (see
+    // `walk_refined_predicates_mut`). Feeding only the callback's bit into the
+    // fixpoint would let a re-pointing go unnoticed for an iteration.
+    changed |= walk_refined_predicates_mut(&mut expr.ty, memo, &mut |pred, memo| {
         // Reporting "unchanged" keeps the origin `Rc` in the slot, so a predicate
         // simplify has nothing to say about stays pointer-shared with every other
         // occurrence — including ones in nodes this walk never reaches.
-        pred_changed
+        simplify_once(pred, memo).0
     });
     let (children_changed, children_have_iteration) = recurse_simplify(expr, memo);
     changed |= children_changed;

--- a/src/ccl/simplify.rs
+++ b/src/ccl/simplify.rs
@@ -47,9 +47,7 @@
 //! | Zip distribute | `⟨f0, f1⟩ ≫ ⟨g, h⟩` (if g,h will simplify) | `⟨⟨f0, f1⟩ ≫ g, ⟨f0, f1⟩ ≫ h⟩` | ✗ (restructures) |
 //! | String add-to-concat | `Arithmetic(Add) : (String,String)→String` | `Concat` | ✓ |
 
-use std::collections::HashMap;
-
-use crate::ccl::ccl_utils::{is_builtin, walk_refined_predicates_mut};
+use crate::ccl::ccl_utils::{PredMemo, is_builtin, walk_refined_predicates_mut};
 use crate::ccl::infer::debug_typecheck;
 use crate::ccl::lambda_elim::{fun_ty_or_hole, id, zip_pair};
 use crate::ccl::{
@@ -123,7 +121,17 @@ fn is_iteration(expr: &Expr) -> bool {
 /// nested-`Compose` leftovers from the hash-join rewrite's
 /// `replace_tuple_project_with_id`.)
 pub fn simplify(mut expr: Expr) -> Expr {
-    while simplify_once(&mut expr).0 {}
+    // One [`PredMemo`] per `simplify_once` tree-walk (fresh each iteration, since
+    // the previous iteration's rebuilds are this one's origins): every
+    // occurrence of a shared predicate `Rc` in the tree simplifies once and
+    // stays shared. A fresh memo *per node* (the previous shape) re-shared only
+    // within a node and split the sharing across the tree.
+    loop {
+        let mut memo = PredMemo::new();
+        if !simplify_once(&mut expr, &mut memo).0 {
+            break;
+        }
+    }
     expr
 }
 
@@ -137,7 +145,7 @@ pub fn simplify(mut expr: Expr) -> Expr {
 ///   Passing it to [`apply_simplification_rules`] lets the discard-rule guard
 ///   read it in O(1) instead of re-scanning the whole subtree at every node —
 ///   the re-scan was O(n²) over the long compose chains planning emits.
-fn simplify_once(expr: &mut Expr) -> (bool, bool) {
+fn simplify_once(expr: &mut Expr, memo: &mut PredMemo) -> (bool, bool) {
     let mut changed = false;
     // A refinement's predicate is itself an immutable `Expr`; simplify *every*
     // predicate reachable from this node's type, rebuilding each as a fresh
@@ -148,10 +156,10 @@ fn simplify_once(expr: &mut Expr) -> (bool, bool) {
     // occurrences that shared a predicate term. A predicate's own iteration-containment is
     // irrelevant to the term-tree guard (`iterate` sources live in the term
     // tree, never inside predicates), so the iteration bit is discarded here.
-    walk_refined_predicates_mut(&mut expr.ty, &mut HashMap::new(), &mut |pred, _| {
-        changed |= simplify_once(pred).0;
+    walk_refined_predicates_mut(&mut expr.ty, memo, &mut |pred, memo| {
+        changed |= simplify_once(pred, memo).0;
     });
-    let (children_changed, children_have_iteration) = recurse_simplify(expr);
+    let (children_changed, children_have_iteration) = recurse_simplify(expr, memo);
     changed |= children_changed;
     let contains_iteration = children_have_iteration || is_iteration(expr);
     changed |= apply_simplification_rules(expr, contains_iteration);
@@ -163,9 +171,9 @@ fn simplify_once(expr: &mut Expr) -> (bool, bool) {
 /// Returns `(changed, contains_iteration)`: whether any child was modified,
 /// and whether any child's subtree contains an `iterate` source (OR-ed up so
 /// the parent need not re-scan its descendants).
-fn recurse_simplify(expr: &mut Expr) -> (bool, bool) {
+fn recurse_simplify(expr: &mut Expr, memo: &mut PredMemo) -> (bool, bool) {
     let (mut changed, has_iteration) = expr.fold_children_mut((false, false), |(c, it), e| {
-        let (child_changed, child_has_iteration) = simplify_once(e);
+        let (child_changed, child_has_iteration) = simplify_once(e, memo);
         (c | child_changed, it | child_has_iteration)
     });
     // After simplifying children, propagate the Let body's type up to the Let

--- a/src/ccl/simplify.rs
+++ b/src/ccl/simplify.rs
@@ -157,7 +157,12 @@ fn simplify_once(expr: &mut Expr, memo: &mut PredMemo) -> (bool, bool) {
     // irrelevant to the term-tree guard (`iterate` sources live in the term
     // tree, never inside predicates), so the iteration bit is discarded here.
     walk_refined_predicates_mut(&mut expr.ty, memo, &mut |pred, memo| {
-        changed |= simplify_once(pred, memo).0;
+        let pred_changed = simplify_once(pred, memo).0;
+        changed |= pred_changed;
+        // Reporting "unchanged" keeps the origin `Rc` in the slot, so a predicate
+        // simplify has nothing to say about stays pointer-shared with every other
+        // occurrence — including ones in nodes this walk never reaches.
+        pred_changed
     });
     let (children_changed, children_have_iteration) = recurse_simplify(expr, memo);
     changed |= children_changed;

--- a/src/ccl/simplify.rs
+++ b/src/ccl/simplify.rs
@@ -161,6 +161,15 @@ fn simplify_once(expr: &mut Expr, memo: &PredMemo) -> (bool, bool) {
     // re-pointing a slot is another that the callback cannot observe (see
     // `walk_refined_predicates_mut`). Feeding only the callback's bit into the
     // fixpoint would let a re-pointing go unnoticed for an iteration.
+    // `expr.ty` only, and not [`Expr::walk_type_slots_mut`] like the other
+    // rewriting passes. Two structural facts make the other slots empty *here*: this
+    // runs after lambda elimination, which has removed the `Lambda` nodes whose
+    // `param.ty` would carry a domain refinement, and `lambda_elim::run` follows it
+    // with `sync_cast_targets`, which re-points every `Cast`'s `target` at the
+    // node's own (already simplified) `ty` rather than needing it simplified
+    // separately. Measured across the suite, no node reaching this walk carries a
+    // refinement in a slot `expr.ty` does not reach; widening it costs ~30% of
+    // compile time on a nested comprehension and finds nothing.
     changed |= walk_refined_predicates_mut(&mut expr.ty, memo, &(), &mut |pred, memo| {
         // Reporting "unchanged" keeps the origin `Rc` in the slot, so a predicate
         // simplify has nothing to say about stays pointer-shared with every other

--- a/src/ccl/simplify.rs
+++ b/src/ccl/simplify.rs
@@ -127,8 +127,8 @@ pub fn simplify(mut expr: Expr) -> Expr {
     // stays shared. A fresh memo *per node* (the previous shape) re-shared only
     // within a node and split the sharing across the tree.
     loop {
-        let mut memo = PredMemo::new();
-        if !simplify_once(&mut expr, &mut memo).0 {
+        let memo = PredMemo::new();
+        if !simplify_once(&mut expr, &memo).0 {
             break;
         }
     }
@@ -145,7 +145,7 @@ pub fn simplify(mut expr: Expr) -> Expr {
 ///   Passing it to [`apply_simplification_rules`] lets the discard-rule guard
 ///   read it in O(1) instead of re-scanning the whole subtree at every node —
 ///   the re-scan was O(n²) over the long compose chains planning emits.
-fn simplify_once(expr: &mut Expr, memo: &mut PredMemo) -> (bool, bool) {
+fn simplify_once(expr: &mut Expr, memo: &PredMemo) -> (bool, bool) {
     let mut changed = false;
     // A refinement's predicate is itself an immutable `Expr`; simplify *every*
     // predicate reachable from this node's type, rebuilding each as a fresh
@@ -161,7 +161,7 @@ fn simplify_once(expr: &mut Expr, memo: &mut PredMemo) -> (bool, bool) {
     // re-pointing a slot is another that the callback cannot observe (see
     // `walk_refined_predicates_mut`). Feeding only the callback's bit into the
     // fixpoint would let a re-pointing go unnoticed for an iteration.
-    changed |= walk_refined_predicates_mut(&mut expr.ty, memo, &mut |pred, memo| {
+    changed |= walk_refined_predicates_mut(&mut expr.ty, memo, &(), &mut |pred, memo| {
         // Reporting "unchanged" keeps the origin `Rc` in the slot, so a predicate
         // simplify has nothing to say about stays pointer-shared with every other
         // occurrence — including ones in nodes this walk never reaches.
@@ -179,7 +179,7 @@ fn simplify_once(expr: &mut Expr, memo: &mut PredMemo) -> (bool, bool) {
 /// Returns `(changed, contains_iteration)`: whether any child was modified,
 /// and whether any child's subtree contains an `iterate` source (OR-ed up so
 /// the parent need not re-scan its descendants).
-fn recurse_simplify(expr: &mut Expr, memo: &mut PredMemo) -> (bool, bool) {
+fn recurse_simplify(expr: &mut Expr, memo: &PredMemo) -> (bool, bool) {
     let (mut changed, has_iteration) = expr.fold_children_mut((false, false), |(c, it), e| {
         let (child_changed, child_has_iteration) = simplify_once(e, memo);
         (c | child_changed, it | child_has_iteration)

--- a/src/ccl/simplify.rs
+++ b/src/ccl/simplify.rs
@@ -161,21 +161,23 @@ fn simplify_once(expr: &mut Expr, memo: &PredMemo) -> (bool, bool) {
     // re-pointing a slot is another that the callback cannot observe (see
     // `walk_refined_predicates_mut`). Feeding only the callback's bit into the
     // fixpoint would let a re-pointing go unnoticed for an iteration.
-    // `expr.ty` only, and not [`Expr::walk_type_slots_mut`] like the other
-    // rewriting passes. Two structural facts make the other slots empty *here*: this
-    // runs after lambda elimination, which has removed the `Lambda` nodes whose
-    // `param.ty` would carry a domain refinement, and `lambda_elim::run` follows it
-    // with `sync_cast_targets`, which re-points every `Cast`'s `target` at the
-    // node's own (already simplified) `ty` rather than needing it simplified
-    // separately. Measured across the suite, no node reaching this walk carries a
-    // refinement in a slot `expr.ty` does not reach; widening it costs ~30% of
-    // compile time on a nested comprehension and finds nothing.
-    changed |= walk_refined_predicates_mut(&mut expr.ty, memo, &(), &mut |pred, memo| {
-        // Reporting "unchanged" keeps the origin `Rc` in the slot, so a predicate
-        // simplify has nothing to say about stays pointer-shared with every other
-        // occurrence — including ones in nodes this walk never reaches.
-        simplify_once(pred, memo).0
+    // Every type slot the node carries, like the other rewriting passes. `expr.ty`
+    // alone is not enough: a `Let` binding's declared type routinely carries a
+    // literal singleton (`x := 0` gives `let x : 0 = 0`), and an unvisited
+    // occurrence keeps its origin `Rc` while a visited sibling moves to the
+    // rebuild — a split, in the pass whose output the post-pass `typecheck`
+    // compares by structural refinement equality.
+    let mut slot_changed = false;
+    expr.walk_type_slots_mut(|ty| {
+        slot_changed |= walk_refined_predicates_mut(ty, memo, &(), &mut |pred, memo| {
+            // Reporting "unchanged" keeps the origin `Rc` in the slot, so a
+            // predicate simplify has nothing to say about stays pointer-shared with
+            // every other occurrence — including ones in nodes this walk never
+            // reaches.
+            simplify_once(pred, memo).0
+        });
     });
+    changed |= slot_changed;
     let (children_changed, children_have_iteration) = recurse_simplify(expr, memo);
     changed |= children_changed;
     let contains_iteration = children_have_iteration || is_iteration(expr);

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -41,10 +41,15 @@
 //!   `Rc`, exactly as transport mode does.
 //!
 //! Both modes share the same discipline: a
-//! [`PredMemo`](crate::ccl::ccl_utils::PredMemo) keyed on the origin predicate's
-//! identity re-points every occurrence that shared one predicate term at the
-//! *same* result, so one rewrite is observed uniformly across the aliases and
-//! occurrences that entered a rewrite sharing one `Rc` leave sharing one `Rc`.
+//! [`PredMemo`](crate::ccl::ccl_utils::PredMemo) re-points every occurrence that
+//! shared one predicate term at the *same* result, so one rewrite is observed
+//! uniformly across the aliases and occurrences that entered sharing one `Rc` leave
+//! sharing one `Rc`. Its context (`C`) is **the active substitution**: an entry is
+//! reused only for an occurrence under the same one, so a rebuild made outside a
+//! scope that rebinds a substituted variable is never served to an occurrence
+//! inside it. That is what makes threading a single memo across binder crossings
+//! correct — acting differently in different scopes is the whole job of a
+//! substitution, so scope cannot be left out of the key.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
@@ -532,7 +537,7 @@ impl Subst {
         if self.is_id() {
             return;
         }
-        self.rewrite_expr_go(e, &mut PredMemo::new());
+        self.rewrite_expr_go(e, &PredMemo::new());
     }
 
     /// Discharge `binder ↦ term` over `e` **in place**, cloning `term` only
@@ -548,7 +553,7 @@ impl Subst {
         Subst::discharge(binder.clone(), term.clone()).rewrite_expr(e);
     }
 
-    fn rewrite_expr_go(&self, e: &mut TypedExpr, memo: &mut PredMemo) {
+    fn rewrite_expr_go(&self, e: &mut TypedExpr, memo: &PredMemo<Subst>) {
         // Inert subtree (no substituted binder free in value or type slots):
         // leave it untouched — predicates in particular stay un-rebuilt,
         // mirroring the transport mode's `Rc`-sharing guarantee.
@@ -619,12 +624,10 @@ impl Subst {
                 for (b, _) in bindings.iter() {
                     inner.assert_no_capture(&b.name);
                 }
-                self.recurse_shrunk(&inner, memo, |s, m| {
-                    for (_, def) in bindings.iter_mut() {
-                        s.rewrite_expr_go(def, m);
-                    }
-                    s.rewrite_expr_go(body, m);
-                });
+                for (_, def) in bindings.iter_mut() {
+                    inner.rewrite_expr_go(def, memo);
+                }
+                inner.rewrite_expr_go(body, memo);
             }
 
             TypedExprNode::Case {
@@ -642,10 +645,8 @@ impl Subst {
                     if let Some(p) = &b.pattern {
                         inner.assert_no_capture(&p.binding.name);
                     }
-                    self.recurse_shrunk(&inner, memo, |s, m| {
-                        s.rewrite_expr_go(&mut b.guard, m);
-                        s.rewrite_expr_go(&mut b.body, m);
-                    });
+                    inner.rewrite_expr_go(&mut b.guard, memo);
+                    inner.rewrite_expr_go(&mut b.body, memo);
                 }
             }
 
@@ -669,47 +670,13 @@ impl Subst {
 
     /// In-place analogue of [`Self::under_binder`]: shadow, assert
     /// no-capture, recurse into the binder's scope.
-    fn under_binder_mut(&self, binder: &Name, body: &mut TypedExpr, memo: &mut PredMemo) {
+    fn under_binder_mut(&self, binder: &Name, body: &mut TypedExpr, memo: &PredMemo<Subst>) {
         let restricted = self.shadow(binder);
         if !restricted.0.keys().any(|k| is_free(k, body)) {
             return;
         }
         restricted.assert_no_capture(binder);
-        self.recurse_shrunk(&restricted, memo, |s, m| s.rewrite_expr_go(body, m));
-    }
-
-    /// Recurse with `shrunk` in force, handing it `memo` **only if the
-    /// substitution did not actually change**.
-    ///
-    /// [`PredMemo`] is keyed on the predicate `Rc`'s address and nothing else, so
-    /// reusing a rebuild is sound only while everything else the transform depends
-    /// on is held fixed. For substitution that "everything else" is the active
-    /// substitution itself — and acting differently in different scopes is not an
-    /// incidental dependency, it is the *point*. A binder crossing that shadows a
-    /// substituted variable is precisely the substitution changing, so a memo
-    /// carried across it is wrong in both directions:
-    ///
-    /// - a rebuild recorded outside would be served to an occurrence inside, where
-    ///   the variable is rebound — discharging a binder the inner scope owns;
-    /// - a `finish_unchanged` recorded inside, where the substitution is inert,
-    ///   would tell a later occurrence outside that there is nothing to do.
-    ///
-    /// Scoping the memo to the substitution keeps the transform key-determined
-    /// *within* each memo, which is the property [`PredMemo`] requires, rather
-    /// than widening the key to carry a whole `Subst`. Sharing is unaffected in the
-    /// common case: with no shadowing, `shrunk == *self` and one memo spans the
-    /// whole walk.
-    fn recurse_shrunk(
-        &self,
-        shrunk: &Subst,
-        memo: &mut PredMemo,
-        f: impl FnOnce(&Subst, &mut PredMemo),
-    ) {
-        if shrunk == self {
-            f(shrunk, memo);
-        } else {
-            f(shrunk, &mut PredMemo::new());
-        }
+        restricted.rewrite_expr_go(body, memo);
     }
 
     /// The Barendregt no-capture invariant at a binder crossing (see
@@ -730,10 +697,10 @@ impl Subst {
         if self.is_id() {
             return;
         }
-        self.rewrite_type_go(ty, &mut PredMemo::new());
+        self.rewrite_type_go(ty, &PredMemo::new());
     }
 
-    fn rewrite_type_go(&self, ty: &mut Type, memo: &mut PredMemo) {
+    fn rewrite_type_go(&self, ty: &mut Type, memo: &PredMemo<Subst>) {
         match ty {
             Type::Base(_)
             | Type::UIntRange(_)
@@ -773,42 +740,32 @@ impl Subst {
                 self.rewrite_type_go(domain, memo);
                 let restricted = self.shadow(b);
                 restricted.assert_no_capture(b);
-                self.recurse_shrunk(&restricted, memo, |s, m| s.rewrite_type_go(codomain, m));
+                restricted.rewrite_type_go(codomain, memo);
             }
 
             Type::Refinement(base, r) => {
-                // A memo hit re-points at the single rebuild; on a miss, decide
-                // whether this substitution has anything to do here at all.
-                if let Some((origin, mut pred)) = memo.begin(r) {
-                    // The refinement implicitly binds REFINEMENT_BINDER in its
-                    // bare predicate, so the substitution acts *under* that
-                    // binder. Cloning the map is only worth it on the paths that
-                    // use it — not on the memo-hit path above. (In practice this
-                    // never shrinks — `REFINEMENT_BINDER` is reserved and no
-                    // `Subst` maps it — but it goes through `recurse_shrunk` so
-                    // the invariant holds by construction at every crossing
-                    // rather than by that argument.)
-                    let restricted = self.shadow(&Name::elem());
-                    if restricted.0.keys().any(|k| is_free(k, &pred)) {
-                        self.recurse_shrunk(&restricted, memo, |s, m| {
-                            s.rewrite_expr_go(&mut pred, m)
-                        });
-                        memo.finish(r, origin, pred);
-                    } else {
-                        // Vacuous — no substituted binder occurs free in the
-                        // predicate — so keep the origin `Rc`, leaving a
-                        // predicate this substitution doesn't touch *shared*
-                        // across its occurrences (mirrors
-                        // [`Self::force_refinement`]'s transport path). Without
-                        // it, every `substitute` in a pass like `lambda_elim`
-                        // would rebuild every predicate it merely walks past into
-                        // a fresh `Rc`, splitting the sharing inference
-                        // established. Recording it also makes the `is_free` scan
-                        // above run once per *distinct* predicate rather than
-                        // once per occurrence.
-                        memo.finish_unchanged(r, origin);
+                // The refinement implicitly binds REFINEMENT_BINDER in its bare
+                // predicate, so the substitution acts *under* that binder.
+                let restricted = self.shadow(&Name::elem());
+                // `restricted` is the memo's context: an entry is reused only for
+                // an occurrence under the *same* active substitution, so a rebuild
+                // made outside a scope that shadows a substituted binder is never
+                // served to an occurrence inside it (and a vacuous decision made
+                // inside is never served outside). That is what makes threading one
+                // memo across binder crossings correct — see `PredMemo`.
+                memo.rebuild(r, &restricted, |pred| {
+                    if !restricted.0.keys().any(|k| is_free(k, pred)) {
+                        // Vacuous: no substituted binder occurs free here, so report
+                        // no change and keep the origin `Rc` — a predicate this
+                        // substitution merely walks past stays shared with its other
+                        // occurrences (mirroring `force_refinement`'s transport
+                        // path). Memoizing the decision also makes this `is_free`
+                        // scan run once per distinct predicate, not per occurrence.
+                        return false;
                     }
-                }
+                    restricted.rewrite_expr_go(pred, memo);
+                    true
+                });
                 self.rewrite_type_go(base, memo);
             }
 

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -565,15 +565,18 @@ impl Subst {
             *e = repl.as_expr();
             return;
         }
-        self.rewrite_type_go(&mut e.ty, memo);
-        if let Some(ann) = &mut e.user_annotation {
-            self.rewrite_type_go(ann, memo);
-        }
+        // *Every* type slot the node carries, not just `ty` and the annotation: a
+        // `Cast`'s `target` and each binder's declared type hold their own
+        // predicate `Rc`s, so rewriting only `ty` leaves those stale against it —
+        // the same defect the retype walk had. A binder's own type is in the
+        // *enclosing* scope (a binder does not bind in its own type), so the
+        // unrestricted substitution is the right one for it, and the binder
+        // crossings below still only guard the children.
+        e.walk_type_slots_mut(|ty| self.rewrite_type_go(ty, memo));
         match &mut e.node {
             TypedExprNode::Var(_) => {}
 
-            TypedExprNode::Cast { value, target } => {
-                self.rewrite_type_go(target, memo);
+            TypedExprNode::Cast { value, .. } => {
                 self.rewrite_expr_go(value, memo);
             }
 
@@ -585,9 +588,10 @@ impl Subst {
             }
 
             TypedExprNode::Lambda { param, body } => {
-                // The param's domain refinement is reached through `e.ty`'s
-                // `Fun` domain (rewritten above, rebuilding the predicate via
-                // `memo`); only the body is under the binder here.
+                // `param.ty` was rewritten with the node's other type slots above
+                // — it is an independent `Rc` from the one on `e.ty`'s `Fun`
+                // domain, so it needs its own visit. Only the body is under the
+                // binder.
                 self.under_binder_mut(&param.name, body, memo);
             }
 
@@ -615,10 +619,12 @@ impl Subst {
                 for (b, _) in bindings.iter() {
                     inner.assert_no_capture(&b.name);
                 }
-                for (_, def) in bindings.iter_mut() {
-                    inner.rewrite_expr_go(def, memo);
-                }
-                inner.rewrite_expr_go(body, memo);
+                self.recurse_shrunk(&inner, memo, |s, m| {
+                    for (_, def) in bindings.iter_mut() {
+                        s.rewrite_expr_go(def, m);
+                    }
+                    s.rewrite_expr_go(body, m);
+                });
             }
 
             TypedExprNode::Case {
@@ -636,8 +642,10 @@ impl Subst {
                     if let Some(p) = &b.pattern {
                         inner.assert_no_capture(&p.binding.name);
                     }
-                    inner.rewrite_expr_go(&mut b.guard, memo);
-                    inner.rewrite_expr_go(&mut b.body, memo);
+                    self.recurse_shrunk(&inner, memo, |s, m| {
+                        s.rewrite_expr_go(&mut b.guard, m);
+                        s.rewrite_expr_go(&mut b.body, m);
+                    });
                 }
             }
 
@@ -667,7 +675,41 @@ impl Subst {
             return;
         }
         restricted.assert_no_capture(binder);
-        restricted.rewrite_expr_go(body, memo);
+        self.recurse_shrunk(&restricted, memo, |s, m| s.rewrite_expr_go(body, m));
+    }
+
+    /// Recurse with `shrunk` in force, handing it `memo` **only if the
+    /// substitution did not actually change**.
+    ///
+    /// [`PredMemo`] is keyed on the predicate `Rc`'s address and nothing else, so
+    /// reusing a rebuild is sound only while everything else the transform depends
+    /// on is held fixed. For substitution that "everything else" is the active
+    /// substitution itself — and acting differently in different scopes is not an
+    /// incidental dependency, it is the *point*. A binder crossing that shadows a
+    /// substituted variable is precisely the substitution changing, so a memo
+    /// carried across it is wrong in both directions:
+    ///
+    /// - a rebuild recorded outside would be served to an occurrence inside, where
+    ///   the variable is rebound — discharging a binder the inner scope owns;
+    /// - a `finish_unchanged` recorded inside, where the substitution is inert,
+    ///   would tell a later occurrence outside that there is nothing to do.
+    ///
+    /// Scoping the memo to the substitution keeps the transform key-determined
+    /// *within* each memo, which is the property [`PredMemo`] requires, rather
+    /// than widening the key to carry a whole `Subst`. Sharing is unaffected in the
+    /// common case: with no shadowing, `shrunk == *self` and one memo spans the
+    /// whole walk.
+    fn recurse_shrunk(
+        &self,
+        shrunk: &Subst,
+        memo: &mut PredMemo,
+        f: impl FnOnce(&Subst, &mut PredMemo),
+    ) {
+        if shrunk == self {
+            f(shrunk, memo);
+        } else {
+            f(shrunk, &mut PredMemo::new());
+        }
     }
 
     /// The Barendregt no-capture invariant at a binder crossing (see
@@ -731,7 +773,7 @@ impl Subst {
                 self.rewrite_type_go(domain, memo);
                 let restricted = self.shadow(b);
                 restricted.assert_no_capture(b);
-                restricted.rewrite_type_go(codomain, memo);
+                self.recurse_shrunk(&restricted, memo, |s, m| s.rewrite_type_go(codomain, m));
             }
 
             Type::Refinement(base, r) => {
@@ -741,10 +783,16 @@ impl Subst {
                     // The refinement implicitly binds REFINEMENT_BINDER in its
                     // bare predicate, so the substitution acts *under* that
                     // binder. Cloning the map is only worth it on the paths that
-                    // use it — not on the memo-hit path above.
+                    // use it — not on the memo-hit path above. (In practice this
+                    // never shrinks — `REFINEMENT_BINDER` is reserved and no
+                    // `Subst` maps it — but it goes through `recurse_shrunk` so
+                    // the invariant holds by construction at every crossing
+                    // rather than by that argument.)
                     let restricted = self.shadow(&Name::elem());
                     if restricted.0.keys().any(|k| is_free(k, &pred)) {
-                        restricted.rewrite_expr_go(&mut pred, memo);
+                        self.recurse_shrunk(&restricted, memo, |s, m| {
+                            s.rewrite_expr_go(&mut pred, m)
+                        });
                         memo.finish(r, origin, pred);
                     } else {
                         // Vacuous — no substituted binder occurs free in the

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -36,15 +36,20 @@
 //!   stays intact and the common case allocates nothing).
 //! * **In-place rewrite** ([`Subst::rewrite_expr`]) mutates the *term tree* the
 //!   caller owns (lambda elimination, inlining, defer desugaring, lowering's
-//!   uncurrying), but still rebuilds each predicate as a fresh `Rc`. A `memo`
-//!   keyed on the original predicate's identity re-points every occurrence
-//!   that shared one predicate term in the tree at the *same* rebuilt term, so
-//!   one rewrite is observed uniformly across the aliases.
+//!   uncurrying). A predicate the substitution actually touches is rebuilt as a
+//!   fresh `Rc`; one it doesn't — no substituted binder free in it — keeps its
+//!   `Rc`, exactly as transport mode does.
+//!
+//! Both modes share the same discipline: a
+//! [`PredMemo`](crate::ccl::ccl_utils::PredMemo) keyed on the origin predicate's
+//! identity re-points every occurrence that shared one predicate term at the
+//! *same* result, so one rewrite is observed uniformly across the aliases and
+//! occurrences that entered a rewrite sharing one `Rc` leave sharing one `Rc`.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
-use crate::ccl::ccl_utils::is_free;
+use crate::ccl::ccl_utils::{PredMemo, is_free};
 use crate::ccl::{Branch, Name, PredicateId, Type, TypedExpr, TypedExprNode};
 
 /// A term binder name.
@@ -527,7 +532,7 @@ impl Subst {
         if self.is_id() {
             return;
         }
-        self.rewrite_expr_go(e, &mut BTreeMap::new());
+        self.rewrite_expr_go(e, &mut PredMemo::new());
     }
 
     /// Discharge `binder ↦ term` over `e` **in place**, cloning `term` only
@@ -543,7 +548,7 @@ impl Subst {
         Subst::discharge(binder.clone(), term.clone()).rewrite_expr(e);
     }
 
-    fn rewrite_expr_go(&self, e: &mut TypedExpr, memo: &mut BTreeMap<PredicateId, Rc<TypedExpr>>) {
+    fn rewrite_expr_go(&self, e: &mut TypedExpr, memo: &mut PredMemo) {
         // Inert subtree (no substituted binder free in value or type slots):
         // leave it untouched — predicates in particular stay un-rebuilt,
         // mirroring the transport mode's `Rc`-sharing guarantee.
@@ -656,12 +661,7 @@ impl Subst {
 
     /// In-place analogue of [`Self::under_binder`]: shadow, assert
     /// no-capture, recurse into the binder's scope.
-    fn under_binder_mut(
-        &self,
-        binder: &Name,
-        body: &mut TypedExpr,
-        memo: &mut BTreeMap<PredicateId, Rc<TypedExpr>>,
-    ) {
+    fn under_binder_mut(&self, binder: &Name, body: &mut TypedExpr, memo: &mut PredMemo) {
         let restricted = self.shadow(binder);
         if !restricted.0.keys().any(|k| is_free(k, body)) {
             return;
@@ -688,10 +688,10 @@ impl Subst {
         if self.is_id() {
             return;
         }
-        self.rewrite_type_go(ty, &mut BTreeMap::new());
+        self.rewrite_type_go(ty, &mut PredMemo::new());
     }
 
-    fn rewrite_type_go(&self, ty: &mut Type, memo: &mut BTreeMap<PredicateId, Rc<TypedExpr>>) {
+    fn rewrite_type_go(&self, ty: &mut Type, memo: &mut PredMemo) {
         match ty {
             Type::Base(_)
             | Type::UIntRange(_)
@@ -735,28 +735,31 @@ impl Subst {
             }
 
             Type::Refinement(base, r) => {
-                let original = r.predicate_id();
-                // The refinement implicitly binds REFINEMENT_BINDER in its bare
-                // predicate, so the substitution acts *under* that binder.
-                let restricted = self.shadow(&Name::elem());
-                if let Some(rebuilt) = memo.get(&original) {
-                    r.predicate = Rc::clone(rebuilt);
-                } else if !restricted.0.keys().any(|k| is_free(k, &r.predicate)) {
-                    // Vacuous — no substituted binder occurs free in the
-                    // predicate — so keep the original `Rc`, leaving a predicate
-                    // this substitution doesn't touch *shared* across its
-                    // occurrences (mirrors [`Self::force_refinement`]'s transport
-                    // path). Without this, every `substitute` in a pass like
-                    // `lambda_elim` would rebuild every predicate it merely walks
-                    // past into a fresh `Rc`, splitting the sharing inference
-                    // established — the regression [`crate::ccl::ccl_utils::PredMemo`]
-                    // prevents on the memo side, here on the in-place-rewrite side.
-                } else {
-                    let mut pred = (*r.predicate).clone();
-                    restricted.rewrite_expr_go(&mut pred, memo);
-                    let rebuilt = Rc::new(pred);
-                    memo.insert(original, Rc::clone(&rebuilt));
-                    r.predicate = rebuilt;
+                // A memo hit re-points at the single rebuild; on a miss, decide
+                // whether this substitution has anything to do here at all.
+                if let Some((origin, mut pred)) = memo.begin(r) {
+                    // The refinement implicitly binds REFINEMENT_BINDER in its
+                    // bare predicate, so the substitution acts *under* that
+                    // binder. Cloning the map is only worth it on the paths that
+                    // use it — not on the memo-hit path above.
+                    let restricted = self.shadow(&Name::elem());
+                    if restricted.0.keys().any(|k| is_free(k, &pred)) {
+                        restricted.rewrite_expr_go(&mut pred, memo);
+                        memo.finish(r, origin, pred);
+                    } else {
+                        // Vacuous — no substituted binder occurs free in the
+                        // predicate — so keep the origin `Rc`, leaving a
+                        // predicate this substitution doesn't touch *shared*
+                        // across its occurrences (mirrors
+                        // [`Self::force_refinement`]'s transport path). Without
+                        // it, every `substitute` in a pass like `lambda_elim`
+                        // would rebuild every predicate it merely walks past into
+                        // a fresh `Rc`, splitting the sharing inference
+                        // established. Recording it also makes the `is_free` scan
+                        // above run once per *distinct* predicate rather than
+                        // once per occurrence.
+                        memo.finish_unchanged(r, origin);
+                    }
                 }
                 self.rewrite_type_go(base, memo);
             }
@@ -841,9 +844,10 @@ impl Subst {
                 );
             }
         }
-        let mut r2 = r.clone();
-        r2.predicate = Rc::new(new_pred);
-        r2
+        // A substituted predicate is a genuinely new term (the transport mode
+        // builds rather than rewrites), so `born` is the right spelling; the
+        // vacuous case returned above kept the source's `Rc` instead.
+        crate::ccl::Refinement::born(Rc::new(new_pred))
     }
 
     /// This substitution with `binder` removed from its source domain (the
@@ -1213,9 +1217,7 @@ mod tests {
     fn type_slot_occurrence_is_discharged() {
         use std::rc::Rc;
         // y : {_ | k > 0} — `k` appears only in the type slot's predicate.
-        let slot_ref = Refinement {
-            predicate: Rc::new(gt(var("k"), int(0))),
-        };
+        let slot_ref = Refinement::born(Rc::new(gt(var("k"), int(0))));
         let e = var("y").with_ty(Type::Refinement(Box::new(Type::Hole), slot_ref.clone()));
         let dis = Subst::discharge("k", int(5));
 
@@ -1236,9 +1238,7 @@ mod tests {
 
         // force_refinement on a predicate whose *sub-expression type*
         // mentions `k` is no longer vacuous: the nested slot is rewritten.
-        let outer = Refinement {
-            predicate: Rc::new(e),
-        };
+        let outer = Refinement::born(Rc::new(e));
         let forced = dis.force_refinement(&outer);
         assert!(!Rc::ptr_eq(&forced.predicate, &outer.predicate));
         let forced_pred = &*forced.predicate;
@@ -1278,12 +1278,7 @@ mod tests {
     #[test]
     fn scenario_f_context_check() {
         let pred = TypedExpr::lambda("y", Type::Hole, gt(var("y"), var("k")));
-        let bad = Type::Refinement(
-            Box::new(Type::infer()),
-            Refinement {
-                predicate: Rc::new(pred),
-            },
-        );
+        let bad = Type::Refinement(Box::new(Type::infer()), Refinement::born(Rc::new(pred)));
         let only_x: BTreeSet<Binder> = [Name::raw("x")].into_iter().collect();
         let only_k: BTreeSet<Binder> = [Name::raw("k")].into_iter().collect();
         assert!(!well_formed(&bad, &only_x));
@@ -1308,9 +1303,7 @@ mod tests {
     // outer binder — the dependent-application shape `g(5)`.
     #[test]
     fn apply_type_discharges_refinement_predicate() {
-        let r = Refinement {
-            predicate: Rc::new(gt(var("i"), var("k"))),
-        };
+        let r = Refinement::born(Rc::new(gt(var("i"), var("k"))));
         let ty = Type::fun(Type::Refinement(Box::new(Type::infer()), r), Type::infer());
         let out = Subst::discharge("k", int(5)).apply_type(&ty);
         let Type::Fun { domain, .. } = &out else {
@@ -1326,9 +1319,7 @@ mod tests {
     // rebinds k.
     #[test]
     fn apply_type_shadows_pi_binder() {
-        let r = Refinement {
-            predicate: Rc::new(gt(var("i"), var("k"))),
-        };
+        let r = Refinement::born(Rc::new(gt(var("i"), var("k"))));
         // (k: _) ⇒ {i | i > k} ⇒ _  — the inner k is bound by the Pi.
         let inner = Type::fun(Type::Refinement(Box::new(Type::infer()), r), Type::infer());
         let ty = Type::pi("k", Type::infer(), inner);
@@ -1373,18 +1364,8 @@ mod rewrite_tests {
         let shared = Rc::new(gt(var("k"), int(0)));
         // Two refinement occurrences sharing one predicate term, both inside a
         // single type (a function's domain and codomain).
-        let dom = Type::Refinement(
-            Box::new(Type::Hole),
-            Refinement {
-                predicate: Rc::clone(&shared),
-            },
-        );
-        let cod = Type::Refinement(
-            Box::new(Type::Hole),
-            Refinement {
-                predicate: Rc::clone(&shared),
-            },
-        );
+        let dom = Type::Refinement(Box::new(Type::Hole), Refinement::sharing(&shared));
+        let cod = Type::Refinement(Box::new(Type::Hole), Refinement::sharing(&shared));
         let mut e = var("y").with_ty(Type::fun(dom, cod));
 
         Subst::discharge("k", int(5)).rewrite_expr(&mut e);

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -736,13 +736,24 @@ impl Subst {
 
             Type::Refinement(base, r) => {
                 let original = r.predicate_id();
+                // The refinement implicitly binds REFINEMENT_BINDER in its bare
+                // predicate, so the substitution acts *under* that binder.
+                let restricted = self.shadow(&Name::elem());
                 if let Some(rebuilt) = memo.get(&original) {
                     r.predicate = Rc::clone(rebuilt);
+                } else if !restricted.0.keys().any(|k| is_free(k, &r.predicate)) {
+                    // Vacuous — no substituted binder occurs free in the
+                    // predicate — so keep the original `Rc`, leaving a predicate
+                    // this substitution doesn't touch *shared* across its
+                    // occurrences (mirrors [`Self::force_refinement`]'s transport
+                    // path). Without this, every `substitute` in a pass like
+                    // `lambda_elim` would rebuild every predicate it merely walks
+                    // past into a fresh `Rc`, splitting the sharing inference
+                    // established — the regression [`crate::ccl::ccl_utils::PredMemo`]
+                    // prevents on the memo side, here on the in-place-rewrite side.
                 } else {
-                    // The refinement implicitly binds REFINEMENT_BINDER in
-                    // its bare predicate, so rewrite under that binder.
                     let mut pred = (*r.predicate).clone();
-                    self.shadow(&Name::elem()).rewrite_expr_go(&mut pred, memo);
+                    restricted.rewrite_expr_go(&mut pred, memo);
                     let rebuilt = Rc::new(pred);
                     memo.insert(original, Rc::clone(&rebuilt));
                     r.predicate = rebuilt;

--- a/src/ccl/symbolic.rs
+++ b/src/ccl/symbolic.rs
@@ -800,9 +800,7 @@ in x"
             "x",
             Type::Refinement(
                 Box::new(Type::Base(BaseType::Int)),
-                Refinement {
-                    predicate: Rc::new(Expr::lit(Lit::Bool(true))),
-                },
+                Refinement::born(Rc::new(Expr::lit(Lit::Bool(true)))),
             ),
             Expr::var("x"),
         ),

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -658,6 +658,20 @@ impl Refinement {
         Refinement { predicate }
     }
 
+    /// Construct a refinement **deliberately sharing** an existing predicate
+    /// term: a second occurrence of *the same* refinement, in another type slot.
+    /// This is what lowering does when one filtered domain rides a source, a map,
+    /// a cast target, and a consumer contract — one allocation, several slots —
+    /// and it is the sharing every rebuilding pass then has to preserve.
+    ///
+    /// Distinct from [`born`](Self::born) in intent, not mechanism: `born` says
+    /// "this predicate did not exist before", this says "this predicate already
+    /// exists and I mean to alias it". Together they are the only two spellings —
+    /// a `Refinement { predicate }` literal states neither.
+    pub fn sharing(predicate: &Rc<TypedExpr>) -> Self {
+        Refinement::born(Rc::clone(predicate))
+    }
+
     /// The [`PredicateId`] of this refinement's predicate term.
     pub fn predicate_id(&self) -> PredicateId {
         Rc::as_ptr(&self.predicate)
@@ -989,9 +1003,7 @@ mod tests {
                 ccl_utils::refined_fn_type(Type::Hole, filter(op), Type::Hole),
             )
         };
-        let refinement = |pred: TypedExpr| Refinement {
-            predicate: Rc::new(pred),
-        };
+        let refinement = |pred: TypedExpr| Refinement::born(Rc::new(pred));
 
         let gt = refinement(cast_pred(CompareKind::Greater));
         let gt_twin = refinement(cast_pred(CompareKind::Greater));

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -613,6 +613,18 @@ pub struct Refinement {
     /// `Rc` sharing keeps that cheap); nothing mutates a predicate in place,
     /// so a predicate that flows around is never resolved out from under a
     /// hash key.
+    ///
+    /// **Rewriting predicates in a pass? Do not assign a freshly-built `Rc`
+    /// here per occurrence.** One predicate term rides many type slots as a
+    /// *shared* `Rc` (a comprehension's filtered domain appears on its source,
+    /// map, cast, and consumer-contract types); rebuilding each occurrence
+    /// independently splits that sharing, and while that's invisible to
+    /// correctness it makes planning recompile one predicate once per
+    /// occurrence — superlinearly, on nested comprehensions. Route rewrites
+    /// through [`crate::ccl::ccl_utils::walk_refined_predicates_mut`] /
+    /// [`crate::ccl::ccl_utils::PredMemo`], which preserve the sharing across a
+    /// pass. Use [`Refinement::born`] only for a genuinely *new* predicate.
+    /// Guarded by `tests/predicate_sharing.rs`.
     pub predicate: Rc<TypedExpr>,
 }
 
@@ -634,6 +646,18 @@ pub type PredicateId = *const TypedExpr;
 pub const REFINEMENT_BINDER: &str = "__elem";
 
 impl Refinement {
+    /// Construct a refinement over a **genuinely new** predicate term — one this
+    /// call site is *creating*, with no prior refinement identity to preserve
+    /// (a freshly-emitted filter, a synthesized loop-join condition, a compiled
+    /// predicate). Prefer this to a `Refinement { predicate }` literal so the
+    /// intent is legible: `born` is *wrong* for a **rewrite** of an existing
+    /// predicate, which must instead flow through
+    /// [`crate::ccl::ccl_utils::PredMemo`] to keep occurrences that shared one
+    /// `Rc` sharing one `Rc` (see the note on [`Refinement::predicate`]).
+    pub fn born(predicate: Rc<TypedExpr>) -> Self {
+        Refinement { predicate }
+    }
+
     /// The [`PredicateId`] of this refinement's predicate term.
     pub fn predicate_id(&self) -> PredicateId {
         Rc::as_ptr(&self.predicate)

--- a/src/ccl/uniquify.rs
+++ b/src/ccl/uniquify.rs
@@ -94,6 +94,19 @@ struct Uniquifier {
     /// discipline, without which overwriting `r.predicate` could free an address
     /// a later `Rc::new` in the same walk reclaims, colliding an unrelated
     /// predicate with this entry.
+    ///
+    /// **Why reusing an entry is sound here**, given that the transform resolves
+    /// free variables against `env` — context the memo key does not name (see
+    /// [`PredMemo`]'s note on key-determined transforms). Lowering shares a
+    /// predicate `Rc` across slots only by *copying one refinement*, and where it
+    /// copies an already-lowered subtree it runs this pass on that subtree
+    /// **before** cloning (see the module docs' "mint before copy"). So every
+    /// occurrence sharing an `Rc` either sits in one scope, or is a copy whose
+    /// binders are already minted and whose free variables therefore resolve the
+    /// same way wherever the copy lands. Two occurrences that *should* uniquify
+    /// differently — the same predicate spelling under two different bindings —
+    /// arrive as distinct `Rc`s, which is what the scope-blind-equality test at the
+    /// bottom of this file pins.
     memo: PredMemo,
 }
 

--- a/src/ccl/uniquify.rs
+++ b/src/ccl/uniquify.rs
@@ -33,7 +33,7 @@
 //! Predicates are immutable `Rc<TypedExpr>`, so uniquifying one **rebuilds**
 //! it. A predicate term shared by `Rc` across occurrences (lowering's clones
 //! share predicate terms deliberately) is rebuilt **once** — keyed by
-//! [`PredicateId`] in `memo` — and every occurrence is re-pointed at the same
+//! [`crate::ccl::PredicateId`] in `memo` — and every occurrence is re-pointed at the same
 //! rebuilt `Rc`, preserving the sharing.
 //!
 //! A variable that resolves to no binder is left raw — it is either a
@@ -59,16 +59,15 @@
 
 use std::collections::HashMap;
 
-use std::rc::Rc;
-
-use crate::ccl::{Expr, Name, PredicateId, Type, TypedBinding, TypedExprNode};
+use crate::ccl::ccl_utils::PredMemo;
+use crate::ccl::{Expr, Name, Type, TypedBinding, TypedExprNode};
 
 /// α-uniquify every binder in `expr` (see module docs). Runs once per
 /// program, immediately after lowering and before defer desugaring.
 pub fn run(mut expr: Expr) -> Expr {
     let mut u = Uniquifier {
         env: HashMap::new(),
-        memo: HashMap::new(),
+        memo: PredMemo::new(),
     };
     u.expr(&mut expr);
     debug_assert!(
@@ -90,15 +89,12 @@ struct Uniquifier {
     /// uniquified once, and every occurrence is re-pointed at the same
     /// rebuilt term.
     ///
-    /// The `keepalive` clone is load-bearing: [`Uniquifier::ty`] overwrites
-    /// `r.predicate` with the rebuilt result, which drops the *original* `Rc`
-    /// if this was its only strong reference. Without a clone held here, that
-    /// free can hand the address straight back to an unrelated `Rc::new`
-    /// later in the same walk, so a subsequent, unrelated predicate landing
-    /// on that address would collide with this entry and wrongly inherit its
-    /// `rebuilt` value — [`PredicateId`] is only a sound stand-in for
-    /// identity while the address it names cannot be reused.
-    memo: HashMap<PredicateId, (Rc<Expr>, Rc<Expr>)>,
+    /// Uniquification is a predicate-*rebuilding* pass like every other, so it
+    /// memoizes with the shared [`PredMemo`] — including its keepalive
+    /// discipline, without which overwriting `r.predicate` could free an address
+    /// a later `Rc::new` in the same walk reclaims, colliding an unrelated
+    /// predicate with this entry.
+    memo: PredMemo,
 }
 
 impl Uniquifier {
@@ -222,19 +218,11 @@ impl Uniquifier {
     /// (see module docs), with every occurrence re-pointed at the rebuilt `Rc`
     /// via `memo`.
     fn ty(&mut self, t: &mut Type) {
-        if let Type::Refinement(_, r) = t {
-            let original_rc = Rc::clone(&r.predicate);
-            let original = Rc::as_ptr(&original_rc);
-            if let Some((_, rebuilt)) = self.memo.get(&original) {
-                r.predicate = Rc::clone(rebuilt);
-            } else {
-                let mut pred = (*r.predicate).clone();
-                self.expr(&mut pred);
-                let rebuilt = Rc::new(pred);
-                self.memo
-                    .insert(original, (original_rc, Rc::clone(&rebuilt)));
-                r.predicate = rebuilt;
-            }
+        if let Type::Refinement(_, r) = t
+            && let Some((origin, mut pred)) = self.memo.begin(r)
+        {
+            self.expr(&mut pred);
+            self.memo.finish(r, origin, pred);
         }
         t.walk_children_mut(|c| self.ty(c));
     }

--- a/src/ccl/uniquify.rs
+++ b/src/ccl/uniquify.rs
@@ -231,11 +231,14 @@ impl Uniquifier {
     /// (see module docs), with every occurrence re-pointed at the rebuilt `Rc`
     /// via `memo`.
     fn ty(&mut self, t: &mut Type) {
-        if let Type::Refinement(_, r) = t
-            && let Some((origin, mut pred)) = self.memo.begin(r)
-        {
-            self.expr(&mut pred);
-            self.memo.finish(r, origin, pred);
+        if let Type::Refinement(_, r) = t {
+            // A handle clone, so `self` stays freely borrowable for the rebuild —
+            // which re-enters this same memo through `self.expr` → `self.ty`.
+            let memo = self.memo.clone();
+            memo.rebuild(r, &(), |pred| {
+                self.expr(pred);
+                true
+            });
         }
         t.walk_children_mut(|c| self.ty(c));
     }

--- a/tests/predicate_sharing.rs
+++ b/tests/predicate_sharing.rs
@@ -13,20 +13,30 @@
 //! which later makes planning recompile one predicate once per occurrence,
 //! superlinearly.
 //!
+//! **What is asserted, and why it is not a threshold.** A split leaves a
+//! recognizable shape: one origin term rebuilt into several `Rc`-distinct copies
+//! that are *structurally equal*. Asserting "no two distinct predicate `Rc`s are
+//! structurally equal" names that defect directly. A bound on the distinct-`Rc`
+//! count cannot: it needs a magic number, it drifts as unrelated changes shift
+//! the count, and slack in it silently tolerates the very growth it is meant to
+//! catch.
+//!
 //! We measure at **post-inference** (cheap — milliseconds), which is where the
 //! sharing is established and preserved; the downstream slowdown a regression
-//! causes is in planning, but the *cause* is visible here as an inflated count.
+//! causes is in planning, but the *cause* is visible here as duplicated terms.
 
-use cambra::ccl::ccl_utils::distinct_predicate_rcs;
+use cambra::ccl::ccl_utils::{distinct_predicate_rcs, reachable_refinements};
 use cambra::ccl::infer::{TypeInferenceContext, infer};
 use cambra::ccl::lower::{LoweringContext, lower_stmts};
+use cambra::ccl::symbolic::symbolic;
 use cambra::ccl::uniquify;
+use cambra::ccl::{BaseType, Expr, Lit, Refinement, Type, TypedExprNode};
 use cambra::chl_parser;
+use std::rc::Rc;
 
 /// Parse → lower → uniquify → infer `code` (the pipeline prefix through type
-/// inference; comprehensions over literals need no source registration), then
-/// count the distinct refinement-predicate `Rc`s in the inferred tree.
-fn distinct_rcs_post_infer(code: &str) -> usize {
+/// inference; comprehensions over literals need no source registration).
+fn infer_source(code: &str) -> Expr {
     let module = chl_parser::parse_module(code)
         .value
         .expect("parse should succeed");
@@ -37,56 +47,140 @@ fn distinct_rcs_post_infer(code: &str) -> usize {
     expr = uniquify::run(expr);
     let mut ictx = TypeInferenceContext::new();
     infer(&mut expr, &mut ictx).expect("inference should succeed");
-    distinct_predicate_rcs(&expr)
+    expr
 }
 
-/// A doubly-nested comprehension whose filtered domains ride many type slots.
-/// Under the sharing bug this reached ~9 independent `Rc`s *per* structural
-/// predicate (dozens total, multiplying downstream); with sharing preserved it
-/// is one `Rc` per predicate the program actually contains — a small handful.
-#[test]
-fn nested_comprehension_shares_predicate_rcs() {
-    let code = "[a + b
-        for a in [c + d for c in ['a'] for d in ['b', 'c'] if c < d]
-        for b in [e + f for e in ['d', 'e'] for f in ['f'] if e < f]
-    if a != b]";
-    let n = distinct_rcs_post_infer(code);
-    assert!(
-        n <= 8,
-        "nested-comprehension predicate `Rc`s not shared: {n} distinct (expected one per \
-         distinct predicate the program contains; a larger count means an inference pass \
-         rebuilt predicates per-occurrence instead of preserving `Rc` sharing)"
+/// Group `expr`'s `Rc`-distinct refinements by `Refinement`'s own (structural,
+/// type-blind) equality and report every group with more than one member: each
+/// surplus member is one refinement that entered inference as a single `Rc` and
+/// left it as several — which is exactly what defeats planning's `Rc`-keyed
+/// compile memo.
+///
+/// (Two *independently authored* predicates that happened to coincide would be a
+/// false positive, so the programs below use pairwise-distinct filters — any
+/// duplicate group is a genuine split.)
+fn splits(expr: &Expr) -> (usize, String) {
+    let mut groups: Vec<(Refinement, usize)> = Vec::new();
+    for r in reachable_refinements(expr) {
+        match groups.iter_mut().find(|(q, _)| *q == r) {
+            Some(g) => g.1 += 1,
+            None => groups.push((r, 1)),
+        }
+    }
+    let surplus = groups.iter().map(|(_, n)| n - 1).sum();
+    let detail = groups
+        .iter()
+        .filter(|(_, n)| *n > 1)
+        .map(|(r, n)| format!("\n  {n}x  {}", symbolic(&r.predicate)))
+        .collect();
+    (surplus, detail)
+}
+
+/// Assert every structurally-distinct predicate in `code` survives inference as
+/// exactly one `Rc`.
+fn assert_no_split(code: &str) {
+    let expr = infer_source(code);
+    let (surplus, detail) = splits(&expr);
+    assert_eq!(
+        surplus,
+        0,
+        "inference left {surplus} redundant predicate `Rc`(s) of {} distinct: a structural \
+         predicate was rebuilt per-occurrence instead of staying shared, which makes planning \
+         recompile it once per occurrence.{detail}",
+        distinct_predicate_rcs(&expr),
     );
 }
 
-/// Sharing must not degrade *multiplicatively* with nesting depth: adding a
-/// `for … if a_i == a_{i+1}` binder is a bounded, additive increment to the
-/// distinct-`Rc` count, not a multiplicative blowup (the regression that made
-/// planning superlinear).
+/// The motivating case. Two levels of nesting are required: in a *singly*-nested
+/// comprehension every predicate also rides some node's `ty`, so a pass that
+/// misses the binder slots and cast targets happens to cost nothing. At two
+/// levels, a filter predicate reachable only through a `Cast.target` appears —
+/// and that is the slot `lambda_elim` and operator conversion read it from.
 #[test]
-fn filtered_join_nesting_stays_additive() {
-    let counts: Vec<usize> = (2..=6)
-        .map(|n| {
-            let binders: Vec<String> = (0..n).map(|i| format!("a{i}")).collect();
-            let sum = binders.join(" + ");
-            let fors: String = binders
-                .iter()
-                .map(|b| format!("for {b} in [1, 2, 3]"))
-                .collect::<Vec<_>>()
-                .join(" ");
-            let conds: String = binders
-                .windows(2)
-                .map(|w| format!("if {} == {}", w[0], w[1]))
-                .collect::<Vec<_>>()
-                .join(" ");
-            distinct_rcs_post_infer(&format!("[{sum} {fors} {conds}]"))
-        })
-        .collect();
-    for w in counts.windows(2) {
-        assert!(
-            w[1] <= w[0] + 4,
-            "distinct predicate `Rc`s grew multiplicatively across nesting depth: {counts:?} \
-             (sharing lost — an inference pass is rebuilding predicates per-occurrence)"
-        );
+fn nested_comprehension_shares_predicate_rcs() {
+    assert_no_split(
+        "[a + b
+            for a in [c + d for c in ['a'] for d in ['b', 'c'] if c < d]
+            for b in [e + f for e in ['d', 'e'] for f in ['f'] if e < f]
+        if a != b]",
+    );
+}
+
+/// Sharing must survive at every nesting depth, not just the one depth a fixture
+/// happens to pin: the regression that made planning superlinear grew with depth.
+/// Each `for … if a_i == a_{i+1}` binder contributes one distinct filter
+/// predicate, and it must stay one `Rc`.
+#[test]
+fn filtered_join_nesting_stays_shared() {
+    for n in 2..=6 {
+        let binders: Vec<String> = (0..n).map(|i| format!("a{i}")).collect();
+        let sum = binders.join(" + ");
+        let fors: String = binders
+            .iter()
+            .map(|b| format!("for {b} in [1, 2, 3]"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let conds: String = binders
+            .windows(2)
+            .map(|w| format!("if {} == {}", w[0], w[1]))
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert_no_split(&format!("[{sum} {fors} {conds}]"));
     }
+}
+
+// ---------------------------------------------------------------------------
+// Coverage of the metric itself.
+//
+// The assertions above are only as good as the traversal behind them: a metric
+// blind to a type slot cannot observe a split there, and `Expr::walk_children`
+// deliberately descends into *neither* binder-declared types nor a `Cast`'s
+// `target` — the slot a comprehension filter's predicate actually lives in. A
+// count-based guard with that blind spot stays green while the predicates it
+// was written to protect are split. These pin each slot on a hand-built node,
+// so they cannot go vacuous the way a program fixture can: once sharing is
+// preserved, a cast's `target` and its `ty` hold the *same* `Rc` and a
+// `ty`-only walk reaches everything.
+// ---------------------------------------------------------------------------
+
+/// `{Int | true}` over a fresh predicate `Rc`.
+fn refined_int() -> Type {
+    Type::Refinement(
+        Box::new(Type::Base(BaseType::Int)),
+        Refinement::born(Rc::new(Expr::lit(Lit::Bool(true)))),
+    )
+}
+
+/// A predicate riding only a `Cast`'s `target`. `Expr::walk_children` visits a
+/// cast's `value` but not its `target`, and downstream (`lambda_elim`, operator
+/// conversion) reads the predicate from `target`.
+#[test]
+fn metric_counts_predicate_on_cast_target() {
+    let expr = Expr::cast(Expr::lit(Lit::Int(1)), refined_int());
+    assert_eq!(distinct_predicate_rcs(&expr), 1);
+}
+
+/// A predicate riding only a `Lambda`'s `param.ty`. `Expr::lambda` also stamps
+/// the refinement onto the node's own `ty` (as the `Fun` domain), which *is*
+/// traversed — so the node type is cleared to isolate the binder slot.
+#[test]
+fn metric_counts_predicate_on_lambda_param_slot() {
+    let expr = Expr::lambda("x", refined_int(), Expr::var("x")).with_ty(Type::Hole);
+    assert_eq!(distinct_predicate_rcs(&expr), 1);
+}
+
+/// A predicate riding only a `Let`'s `binding.ty`. `Expr::let_bind` copies
+/// `bound_expr.ty` into `binding.ty`, so the bound expression's own type slot is
+/// cleared to isolate the binder slot.
+#[test]
+fn metric_counts_predicate_on_let_binding_slot() {
+    let mut expr = Expr::let_bind(
+        "x",
+        Expr::lit(Lit::Int(1)).with_ty(refined_int()),
+        Expr::var("x"),
+    );
+    if let TypedExprNode::Let { bound_expr, .. } = &mut expr.node {
+        bound_expr.ty = Type::Hole;
+    }
+    assert_eq!(distinct_predicate_rcs(&expr), 1);
 }

--- a/tests/predicate_sharing.rs
+++ b/tests/predicate_sharing.rs
@@ -1,0 +1,92 @@
+//! Regression guard for **refinement-predicate `Rc` sharing** through type
+//! inference.
+//!
+//! Predicates are immutable `Rc<TypedExpr>`s specifically so that a predicate
+//! riding many type slots (a comprehension's filtered domain appears on its
+//! source, map, cast, and consumer-contract types) is *one* allocation shared
+//! by `Rc`, not one copy per occurrence. Every inference pass that rewrites
+//! predicates (coalesce, retype) and every substitution
+//! (`subst`/`lambda_elim`) threads a pass-scoped `ccl_utils::PredMemo` (or, for
+//! substitution, keeps vacuous rewrites `Rc`-identical) to preserve that
+//! sharing. If any pass regresses to an independent rebuild per occurrence, the
+//! distinct-`Rc` count balloons multiplicatively with comprehension nesting —
+//! which later makes planning recompile one predicate once per occurrence,
+//! superlinearly.
+//!
+//! We measure at **post-inference** (cheap — milliseconds), which is where the
+//! sharing is established and preserved; the downstream slowdown a regression
+//! causes is in planning, but the *cause* is visible here as an inflated count.
+
+use cambra::ccl::ccl_utils::distinct_predicate_rcs;
+use cambra::ccl::infer::{TypeInferenceContext, infer};
+use cambra::ccl::lower::{LoweringContext, lower_stmts};
+use cambra::ccl::uniquify;
+use cambra::chl_parser;
+
+/// Parse → lower → uniquify → infer `code` (the pipeline prefix through type
+/// inference; comprehensions over literals need no source registration), then
+/// count the distinct refinement-predicate `Rc`s in the inferred tree.
+fn distinct_rcs_post_infer(code: &str) -> usize {
+    let module = chl_parser::parse_module(code)
+        .value
+        .expect("parse should succeed");
+    let mut lctx = LoweringContext::default();
+    let mut expr = lower_stmts(&module.body, &mut lctx)
+        .value
+        .expect("lowering should succeed");
+    expr = uniquify::run(expr);
+    let mut ictx = TypeInferenceContext::new();
+    infer(&mut expr, &mut ictx).expect("inference should succeed");
+    distinct_predicate_rcs(&expr)
+}
+
+/// A doubly-nested comprehension whose filtered domains ride many type slots.
+/// Under the sharing bug this reached ~9 independent `Rc`s *per* structural
+/// predicate (dozens total, multiplying downstream); with sharing preserved it
+/// is one `Rc` per predicate the program actually contains — a small handful.
+#[test]
+fn nested_comprehension_shares_predicate_rcs() {
+    let code = "[a + b
+        for a in [c + d for c in ['a'] for d in ['b', 'c'] if c < d]
+        for b in [e + f for e in ['d', 'e'] for f in ['f'] if e < f]
+    if a != b]";
+    let n = distinct_rcs_post_infer(code);
+    assert!(
+        n <= 8,
+        "nested-comprehension predicate `Rc`s not shared: {n} distinct (expected one per \
+         distinct predicate the program contains; a larger count means an inference pass \
+         rebuilt predicates per-occurrence instead of preserving `Rc` sharing)"
+    );
+}
+
+/// Sharing must not degrade *multiplicatively* with nesting depth: adding a
+/// `for … if a_i == a_{i+1}` binder is a bounded, additive increment to the
+/// distinct-`Rc` count, not a multiplicative blowup (the regression that made
+/// planning superlinear).
+#[test]
+fn filtered_join_nesting_stays_additive() {
+    let counts: Vec<usize> = (2..=6)
+        .map(|n| {
+            let binders: Vec<String> = (0..n).map(|i| format!("a{i}")).collect();
+            let sum = binders.join(" + ");
+            let fors: String = binders
+                .iter()
+                .map(|b| format!("for {b} in [1, 2, 3]"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let conds: String = binders
+                .windows(2)
+                .map(|w| format!("if {} == {}", w[0], w[1]))
+                .collect::<Vec<_>>()
+                .join(" ");
+            distinct_rcs_post_infer(&format!("[{sum} {fors} {conds}]"))
+        })
+        .collect();
+    for w in counts.windows(2) {
+        assert!(
+            w[1] <= w[0] + 4,
+            "distinct predicate `Rc`s grew multiplicatively across nesting depth: {counts:?} \
+             (sharing lost — an inference pass is rebuilding predicates per-occurrence)"
+        );
+    }
+}

--- a/tests/predicate_sharing_review.rs
+++ b/tests/predicate_sharing_review.rs
@@ -193,12 +193,12 @@ fn is_free_sees_a_predicate_on_a_let_binding_slot() {
 /// which reports only whether a *rule fired*.
 #[test]
 fn walk_preserves_a_repointing_made_by_a_nested_memo_hit() {
-    let mut memo = PredMemo::new();
+    let memo: PredMemo = PredMemo::new();
 
     // An inner predicate `q`, rebuilt through the memo by some earlier occurrence.
     let q = Rc::new(gt(var("a"), int(0)));
     let mut t_q = refined(&q);
-    walk_refined_predicates_mut(&mut t_q, &mut memo, &mut |pred, _| {
+    walk_refined_predicates_mut(&mut t_q, &memo, &(), &mut |pred, _| {
         *pred = gt(var("a"), int(1)); // a real rewrite
         true
     });
@@ -209,9 +209,9 @@ fn walk_preserves_a_repointing_made_by_a_nested_memo_hit() {
     // slot. The transform has nothing to say about `p` itself.
     let p = Rc::new(int(1).with_ty(refined(&q)));
     let mut t_p = refined(&p);
-    walk_refined_predicates_mut(&mut t_p, &mut memo, &mut |pred, memo| {
+    walk_refined_predicates_mut(&mut t_p, &memo, &(), &mut |pred, memo| {
         // Recurse into the predicate's own type slots, as every caller does.
-        walk_refined_predicates_mut(&mut pred.ty, memo, &mut |_, _| false);
+        walk_refined_predicates_mut(&mut pred.ty, memo, &(), &mut |_, _| false);
         false // "no rule fired at this level"
     });
 

--- a/tests/predicate_sharing_review.rs
+++ b/tests/predicate_sharing_review.rs
@@ -1,0 +1,223 @@
+//! Failing guards for the review findings on the predicate-sharing work.
+//!
+//! Each test states one property the current code violates. They are written
+//! against the smallest construction that exhibits the defect, not against a
+//! source-level fixture, so a fix can be verified without reasoning about which
+//! program shape happens to produce the sharing.
+
+use cambra::ccl::ccl_utils::{
+    PredMemo, distinct_predicate_rcs, is_free, walk_refined_predicates_mut,
+};
+use cambra::ccl::subst::Subst;
+use cambra::ccl::{
+    BinOpKind, CompareKind, Expr, Lit, Name, Refinement, Type, TypedExpr, TypedExprNode,
+};
+use std::rc::Rc;
+
+fn var(s: &str) -> TypedExpr {
+    TypedExpr::var(s)
+}
+fn int(n: i64) -> TypedExpr {
+    TypedExpr::lit(Lit::Int(n))
+}
+fn gt(l: TypedExpr, r: TypedExpr) -> TypedExpr {
+    TypedExpr::binop(l, BinOpKind::Compare(CompareKind::Greater), r)
+}
+/// `{_ | pred}`, a second occurrence of an existing predicate term.
+fn refined(pred: &Rc<TypedExpr>) -> Type {
+    Type::Refinement(Box::new(Type::Hole), Refinement::sharing(pred))
+}
+/// The predicate term of a `{_ | p}`.
+fn predicate_of(ty: &Type) -> &Rc<TypedExpr> {
+    let Type::Refinement(_, r) = ty else {
+        panic!("expected a refinement, got {ty}");
+    };
+    &r.predicate
+}
+
+// ---------------------------------------------------------------------------
+// Finding 1 — `subst`'s `PredMemo` is threaded across shadowing boundaries,
+// but substitution is scope-dependent.
+// ---------------------------------------------------------------------------
+
+/// `rewrite_expr` rewrites a node's own type slots *before* descending under its
+/// binders, and threads one memo across that crossing. So the occurrence rebuilt
+/// in the outer scope is served to an occurrence inside a scope that **rebinds**
+/// the substituted variable — applying a substitution under a binder that
+/// shadows it.
+///
+/// Two substituted binders are needed: with only `k`, `under_binder_mut`'s
+/// empty-restriction early return declines to enter the body at all.
+#[test]
+fn rewrite_does_not_leak_an_outer_rebuild_into_a_shadowing_scope() {
+    let shared = Rc::new(gt(var("k"), int(0)));
+    // λ k → (j > 0) : {_ | k > 0}          — the body's `k` is the lambda's own.
+    //   with the lambda's own ty = ({_ | k > 0} ⇒ _), sharing that one predicate.
+    let body = gt(var("j"), int(0)).with_ty(refined(&shared));
+    let mut e =
+        TypedExpr::lambda("k", Type::Hole, body).with_ty(Type::fun(refined(&shared), Type::Hole));
+
+    // [k ↦ 5, j ↦ 6]: `j` keeps the body reachable, `k` is shadowed by the lambda.
+    let s = Subst::then(
+        &Subst::discharge("k", int(5)),
+        &Subst::discharge("j", int(6)),
+    );
+    s.rewrite_expr(&mut e);
+
+    let Type::Fun { domain, .. } = &e.ty else {
+        panic!("function type preserved");
+    };
+    assert_eq!(
+        **predicate_of(domain),
+        gt(int(5), int(0)),
+        "the outer occurrence is not under the binder, so it discharges"
+    );
+
+    let TypedExprNode::Lambda { body, .. } = &e.node else {
+        panic!("lambda preserved");
+    };
+    assert_eq!(
+        **predicate_of(&body.ty),
+        gt(var("k"), int(0)),
+        "the occurrence inside `λ k` refers to the lambda's own `k`, which the \
+         substitution must not touch — but the memo served it the outer rebuild"
+    );
+}
+
+/// Control for the test above: the *same two occurrences*, but as two distinct
+/// `Rc`s. This passes — which localizes the defect to the memo rather than to
+/// the shadowing walk, and shows that improving sharing is what exposes it.
+#[test]
+fn rewrite_respects_shadowing_when_the_occurrences_are_not_shared() {
+    let outer = Rc::new(gt(var("k"), int(0)));
+    let inner = Rc::new(gt(var("k"), int(0)));
+    let body = gt(var("j"), int(0)).with_ty(refined(&inner));
+    let mut e =
+        TypedExpr::lambda("k", Type::Hole, body).with_ty(Type::fun(refined(&outer), Type::Hole));
+
+    let s = Subst::then(
+        &Subst::discharge("k", int(5)),
+        &Subst::discharge("j", int(6)),
+    );
+    s.rewrite_expr(&mut e);
+
+    let Type::Fun { domain, .. } = &e.ty else {
+        panic!("function type preserved");
+    };
+    assert_eq!(**predicate_of(domain), gt(int(5), int(0)));
+    let TypedExprNode::Lambda { body, .. } = &e.node else {
+        panic!("lambda preserved");
+    };
+    assert_eq!(**predicate_of(&body.ty), gt(var("k"), int(0)));
+}
+
+// ---------------------------------------------------------------------------
+// Finding 3 — `rewrite_expr_go` never rewrites binder-slot types, so a
+// predicate riding `param.ty` is left stale against the same predicate on `ty`.
+// ---------------------------------------------------------------------------
+
+/// A lambda's domain refinement rides both `expr.ty`'s `Fun` domain and
+/// `param.ty`, as two occurrences of one `Rc`. `rewrite_expr` rebuilds the
+/// former and never visits the latter, so after the rewrite the two slots
+/// disagree — the same stale-copy defect `retype_pred_expr` had.
+#[test]
+fn rewrite_reaches_the_lambda_param_type_slot() {
+    let shared = Rc::new(gt(var("k"), int(0)));
+    let mut e = TypedExpr::lambda("x", refined(&shared), var("x"))
+        .with_ty(Type::fun(refined(&shared), Type::Hole));
+
+    Subst::discharge("k", int(5)).rewrite_expr(&mut e);
+
+    let TypedExprNode::Lambda { param, .. } = &e.node else {
+        panic!("lambda preserved");
+    };
+    assert_eq!(
+        **predicate_of(&param.ty),
+        gt(int(5), int(0)),
+        "`param.ty` holds its own `Rc`, so the discharge must reach it too"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Finding 4 — `count_free`/`is_free` does not walk binder-slot types, while
+// `walk_type_slots` does. Three "skip the work" fast paths gate on `is_free`.
+// ---------------------------------------------------------------------------
+
+/// `let y = 1 in unit` with `y : {_ | k > 0}` — `k` occurs *only* in the
+/// predicate riding the `Let` binding's declared type.
+///
+/// `distinct_predicate_rcs` (i.e. `walk_type_slots`) sees that slot; `is_free`
+/// does not. The asymmetry is load-bearing: `inline_in_type_predicates` now
+/// returns early on `!is_free(name, pred)`, and `subst` skips both inert
+/// subtrees and vacuous predicates the same way — so an occurrence only
+/// `walk_type_slots` can see is silently left un-rewritten.
+#[test]
+fn is_free_sees_a_predicate_on_a_let_binding_slot() {
+    let k = Name::raw("k");
+    let mut e = Expr::let_bind(
+        "y",
+        Expr::lit(Lit::Int(1)).with_ty(refined(&Rc::new(gt(var("k"), int(0))))),
+        Expr::lit(Lit::Unit),
+    );
+    // `let_bind` copies `bound_expr.ty` into `binding.ty`; clear the former so
+    // the binder slot is the only place the predicate rides.
+    if let TypedExprNode::Let { bound_expr, .. } = &mut e.node {
+        bound_expr.ty = Type::Hole;
+    }
+
+    assert_eq!(
+        distinct_predicate_rcs(&e),
+        1,
+        "walk_type_slots reaches the binding's declared type",
+    );
+    assert!(
+        is_free(&k, &e),
+        "`k` occurs free in `e` — in the predicate on the `Let` binding's type. \
+         Every fast path that skips work on `!is_free` misses it.",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Finding 5 — the `changed` bit a callback returns cannot see the re-pointings
+// a nested memo *hit* performs, so `finish_unchanged` discards them.
+// ---------------------------------------------------------------------------
+
+/// A callback that recurses through the memo (which is why the combinator hands
+/// it one) can have its copy mutated by a nested memo hit while having nothing
+/// of its own to report. Reporting `false` then throws the copy away, so the
+/// nested slot keeps a predicate the pass already rebuilt — and the outer
+/// predicate is memoized as `origin ↦ origin`, fixing that staleness for every
+/// later occurrence.
+///
+/// This is `simplify`'s exact shape: it returns `simplify_once(pred, memo).0`,
+/// which reports only whether a *rule fired*.
+#[test]
+fn walk_preserves_a_repointing_made_by_a_nested_memo_hit() {
+    let mut memo = PredMemo::new();
+
+    // An inner predicate `q`, rebuilt through the memo by some earlier occurrence.
+    let q = Rc::new(gt(var("a"), int(0)));
+    let mut t_q = refined(&q);
+    walk_refined_predicates_mut(&mut t_q, &mut memo, &mut |pred, _| {
+        *pred = gt(var("a"), int(1)); // a real rewrite
+        true
+    });
+    let q_rebuilt = Rc::clone(predicate_of(&t_q));
+    assert!(!Rc::ptr_eq(&q_rebuilt, &q), "q was rebuilt");
+
+    // An outer predicate `p` carrying a second occurrence of `q` on its own type
+    // slot. The transform has nothing to say about `p` itself.
+    let p = Rc::new(int(1).with_ty(refined(&q)));
+    let mut t_p = refined(&p);
+    walk_refined_predicates_mut(&mut t_p, &mut memo, &mut |pred, memo| {
+        // Recurse into the predicate's own type slots, as every caller does.
+        walk_refined_predicates_mut(&mut pred.ty, memo, &mut |_, _| false);
+        false // "no rule fired at this level"
+    });
+
+    assert!(
+        Rc::ptr_eq(predicate_of(&predicate_of(&t_p).ty), &q_rebuilt),
+        "the nested occurrence of `q` must end up at the single rebuild, not at \
+         the stale origin the discarded copy was re-pointed away from",
+    );
+}

--- a/tests/predicate_sharing_review.rs
+++ b/tests/predicate_sharing_review.rs
@@ -179,7 +179,7 @@ fn is_free_sees_a_predicate_on_a_let_binding_slot() {
 
 // ---------------------------------------------------------------------------
 // Finding 5 — the `changed` bit a callback returns cannot see the re-pointings
-// a nested memo *hit* performs, so `finish_unchanged` discards them.
+// a nested memo *reuse* performs, so reporting "unchanged" discards them.
 // ---------------------------------------------------------------------------
 
 /// A callback that recurses through the memo (which is why the combinator hands


### PR DESCRIPTION
Preserve refinement-predicate `Rc` sharing across inference and planning

Refinement predicates are immutable `Rc<TypedExpr>`s so that one predicate riding many type slots — a comprehension's filtered domain appears on its source, map, cast target, and consumer-contract types — is a single shared allocation. But every pass that "updates" a predicate *rebuilds* it, and none of the rebuilding passes preserved that sharing. By planning time one structural predicate had scattered into roughly one `Rc` per occurrence, defeating planning's `Rc`-keyed compile memo, which then recompiled the same predicate once per occurrence — superlinearly on nested comprehensions.

On the motivating doubly-nested comprehension, inference left **7** distinct predicate `Rc`s where 3 suffice. It now leaves **3**, with no two of them structurally equal.

## One memo, threaded through every rebuilding pass

`ccl_utils::PredMemo` is the pass-scoped memo that maps an origin predicate `Rc` to a single rebuild, so occurrences that enter a pass sharing one `Rc` leave sharing one `Rc`. Its protocol makes misuse inexpressible:

- `begin(&mut Refinement) -> Option<(Origin, Expr)>` — on a hit, re-points the slot and returns `None`; on a miss, hands back an owned copy plus an `Origin` token.
- `finish(refinement, origin, rebuilt)` — installs the rebuild and records it.
- `finish_unchanged(refinement, origin)` — the transform had nothing to do: keep the origin `Rc`, record `origin ↦ origin`.

`Origin` is minted only by `begin` and consumed only by the two `finish`es, so the keepalive that makes address-keying sound cannot be forgotten or confused with a rebuild. That keepalive is load-bearing, not bookkeeping: overwriting a predicate slot can drop the last reference to the origin and free an address a later `Rc::new` in the same walk reclaims, at which point an unrelated predicate collides with the entry and inherits its rebuild.

Every rebuilding pass now threads it — `uniquify`, constraint emission, `coalesce`, `retype`, `subst`'s both modes, `inline`, `simplify`, and planning's predicate compilation. Two of those were *first-pass* splitters, so no later pass could have recovered the sharing:

- **Constraint emission.** `emit_bare_predicate` rebuilds every predicate it types and threaded no memo, so the very first walk over the tree split sharing. A nested comprehension's inner filter is reached twice — once on the term-level `Cast`'s `target`, once on the copy of that `Cast` inside the enclosing comprehension's own filter predicate. It now threads a memo via a `Typing::pred_memo` accessor, so Emit and Check both inherit it. Sharing the memoized copy also makes those occurrences share inference variables, which is correct rather than incidental: a bare predicate is closed but for `REFINEMENT_BINDER`, so two occurrences of one refinement `Rc` denote the same refinement over the same base and their slots have a single solution.
- **`retype`.** `retype_pred_expr` was a hand-rolled near-duplicate of `retype_predicate_slots` that omitted the binder slots and had no `Cast` arm at all, so a `Cast` nested inside a predicate was reached only by the copy that could not see it. A predicate *is* a term, so the two walks are now one function: `retype_in_type` hands each predicate back to `retype_predicate_slots`. Closing that also picked up the `For` and `LetRec` binder scopes the old walk dropped into its catch-all arm.

`walk_refined_predicates_mut` is the type-walk combinator built on the memo. Its callback returns whether it *changed* the predicate; returning `false` keeps the origin `Rc`, so a pass preserves sharing for predicates it merely walks past rather than reallocating them per node visited. `coalesce` drives the same protocol inline instead of through the combinator — its transform needs `&mut CoalesceCtx`, which holds the memo — with the scope-independence precondition the `Rc`-only key relies on written down at the call site.

## `Expr::walk_type_slots`: one enumeration of a node's type slots

A predicate can ride a node's `ty`, its `user_annotation`, a `Cast`'s `target`, or any binder's declared type — each an independent `Rc`. That set was enumerated by hand in six places, two of them incompletely, and both omissions were live defects:

- `distinct_predicate_rcs` — the sharing metric itself — recursed with `Expr::walk_children`, which reaches neither the binder slots nor `Cast.target`. Since `target` is where a comprehension filter's predicate is written (and where `lambda_elim` and operator conversion read it from), the metric could not observe a split in the one slot that mattered most.
- `inline_and_beta_reduce` missed the binder slots, so a UDF use inside a binder-slot predicate could survive as a dangling `Var` once the enclosing `Let` was dropped.

`Expr::walk_type_slots{,_mut}` is now the single source of truth for that set, built on the existing `walk_binders`. The metric, `retype_predicate_slots`, `inline_and_beta_reduce`, and `planning::compile_refinement_predicates` all share it, so a new type-slot-bearing variant updates one match instead of every pass and a pass cannot acquire a blind spot by omission.

## Guards

`tests/predicate_sharing.rs` asserts, end to end and post-inference, that **no two `Rc`-distinct refinements reachable from an inferred tree are structurally equal** — compared with `Refinement`'s own type-blind `PartialEq`. That is exactly the shape a split leaves: one origin term rebuilt into several `Rc`-distinct but value-equal copies. It needs no threshold, so nothing drifts, and the failure message prints the duplicated predicates in symbolic form. The property is asserted at every comprehension nesting depth 2–6, and `ccl_utils::reachable_refinements` exposes the traversal the count derives from so the test can ask that question directly.

Three unit tests pin the metric's own coverage of `Cast.target`, `Lambda.param.ty`, and `Let.binding.ty` on hand-built nodes. Hand-built rather than program-derived on purpose: once sharing is preserved, a cast's `target` and its `ty` hold the same `Rc`, so a fixture-based coverage check goes vacuous the moment the bug is gone.

Per phase, a debug-only tripwire checks that `retype` — a rewrite-only pass — never *increases* the distinct-predicate count. That count is the necessary check; the equal-but-distinct assertion is the sufficient one, and both are documented as such.

## Steering

`Refinement` has exactly two constructors, so a bare struct literal (which states neither intent) no longer appears anywhere:

- `born(Rc)` — a genuinely new predicate term, with no prior identity to preserve.
- `sharing(&Rc)` — a second occurrence of an *existing* predicate, deliberately aliased. This is what lowering does when one filtered domain rides four slots, and it is the sharing every rebuilding pass then has to preserve.

A warning doc-comment on `Refinement.predicate` points rewrites at the memo.

## Docs

`src/ccl/design/type-inference.md` gains a "Sharing is an invariant, not an optimization detail" subsection: the full list of rebuilding passes, why the keepalive is load-bearing, why the cost lands in planning, and what each of the two guards does.

## Noted, not fixed

`retype_predicate_slots`, `subst::rewrite_expr_go`, and `infer::api`'s scope walks each spell out "walk children, each under the binders that scope it" by hand. Unlike the type-slot set, the scoping is genuinely non-uniform — `Let` binds only its body, `LetRec` binds everything, a `Case` branch binds its guard and body — so a `walk_children_scoped` combinator would have to encode that structure. Flagged at the call site rather than folded in here.


## Also carried: the `deep-typecheck` gate

This branch additionally contains **#33** — gating the per-operation `debug_typecheck` behind an opt-in `deep-typecheck` cargo feature (`Cargo.toml`, `ci.sh`, `.github/workflows/ci.yml`, `src/ccl/infer/api.rs`). That PR was merged into *this* branch rather than into `main`, so it rides along here and will land on `main` under this squash. Its own description has the rationale; the short version is that the per-operation typecheck is a bisection tool, too expensive to run unconditionally, and CI sets `DEEP_TYPECHECK=1` so automated runs keep the coverage.

Worth knowing when reading this diff: `ci_test` is `cargo test -q ${DEEP_TYPECHECK:+--features deep-typecheck}`, and the predicate-sharing work below was verified both with the feature off and on.

