### PR TITLE
BaseType: single-source keyword spelling via `keyword()`/`from_keyword()`

### DIFF
--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -881,8 +881,8 @@ fn is_mut_annotation(annotation: &Spanned<ChlExpr>) -> bool {
 ///
 /// Recognised forms:
 /// - Capitalized primitive names (`Caps` means type — `docs/chl-spec.md`):
-///   `Int` → [`Type::Base`]([`BaseType::Int`]), `String` → `String`,
-///   `Bool` → `Bool`.
+///   any [`BaseType`] spelling ([`BaseType::keyword`]) → [`Type::Base`], i.e.
+///   `Int`, `UInt`, `String`, `Bool`, `Unit`.
 /// - `None` (the constant) → `Unit`, and the wildcard `_` → [`Type::Hole`]
 ///   ("infer this slot" — inference normalizes an annotation `Hole` to a fresh
 ///   variable, so the slot is unconstrained; see `bind_annotation`).
@@ -939,13 +939,15 @@ pub(super) fn lower_type_annotation(annotation: &Spanned<ChlExpr>) -> Result<Typ
 /// `docs/chl-spec.md`), or the
 /// inference wildcard `_`. Returns `None` for any other identifier.
 fn name_type(id: &str) -> Option<Type> {
-    Some(match id {
-        "Int" => Type::Base(BaseType::Int),
-        "String" => Type::Base(BaseType::String),
-        "Bool" => Type::Base(BaseType::Bool),
-        "_" => Type::Hole,
-        _ => return None,
-    })
+    if let Some(base) = BaseType::from_keyword(id) {
+        return Some(Type::Base(base));
+    }
+    // `_` is the inference wildcard, not a primitive, so it is not a
+    // `BaseType`; handle it alongside the primitive round-trip.
+    match id {
+        "_" => Some(Type::Hole),
+        _ => None,
+    }
 }
 
 /// Extract the simple-name head of a type application (`List` in `List(T)`).

--- a/src/ccl/ops.rs
+++ b/src/ccl/ops.rs
@@ -24,6 +24,38 @@ pub enum BaseType {
     Unit,
 }
 
+impl BaseType {
+    /// The CHL/CCL surface spelling of this primitive (`Caps` means type —
+    /// `docs/chl-spec.md`). Single source of truth for the reader
+    /// ([`from_keyword`](Self::from_keyword)) and every `Display`/pretty site,
+    /// so a new variant fails to compile until all of them are updated rather
+    /// than silently diverging.
+    pub const fn keyword(&self) -> &'static str {
+        match self {
+            BaseType::Int => "Int",
+            BaseType::UInt => "UInt",
+            BaseType::String => "String",
+            BaseType::Bool => "Bool",
+            BaseType::Unit => "Unit",
+        }
+    }
+
+    /// Inverse of [`keyword`](Self::keyword): recognise a primitive-type name.
+    /// Total round-trip over every variant (`from_keyword(b.keyword()) ==
+    /// Some(b)`), so all five spellings — `UInt` and `Unit` included — are
+    /// accepted wherever a primitive annotation is read.
+    pub fn from_keyword(s: &str) -> Option<Self> {
+        Some(match s {
+            "Int" => BaseType::Int,
+            "UInt" => BaseType::UInt,
+            "String" => BaseType::String,
+            "Bool" => BaseType::Bool,
+            "Unit" => BaseType::Unit,
+            _ => return None,
+        })
+    }
+}
+
 /// Errors about types that can be used by any phase of compilation
 pub enum TypeError {
     /// Generic type error
@@ -524,4 +556,25 @@ pub enum ProjKey {
     Index(usize),
     /// Named record-field projection: `.fieldname`.
     Field(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `from_keyword` is a total inverse of `keyword` over every variant — the
+    /// law that lets the reader and all writer sites share one spelling table.
+    #[test]
+    fn base_type_keyword_round_trips() {
+        for b in [
+            BaseType::Int,
+            BaseType::UInt,
+            BaseType::String,
+            BaseType::Bool,
+            BaseType::Unit,
+        ] {
+            assert_eq!(BaseType::from_keyword(b.keyword()), Some(b));
+        }
+        assert_eq!(BaseType::from_keyword("List"), None);
+    }
 }

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -280,17 +280,7 @@ fn synthetic_payloads(tags: &[(FieldKey, Type)]) -> Option<Vec<Type>> {
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Type::Base(b) => write!(
-                f,
-                "{}",
-                match b {
-                    BaseType::Int => "Int",
-                    BaseType::UInt => "UInt",
-                    BaseType::String => "String",
-                    BaseType::Bool => "Bool",
-                    BaseType::Unit => "Unit",
-                }
-            ),
+            Type::Base(b) => write!(f, "{}", b.keyword()),
             // `n == 0` means an empty range (e.g. the domain of `[]`); render
             // it as `∅` instead of computing `n - 1` and underflowing.
             Type::UIntRange(0) => write!(f, "∅"),

--- a/src/interpreter/types/extent.rs
+++ b/src/interpreter/types/extent.rs
@@ -315,13 +315,7 @@ impl Eq for dyn DataSourceDomainExtentImpl {}
 
 impl std::fmt::Display for BaseType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BaseType::Int => write!(f, "Int"),
-            BaseType::UInt => write!(f, "UInt"),
-            BaseType::String => write!(f, "String"),
-            BaseType::Bool => write!(f, "Bool"),
-            BaseType::Unit => write!(f, "Unit"),
-        }
+        write!(f, "{}", self.keyword())
     }
 }
 

