### PR TITLE
ci.sh: add `fast` inner-loop gate for local iteration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,13 @@ cargo fmt        # Run formatter
 cargo build      # Build the project
 cargo clippy --all-targets -- -D warnings            # Lint (debug) — fast inner-loop check, NOT the full gate
 cargo clippy --release --all-targets -- -D warnings  # Lint (release) — CI runs this too; catches debug-only (cfg(debug_assertions)) breakage the debug pass misses
+./ci.sh fast     # Inner-loop gate: fmt + debug clippy (lib/bins) + tests. Skips the release clippy pass, doc, shellcheck, doc-refs. ~1/3 the time of the full gate — use this while iterating.
 ./ci.sh --fix    # Authoritative gate: fmt + BOTH clippy passes + doc + tests, auto-formatting first. Must pass before pushing a PR.
 cargo test -q --no-fail-fast      # Run all tests
 cargo test <name>  # Run a specific test by name
 ```
+
+For the tight edit→check loop, prefer `./ci.sh fast` (or a bare `cargo test <name>`) over the full `./ci.sh`; run the full gate before pushing.
 
 CI lints in **both** debug and release (`ci_clippy` and `ci_clippy_release` in `ci.sh`). Passing the plain debug `cargo clippy` is **not** sufficient — a release-only failure (e.g. a `#[cfg(debug_assertions)]`-gated item referenced by ungated code) passes locally but fails GitHub CI. Run `./ci.sh` to catch both.
 
@@ -145,7 +148,7 @@ Do not render type information as Rust struct syntax (e.g., `Fun { name: Some("k
 
 ### Workflow
 
-After making code changes, run the formatter before running the code; prefer running the linter after ensuring the project builds. **Before creating or pushing a PR, run `./ci.sh` and confirm it is clean** — GitHub CI gates on the same checks, and `./ci.sh` runs the parts no single `cargo` command covers: clippy in *both* debug and release mode plus the doc build. A green debug `cargo clippy` is not enough (see Build Commands above).
+After making code changes, run the formatter before running the code; prefer running the linter after ensuring the project builds. While iterating, `./ci.sh fast` (fmt + debug clippy + tests) is the quick check — roughly a third of the full gate's time. **Before creating or pushing a PR, run the full `./ci.sh` and confirm it is clean** — GitHub CI gates on the same checks, and `./ci.sh` runs the parts no single `cargo` command covers and that `fast` skips: clippy in *both* debug and release mode plus the doc build. A green debug `cargo clippy` (or `./ci.sh fast`) is not enough (see Build Commands above).
 
 When planning, include updates to the appropriate docs to reflect the changes; validate the docs are up to date before creating a PR. This includes `docs/design.md` and other `*/design-*.md` files close to source files that were changed.
 

--- a/ci.sh
+++ b/ci.sh
@@ -6,7 +6,12 @@ ci_fmt() {
   if ((fix)); then cargo fmt; fi
   cargo fmt --check
 }
-# --all-targets lints test code too and warms the cache for cargo test
+# --all-targets lints the test/example/bench code too, not just the lib. It does
+# *not* speed up the later `cargo test` compile: clippy runs via clippy-driver,
+# which cargo fingerprints separately from plain rustc, so `test` rebuilds those
+# targets regardless. That extra target-checking is why `ci_fast` drops
+# `--all-targets` for the local iteration loop (it is kept here so the full gate
+# still lints test code).
 ci_clippy() { cargo clippy --all-targets -- -D warnings; }
 # Same lint, in release. The debug checks never compile the test target in
 # release, so a `#[cfg(debug_assertions)]`-gated item referenced by ungated code
@@ -26,6 +31,28 @@ ci_shellcheck() { find . -name '*.sh' -not -path './.git/*' -exec shellcheck -a 
 ci_doc_refs() {
   python3 .github/scripts/doc-refs/test_check_doc_refs.py
   python3 .github/scripts/doc-refs/check_doc_refs.py
+}
+
+# Fast inner-loop gate for local iteration: format, lint (debug, lib+bins only),
+# and test. Deliberately skips the phases whose cost is compile-bound and rarely
+# relevant mid-iteration — the *release* clippy pass (~2x the debug one; only
+# catches `cfg(debug_assertions)`-gated breakage), the doc build, shellcheck, and
+# the doc-ref check — and drops clippy's `--all-targets` (see `ci_clippy`: it
+# doubles the debug clippy time to check test targets `cargo test` then rebuilds
+# anyway). Roughly a third of a full `./ci.sh` after a one-file edit. Run the
+# full `./ci.sh` before pushing — CI gates on everything, and the release clippy
+# pass in particular fails there if skipped locally. `--fix` still applies.
+ci_fast() {
+  local failed=0
+  # shellcheck disable=SC2310
+  # intentional: || captures failure without exiting
+  ci_fmt || failed=1
+  # Lib+bins only (no --all-targets) — see the comment on `ci_clippy`.
+  # shellcheck disable=SC2310
+  { cargo clippy -- -D warnings; } || failed=1
+  # shellcheck disable=SC2310
+  ci_test || failed=1
+  exit "${failed}"
 }
 
 ci_all() {


### PR DESCRIPTION
ci.sh: add `fast` inner-loop gate for local iteration

The full `./ci.sh` runs six phases; on a one-file edit the two heaviest are the
release clippy pass and the doc build, and clippy's `--all-targets` roughly
doubles the debug clippy time to check test targets that `cargo test` then
recompiles anyway (clippy-driver fingerprints separately from rustc, so nothing
is shared — the old `ci_clippy` comment claiming it "warms the cache for cargo
test" was wrong, now corrected).

`./ci.sh fast` runs just what an edit→check loop needs: fmt + debug clippy
(lib/bins, no `--all-targets`) + tests. It skips the release clippy pass, the
doc build, shellcheck, and the doc-ref check — all of which the full `./ci.sh`
(and CI) still gate on before push. Roughly a third of the full gate's time
after a one-file edit. CLAUDE.md now points the iteration loop at it while
keeping the full gate as the pre-push requirement.

