### PR TITLE
tests: failing guards for five predicate-sharing review findings

### DIFF
--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -1282,3 +1282,52 @@ pub(super) fn emit_transact<C: Typing>(
     }
     Ok(Type::Record(fields))
 }
+
+#[cfg(test)]
+mod review_tests {
+    use super::*;
+    use crate::ccl::{BinOpKind, CompareKind, Lit, TypedExpr};
+    use std::rc::Rc;
+
+    /// Finding 2: [`emit_bare_predicate`]'s transform is parameterized by
+    /// `domain`, which is not part of the memo key. `emit_cast` passes a *fresh*
+    /// inference variable per cast node, so two occurrences of one shared
+    /// predicate `Rc` are typed against two different domains — and the memo
+    /// makes the second one emit nothing at all, leaving its domain with none of
+    /// the constraints the predicate imposes on `REFINEMENT_BINDER`.
+    #[test]
+    fn each_occurrence_constrains_its_own_domain() {
+        // `__elem > 0` — using the element binder is what makes the predicate
+        // constrain the domain it is typed against.
+        let shared = Rc::new(TypedExpr::binop(
+            TypedExpr::var(Name::elem()),
+            BinOpKind::Compare(CompareKind::Greater),
+            TypedExpr::lit(Lit::Int(0)),
+        ));
+        let mut r1 = Refinement::sharing(&shared);
+        let mut r2 = Refinement::sharing(&shared);
+
+        let mut ctx = InferCtx::new(std::collections::HashMap::new());
+        let d1 = ctx.fresh();
+        let d2 = ctx.fresh();
+        emit_bare_predicate(&mut r1, &d1, &mut ctx).expect("first occurrence types");
+        emit_bare_predicate(&mut r2, &d2, &mut ctx).expect("second occurrence types");
+
+        let bound_count = |t: &Type| {
+            let Type::Infer(v) = t else {
+                panic!("fresh() yields a variable");
+            };
+            let b = v.bounds.borrow();
+            b.lower.len() + b.upper.len()
+        };
+        assert!(
+            bound_count(&d1) > 0,
+            "sanity: typing `__elem > 0` at `d1` constrains `d1`",
+        );
+        assert!(
+            bound_count(&d2) > 0,
+            "the second occurrence's domain must be constrained by the predicate \
+             too — the memo hit skipped emission and left `d2` unbounded",
+        );
+    }
+}

