### PR TITLE
Gate per-operation debug_typecheck behind opt-in `deep-typecheck` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,11 @@ jobs:
         # Read more about the "hidden ifs" and general inanity here
         # https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions
         if: steps.filter.outputs.code == 'true' && (success() || failure())
-        run: ./ci.sh test
+        # Enable the opt-in per-operation typecheck (the `deep-typecheck`
+        # feature) in automated runs so it keeps guarding against a pass that
+        # produces an ill-typed tree — it is off by default locally because it is
+        # superlinear on nested comprehensions (see `ci_test` / `debug_typecheck`).
+        run: DEEP_TYPECHECK=1 ./ci.sh test
 
         # 4. Success Signal for noops
       - name: No-op for docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,16 @@ readme = "README.md"
 # to a crate's dev-dependencies to enable.
 test-helpers = []
 
+# Run the *per-operation* post-rewrite typecheck ([`debug_typecheck`]) that
+# pass-internal helpers (lambda elimination, substitution, simplify) invoke
+# after each rewrite. It is a debugging aid that localizes *which* operation
+# first produced an ill-typed tree; `compile_program`'s pass-boundary
+# `check_pre_desugar` walls remain the always-on correctness net. Off by default
+# (even in debug): the check is O(subtree) and fires per rewrite, so on nested
+# comprehensions it was superlinear and dominated debug/test compile time.
+# Enable when bisecting a miscompile: `cargo test --features deep-typecheck`.
+deep-typecheck = []
+
 [dev-dependencies]
 microbench = "0.5.0"
 rstest = { version = "0.26.1", features = ["async-timeout"] }

--- a/ci.sh
+++ b/ci.sh
@@ -13,7 +13,11 @@ ci_clippy() { cargo clippy --all-targets -- -D warnings; }
 # (e.g. a test calling a debug-only fn) only breaks here. `-- -D warnings` is
 # scoped to our crate, not deps.
 ci_clippy_release() { cargo clippy --release --all-targets -- -D warnings; }
-ci_test() { cargo test -q; }
+# `DEEP_TYPECHECK=1` turns on the opt-in per-operation typecheck (see the
+# `deep-typecheck` feature). The GitHub workflow sets it so automated runs keep
+# exercising that check; it stays off for a bare local `./ci.sh` because it is
+# superlinear on nested comprehensions (that cost is why it is gated).
+ci_test() { cargo test -q ${DEEP_TYPECHECK:+--features deep-typecheck}; }
 ci_doc() {
   RUSTDOCFLAGS="-A warnings -D rustdoc::broken_intra_doc_links" \
     cargo doc --no-deps

--- a/src/ccl/infer/api.rs
+++ b/src/ccl/infer/api.rs
@@ -26,7 +26,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
 
-use crate::ccl::symbolic::{symbolic, symbolic_typed};
+use crate::ccl::symbolic::symbolic;
 use crate::ccl::{Expr, HistoryKind, InferVarId, Name, Type, TypedBinding, TypedExprNode};
 use crate::util::ScopeStack;
 
@@ -1160,20 +1160,33 @@ fn check_mut_write_targets_go(
     expr.walk_children(|c| check_mut_write_targets_go(c, muts, errors));
 }
 
-/// In debug mode only, typecheck the expression and panic if any errors are found.
+/// Per-operation post-rewrite typecheck — a **debugging aid**, off by default.
 ///
-/// Routes through [`check_pre_desugar`], which self-selects strictness: a
+/// Pass-internal helpers (lambda elimination, substitution, simplify) call this
+/// after each rewrite to localize *which* operation first produced an ill-typed
+/// tree. Routes through [`check_pre_desugar`], which self-selects strictness: a
 /// (sub)tree carrying defer artifacts (a `Feed`/`Infer` channel type — which
 /// `substitute` now sees, since inline runs before desugar) is checked at the
 /// relaxed `PreDesugar` level; a fully-desugared tree is checked strictly (the
 /// `typecheck` bar).
+///
+/// Gated behind the opt-in `deep-typecheck` feature. `compile_program` already
+/// runs [`check_pre_desugar`] at every *pass boundary* — those walls are the
+/// always-on correctness net — so this per-op version only adds localization.
+/// It is O(subtree) and fires once per rewrite, so on nested comprehensions it
+/// is superlinear (O(rewrites) × O(subtree)) and dominated debug/test compile
+/// time; release built it out entirely. Enable it (`cargo test --features
+/// deep-typecheck`) to bisect a miscompile to its introducing operation.
 pub fn debug_typecheck(expr: &Expr) {
-    debug_assert_eq!(
+    #[cfg(feature = "deep-typecheck")]
+    assert_eq!(
         check_pre_desugar(expr),
         Ok(()),
         "Failed post-transform typecheck: {}",
-        symbolic_typed(expr)
+        crate::ccl::symbolic::symbolic_typed(expr)
     );
+    #[cfg(not(feature = "deep-typecheck"))]
+    let _ = expr;
 }
 
 // Helper to run typechecking inline when building an Expr


### PR DESCRIPTION
Gate per-operation debug_typecheck behind opt-in `deep-typecheck` feature

`debug_typecheck` runs a full `check_pre_desugar` over the whole (sub)tree, and
pass-internal helpers (lambda elimination, substitution, simplify) call it after
*every* rewrite to localize which operation first produced an ill-typed tree.
That is O(subtree) per rewrite, so on nested comprehensions it is superlinear
(O(rewrites) × O(subtree)) and dominated *debug* compile time — release builds
compiled it out, so it only ever taxed `cargo test` / local iteration. The
lambda-elimination algorithm itself is near-linear (release compiles the deepest
cases measured here in milliseconds).

`compile_program` already runs `check_pre_desugar` at every pass boundary; those
walls are the always-on correctness net. The per-operation version only adds
localization, so gate it behind an opt-in `deep-typecheck` feature (off by
default, even in debug). Enable it — `cargo test --features deep-typecheck` — to
bisect a miscompile to its introducing operation.

Automated GitHub runs keep the check on: `ci_test` enables the feature when
`DEEP_TYPECHECK` is set, and the workflow's test step sets it. So CI still
guards against a pass emitting an ill-typed tree, while a bare local `./ci.sh`
and normal `cargo test` stay fast. Verified the whole compilation-pipeline suite
still passes with the feature on, so nothing relied on the per-op check to catch
a live error.

Effect on the compilation-pipeline test binary (debug, parallel, feature off):
~3.2s -> ~0.27s (~11x). Combined with the predicate-Rc-sharing fix this stacks
on, the binary is down from ~6.8s to ~0.27s.

