### PR TITLE
Fix false "value-dependent dependent function" panic on nested filters

### DIFF
--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -691,6 +691,17 @@ fn count_free_in_type_with_visited(
     ty: &Type,
     visited: &mut HashSet<PredicateId>,
 ) -> usize {
+    // The only variable a type can bind is the refinement element binder
+    // ([`crate::ccl::REFINEMENT_BINDER`]): it occurs *only* inside refinement
+    // predicates, and each such occurrence is bound by its enclosing refinement.
+    // So it is never free in a type — counting its (bound) occurrences would
+    // falsely report the binder as free, e.g. tripping lambda-elim's
+    // "value-dependent dependent function" guard when a predicate merely carries
+    // a nested refinement over `__elem`. Every *other* name in a predicate is a
+    // free reference to the enclosing lexical scope and is counted.
+    if name.is_elem() {
+        return 0;
+    }
     let mut count = 0;
     walk_refined_predicates(ty, visited, &mut |pred, vis| {
         count += count_free_with_visited(name, pred, vis);

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -415,6 +415,12 @@ fn refine_with(base: Type, predicate: &Expr) -> Type {
 /// nodes treat their `name` field as a use of the defer-handle variable,
 /// so writes to that defer count as occurrences too.
 ///
+/// A [`Type::Refinement`] is a binding form too — it binds
+/// [`crate::ccl::REFINEMENT_BINDER`] (`__elem`) in its predicate — so occurrences
+/// of that one name inside a type are **bound, never free** (see
+/// [`is_free_in_type`]). Every other name in a predicate is a free reference to
+/// the enclosing lexical scope and is counted.
+///
 /// Used by:
 /// - [`is_free`] — the bool wrapper for "does `name` appear at all?"
 /// - [`crate::ccl::channelize`] — to detect when a defer's value
@@ -678,6 +684,11 @@ fn count_free_in_value(name: &Name, expr: &Expr) -> usize {
 /// it to detect when a term substitution would need to reach into a
 /// type-carried predicate (e.g. a `cast`-introduced domain refinement that
 /// closes over the substituted variable).
+///
+/// **Always `false` for [`crate::ccl::REFINEMENT_BINDER`]** — a type's only
+/// binding form is the refinement, and every `__elem` occurrence sits under the
+/// refinement that binds it, so the element binder is never a free reference to
+/// anything a substitution could supply.
 pub fn is_free_in_type(name: &Name, ty: &Type) -> bool {
     count_free_in_type_with_visited(name, ty, &mut HashSet::new()) > 0
 }

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -1276,34 +1276,55 @@ mod tests {
     // is_free / is_free_in_type
     // -----------------------------------------------------------------------
 
-    /// Regression test: `is_free_in_type` must use `any`, not `all`, for tuples.
+    /// Two properties of `is_free_in_type`, on one fixture so they contrast:
     ///
-    /// A variable is free in a tuple type if it appears in ANY component.
-    /// The old bug used `.all()`, so a variable appearing in only one component
-    /// of a multi-element tuple type would not be detected as free, causing
-    /// `substitute` to silently skip the substitution.
+    /// 1. A name is free in a tuple type if it appears in **any** component. The
+    ///    original bug here used `.all()`, so a variable appearing in only one
+    ///    component of a multi-element tuple went undetected and `substitute`
+    ///    silently skipped it.
+    /// 2. `REFINEMENT_BINDER` is **never** free in a type: a refinement is a
+    ///    binding form, and every `__elem` occurrence sits under the refinement
+    ///    that binds it. Reporting it free tripped the "value-dependent dependent
+    ///    function" guard below on any nested filter, whose predicate carries a
+    ///    refinement over `__elem`.
+    ///
+    /// One predicate exercises both — `__elem > x` mentions the bound element
+    /// binder and a free reference to the enclosing scope — so an implementation
+    /// that answered uniformly (everything free, or nothing free) fails one half.
     #[test]
-    fn is_free_detects_var_in_partial_tuple_refinement() {
+    fn is_free_in_type_sees_free_names_but_not_the_bound_element_binder() {
         use crate::ccl::Refinement;
         use std::rc::Rc;
 
-        // pred = Var("x") — the refinement predicate references x.
-        let pred = Rc::new(Expr::var("x"));
+        // pred = `__elem > x`: `__elem` is bound by the enclosing refinement,
+        // `x` is a free reference to whatever scope the type sits in.
+        let pred = Rc::new(Expr::binop(
+            Expr::var(Name::elem()),
+            BinOpKind::Compare(CompareKind::Greater),
+            Expr::var("x"),
+        ));
         let refinement = Refinement { predicate: pred };
 
-        // Tuple([Int, Refinement(Int, pred_x)]): x only appears in the second component.
+        // Tuple([Int, {Int | __elem > x}]): the predicate rides only the second
+        // component, so `any`-vs-`all` is observable.
         let tuple_ty = Type::Tuple(vec![
             int_ty(),
             Type::Refinement(Box::new(int_ty()), refinement),
         ]);
 
-        // Lit(42) typed with the tuple above — the expression node has no free vars,
-        // so the result depends entirely on is_free_in_type finding x in the type.
+        // Lit(42) typed with the tuple above — the expression node itself has no
+        // free vars, so both answers come entirely from `is_free_in_type`.
         let expr = Expr::lit(Lit::Int(42)).with_ty(tuple_ty);
 
         assert!(
             is_free(&Name::raw("x"), &expr),
             "x should be free: it appears in the refinement of the second tuple component"
+        );
+        assert!(
+            !is_free(&Name::elem(), &expr),
+            "the refinement element binder is bound by its refinement, so it is never \
+             free in a type — reporting it free is what falsely tripped the \
+             value-dependent-dependent-function guard on nested filters"
         );
     }
 }

--- a/tests/compilation_pipeline/comprehensions.rs
+++ b/tests/compilation_pipeline/comprehensions.rs
@@ -20,6 +20,15 @@ use crate::helpers::*;
 #[case("[42 for x in [10, 20]]", make_int_list(&[42, 42]))]
 #[case("[y for y in [x for x in [10, 20]]]", make_int_list(&[10, 20]))]
 #[case("[x + 2 for x in [10, 20]]", make_int_list(&[12, 22]))]
+// Nested *filtered* comprehensions (filter over a filtered comprehension). At
+// depth ≥3 this used to panic in lambda-elim: a refinement predicate carrying a
+// nested refinement over `__elem` made `is_free` mis-report the (bound) element
+// binder as free, tripping the "value-dependent dependent function" guard.
+#[case("[a for a in [b for b in [1, 2, 3, 4] if b < 3] if a < 3]", make_int_list(&[1, 2]))]
+#[case(
+    "[a for a in [b for b in [c for c in [1, 2, 3, 4] if c < 3] if b < 3] if a < 3]",
+    make_int_list(&[1, 2])
+)]
 fn test_comprehensions(#[case] code: &str, #[case] expected: Tile) {
     check_tile(code, expected);
 }


### PR DESCRIPTION
Fix false "value-dependent dependent function" panic on nested filters

Filtering a filtered comprehension at nesting depth ≥3 —
`[a for a in [b for b in [c for c in L if p] if q] if r]` — panicked in lambda
elimination with "value-dependent dependent function unsupported: `__elem`
occurs in the cast value". It was a false positive: nothing is actually
value-dependent.

The refinement element binder `REFINEMENT_BINDER` (`__elem`) occurs *only* inside
refinement predicates, and each occurrence is bound by its enclosing refinement.
But `count_free_in_type_with_visited` counted those bound occurrences as free, so
`is_free(__elem, value)` returned true whenever `value` merely carried a type
slot with a nested refinement over `__elem` — which a nested filter's predicate
does. That tripped lambda-elim's guard against genuine value-dependent dependent
functions.

Fix: `count_free` of the element binder in a type is always 0 — it is never free
there, since a type binds nothing else and every `__elem` sits under a
refinement that binds it. Other names in a predicate remain free references to
the enclosing scope and are still counted.

Adds pipeline regression cases (depth-2 and the previously-panicking depth-3)
that now compile and evaluate correctly.

Known follow-up (separate, deeper): the *type* of a nested filtered
comprehension still grows exponentially — inference stamps the refined element
type onto ~4-6 slots of each enclosing comprehension, and `Type` is a `Box`-tree
(subtrees are copied, not shared), so it compounds ~4-6x per level (compile:
~10ms at depth 3, ~5s at depth 7). Realistic nesting (≤5) is sub-200ms. The real
fix is representational (share `Type` subtrees) and is out of scope here.