--- a/tests/predicate_sharing_review.rs
+++ b/tests/predicate_sharing_review.rs
@@ -1,0 +1,223 @@
+//! Failing guards for the review findings on the predicate-sharing work.
+//!
+//! Each test states one property the current code violates. They are written
+//! against the smallest construction that exhibits the defect, not against a
+//! source-level fixture, so a fix can be verified without reasoning about which
+//! program shape happens to produce the sharing.
+
+use cambra::ccl::ccl_utils::{
+    PredMemo, distinct_predicate_rcs, is_free, walk_refined_predicates_mut,
+};
+use cambra::ccl::subst::Subst;
+use cambra::ccl::{
+    BinOpKind, CompareKind, Expr, Lit, Name, Refinement, Type, TypedExpr, TypedExprNode,
+};
+use std::rc::Rc;
+
+fn var(s: &str) -> TypedExpr {
+    TypedExpr::var(s)
+}
+fn int(n: i64) -> TypedExpr {
+    TypedExpr::lit(Lit::Int(n))
+}
+fn gt(l: TypedExpr, r: TypedExpr) -> TypedExpr {
+    TypedExpr::binop(l, BinOpKind::Compare(CompareKind::Greater), r)
+}
+/// `{_ | pred}`, a second occurrence of an existing predicate term.
+fn refined(pred: &Rc<TypedExpr>) -> Type {
+    Type::Refinement(Box::new(Type::Hole), Refinement::sharing(pred))
+}
+/// The predicate term of a `{_ | p}`.
+fn predicate_of(ty: &Type) -> &Rc<TypedExpr> {
+    let Type::Refinement(_, r) = ty else {
+        panic!("expected a refinement, got {ty}");
+    };
+    &r.predicate
+}
+
+// ---------------------------------------------------------------------------
+// Finding 1 — `subst`'s `PredMemo` is threaded across shadowing boundaries,
+// but substitution is scope-dependent.
+// ---------------------------------------------------------------------------
+
+/// `rewrite_expr` rewrites a node's own type slots *before* descending under its
+/// binders, and threads one memo across that crossing. So the occurrence rebuilt
+/// in the outer scope is served to an occurrence inside a scope that **rebinds**
+/// the substituted variable — applying a substitution under a binder that
+/// shadows it.
+///
+/// Two substituted binders are needed: with only `k`, `under_binder_mut`'s
+/// empty-restriction early return declines to enter the body at all.
+#[test]
+fn rewrite_does_not_leak_an_outer_rebuild_into_a_shadowing_scope() {
+    let shared = Rc::new(gt(var("k"), int(0)));
+    // λ k → (j > 0) : {_ | k > 0}          — the body's `k` is the lambda's own.
+    //   with the lambda's own ty = ({_ | k > 0} ⇒ _), sharing that one predicate.
+    let body = gt(var("j"), int(0)).with_ty(refined(&shared));
+    let mut e =
+        TypedExpr::lambda("k", Type::Hole, body).with_ty(Type::fun(refined(&shared), Type::Hole));
+
+    // [k ↦ 5, j ↦ 6]: `j` keeps the body reachable, `k` is shadowed by the lambda.
+    let s = Subst::then(
+        &Subst::discharge("k", int(5)),
+        &Subst::discharge("j", int(6)),
+    );
+    s.rewrite_expr(&mut e);
+
+    let Type::Fun { domain, .. } = &e.ty else {
+        panic!("function type preserved");
+    };
+    assert_eq!(
+        **predicate_of(domain),
+        gt(int(5), int(0)),
+        "the outer occurrence is not under the binder, so it discharges"
+    );
+
+    let TypedExprNode::Lambda { body, .. } = &e.node else {
+        panic!("lambda preserved");
+    };
+    assert_eq!(
+        **predicate_of(&body.ty),
+        gt(var("k"), int(0)),
+        "the occurrence inside `λ k` refers to the lambda's own `k`, which the \
+         substitution must not touch — but the memo served it the outer rebuild"
+    );
+}
+
+/// Control for the test above: the *same two occurrences*, but as two distinct
+/// `Rc`s. This passes — which localizes the defect to the memo rather than to
+/// the shadowing walk, and shows that improving sharing is what exposes it.
+#[test]
+fn rewrite_respects_shadowing_when_the_occurrences_are_not_shared() {
+    let outer = Rc::new(gt(var("k"), int(0)));
+    let inner = Rc::new(gt(var("k"), int(0)));
+    let body = gt(var("j"), int(0)).with_ty(refined(&inner));
+    let mut e =
+        TypedExpr::lambda("k", Type::Hole, body).with_ty(Type::fun(refined(&outer), Type::Hole));
+
+    let s = Subst::then(
+        &Subst::discharge("k", int(5)),
+        &Subst::discharge("j", int(6)),
+    );
+    s.rewrite_expr(&mut e);
+
+    let Type::Fun { domain, .. } = &e.ty else {
+        panic!("function type preserved");
+    };
+    assert_eq!(**predicate_of(domain), gt(int(5), int(0)));
+    let TypedExprNode::Lambda { body, .. } = &e.node else {
+        panic!("lambda preserved");
+    };
+    assert_eq!(**predicate_of(&body.ty), gt(var("k"), int(0)));
+}
+
+// ---------------------------------------------------------------------------
+// Finding 3 — `rewrite_expr_go` never rewrites binder-slot types, so a
+// predicate riding `param.ty` is left stale against the same predicate on `ty`.
+// ---------------------------------------------------------------------------
+
+/// A lambda's domain refinement rides both `expr.ty`'s `Fun` domain and
+/// `param.ty`, as two occurrences of one `Rc`. `rewrite_expr` rebuilds the
+/// former and never visits the latter, so after the rewrite the two slots
+/// disagree — the same stale-copy defect `retype_pred_expr` had.
+#[test]
+fn rewrite_reaches_the_lambda_param_type_slot() {
+    let shared = Rc::new(gt(var("k"), int(0)));
+    let mut e = TypedExpr::lambda("x", refined(&shared), var("x"))
+        .with_ty(Type::fun(refined(&shared), Type::Hole));
+
+    Subst::discharge("k", int(5)).rewrite_expr(&mut e);
+
+    let TypedExprNode::Lambda { param, .. } = &e.node else {
+        panic!("lambda preserved");
+    };
+    assert_eq!(
+        **predicate_of(&param.ty),
+        gt(int(5), int(0)),
+        "`param.ty` holds its own `Rc`, so the discharge must reach it too"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Finding 4 — `count_free`/`is_free` does not walk binder-slot types, while
+// `walk_type_slots` does. Three "skip the work" fast paths gate on `is_free`.
+// ---------------------------------------------------------------------------
+
+/// `let y = 1 in unit` with `y : {_ | k > 0}` — `k` occurs *only* in the
+/// predicate riding the `Let` binding's declared type.
+///
+/// `distinct_predicate_rcs` (i.e. `walk_type_slots`) sees that slot; `is_free`
+/// does not. The asymmetry is load-bearing: `inline_in_type_predicates` now
+/// returns early on `!is_free(name, pred)`, and `subst` skips both inert
+/// subtrees and vacuous predicates the same way — so an occurrence only
+/// `walk_type_slots` can see is silently left un-rewritten.
+#[test]
+fn is_free_sees_a_predicate_on_a_let_binding_slot() {
+    let k = Name::raw("k");
+    let mut e = Expr::let_bind(
+        "y",
+        Expr::lit(Lit::Int(1)).with_ty(refined(&Rc::new(gt(var("k"), int(0))))),
+        Expr::lit(Lit::Unit),
+    );
+    // `let_bind` copies `bound_expr.ty` into `binding.ty`; clear the former so
+    // the binder slot is the only place the predicate rides.
+    if let TypedExprNode::Let { bound_expr, .. } = &mut e.node {
+        bound_expr.ty = Type::Hole;
+    }
+
+    assert_eq!(
+        distinct_predicate_rcs(&e),
+        1,
+        "walk_type_slots reaches the binding's declared type",
+    );
+    assert!(
+        is_free(&k, &e),
+        "`k` occurs free in `e` — in the predicate on the `Let` binding's type. \
+         Every fast path that skips work on `!is_free` misses it.",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Finding 5 — the `changed` bit a callback returns cannot see the re-pointings
+// a nested memo *hit* performs, so `finish_unchanged` discards them.
+// ---------------------------------------------------------------------------
+
+/// A callback that recurses through the memo (which is why the combinator hands
+/// it one) can have its copy mutated by a nested memo hit while having nothing
+/// of its own to report. Reporting `false` then throws the copy away, so the
+/// nested slot keeps a predicate the pass already rebuilt — and the outer
+/// predicate is memoized as `origin ↦ origin`, fixing that staleness for every
+/// later occurrence.
+///
+/// This is `simplify`'s exact shape: it returns `simplify_once(pred, memo).0`,
+/// which reports only whether a *rule fired*.
+#[test]
+fn walk_preserves_a_repointing_made_by_a_nested_memo_hit() {
+    let mut memo = PredMemo::new();
+
+    // An inner predicate `q`, rebuilt through the memo by some earlier occurrence.
+    let q = Rc::new(gt(var("a"), int(0)));
+    let mut t_q = refined(&q);
+    walk_refined_predicates_mut(&mut t_q, &mut memo, &mut |pred, _| {
+        *pred = gt(var("a"), int(1)); // a real rewrite
+        true
+    });
+    let q_rebuilt = Rc::clone(predicate_of(&t_q));
+    assert!(!Rc::ptr_eq(&q_rebuilt, &q), "q was rebuilt");
+
+    // An outer predicate `p` carrying a second occurrence of `q` on its own type
+    // slot. The transform has nothing to say about `p` itself.
+    let p = Rc::new(int(1).with_ty(refined(&q)));
+    let mut t_p = refined(&p);
+    walk_refined_predicates_mut(&mut t_p, &mut memo, &mut |pred, memo| {
+        // Recurse into the predicate's own type slots, as every caller does.
+        walk_refined_predicates_mut(&mut pred.ty, memo, &mut |_, _| false);
+        false // "no rule fired at this level"
+    });
+
+    assert!(
+        Rc::ptr_eq(predicate_of(&predicate_of(&t_p).ty), &q_rebuilt),
+        "the nested occurrence of `q` must end up at the single rebuild, not at \
+         the stale origin the discarded copy was re-pointed away from",
+    );
+}


### PR DESCRIPTION
Review response to the predicate-`Rc`-sharing work (`dmills/predicate-rc-sharing`, which this branch is based on). Five red tests, one per finding, plus one passing control.

**CI is expected red.** That is the deliverable: each test asserts a property the branch currently violates. `cargo test --test predicate_sharing_review` and `cargo test --lib review_tests`.

## The findings

Detail is in each test's doc comment; this is the index.

1. **`subst`'s memo crosses shadowing boundaries.** One `PredMemo` spans all four places the active substitution shrinks, so a rebuild from an outer scope is served to an occurrence whose scope rebinds the substituted variable — and, via `finish_unchanged`, a vacuous decision made under a restricted substitution skips a later occurrence under the full one. *(`rewrite_does_not_leak_an_outer_rebuild_into_a_shadowing_scope`, with `rewrite_respects_shadowing_when_the_occurrences_are_not_shared` as the passing control.)*
2. **Constraint emission's memo hit drops the occurrence's own domain.** `emit_bare_predicate` is parameterized by the domain the element binder is bound to; `emit_cast` mints a fresh one per cast node, so the second occurrence emits nothing and its domain is left unbounded. *(`each_occurrence_constrains_its_own_domain`.)*
3. **`subst::rewrite_expr_go` never rewrites binder-slot types.** A predicate on `param.ty` is left stale against the same predicate on `ty` — the defect `retype_pred_expr` had. *(`rewrite_reaches_the_lambda_param_type_slot`.)*
4. **`count_free`/`is_free` does not reach binder-slot predicates.** Three fast paths now skip work on `!is_free` — `inline_in_type_predicates`' early return, `subst`'s inert-subtree check, and `subst`'s vacuous-predicate check — so the coverage gap against `walk_type_slots` decides whether a rewrite happens. *(`is_free_sees_a_predicate_on_a_let_binding_slot`.)*
5. **The combinator's `changed` bit cannot see a nested memo hit's re-pointing.** `finish_unchanged` then discards the copy and memoizes the staleness. `simplify`'s fixpoint loop repairs the result on a later iteration, so this is latent — the fix is for the combinator to return the bit, since it is what knows. *(`walk_preserves_a_repointing_made_by_a_nested_memo_hit`.)*

## The pattern: one memo protocol, several different transforms

`PredMemo` is keyed on the predicate `Rc`'s address alone. That key determines the result only for a transform that is a function of the predicate term. The passes now threading it split in two:

- **Key-determined** — `uniquify`, `coalesce`, `retype`. The rebuild depends on the term plus context the branch argues is invariant across occurrences.
- **Context-determined** — the transform depends on something the key does not name: `subst` (the *active substitution*), constraint emission (the *domain*), planning's compilation (the refinement's *base*, which `fn_of_bare_predicate`/`bare_predicate_of_fn` both consume).

`coalesce_type_predicates` is the only one with a written precondition: resolution reads inference variables out of one live constraint graph, so two occurrences of one term resolve identically. That does not transfer to the second group, and for `subst` it inverts — substitution's job is to act differently in different scopes, so "same term ⇒ same result" is what shadowing denies. Findings 1 and 2 are where I think this is live rather than merely undocumented; planning's base-keyed compilation is the same shape and wants at least the same paragraph, or a `debug_assert!` that the bases agree on the hit path.

Formerly unreachable code paths are exposed by `Rc` sharing; the `rewrite_respects_shadowing_when_the_occurrences_are_not_shared` control illustrates this with shared/unshared versions of the same tree.

For `subst`: not letting the memo cross a shrink (fresh memo when `restricted != *self`) keeps the win and closes both directions.

`Expr::walk_type_slots{,_mut}` unified the type-slot walks; the two remaining hand-rolled copies are exactly findings 3 and 4. Converting `count_free_with_visited` is the highest-value follow-up.