--- a/src/pretty_graph.rs
+++ b/src/pretty_graph.rs
@@ -11,7 +11,7 @@
 //! ```
 
 use crate::interpreter::{
-    ArithmeticKind, BaseType, BinOpKind, CompareKind, Extent, LogicKind,
+    ArithmeticKind, BinOpKind, CompareKind, Extent, LogicKind,
     tile_operators::{TileOperator, TileProducer},
 };
 pub use crate::pretty_tree::{InspectNode, render, render_with_max_depth};
@@ -78,13 +78,7 @@ impl VizOptions {
 /// Format an Extent compactly for display.
 pub fn fmt_extent(extent: &Extent) -> String {
     match extent {
-        Extent::Base(base) => match base {
-            BaseType::Int => "Int".to_string(),
-            BaseType::UInt => "UInt".to_string(),
-            BaseType::String => "String".to_string(),
-            BaseType::Bool => "Bool".to_string(),
-            BaseType::Unit => "Unit".to_string(),
-        },
+        Extent::Base(base) => base.keyword().to_string(),
         Extent::Function { domain, codomain } => {
             let d = fmt_extent(domain);
             let c = fmt_extent(codomain);


### PR DESCRIPTION
The surface spelling of each primitive type (`Int`/`UInt`/`String`/`Bool`/`Unit`) was hand-written at four independent sites — three writers (`Display for Type` in `src/ccl/ty.rs`, `Display for BaseType` in `src/interpreter/types/extent.rs`, `fmt_extent` in `src/pretty_graph.rs`) and one reader (`name_type` in `src/ccl/lower/stmts.rs`). A renamed or added `BaseType` variant could silently diverge across them.

This collapses the spelling into a single source of truth on `BaseType`:

- `BaseType::keyword(&self) -> &'static str` — the surface spelling (a `const fn`).
- `BaseType::from_keyword(&str) -> Option<Self>` — its total inverse (`from_keyword(b.keyword()) == Some(b)` for every variant), covered by a round-trip test.

All three writer sites now format through `keyword()`, and `name_type` recognises primitives through `from_keyword()`. Adding a `BaseType` variant is now a compile error at every site until it is handled, rather than a silent divergence.

Because the round-trip is total, type annotations now also accept `UInt` and `Unit` — previously `name_type` accepted only `Int`/`String`/`Bool`. The inference wildcard `_` stays handled separately in `name_type`; it is not a `BaseType`.

Not addressed here: `Type::Txn` and `Type::History` `Display` still hand-spell `Txn`/`Mut`/`feed` outside any shared helper. Consolidating the full type-surface vocabulary is a separate change, and a parser-level "reserved type keyword" concept was investigated and rejected as incoherent with CHL's capitalization-defined, open type namespace.