### PR TITLE
Binder scoping: one exhaustive scoped-children walk, four folds over it

### DIFF
--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
+use crate::ccl::scope::{ScopedItem, for_each_scoped_item};
 use crate::ccl::{
     BaseType, Builtin, Expr, Lit, Name, PredicateId, Refinement, Type, TypedExprNode,
 };
@@ -397,12 +398,14 @@ fn refine_with(base: Type, predicate: &Expr) -> Type {
 /// Count free occurrences of `name` in `expr`, including occurrences in
 /// any refinement predicates carried by the expression's type.
 ///
-/// A variable is *free* at a use site when no enclosing
-/// [`TypedExprNode::Lambda`] or [`TypedExprNode::Let`] inside `expr`
-/// shadows the name on the path to that use; the count is the number of
-/// such free uses.  [`TypedExprNode::Feed`] / [`TypedExprNode::Define`]
-/// nodes treat their `name` field as a use of the defer-handle variable,
-/// so writes to that defer count as occurrences too.
+/// A variable is *free* at a use site when no binder inside `expr` shadows the
+/// name on the path to that use; the count is the number of such free uses.
+/// The shadowing rules are not restated here — the walk folds over
+/// [`crate::ccl::scope::for_each_scoped_item`], which declares them once for the
+/// whole crate. Consequently [`TypedExprNode::Feed`] / [`TypedExprNode::Define`]
+/// / [`TypedExprNode::MutWrite`] target names count as occurrences (they are
+/// *uses* of the handle / mutable variable), while a
+/// [`TypedExprNode::Transact`] register key does not (it is a field label).
 ///
 /// A [`Type::Refinement`] is a binding form too — it binds
 /// [`crate::ccl::REFINEMENT_BINDER`] (`__elem`) in its predicate — so occurrences
@@ -446,115 +449,23 @@ fn count_free_with_visited(name: &Name, expr: &Expr, visited: &mut HashSet<Predi
     // sharing improves) is still counted once.
     let mut in_type = 0;
     expr.walk_type_slots(|ty| in_type += count_free_in_type_with_visited(name, ty, visited));
-    let in_node = match &expr.node {
-        TypedExprNode::Var(n) => (n == name) as usize,
-
-        TypedExprNode::Lambda { param, body } => {
-            // Domain refinements ride the type lattice, so any free
-            // occurrences in a refinement predicate are counted by
-            // `count_free_in_type_with_visited` on `expr.ty` above (and live
-            // in the *outer* scope, unshadowed). Here `param.name` shadows
-            // `name` inside the lambda body.
-            if &param.name == name {
-                0
-            } else {
-                count_free_with_visited(name, body, visited)
+    // The term spine is a fold over the shared scoping walk: a child whose
+    // binder list mentions `name` is shadowed and contributes nothing;
+    // everything else recurses. Register-key labels (`KeyRef`) are not variable
+    // occurrences, so they do not count.
+    let mut in_node = 0;
+    for_each_scoped_item(expr, &mut |item| match item {
+        ScopedItem::VarRef(n) => in_node += (n == name) as usize,
+        ScopedItem::KeyRef(_) => {}
+        ScopedItem::Child {
+            expr: child,
+            binders,
+        } => {
+            if !binders.iter().any(|b| &b.name == name) {
+                in_node += count_free_with_visited(name, child, visited);
             }
         }
-
-        TypedExprNode::Let {
-            binding,
-            bound_expr,
-            body,
-        } => {
-            // `binding.name` shadows `name` inside `body` only.
-            count_free_with_visited(name, bound_expr, visited)
-                + if &binding.name == name {
-                    0
-                } else {
-                    count_free_with_visited(name, body, visited)
-                }
-        }
-
-        // Mutual recursion: every group binder scopes every binding body
-        // and the letrec body, so a group binder matching `name` shadows it
-        // across the whole group.
-        TypedExprNode::LetRec { bindings, body } => {
-            if bindings.iter().any(|(b, _)| &b.name == name) {
-                0
-            } else {
-                bindings
-                    .iter()
-                    .map(|(_, def)| count_free_with_visited(name, def, visited))
-                    .sum::<usize>()
-                    + count_free_with_visited(name, body, visited)
-            }
-        }
-
-        // The `name` field of Feed/Define/MutWrite is a *use* of the defer
-        // handle / mutable variable — `Feed("x", v)` (and `x := v`) is a
-        // write to `x`, so `x` is free here in addition to any free uses
-        // inside `value`.
-        TypedExprNode::Feed {
-            name: handle,
-            value,
-        }
-        | TypedExprNode::Define {
-            name: handle,
-            value,
-        }
-        | TypedExprNode::MutWrite {
-            name: handle,
-            value,
-        } => (handle == name) as usize + count_free_with_visited(name, value, visited),
-
-        // The loop target shadows `name` inside the body only; the source
-        // is evaluated in the outer scope.
-        TypedExprNode::For { target, iter, body } => {
-            count_free_with_visited(name, iter, visited)
-                + if &target.name == name {
-                    0
-                } else {
-                    count_free_with_visited(name, body, visited)
-                }
-        }
-
-        // A `Case` branch's structural pattern binds its payload name,
-        // shadowing `name` inside that branch's guard and body.
-        // `walk_children` only visits child Exprs and can't see that
-        // `pattern.binding.name` shadows `name`, so it would over-count
-        // free occurrences in shadowing branches. Handle `Case` explicitly.
-        // (Guard-only branches have `pattern: None` and never shadow.)
-        TypedExprNode::Case {
-            scrutinee,
-            branches,
-        } => {
-            let scrut = scrutinee
-                .as_ref()
-                .map_or(0, |s| count_free_with_visited(name, s, visited));
-            scrut
-                + branches
-                    .iter()
-                    .map(|b| {
-                        if b.pattern.as_ref().is_some_and(|p| &p.binding.name == name) {
-                            0
-                        } else {
-                            count_free_with_visited(name, &b.guard, visited)
-                                + count_free_with_visited(name, &b.body, visited)
-                        }
-                    })
-                    .sum::<usize>()
-        }
-
-        // VariantCtor payload and all other variants: just sum counts
-        // across the direct children.  Atoms (Lit/Proj/Builtin/Source/
-        // Defer) have no children, so the fold returns 0.
-        _ => {
-            let mut sum = 0;
-            expr.walk_children(|e| sum += count_free_with_visited(name, e, visited));
-            sum
-        }
-    };
+    });
     in_node + in_type
 }
 
@@ -580,89 +491,25 @@ pub fn is_free_in_value(name: &Name, expr: &Expr) -> bool {
     count_free_in_value(name, expr) > 0
 }
 
-/// Value-only worker for [`is_free_in_value`]: mirrors [`count_free`]'s
-/// shadowing rules over the node tree but never descends into type slots (and so
-/// a refinement on a `Lambda` param — which lives in the type — is ignored).
+/// Value-only worker for [`is_free_in_value`]: the same fold over
+/// [`crate::ccl::scope::for_each_scoped_item`] as [`count_free`], minus the type
+/// slots (so a refinement on a `Lambda` param — which lives in the type — is
+/// ignored).
 fn count_free_in_value(name: &Name, expr: &Expr) -> usize {
-    match &expr.node {
-        TypedExprNode::Var(n) => (n == name) as usize,
-        TypedExprNode::Lambda { param, body, .. } => {
-            if &param.name == name {
-                0
-            } else {
-                count_free_in_value(name, body)
+    let mut sum = 0;
+    for_each_scoped_item(expr, &mut |item| match item {
+        ScopedItem::VarRef(n) => sum += (n == name) as usize,
+        ScopedItem::KeyRef(_) => {}
+        ScopedItem::Child {
+            expr: child,
+            binders,
+        } => {
+            if !binders.iter().any(|b| &b.name == name) {
+                sum += count_free_in_value(name, child);
             }
         }
-        TypedExprNode::Let {
-            binding,
-            bound_expr,
-            body,
-        } => {
-            count_free_in_value(name, bound_expr)
-                + if &binding.name == name {
-                    0
-                } else {
-                    count_free_in_value(name, body)
-                }
-        }
-        // See the LetRec arm of `count_free_with_visited`: group binders
-        // shadow `name` across every binding body and the letrec body.
-        TypedExprNode::LetRec { bindings, body } => {
-            if bindings.iter().any(|(b, _)| &b.name == name) {
-                0
-            } else {
-                bindings
-                    .iter()
-                    .map(|(_, def)| count_free_in_value(name, def))
-                    .sum::<usize>()
-                    + count_free_in_value(name, body)
-            }
-        }
-        TypedExprNode::Feed {
-            name: handle,
-            value,
-        }
-        | TypedExprNode::Define {
-            name: handle,
-            value,
-        }
-        | TypedExprNode::MutWrite {
-            name: handle,
-            value,
-        } => (handle == name) as usize + count_free_in_value(name, value),
-        // The loop target shadows `name` in the body only.
-        TypedExprNode::For { target, iter, body } => {
-            count_free_in_value(name, iter)
-                + if &target.name == name {
-                    0
-                } else {
-                    count_free_in_value(name, body)
-                }
-        }
-        TypedExprNode::Case {
-            scrutinee,
-            branches,
-        } => {
-            scrutinee
-                .as_ref()
-                .map_or(0, |s| count_free_in_value(name, s))
-                + branches
-                    .iter()
-                    .map(|b| {
-                        if b.pattern.as_ref().is_some_and(|p| &p.binding.name == name) {
-                            0
-                        } else {
-                            count_free_in_value(name, &b.guard) + count_free_in_value(name, &b.body)
-                        }
-                    })
-                    .sum::<usize>()
-        }
-        _ => {
-            let mut sum = 0;
-            expr.walk_children(|e| sum += count_free_in_value(name, e));
-            sum
-        }
-    }
+    });
+    sum
 }
 
 /// Returns `true` if `name` appears free inside a refinement predicate

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -461,7 +461,7 @@ fn count_free_with_visited(name: &Name, expr: &Expr, visited: &mut HashSet<Predi
             expr: child,
             binders,
         } => {
-            if !binders.iter().any(|b| &b.name == name) {
+            if !binders.shadows(name) {
                 in_node += count_free_with_visited(name, child, visited);
             }
         }
@@ -504,7 +504,7 @@ fn count_free_in_value(name: &Name, expr: &Expr) -> usize {
             expr: child,
             binders,
         } => {
-            if !binders.iter().any(|b| &b.name == name) {
+            if !binders.shadows(name) {
                 sum += count_free_in_value(name, child);
             }
         }

--- a/src/ccl/design/README.md
+++ b/src/ccl/design/README.md
@@ -25,7 +25,7 @@ CHL source
 
 | Doc | Covers |
 | --- | --- |
-| [ir.md](ir.md) | The typed AST: `TypedExpr`/`Type`, the purity invariant, structured names & α-uniquification, the Lambda/Apply iteration encoding, the `Aggregate`/`Cast`/`Case`/`Transact`/`LetRec` nodes, `TypedBinding`, and the transient `Hole`/`Infer`/`Feed`/`Mut` variants. |
+| [ir.md](ir.md) | The typed AST: `TypedExpr`/`Type`, the purity invariant, structured names & α-uniquification, the single statement of binding structure (`ccl/scope.rs`), the Lambda/Apply iteration encoding, the `Aggregate`/`Cast`/`Case`/`Transact`/`LetRec` nodes, `TypedBinding`, and the transient `Hole`/`Infer`/`Feed`/`Mut` variants. |
 | [type-inference.md](type-inference.md) | Cambra's inference algorithm: the two-pass emit → coalesce engine (`ccl/infer/`), the constraint solver (`ccl/infer/solver/`), let-polymorphism, dependent Pi types and refinements, and post-inference validation. |
 | [lowering.md](lowering.md) | CHL → CCL lowering: how comprehensions, lambdas, `def`s, and generators become CCL shapes, and the surface syntax of the deferred-collection operators. |
 | [optimization.md](optimization.md) | The optimization/compilation passes: inlining, lambda elimination, join/aggregate planning, algebraic simplification, and conversion to tile operators. |

--- a/src/ccl/design/ir.md
+++ b/src/ccl/design/ir.md
@@ -51,7 +51,7 @@ Renaming happens at the name level only — the tree shape is untouched, so this
 
 ### Binding structure lives in one place
 
-Which children a node's binders scope over is stated once, in `ccl/scope.rs`'s `for_each_scoped_item`: it visits each direct child paired with the binders in scope for it, plus the name *occurrences* the node makes itself. Every scope-aware walk in the crate is a fold over it — free-occurrence counting (`ccl_utils`'s `count_free`, `count_free_in_value`), free-variable collection (`subst`'s `collect_expr_fv`), and capture-avoiding substitution (`Subst::rewrite_expr`, via the `for_each_scoped_child_mut` adapter).
+Which children a node's binders scope over is stated once, in `ccl/scope.rs`'s `for_each_scoped_item`: it visits each direct child paired with the binders in scope for it, plus the name *occurrences* the node makes itself. Every scope-aware walk in the crate is a fold over it — free-occurrence counting (`ccl_utils`'s `count_free`, `count_free_in_value`), free-variable collection (`subst`'s `collect_expr_fv`), and capture-avoiding substitution (`Subst::rewrite_expr`, via the `for_each_scoped_item_mut` adapter).
 
 The rules themselves:
 
@@ -63,11 +63,17 @@ The rules themselves:
 - `Feed` / `Define` / `MutWrite` — the `name` field is a *use* of the binder it names, not a binder.
 - `Transact` — introduces no binder; its keys are labels of the register record the node denotes, so they are surfaced as a distinct occurrence kind that free-*variable* analyses skip while an identity-sensitive consumer still folds them in.
 
-The walk's `match` is exhaustive with **no wildcard arm**, deliberately: before this existed, the walkers ended in `_ => walk_children(..)`, so a new binding form compiled clean in all of them and silently got the wrong scope in every one. Now it is a compile error until the new form declares its scope. `TypedExpr::walk_binders` — the enumeration of binding *slots*, which the scoped walk is checked against and which `uniquify`'s post-pass mint assertion runs on — is exhaustive for the same reason: a wildcard there would let a new binding form be invisible to the assertion that is supposed to catch a forgotten mint, which is the same failure mode one layer down.
+Every `match` that decides one of these rules is exhaustive with **no wildcard arm**, deliberately: before this existed, the walkers ended in `_ => walk_children(..)`, so a new binding form compiled clean in all of them and silently got the wrong scope in every one. Now it is a compile error until the new form declares its scope. That covers three matches, each closing the same failure mode at a different layer:
+
+- `for_each_scoped_item` — which children each binder scopes over.
+- `for_each_scoped_item_mut`'s name half — which names a node mentions of its own, so that a rename retargets a new node's name reference instead of walking past it. Its agreement with the immutable walk is a corpus test.
+- `TypedExpr::walk_binders` — the enumeration of binding *slots*, which the scoped walk is checked against and which `uniquify`'s post-pass mint assertion runs on. A wildcard here would let a new binding form be invisible to the assertion that is supposed to catch a forgotten mint.
 
 Two passes stay outside the fold and say why in their own docs: `ccl/uniquify.rs` *mints* binders rather than observing them, and substitution's transport mode (`Subst::apply_expr_inner`) rebuilds nodes rather than walking them.
 
-Consumers may rely on three properties of the walk, each asserted in `scope.rs`'s tests: the `Child` items come in `walk_children` order (so the `&mut` adapter can pair binder lists positionally), the binders it declares are exactly `walk_binders`', and a scope's children are consecutive with a binder-introducing scope entered only once. The last is what lets a consumer build per-scope state once per scope rather than once per child — `Subst::shadow_all` restricting a substitution across a `LetRec` group, for instance, which borrows instead of cloning whenever the group names nothing the substitution acts on.
+A scope is a type, `Binders`, not a collected list of binder references: it borrows the node's binder slots in place, so the walk allocates nothing even for a `LetRec` group — which matters because it sits under `is_free`, and substitution consults that once per mapped binder per node. `Binders` also owns `shadows`, the question every consumer actually asks, so "does this scope shadow this name" is answered once rather than at each fold.
+
+Consumers may rely on three properties of the walk, each asserted in `scope.rs`'s tests: the `Child` items come in `walk_children` order (so the `&mut` walk can pair scopes with children positionally), the binders it declares are exactly `walk_binders`', and a scope's children are consecutive with a binder-introducing scope entered only once. The last is what lets a consumer build per-scope state once per scope rather than once per child, and the `&mut` walk hands it the change point directly, as a `Scope` item ahead of the run of children it covers. Substitution needs both halves of that: restricting the substitution across the scope (`Subst::shadow_all`, which borrows instead of cloning whenever the scope names nothing the substitution acts on) and the Barendregt no-capture check, which is release-active and walks every replacement term — so a `LetRec` group of *n* binders owes *n* checks, and paying per child instead would cost *n*(*n*+1).
 
 ### Application shape
 

--- a/src/ccl/design/ir.md
+++ b/src/ccl/design/ir.md
@@ -49,6 +49,26 @@ After uniquification, shadowing ceases to exist for every downstream pass: plain
 
 Renaming happens at the name level only — the tree shape is untouched, so this does not over-normalize the way strict ANF or SSA conversion would.
 
+### Binding structure lives in one place
+
+Which children a node's binders scope over is stated once, in `ccl/scope.rs`'s `for_each_scoped_item`: it visits each direct child paired with the binders in scope for it, plus the name *occurrences* the node makes itself. Every scope-aware walk in the crate is a fold over it — free-occurrence counting (`ccl_utils`'s `count_free`, `count_free_in_value`), free-variable collection (`subst`'s `collect_expr_fv`), and capture-avoiding substitution (`Subst::rewrite_expr`, via the `for_each_scoped_child_mut` adapter).
+
+The rules themselves:
+
+- `Lambda` — `param` scopes over `body`.
+- `Let` — `binding` scopes over `body` only; `bound_expr` is outside it (CCL's `let` is non-recursive).
+- `LetRec` — every group binder scopes over every binding's definition and over `body`.
+- `For` — `target` scopes over `body`; `iter` is outside.
+- `Case` — each branch's `pattern.binding` scopes over that branch's `guard` and `body`, and nothing else.
+- `Feed` / `Define` / `MutWrite` — the `name` field is a *use* of the binder it names, not a binder.
+- `Transact` — introduces no binder; its keys are labels of the register record the node denotes, so they are surfaced as a distinct occurrence kind that free-*variable* analyses skip while an identity-sensitive consumer still folds them in.
+
+The walk's `match` is exhaustive with **no wildcard arm**, deliberately: before this existed, the walkers ended in `_ => walk_children(..)`, so a new binding form compiled clean in all of them and silently got the wrong scope in every one. Now it is a compile error until the new form declares its scope. `TypedExpr::walk_binders` — the enumeration of binding *slots*, which the scoped walk is checked against and which `uniquify`'s post-pass mint assertion runs on — is exhaustive for the same reason: a wildcard there would let a new binding form be invisible to the assertion that is supposed to catch a forgotten mint, which is the same failure mode one layer down.
+
+Two passes stay outside the fold and say why in their own docs: `ccl/uniquify.rs` *mints* binders rather than observing them, and substitution's transport mode (`Subst::apply_expr_inner`) rebuilds nodes rather than walking them.
+
+Consumers may rely on three properties of the walk, each asserted in `scope.rs`'s tests: the `Child` items come in `walk_children` order (so the `&mut` adapter can pair binder lists positionally), the binders it declares are exactly `walk_binders`', and a scope's children are consecutive with a binder-introducing scope entered only once. The last is what lets a consumer build per-scope state once per scope rather than once per child — `Subst::shadow_all` restricting a substitution across a `LetRec` group, for instance, which borrows instead of cloning whenever the group names nothing the substitution acts on.
+
 ### Application shape
 
 Function application is a single `Apply(Box<Expr>, Box<Expr>)` node. Single-argument CHL calls `f(a)` lower to `Apply(a, Var(f))` directly. Multi-argument CHL calls `f(a, b, ...)` lower to `Apply(Tuple([a, b, ...]), Var(f))` — the arguments are tupled so the call shape matches how multi-arg CHL lambdas are uncurried at lowering time (see [lowering.md](lowering.md)).

--- a/src/ccl/expr.rs
+++ b/src/ccl/expr.rs
@@ -1660,7 +1660,7 @@ impl TypedExpr {
     /// Does this node declare any binder? The cheap half of
     /// [`walk_binders`](Self::walk_binders), for callers that only need to know
     /// whether a node opens a scope at all (see
-    /// [`crate::ccl::scope::for_each_scoped_child_mut`], which skips its
+    /// [`crate::ccl::scope::for_each_scoped_item_mut`], which skips its
     /// scope-collection pass entirely for the overwhelmingly common node that
     /// binds nothing).
     pub fn binds_any(&self) -> bool {

--- a/src/ccl/expr.rs
+++ b/src/ccl/expr.rs
@@ -1483,13 +1483,18 @@ impl TypedExpr {
     /// child expressions.
     ///
     /// This is the single source of truth for "which nodes bind names", so a
-    /// pass that must cover every binder's type slot (a type-erasing pass, an
-    /// α-renamer) enumerates them here rather than re-deriving the set — adding
-    /// a new binding node updates this one match instead of every such pass.
-    /// Immutable analog of [`walk_binders_mut`](Self::walk_binders_mut): visit
-    /// each `TypedBinding` this node declares (the single source of truth for
-    /// binder-slot coverage, for read-only passes). Kept in lockstep with the
-    /// mutable version — any new binder-bearing variant must appear in both.
+    /// pass that must cover every binder's slot (a type-erasing pass, an
+    /// α-renamer, `uniquify`'s post-pass mint check) enumerates them here rather
+    /// than re-deriving the set. The match is **exhaustive with no wildcard
+    /// arm**, deliberately and for the same reason
+    /// [`crate::ccl::scope::for_each_scoped_item`] is: a `_ => {}` catch-all
+    /// would make a newly-added binding form silently invisible to every such
+    /// pass, which is exactly the failure mode both walks exist to prevent.
+    /// Whether the two agree on the declaration set is a test in
+    /// `crate::ccl::scope`.
+    ///
+    /// Immutable analog of [`walk_binders_mut`](Self::walk_binders_mut), which
+    /// is kept in lockstep — a new binder-bearing variant appears in both.
     pub fn walk_binders(&self, mut f: impl FnMut(&TypedBinding)) {
         match &self.node {
             TypedExprNode::Lambda { param, .. }
@@ -1505,10 +1510,36 @@ impl TypedExpr {
                     }
                 }
             }
-            _ => {}
+            // Declares no binder. Enumerated rather than wildcarded — see above.
+            TypedExprNode::Lit(_)
+            | TypedExprNode::Var(_)
+            | TypedExprNode::Builtin(_)
+            | TypedExprNode::Proj(_)
+            | TypedExprNode::Source(_)
+            | TypedExprNode::Defer
+            | TypedExprNode::Error
+            | TypedExprNode::Apply { .. }
+            | TypedExprNode::Cast { .. }
+            | TypedExprNode::BinOp { .. }
+            | TypedExprNode::UnaryOp(..)
+            | TypedExprNode::Aggregate { .. }
+            | TypedExprNode::VariantCtor { .. }
+            | TypedExprNode::List(_)
+            | TypedExprNode::Tuple(_)
+            | TypedExprNode::Record(_)
+            | TypedExprNode::Compose(_)
+            | TypedExprNode::CollectionUnion(_)
+            | TypedExprNode::ExprStmt { .. }
+            | TypedExprNode::Begin { .. }
+            | TypedExprNode::Feed { .. }
+            | TypedExprNode::Define { .. }
+            | TypedExprNode::MutWrite { .. }
+            | TypedExprNode::Transact { .. } => {}
         }
     }
 
+    /// Mutable analog of [`walk_binders`](Self::walk_binders) — same
+    /// declaration set, same deliberate exhaustiveness.
     pub fn walk_binders_mut(&mut self, mut f: impl FnMut(&mut TypedBinding)) {
         match &mut self.node {
             TypedExprNode::Lambda { param, .. }
@@ -1524,7 +1555,32 @@ impl TypedExpr {
                     }
                 }
             }
-            _ => {}
+            // Declares no binder. Enumerated rather than wildcarded — see
+            // [`walk_binders`](Self::walk_binders).
+            TypedExprNode::Lit(_)
+            | TypedExprNode::Var(_)
+            | TypedExprNode::Builtin(_)
+            | TypedExprNode::Proj(_)
+            | TypedExprNode::Source(_)
+            | TypedExprNode::Defer
+            | TypedExprNode::Error
+            | TypedExprNode::Apply { .. }
+            | TypedExprNode::Cast { .. }
+            | TypedExprNode::BinOp { .. }
+            | TypedExprNode::UnaryOp(..)
+            | TypedExprNode::Aggregate { .. }
+            | TypedExprNode::VariantCtor { .. }
+            | TypedExprNode::List(_)
+            | TypedExprNode::Tuple(_)
+            | TypedExprNode::Record(_)
+            | TypedExprNode::Compose(_)
+            | TypedExprNode::CollectionUnion(_)
+            | TypedExprNode::ExprStmt { .. }
+            | TypedExprNode::Begin { .. }
+            | TypedExprNode::Feed { .. }
+            | TypedExprNode::Define { .. }
+            | TypedExprNode::MutWrite { .. }
+            | TypedExprNode::Transact { .. } => {}
         }
     }
 
@@ -1599,6 +1655,18 @@ impl TypedExpr {
                 f(annotation);
             }
         });
+    }
+
+    /// Does this node declare any binder? The cheap half of
+    /// [`walk_binders`](Self::walk_binders), for callers that only need to know
+    /// whether a node opens a scope at all (see
+    /// [`crate::ccl::scope::for_each_scoped_child_mut`], which skips its
+    /// scope-collection pass entirely for the overwhelmingly common node that
+    /// binds nothing).
+    pub fn binds_any(&self) -> bool {
+        let mut binds = false;
+        self.walk_binders(|_| binds = true);
+        binds
     }
 
     /// Mutable analog of [`fold_children`](Self::fold_children).

--- a/src/ccl/mod.rs
+++ b/src/ccl/mod.rs
@@ -19,6 +19,7 @@ pub mod mut_elim;
 pub mod names;
 pub mod planning;
 pub mod provenance;
+pub mod scope;
 pub mod simplify;
 pub mod subst;
 pub mod symbolic;

--- a/src/ccl/scope.rs
+++ b/src/ccl/scope.rs
@@ -2,11 +2,12 @@
 //!
 //! Every scope-aware pass — free-variable counting, capture-avoiding
 //! substitution, α-uniquification — needs the same answer to one question:
-//! *which binders scope over which of a node's children?* [`for_each_scoped_item`] is the single place that answers it. Its
-//! `match` is **exhaustive with no wildcard arm**, deliberately: a new
-//! [`TypedExprNode`] variant must declare its scope here before the crate
-//! compiles, instead of falling into a `_ => walk_children(..)` catch-all in
-//! five separate passes and silently getting the wrong one.
+//! *which binders scope over which of a node's children?* [`for_each_scoped_item`]
+//! is the single place that answers it. Its `match` is **exhaustive with no
+//! wildcard arm**, deliberately: a new [`TypedExprNode`] variant must declare
+//! its scope here before the crate compiles, instead of falling into a
+//! `_ => walk_children(..)` catch-all in five separate passes and silently
+//! getting the wrong one.
 //!
 //! Design of record: `src/ccl/design/ir.md`, "Binding structure lives in one
 //! place".
@@ -41,18 +42,19 @@
 //! # Invariants
 //!
 //! - **Child order matches [`TypedExpr::walk_children`]** — the `Child` items
-//!   are yielded in exactly that order. [`for_each_scoped_child_mut`] relies on
-//!   it to pair binder lists with a `&mut` traversal, and the corpus test in
-//!   this module checks it pointer-for-pointer over every variant.
+//!   are yielded in exactly that order. [`for_each_scoped_item_mut`] relies on
+//!   it to pair scopes with a `&mut` traversal, and the corpus test in this
+//!   module checks it pointer-for-pointer over every variant.
 //! - **A scope's children are consecutive, and a scope is entered once** — all
 //!   children under one binder list are yielded together, and a binder-
 //!   introducing scope, once left, is never re-entered. (The node's *own* scope
-//!   — the empty binder list — recurs freely: it is the ambient scope, not a
+//!   — [`Binders::Ambient`] — recurs freely: it is the ambient scope, not a
 //!   scope this node opens. A `Case` alternates between the two as its branches
 //!   do or do not bind a payload.) A consumer may therefore carry per-scope
 //!   state — a shadowed substitution, a pushed environment frame — across a run
-//!   of children and rebuild it only when the binder list changes.
-//! - **Binders are innermost-last** within a list — the order a consumer that
+//!   of children and rebuild it only when the scope changes; the `&mut` walk
+//!   hands it the change point directly, as a [`ScopedItemMut::Scope`] item.
+//! - **Binders are innermost-last** within a scope — the order a consumer that
 //!   maintains a De Bruijn environment needs to push them in.
 //!
 //! # What does *not* live here
@@ -66,16 +68,99 @@
 
 use super::{Name, TypedBinding, TypedExpr, TypedExprNode};
 
+/// The binders a node puts in scope over one of its children.
+///
+/// A type rather than a slice of binder references, for two reasons.
+///
+/// It borrows the node's binder slots **in place**, so the walk allocates
+/// nothing. [`for_each_scoped_item`] sits under
+/// [`is_free`](crate::ccl::ccl_utils::is_free), which capture-avoiding
+/// substitution consults once per mapped binder per node, so collecting a
+/// `LetRec` group into a `Vec` would be an allocation per group *per query*.
+///
+/// And it owns [`shadows`](Self::shadows) — "does this scope shadow this
+/// name?", which is the question every consumer of the walk actually asks.
+/// Answering it here is what keeps it from being re-spelled as
+/// `binders.iter().any(|b| &b.name == name)` once per fold.
+#[derive(Clone, Copy)]
+pub enum Binders<'a> {
+    /// No binder: the child sits in the node's own scope.
+    Ambient,
+    /// A single binder — a [`Lambda`](TypedExprNode::Lambda) param, a
+    /// [`Let`](TypedExprNode::Let) binding, a [`For`](TypedExprNode::For)
+    /// target, a [`Case`](TypedExprNode::Case) branch's payload.
+    One(&'a TypedBinding),
+    /// A whole mutually-recursive group: every member scopes over every child
+    /// the group covers (see [`LetRec`](TypedExprNode::LetRec)).
+    Group(&'a [(TypedBinding, TypedExpr)]),
+}
+
+impl<'a> Binders<'a> {
+    /// Does this scope shadow `name`? A child under a scope that shadows it
+    /// contributes no *free* occurrence of it.
+    pub fn shadows(self, name: &Name) -> bool {
+        match self {
+            Binders::Ambient => false,
+            Binders::One(b) => &b.name == name,
+            Binders::Group(g) => g.iter().any(|(b, _)| &b.name == name),
+        }
+    }
+
+    /// The binders, innermost last — the order a consumer maintaining an
+    /// environment stack pushes them in.
+    pub fn iter(self) -> impl Iterator<Item = &'a TypedBinding> {
+        const EMPTY: &[(TypedBinding, TypedExpr)] = &[];
+        let (one, group) = match self {
+            Binders::Ambient => (None, EMPTY),
+            Binders::One(b) => (Some(b), EMPTY),
+            Binders::Group(g) => (None, g),
+        };
+        one.into_iter().chain(group.iter().map(|(b, _)| b))
+    }
+
+    /// Does this scope introduce nothing? True for [`Binders::Ambient`] — the
+    /// node's own scope, which is not a scope the node opens — and for the
+    /// degenerate empty `Group`. The question a consumer asks when it only needs
+    /// to know whether crossing to this child changes anything: pushing an
+    /// environment frame, restricting a substitution, recording that a subtree
+    /// binds new names.
+    pub fn is_empty(self) -> bool {
+        match self {
+            Binders::Ambient => true,
+            Binders::One(_) => false,
+            Binders::Group(g) => g.is_empty(),
+        }
+    }
+
+    /// Are these the *same* scope — the same binder slots of the same node?
+    ///
+    /// Compared by slot identity rather than by name, because that is what
+    /// "same scope" means: two `Case` branches binding a payload spelled the
+    /// same way are two scopes, and a consumer that reused one branch's
+    /// environment frame for the other would be right only by accident.
+    /// Consecutive children under one scope compare equal here, which is what
+    /// lets [`for_each_scoped_item_mut`] group them into runs.
+    fn is_same_scope(self, other: Binders<'_>) -> bool {
+        match (self, other) {
+            (Binders::Ambient, Binders::Ambient) => true,
+            (Binders::One(a), Binders::One(b)) => std::ptr::eq(a, b),
+            (Binders::Group(a), Binders::Group(b)) => {
+                a.as_ptr() == b.as_ptr() && a.len() == b.len()
+            }
+            _ => false,
+        }
+    }
+}
+
 /// One item of a node's scope structure, as yielded by
 /// [`for_each_scoped_item`].
-pub enum ScopedItem<'a, 'b> {
-    /// A direct child expression together with the binders that scope over it
-    /// (innermost last). Empty when the child sits in the node's own scope.
+pub enum ScopedItem<'a> {
+    /// A direct child expression together with the binders that scope over it.
     Child {
         /// The child term.
         expr: &'a TypedExpr,
         /// The binders this node puts in scope over `expr`.
-        binders: &'b [&'a TypedBinding],
+        binders: Binders<'a>,
     },
     /// A *variable* occurrence the node makes itself: a
     /// [`Var`](TypedExprNode::Var), or the write target of a
@@ -102,19 +187,22 @@ pub enum ScopedItem<'a, 'b> {
 /// single closure type — so monomorphization stays flat.
 pub fn for_each_scoped_item<'a, F>(e: &'a TypedExpr, f: &mut F)
 where
-    F: FnMut(ScopedItem<'a, '_>) + ?Sized,
+    F: FnMut(ScopedItem<'a>) + ?Sized,
 {
     use TypedExprNode as N;
 
     /// Yield a child in the node's own scope (no binder introduced).
-    fn open<'a, F: FnMut(ScopedItem<'a, '_>) + ?Sized>(f: &mut F, expr: &'a TypedExpr) {
-        f(ScopedItem::Child { expr, binders: &[] });
+    fn open<'a, F: FnMut(ScopedItem<'a>) + ?Sized>(f: &mut F, expr: &'a TypedExpr) {
+        f(ScopedItem::Child {
+            expr,
+            binders: Binders::Ambient,
+        });
     }
     /// Yield a child scoped by `binders`.
-    fn under<'a, F: FnMut(ScopedItem<'a, '_>) + ?Sized>(
+    fn under<'a, F: FnMut(ScopedItem<'a>) + ?Sized>(
         f: &mut F,
         expr: &'a TypedExpr,
-        binders: &[&'a TypedBinding],
+        binders: Binders<'a>,
     ) {
         f(ScopedItem::Child { expr, binders });
     }
@@ -163,7 +251,7 @@ where
         }
 
         // ---- Binding nodes --------------------------------------------------
-        N::Lambda { param, body } => under(f, body, &[param]),
+        N::Lambda { param, body } => under(f, body, Binders::One(param)),
 
         N::Let {
             binding,
@@ -171,21 +259,21 @@ where
             body,
         } => {
             open(f, bound_expr);
-            under(f, body, &[binding]);
+            under(f, body, Binders::One(binding));
         }
 
         // Mutual recursion: the whole group is in scope throughout the group.
         N::LetRec { bindings, body } => {
-            let group: Vec<&TypedBinding> = bindings.iter().map(|(b, _)| b).collect();
+            let group = Binders::Group(bindings);
             for (_, def) in bindings {
-                under(f, def, &group);
+                under(f, def, group);
             }
-            under(f, body, &group);
+            under(f, body, group);
         }
 
         N::For { target, iter, body } => {
             open(f, iter);
-            under(f, body, &[target]);
+            under(f, body, Binders::One(target));
         }
 
         N::Case {
@@ -198,9 +286,9 @@ where
             for b in branches {
                 match &b.pattern {
                     Some(p) => {
-                        let bound = [&p.binding];
-                        under(f, &b.guard, &bound);
-                        under(f, &b.body, &bound);
+                        let bound = Binders::One(&p.binding);
+                        under(f, &b.guard, bound);
+                        under(f, &b.body, bound);
                     }
                     None => {
                         open(f, &b.guard);
@@ -229,61 +317,168 @@ where
     }
 }
 
-/// In-place counterpart of [`for_each_scoped_item`]: visit each direct child of
-/// `e` mutably, paired with the names of the binders that scope over it.
+/// One item of a node's scope structure, mutably — the `&mut` counterpart of
+/// [`ScopedItem`], as yielded by [`for_each_scoped_item_mut`].
+pub enum ScopedItemMut<'a> {
+    /// Opens the scope that the `Child` items following it sit in, until the
+    /// next `Scope`. Every `Child` is preceded by the scope it sits in, and a
+    /// scope is opened **once** (the consecutiveness invariant), so a consumer
+    /// builds per-scope state here — a shadowed substitution, a capture check —
+    /// and reuses it across the whole run.
+    ///
+    /// Binder *names*, not `&mut TypedBinding`s: a `&mut` walk cannot hand out a
+    /// borrow into the node whose children it is also handing out.
+    Scope(&'a [Name]),
+    /// A direct child, in the scope most recently opened.
+    Child(&'a mut TypedExpr),
+    /// A variable occurrence the node makes itself — see [`ScopedItem::VarRef`].
+    /// Yielded before any `Scope`, since a node's own occurrences are resolved
+    /// in the node's own scope, not under a binder it introduces.
+    VarRef(&'a mut Name),
+    /// A register-key label occurrence — see [`ScopedItem::KeyRef`]. Every
+    /// occurrence of a key is yielded (the `keys` entry and each writer
+    /// footprint mention), so a consumer that rewrites one can keep them in
+    /// step.
+    KeyRef(&'a mut Name),
+}
+
+/// In-place counterpart of [`for_each_scoped_item`]: visit `e`'s own name
+/// occurrences and each of its direct children mutably, the children grouped
+/// into the scopes that cover them.
 ///
-/// Derived from [`for_each_scoped_item`], so the scoping rules stay stated
-/// once. A `&mut` walk cannot hold borrows into the node it is mutating, so the
-/// binder *names* are cloned up front and the children are then enumerated by
-/// [`TypedExpr::walk_children_mut`]; only the binder-introducing nodes allocate.
-/// The two enumerations agreeing is the invariant this pairing rests on — it is
-/// documented on [`for_each_scoped_item`], checked pointer-for-pointer by this
-/// module's corpus test, and its arity half is asserted here.
-///
-/// Name *occurrences* (`ScopedItem::VarRef` / `KeyRef`) are not surfaced: a
-/// caller that rewrites them (only [`crate::ccl::subst`] does, to retarget a
-/// renamed defer handle) reaches them through its own node match.
-pub fn for_each_scoped_child_mut<F>(e: &mut TypedExpr, f: &mut F)
+/// Derived from [`for_each_scoped_item`], so the scoping rules stay stated once.
+/// A `&mut` walk cannot hold borrows into the node it is mutating, so the binder
+/// *names* are cloned up front — once per scope, not once per child — and the
+/// children are then enumerated by [`TypedExpr::walk_children_mut`]; only
+/// binder-introducing nodes pay for that pass at all. The two enumerations
+/// agreeing is the invariant this pairing rests on: it is documented on
+/// [`for_each_scoped_item`], checked pointer-for-pointer by this module's corpus
+/// test, and its arity half is asserted here.
+pub fn for_each_scoped_item_mut<F>(e: &mut TypedExpr, f: &mut F)
 where
-    F: FnMut(&mut TypedExpr, &[Name]) + ?Sized,
+    F: FnMut(ScopedItemMut<'_>) + ?Sized,
 {
+    for_each_name_mut(e, f);
+
     // A node that declares no binder scopes every child in its own scope, so
-    // there is nothing to collect and nothing to pair — skip straight to the
-    // mutable walk. This is the overwhelmingly common node, and skipping the
-    // collection pass is what keeps the adapter from costing every node in the
-    // tree a second traversal. `binds_any` is `walk_binders`, whose agreement
-    // with the scoping rules is `declared_binders_match_walk_binders` below.
+    // there is nothing to collect and nothing to group — go straight to the
+    // mutable child walk. This is the overwhelmingly common node, and skipping
+    // the collection pass is what keeps the adapter from costing every node in
+    // the tree a second traversal and a `Vec`. `binds_any` is `walk_binders`,
+    // whose agreement with the scoping rules is
+    // `declared_binders_match_walk_binders` below.
     if !e.binds_any() {
-        e.walk_children_mut(|c| f(c, &[]));
+        let mut opened = false;
+        e.walk_children_mut(|c| {
+            if !opened {
+                f(ScopedItemMut::Scope(&[]));
+                opened = true;
+            }
+            f(ScopedItemMut::Child(c));
+        });
         return;
     }
 
-    // Sparse by construction: `scopes` is only as long as the last scoped
-    // child's position, so a `Let` (binder on the second of two children)
-    // allocates one empty leading entry and nothing more.
-    let mut scopes: Vec<Vec<Name>> = Vec::new();
+    // The scope runs, in child order: each run's first-child index and the
+    // binder names it introduces. Children under one scope share an entry —
+    // which is what keeps a `LetRec` group's names to a single clone rather than
+    // one per child, and is what makes the per-scope `Scope` item expressible at
+    // all. Sound because a scope's children are consecutive.
+    let mut runs: Vec<(usize, Vec<Name>)> = Vec::new();
     let mut children = 0usize;
-    for_each_scoped_item(e, &mut |item| {
-        if let ScopedItem::Child { binders, .. } = item {
-            children += 1;
-            if !binders.is_empty() {
-                scopes.resize(children - 1, Vec::new());
-                scopes.push(binders.iter().map(|b| b.name.clone()).collect());
+    {
+        let mut prev: Option<Binders<'_>> = None;
+        for_each_scoped_item(&*e, &mut |item| {
+            if let ScopedItem::Child { binders, .. } = item {
+                if !prev.is_some_and(|p| p.is_same_scope(binders)) {
+                    runs.push((children, binders.iter().map(|b| b.name.clone()).collect()));
+                    prev = Some(binders);
+                }
+                children += 1;
             }
-        }
-    });
+        });
+    }
 
     let mut i = 0usize;
+    let mut next_run = 0usize;
     e.walk_children_mut(|c| {
-        let binders = scopes.get(i).map_or(&[][..], Vec::as_slice);
+        if let Some((start, names)) = runs.get(next_run)
+            && *start == i
+        {
+            f(ScopedItemMut::Scope(names));
+            next_run += 1;
+        }
         i += 1;
-        f(c, binders);
+        f(ScopedItemMut::Child(c));
     });
     debug_assert_eq!(
         i, children,
         "`walk_children_mut` and `for_each_scoped_item` must enumerate the same children — \
-         the binder lists are paired with the child sequence by position"
+         the scope runs are paired with the child sequence by position"
     );
+    debug_assert_eq!(
+        next_run,
+        runs.len(),
+        "every scope run must be reached: run starts are strictly increasing child indices, \
+         which is what lets one forward pass pair them with the children"
+    );
+}
+
+/// The name occurrences `e` makes itself, mutably — the `&mut` half of
+/// [`ScopedItem::VarRef`] / [`ScopedItem::KeyRef`].
+///
+/// Exhaustive with no wildcard arm for the same reason [`for_each_scoped_item`]
+/// is: which names a node mentions of its own is part of its binding structure,
+/// and a wildcard here would let a new name-mentioning node be silently skipped
+/// by the rename that has to retarget it. `mut_walk_surfaces_the_same_names`
+/// checks this against the immutable walk over the whole corpus.
+fn for_each_name_mut<F>(e: &mut TypedExpr, f: &mut F)
+where
+    F: FnMut(ScopedItemMut<'_>) + ?Sized,
+{
+    use TypedExprNode as N;
+    match &mut e.node {
+        N::Var(n) => f(ScopedItemMut::VarRef(n)),
+        N::Feed { name, .. } | N::Define { name, .. } | N::MutWrite { name, .. } => {
+            f(ScopedItemMut::VarRef(name));
+        }
+        N::Transact { keys, writers, .. } => {
+            for k in keys {
+                f(ScopedItemMut::KeyRef(&mut k.name));
+            }
+            for w in writers {
+                for k in w.read_keys.iter_mut().chain(&mut w.write_keys) {
+                    f(ScopedItemMut::KeyRef(k));
+                }
+            }
+        }
+        // Mentions no name of its own. Enumerated rather than wildcarded — see
+        // above.
+        N::Lit(_)
+        | N::Builtin(_)
+        | N::Proj(_)
+        | N::Source(_)
+        | N::Defer
+        | N::Error
+        | N::Apply { .. }
+        | N::Cast { .. }
+        | N::BinOp { .. }
+        | N::UnaryOp(..)
+        | N::Aggregate { .. }
+        | N::VariantCtor { .. }
+        | N::List(_)
+        | N::Tuple(_)
+        | N::Record(_)
+        | N::Compose(_)
+        | N::CollectionUnion(_)
+        | N::ExprStmt { .. }
+        | N::Begin { .. }
+        | N::Lambda { .. }
+        | N::Let { .. }
+        | N::LetRec { .. }
+        | N::For { .. }
+        | N::Case { .. } => {}
+    }
 }
 
 #[cfg(test)]
@@ -308,9 +503,8 @@ mod tests {
 
     /// One instance of **every** [`TypedExprNode`] variant.
     ///
-    /// [`variant_name`] is exhaustive, so a new variant fails to compile there
-    /// first; extend this corpus at the same time so the consistency checks
-    /// below actually cover it.
+    /// Completeness is *checked*, not merely prompted — see
+    /// [`corpus_covers_every_variant`].
     fn corpus() -> Vec<TypedExpr> {
         vec![
             int(1),
@@ -334,38 +528,9 @@ mod tests {
             }),
             TypedExpr::let_bind("l", var("bound"), var("l")),
             node(N::List(vec![var("e0"), var("e1")])),
-            node(N::Case {
-                scrutinee: Some(Box::new(var("s"))),
-                branches: vec![
-                    Branch {
-                        pattern: Some(Pattern {
-                            tag: "T".into(),
-                            binding: bind("payload"),
-                        }),
-                        guard: var("g0"),
-                        body: var("payload"),
-                    },
-                    Branch {
-                        pattern: None,
-                        guard: var("g1"),
-                        body: var("b1"),
-                    },
-                ],
-            }),
+            case_with_two_branches(),
             TypedExpr::variant_ctor("T", var("pl")),
-            node(N::Transact {
-                keys: vec![crate::ccl::TransactKey {
-                    name: Name::raw("k"),
-                    init: int(0),
-                }],
-                writers: vec![WriterSite {
-                    read_keys: vec![Name::raw("k")],
-                    write_keys: vec![Name::raw("k")],
-                    source: var("src"),
-                    body: var("wbody"),
-                }],
-                domain: Type::Txn,
-            }),
+            transact_one_key_one_writer(),
             TypedExpr::letrec(vec![(bind("f"), var("g")), (bind("g"), var("f"))], var("f")),
             node(N::For {
                 target: bind("t"),
@@ -399,47 +564,116 @@ mod tests {
         ]
     }
 
-    /// Labels a node for the assertion messages below, and — being exhaustive —
-    /// is the prompt to give [`corpus`] an instance of a newly-added variant.
-    /// Only a prompt: nothing here *proves* the corpus is complete (that would
-    /// need reflection over the enum). The guarantee that matters is
-    /// [`for_each_scoped_item`]'s own wildcard-free match, which refuses to
-    /// compile until a new variant declares its scope.
-    fn variant_name(node: &TypedExprNode) -> &'static str {
-        match node {
-            N::Lit(_) => "Lit",
-            N::Var(_) => "Var",
-            N::Builtin(_) => "Builtin",
-            N::Apply { .. } => "Apply",
-            N::Cast { .. } => "Cast",
-            N::BinOp { .. } => "BinOp",
-            N::UnaryOp(..) => "UnaryOp",
-            N::Lambda { .. } => "Lambda",
-            N::Aggregate { .. } => "Aggregate",
-            N::Let { .. } => "Let",
-            N::List(_) => "List",
-            N::Case { .. } => "Case",
-            N::VariantCtor { .. } => "VariantCtor",
-            N::Transact { .. } => "Transact",
-            N::LetRec { .. } => "LetRec",
-            N::For { .. } => "For",
-            N::Tuple(_) => "Tuple",
-            N::Record(_) => "Record",
-            N::Compose(_) => "Compose",
-            N::CollectionUnion(_) => "CollectionUnion",
-            N::ExprStmt { .. } => "ExprStmt",
-            N::Begin { .. } => "Begin",
-            N::Feed { .. } => "Feed",
-            N::Define { .. } => "Define",
-            N::MutWrite { .. } => "MutWrite",
-            N::Proj(_) => "Proj",
-            N::Source(_) => "Source",
-            N::Defer => "Defer",
-            N::Error => "Error",
-        }
+    /// A payload-binding branch followed by a payload-free one: the node that
+    /// alternates between a real scope and the ambient one.
+    fn case_with_two_branches() -> TypedExpr {
+        node(N::Case {
+            scrutinee: Some(Box::new(var("s"))),
+            branches: vec![
+                Branch {
+                    pattern: Some(Pattern {
+                        tag: "T".into(),
+                        binding: bind("payload"),
+                    }),
+                    guard: var("g0"),
+                    body: var("payload"),
+                },
+                Branch {
+                    pattern: None,
+                    guard: var("g1"),
+                    body: var("b1"),
+                },
+            ],
+        })
     }
 
-    /// The invariant [`for_each_scoped_child_mut`] rests on: the scoped walk
+    fn transact_one_key_one_writer() -> TypedExpr {
+        node(N::Transact {
+            keys: vec![crate::ccl::TransactKey {
+                name: Name::raw("k"),
+                init: int(0),
+            }],
+            writers: vec![WriterSite {
+                read_keys: vec![Name::raw("k")],
+                write_keys: vec![Name::raw("k")],
+                source: var("src"),
+                body: var("wbody"),
+            }],
+            domain: Type::Txn,
+        })
+    }
+
+    /// Declares `variant_name` and derives `VARIANT_COUNT` from the *same* arm
+    /// list, which is what turns corpus completeness from a prompt into a check:
+    /// a new [`TypedExprNode`] variant makes the match non-exhaustive, adding
+    /// the arm bumps the count, and the bumped count fails
+    /// [`corpus_covers_every_variant`] until [`corpus`] gains an instance.
+    macro_rules! variants {
+        ($($pat:pat => $name:literal),+ $(,)?) => {
+            /// Labels a node for the assertion messages below.
+            fn variant_name(node: &TypedExprNode) -> &'static str {
+                match node { $($pat => $name),+ }
+            }
+            /// The number of [`TypedExprNode`] variants, derived from the arm
+            /// list above rather than declared independently of it.
+            const VARIANT_COUNT: usize = [$($name),+].len();
+        };
+    }
+
+    variants! {
+        N::Lit(_) => "Lit",
+        N::Var(_) => "Var",
+        N::Builtin(_) => "Builtin",
+        N::Apply { .. } => "Apply",
+        N::Cast { .. } => "Cast",
+        N::BinOp { .. } => "BinOp",
+        N::UnaryOp(..) => "UnaryOp",
+        N::Lambda { .. } => "Lambda",
+        N::Aggregate { .. } => "Aggregate",
+        N::Let { .. } => "Let",
+        N::List(_) => "List",
+        N::Case { .. } => "Case",
+        N::VariantCtor { .. } => "VariantCtor",
+        N::Transact { .. } => "Transact",
+        N::LetRec { .. } => "LetRec",
+        N::For { .. } => "For",
+        N::Tuple(_) => "Tuple",
+        N::Record(_) => "Record",
+        N::Compose(_) => "Compose",
+        N::CollectionUnion(_) => "CollectionUnion",
+        N::ExprStmt { .. } => "ExprStmt",
+        N::Begin { .. } => "Begin",
+        N::Feed { .. } => "Feed",
+        N::Define { .. } => "Define",
+        N::MutWrite { .. } => "MutWrite",
+        N::Proj(_) => "Proj",
+        N::Source(_) => "Source",
+        N::Defer => "Defer",
+        N::Error => "Error",
+    }
+
+    /// Every consistency check below is only as good as the corpus, so the
+    /// corpus is checked too: one instance per variant, no duplicates (a second
+    /// `Apply` would otherwise mask a missing `Begin`).
+    #[test]
+    fn corpus_covers_every_variant() {
+        let mut names: Vec<&str> = corpus().iter().map(|e| variant_name(&e.node)).collect();
+        let instances = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(
+            names.len(),
+            instances,
+            "the corpus has two instances of one variant, which would mask a missing one"
+        );
+        assert_eq!(
+            instances, VARIANT_COUNT,
+            "the corpus is missing a `TypedExprNode` variant — every variant needs an instance \
+             for the walk-consistency checks in this module to cover it"
+        );
+    }
+
+    /// The invariant [`for_each_scoped_item_mut`] rests on: the scoped walk
     /// yields exactly `walk_children`'s children, in order.
     #[test]
     fn child_enumeration_matches_walk_children() {
@@ -469,20 +703,10 @@ mod tests {
             let mut declared: Vec<*const TypedBinding> = Vec::new();
             e.walk_binders(|b| declared.push(b));
 
-            // Consecutive scopes: a binder list repeats across the children it
-            // covers, so dedup adjacent repeats to recover the declaration set.
-            let mut scoped: Vec<*const TypedBinding> = Vec::new();
-            let mut prev: Vec<*const TypedBinding> = Vec::new();
-            for_each_scoped_item(&e, &mut |item| {
-                if let ScopedItem::Child { binders, .. } = item {
-                    let here: Vec<*const TypedBinding> =
-                        binders.iter().map(|b| *b as *const _).collect();
-                    if here != prev {
-                        scoped.extend(here.iter().copied());
-                        prev = here;
-                    }
-                }
-            });
+            let scoped: Vec<*const TypedBinding> = scope_runs(&e)
+                .into_iter()
+                .flat_map(|s| s.iter().map(|b| b as *const _).collect::<Vec<_>>())
+                .collect();
             assert_eq!(
                 declared,
                 scoped,
@@ -492,44 +716,52 @@ mod tests {
         }
     }
 
+    /// The scopes a node opens, in child order, with each run collapsed to one
+    /// entry — the same grouping [`for_each_scoped_item_mut`] performs, and
+    /// well-defined only because a scope's children are consecutive.
+    fn scope_runs(e: &TypedExpr) -> Vec<Binders<'_>> {
+        let mut runs: Vec<Binders<'_>> = Vec::new();
+        for_each_scoped_item(e, &mut |item| {
+            if let ScopedItem::Child { binders, .. } = item
+                && !runs.last().is_some_and(|p| p.is_same_scope(binders))
+            {
+                runs.push(binders);
+            }
+        });
+        runs
+    }
+
     /// The consecutiveness invariant, which two things rest on:
-    /// `declared_binders_match_walk_binders` above recovers the declaration set
-    /// by deduping *adjacent* binder lists, and a consumer that carries
-    /// per-scope state may rebuild it only when the list changes. A node that
-    /// interleaved two scopes would break both. The ambient (empty) list is
-    /// exempt — it is not a scope the node opens, and a `Case` returns to it
-    /// whenever a branch binds no payload.
+    /// [`scope_runs`] recovers each scope by collapsing *adjacent* children, and
+    /// a consumer that carries per-scope state rebuilds it only when the scope
+    /// changes. A node that interleaved two scopes would break both. The
+    /// ambient scope is exempt — it is not a scope the node opens, and a `Case`
+    /// returns to it whenever a branch binds no payload.
     #[test]
     fn scopes_are_consecutive_and_entered_once() {
         for e in corpus() {
-            let mut runs: Vec<Vec<*const TypedBinding>> = Vec::new();
-            for_each_scoped_item(&e, &mut |item| {
-                if let ScopedItem::Child { binders, .. } = item {
-                    let here: Vec<*const TypedBinding> =
-                        binders.iter().map(|b| *b as *const _).collect();
-                    if runs.last() != Some(&here) {
-                        runs.push(here);
-                    }
-                }
-            });
-            let mut scoped: Vec<Vec<*const TypedBinding>> =
-                runs.into_iter().filter(|r| !r.is_empty()).collect();
-            let entered = scoped.len();
-            scoped.sort();
-            scoped.dedup();
+            let opened: Vec<Vec<*const TypedBinding>> = scope_runs(&e)
+                .into_iter()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.iter().map(|b| b as *const _).collect())
+                .collect();
+            let entered = opened.len();
+            let mut distinct = opened;
+            distinct.sort();
+            distinct.dedup();
             assert_eq!(
                 entered,
-                scoped.len(),
+                distinct.len(),
                 "a scope was re-entered after being left in `{}`",
                 variant_name(&e.node)
             );
         }
     }
 
-    /// The mutable adapter must hand each child the same binder names the
-    /// immutable walk scopes over it.
+    /// The mutable walk must hand each child the same binder names the
+    /// immutable walk scopes over it — the positional pairing both rest on.
     #[test]
-    fn mut_adapter_pairs_the_same_binders() {
+    fn mut_walk_pairs_the_same_binders() {
         for e in corpus() {
             let expected: Vec<Vec<Name>> = {
                 let mut v = Vec::new();
@@ -541,12 +773,70 @@ mod tests {
                 v
             };
             let mut actual: Vec<Vec<Name>> = Vec::new();
+            let mut scope: Vec<Name> = Vec::new();
             let mut e = e;
-            for_each_scoped_child_mut(&mut e, &mut |_, binders| actual.push(binders.to_vec()));
+            for_each_scoped_item_mut(&mut e, &mut |item| match item {
+                ScopedItemMut::Scope(names) => scope = names.to_vec(),
+                ScopedItemMut::Child(_) => actual.push(scope.clone()),
+                ScopedItemMut::VarRef(_) | ScopedItemMut::KeyRef(_) => {}
+            });
             assert_eq!(
                 expected,
                 actual,
-                "mut adapter diverged for `{}`",
+                "mut walk diverged for `{}`",
+                variant_name(&e.node)
+            );
+        }
+    }
+
+    /// A `Scope` item per *scope*, not per child. This is what lets a consumer
+    /// pay for a scope crossing once — substitution's Barendregt check walks
+    /// every replacement term, so per-child would make a `LetRec` group
+    /// quadratic in its width.
+    #[test]
+    fn one_scope_item_per_scope_run() {
+        for e in corpus() {
+            let expected = scope_runs(&e).len();
+            let mut opened = 0usize;
+            let mut e = e;
+            for_each_scoped_item_mut(&mut e, &mut |item| {
+                if matches!(item, ScopedItemMut::Scope(_)) {
+                    opened += 1;
+                }
+            });
+            assert_eq!(
+                expected,
+                opened,
+                "`{}` opened {opened} scopes for {expected} runs",
+                variant_name(&e.node)
+            );
+        }
+    }
+
+    /// The mutable walk's own exhaustive name match must surface exactly the
+    /// occurrences the immutable one declares — the agreement that lets
+    /// substitution retarget a renamed handle by folding over the walk instead
+    /// of re-deriving the set behind a wildcard.
+    #[test]
+    fn mut_walk_surfaces_the_same_names() {
+        for e in corpus() {
+            let mut expected: Vec<(&str, Name)> = Vec::new();
+            for_each_scoped_item(&e, &mut |item| match item {
+                ScopedItem::VarRef(n) => expected.push(("var", n.clone())),
+                ScopedItem::KeyRef(n) => expected.push(("key", n.clone())),
+                ScopedItem::Child { .. } => {}
+            });
+            let mut actual: Vec<(&str, Name)> = Vec::new();
+            let mut e = e;
+            for_each_scoped_item_mut(&mut e, &mut |item| match item {
+                ScopedItemMut::VarRef(n) => actual.push(("var", n.clone())),
+                ScopedItemMut::KeyRef(n) => actual.push(("key", n.clone())),
+                ScopedItemMut::Scope(_) | ScopedItemMut::Child(_) => {}
+            });
+            assert_eq!(
+                expected,
+                actual,
+                "name occurrences diverged for `{}`",
                 variant_name(&e.node)
             );
         }
@@ -595,24 +885,7 @@ mod tests {
         );
         // Case: the pattern binder covers its own branch only.
         assert_eq!(
-            binders_of(&node(N::Case {
-                scrutinee: Some(Box::new(var("s"))),
-                branches: vec![
-                    Branch {
-                        pattern: Some(Pattern {
-                            tag: "T".into(),
-                            binding: bind("payload"),
-                        }),
-                        guard: var("g0"),
-                        body: var("payload"),
-                    },
-                    Branch {
-                        pattern: None,
-                        guard: var("g1"),
-                        body: var("b1"),
-                    },
-                ],
-            })),
+            binders_of(&case_with_two_branches()),
             vec![
                 Vec::<String>::new(),
                 vec!["payload".to_string()],
@@ -638,19 +911,7 @@ mod tests {
             });
         };
         record(&TypedExpr::feed("d", var("v")));
-        record(&node(N::Transact {
-            keys: vec![crate::ccl::TransactKey {
-                name: Name::raw("k"),
-                init: int(0),
-            }],
-            writers: vec![WriterSite {
-                read_keys: vec![Name::raw("k")],
-                write_keys: vec![Name::raw("k")],
-                source: var("src"),
-                body: var("wbody"),
-            }],
-            domain: Type::Txn,
-        }));
+        record(&transact_one_key_one_writer());
         assert_eq!(vars, vec!["d".to_string()]);
         assert_eq!(
             keys,

--- a/src/ccl/scope.rs
+++ b/src/ccl/scope.rs
@@ -1,0 +1,660 @@
+//! CCL's binding structure, in one place.
+//!
+//! Every scope-aware pass — free-variable counting, capture-avoiding
+//! substitution, α-uniquification — needs the same answer to one question:
+//! *which binders scope over which of a node's children?* [`for_each_scoped_item`] is the single place that answers it. Its
+//! `match` is **exhaustive with no wildcard arm**, deliberately: a new
+//! [`TypedExprNode`] variant must declare its scope here before the crate
+//! compiles, instead of falling into a `_ => walk_children(..)` catch-all in
+//! five separate passes and silently getting the wrong one.
+//!
+//! Design of record: `src/ccl/design/ir.md`, "Binding structure lives in one
+//! place".
+//!
+//! # The rules
+//!
+//! - [`Lambda`](TypedExprNode::Lambda) — `param` scopes over `body`.
+//! - [`Let`](TypedExprNode::Let) — `binding` scopes over `body` **only**;
+//!   `bound_expr` sits outside it (CCL's `let` is non-recursive).
+//! - [`LetRec`](TypedExprNode::LetRec) — *every* group binder scopes over
+//!   *every* binding's definition and over `body` (mutual recursion).
+//! - [`For`](TypedExprNode::For) — `target` scopes over `body`; `iter` sits
+//!   outside.
+//! - [`Case`](TypedExprNode::Case) — each branch's `pattern.binding` scopes
+//!   over that branch's `guard` and `body`, and nothing else; the scrutinee and
+//!   the other branches are outside it.
+//! - [`Feed`](TypedExprNode::Feed) / [`Define`](TypedExprNode::Define) /
+//!   [`MutWrite`](TypedExprNode::MutWrite) — the `name` field is a *use* of the
+//!   defer handle / mutable variable bound elsewhere, not a binder. It is
+//!   surfaced as a [`ScopedItem::VarRef`].
+//! - [`Transact`](TypedExprNode::Transact) — introduces **no** binder. Its
+//!   `keys` name register fields of the record the node denotes, and a writer's
+//!   `read_keys`/`write_keys` are references to those fields; they are labels,
+//!   not variable occurrences, so they are surfaced as
+//!   [`ScopedItem::KeyRef`] — distinct from `VarRef` precisely so a
+//!   free-*variable* analysis can skip them while a consumer that cares about
+//!   every name a node mentions still folds them in.
+//!
+//! Every other variant introduces no binder and makes no name reference: its
+//! children are yielded in the node's own scope.
+//!
+//! # Invariants
+//!
+//! - **Child order matches [`TypedExpr::walk_children`]** — the `Child` items
+//!   are yielded in exactly that order. [`for_each_scoped_child_mut`] relies on
+//!   it to pair binder lists with a `&mut` traversal, and the corpus test in
+//!   this module checks it pointer-for-pointer over every variant.
+//! - **A scope's children are consecutive, and a scope is entered once** — all
+//!   children under one binder list are yielded together, and a binder-
+//!   introducing scope, once left, is never re-entered. (The node's *own* scope
+//!   — the empty binder list — recurs freely: it is the ambient scope, not a
+//!   scope this node opens. A `Case` alternates between the two as its branches
+//!   do or do not bind a payload.) A consumer may therefore carry per-scope
+//!   state — a shadowed substitution, a pushed environment frame — across a run
+//!   of children and rebuild it only when the binder list changes.
+//! - **Binders are innermost-last** within a list — the order a consumer that
+//!   maintains a De Bruijn environment needs to push them in.
+//!
+//! # What does *not* live here
+//!
+//! Type slots. A node's `ty`, its `user_annotation`, a `Cast`'s `target` and
+//! the refinement predicates they carry are reached by the type walks each pass
+//! owns (`count_free_in_type`, `collect_type_fv`, `hash_type`, …), because the
+//! passes disagree about them on purpose — `count_free` counts occurrences in
+//! predicates, `is_free_in_value` deliberately does not. This module is about
+//! the *term* spine's binding structure only, matching `walk_children`.
+
+use super::{Name, TypedBinding, TypedExpr, TypedExprNode};
+
+/// One item of a node's scope structure, as yielded by
+/// [`for_each_scoped_item`].
+pub enum ScopedItem<'a, 'b> {
+    /// A direct child expression together with the binders that scope over it
+    /// (innermost last). Empty when the child sits in the node's own scope.
+    Child {
+        /// The child term.
+        expr: &'a TypedExpr,
+        /// The binders this node puts in scope over `expr`.
+        binders: &'b [&'a TypedBinding],
+    },
+    /// A *variable* occurrence the node makes itself: a
+    /// [`Var`](TypedExprNode::Var), or the write target of a
+    /// `Feed`/`Define`/`MutWrite`. Free-variable analyses count these.
+    VarRef(&'a Name),
+    /// A register-key *label* occurrence — a [`Transact`](TypedExprNode::Transact)
+    /// key or writer footprint entry. Not a variable use: it names a field of
+    /// the register record the node denotes, so free-variable analyses skip it
+    /// while a consumer that cares about every name a node mentions folds it in.
+    KeyRef(&'a Name),
+}
+
+/// Visit each direct child of `e` together with the binders that scope over it,
+/// plus the name occurrences `e` makes itself.
+///
+/// **The single source of truth for CCL's binding structure** — see the module
+/// docs for the rules and the invariants callers may rely on. Every scope-aware
+/// walk in the crate is a fold over this one.
+///
+/// Generic in the callback rather than taking `&mut dyn FnMut`: this walk sits
+/// under [`crate::ccl::ccl_utils::is_free`], which substitution consults once
+/// per mapped binder per node, so the fold body wants to inline. It is not
+/// itself recursive — the recursion lives in each consumer, which contributes a
+/// single closure type — so monomorphization stays flat.
+pub fn for_each_scoped_item<'a, F>(e: &'a TypedExpr, f: &mut F)
+where
+    F: FnMut(ScopedItem<'a, '_>) + ?Sized,
+{
+    use TypedExprNode as N;
+
+    /// Yield a child in the node's own scope (no binder introduced).
+    fn open<'a, F: FnMut(ScopedItem<'a, '_>) + ?Sized>(f: &mut F, expr: &'a TypedExpr) {
+        f(ScopedItem::Child { expr, binders: &[] });
+    }
+    /// Yield a child scoped by `binders`.
+    fn under<'a, F: FnMut(ScopedItem<'a, '_>) + ?Sized>(
+        f: &mut F,
+        expr: &'a TypedExpr,
+        binders: &[&'a TypedBinding],
+    ) {
+        f(ScopedItem::Child { expr, binders });
+    }
+
+    match &e.node {
+        // ---- Leaves ---------------------------------------------------------
+        N::Lit(_) | N::Builtin(_) | N::Proj(_) | N::Source(_) | N::Defer | N::Error => {}
+        N::Var(n) => f(ScopedItem::VarRef(n)),
+
+        // ---- Non-binding interior nodes -------------------------------------
+        N::Apply { function, argument } => {
+            open(f, function);
+            open(f, argument);
+        }
+        // `target` is a type; its refinement predicate is reached by the
+        // caller's type walk, not here (see the module docs).
+        N::Cast { value, .. } => open(f, value),
+        N::BinOp { left, right, .. } => {
+            open(f, left);
+            open(f, right);
+        }
+        N::UnaryOp(_, inner) => open(f, inner),
+        N::Aggregate { input, .. } => open(f, input),
+        N::VariantCtor { payload, .. } => open(f, payload),
+        N::List(elts) | N::Tuple(elts) | N::Compose(elts) | N::CollectionUnion(elts) => {
+            for c in elts {
+                open(f, c);
+            }
+        }
+        N::Record(fields) => {
+            for (_, c) in fields {
+                open(f, c);
+            }
+        }
+        N::ExprStmt { expr, body } => {
+            open(f, expr);
+            open(f, body);
+        }
+        N::Begin { body } => open(f, body),
+
+        // The write target is a *use* of the binder that introduced the defer
+        // handle / mutable variable, so it resolves like any variable.
+        N::Feed { name, value } | N::Define { name, value } | N::MutWrite { name, value } => {
+            f(ScopedItem::VarRef(name));
+            open(f, value);
+        }
+
+        // ---- Binding nodes --------------------------------------------------
+        N::Lambda { param, body } => under(f, body, &[param]),
+
+        N::Let {
+            binding,
+            bound_expr,
+            body,
+        } => {
+            open(f, bound_expr);
+            under(f, body, &[binding]);
+        }
+
+        // Mutual recursion: the whole group is in scope throughout the group.
+        N::LetRec { bindings, body } => {
+            let group: Vec<&TypedBinding> = bindings.iter().map(|(b, _)| b).collect();
+            for (_, def) in bindings {
+                under(f, def, &group);
+            }
+            under(f, body, &group);
+        }
+
+        N::For { target, iter, body } => {
+            open(f, iter);
+            under(f, body, &[target]);
+        }
+
+        N::Case {
+            scrutinee,
+            branches,
+        } => {
+            if let Some(s) = scrutinee {
+                open(f, s);
+            }
+            for b in branches {
+                match &b.pattern {
+                    Some(p) => {
+                        let bound = [&p.binding];
+                        under(f, &b.guard, &bound);
+                        under(f, &b.body, &bound);
+                    }
+                    None => {
+                        open(f, &b.guard);
+                        open(f, &b.body);
+                    }
+                }
+            }
+        }
+
+        // Post-planning carrier. No binder: a writer body is already point-free
+        // and receives its register snapshots positionally, so the keys are
+        // field labels rather than binders (see the module docs).
+        N::Transact { keys, writers, .. } => {
+            for k in keys {
+                f(ScopedItem::KeyRef(&k.name));
+                open(f, &k.init);
+            }
+            for w in writers {
+                for k in w.read_keys.iter().chain(&w.write_keys) {
+                    f(ScopedItem::KeyRef(k));
+                }
+                open(f, &w.source);
+                open(f, &w.body);
+            }
+        }
+    }
+}
+
+/// In-place counterpart of [`for_each_scoped_item`]: visit each direct child of
+/// `e` mutably, paired with the names of the binders that scope over it.
+///
+/// Derived from [`for_each_scoped_item`], so the scoping rules stay stated
+/// once. A `&mut` walk cannot hold borrows into the node it is mutating, so the
+/// binder *names* are cloned up front and the children are then enumerated by
+/// [`TypedExpr::walk_children_mut`]; only the binder-introducing nodes allocate.
+/// The two enumerations agreeing is the invariant this pairing rests on — it is
+/// documented on [`for_each_scoped_item`], checked pointer-for-pointer by this
+/// module's corpus test, and its arity half is asserted here.
+///
+/// Name *occurrences* (`ScopedItem::VarRef` / `KeyRef`) are not surfaced: a
+/// caller that rewrites them (only [`crate::ccl::subst`] does, to retarget a
+/// renamed defer handle) reaches them through its own node match.
+pub fn for_each_scoped_child_mut<F>(e: &mut TypedExpr, f: &mut F)
+where
+    F: FnMut(&mut TypedExpr, &[Name]) + ?Sized,
+{
+    // A node that declares no binder scopes every child in its own scope, so
+    // there is nothing to collect and nothing to pair — skip straight to the
+    // mutable walk. This is the overwhelmingly common node, and skipping the
+    // collection pass is what keeps the adapter from costing every node in the
+    // tree a second traversal. `binds_any` is `walk_binders`, whose agreement
+    // with the scoping rules is `declared_binders_match_walk_binders` below.
+    if !e.binds_any() {
+        e.walk_children_mut(|c| f(c, &[]));
+        return;
+    }
+
+    // Sparse by construction: `scopes` is only as long as the last scoped
+    // child's position, so a `Let` (binder on the second of two children)
+    // allocates one empty leading entry and nothing more.
+    let mut scopes: Vec<Vec<Name>> = Vec::new();
+    let mut children = 0usize;
+    for_each_scoped_item(e, &mut |item| {
+        if let ScopedItem::Child { binders, .. } = item {
+            children += 1;
+            if !binders.is_empty() {
+                scopes.resize(children - 1, Vec::new());
+                scopes.push(binders.iter().map(|b| b.name.clone()).collect());
+            }
+        }
+    });
+
+    let mut i = 0usize;
+    e.walk_children_mut(|c| {
+        let binders = scopes.get(i).map_or(&[][..], Vec::as_slice);
+        i += 1;
+        f(c, binders);
+    });
+    debug_assert_eq!(
+        i, children,
+        "`walk_children_mut` and `for_each_scoped_item` must enumerate the same children — \
+         the binder lists are paired with the child sequence by position"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccl::{
+        Branch, Builtin, Lit, Pattern, ProjKey, Type, TypedBinding, TypedExprNode as N, WriterSite,
+    };
+
+    fn var(n: &str) -> TypedExpr {
+        TypedExpr::var(n)
+    }
+    fn int(n: i64) -> TypedExpr {
+        TypedExpr::lit(Lit::Int(n))
+    }
+    fn bind(n: &str) -> TypedBinding {
+        TypedBinding::new_unannotated(n)
+    }
+    fn node(n: N) -> TypedExpr {
+        TypedExpr::new(n)
+    }
+
+    /// One instance of **every** [`TypedExprNode`] variant.
+    ///
+    /// [`variant_name`] is exhaustive, so a new variant fails to compile there
+    /// first; extend this corpus at the same time so the consistency checks
+    /// below actually cover it.
+    fn corpus() -> Vec<TypedExpr> {
+        vec![
+            int(1),
+            var("x"),
+            node(N::Builtin(Builtin::Id)),
+            TypedExpr::apply(var("f"), var("a")),
+            node(N::Cast {
+                value: Box::new(var("v")),
+                target: Type::Hole,
+            }),
+            TypedExpr::binop(
+                var("l"),
+                crate::ccl::BinOpKind::Arithmetic(crate::ccl::ArithmeticKind::Add),
+                var("r"),
+            ),
+            node(N::UnaryOp(crate::ccl::UnaryOpKind::Neg, Box::new(var("u")))),
+            TypedExpr::lambda("p", Type::Hole, var("p")),
+            node(N::Aggregate {
+                input: Box::new(var("agg")),
+                kind: crate::ccl::AggregateKind::Sum,
+            }),
+            TypedExpr::let_bind("l", var("bound"), var("l")),
+            node(N::List(vec![var("e0"), var("e1")])),
+            node(N::Case {
+                scrutinee: Some(Box::new(var("s"))),
+                branches: vec![
+                    Branch {
+                        pattern: Some(Pattern {
+                            tag: "T".into(),
+                            binding: bind("payload"),
+                        }),
+                        guard: var("g0"),
+                        body: var("payload"),
+                    },
+                    Branch {
+                        pattern: None,
+                        guard: var("g1"),
+                        body: var("b1"),
+                    },
+                ],
+            }),
+            TypedExpr::variant_ctor("T", var("pl")),
+            node(N::Transact {
+                keys: vec![crate::ccl::TransactKey {
+                    name: Name::raw("k"),
+                    init: int(0),
+                }],
+                writers: vec![WriterSite {
+                    read_keys: vec![Name::raw("k")],
+                    write_keys: vec![Name::raw("k")],
+                    source: var("src"),
+                    body: var("wbody"),
+                }],
+                domain: Type::Txn,
+            }),
+            TypedExpr::letrec(vec![(bind("f"), var("g")), (bind("g"), var("f"))], var("f")),
+            node(N::For {
+                target: bind("t"),
+                iter: Box::new(var("xs")),
+                body: Box::new(var("t")),
+            }),
+            TypedExpr::tuple(vec![var("t0"), var("t1")]),
+            node(N::Record(vec![
+                ("a".into(), var("ra")),
+                ("b".into(), var("rb")),
+            ])),
+            node(N::Compose(vec![var("c0"), var("c1")])),
+            TypedExpr::collection_union(vec![var("cu0"), var("cu1")]),
+            TypedExpr::expr_stmt(var("stmt"), var("rest")),
+            node(N::Begin {
+                body: Box::new(var("bg")),
+            }),
+            TypedExpr::feed("d", var("fv")),
+            node(N::Define {
+                name: Name::raw("d"),
+                value: Box::new(var("dv")),
+            }),
+            node(N::MutWrite {
+                name: Name::raw("m"),
+                value: Box::new(var("mv")),
+            }),
+            node(N::Proj(ProjKey::Index(0))),
+            node(N::Source("src".into())),
+            node(N::Defer),
+            node(N::Error),
+        ]
+    }
+
+    /// Labels a node for the assertion messages below, and — being exhaustive —
+    /// is the prompt to give [`corpus`] an instance of a newly-added variant.
+    /// Only a prompt: nothing here *proves* the corpus is complete (that would
+    /// need reflection over the enum). The guarantee that matters is
+    /// [`for_each_scoped_item`]'s own wildcard-free match, which refuses to
+    /// compile until a new variant declares its scope.
+    fn variant_name(node: &TypedExprNode) -> &'static str {
+        match node {
+            N::Lit(_) => "Lit",
+            N::Var(_) => "Var",
+            N::Builtin(_) => "Builtin",
+            N::Apply { .. } => "Apply",
+            N::Cast { .. } => "Cast",
+            N::BinOp { .. } => "BinOp",
+            N::UnaryOp(..) => "UnaryOp",
+            N::Lambda { .. } => "Lambda",
+            N::Aggregate { .. } => "Aggregate",
+            N::Let { .. } => "Let",
+            N::List(_) => "List",
+            N::Case { .. } => "Case",
+            N::VariantCtor { .. } => "VariantCtor",
+            N::Transact { .. } => "Transact",
+            N::LetRec { .. } => "LetRec",
+            N::For { .. } => "For",
+            N::Tuple(_) => "Tuple",
+            N::Record(_) => "Record",
+            N::Compose(_) => "Compose",
+            N::CollectionUnion(_) => "CollectionUnion",
+            N::ExprStmt { .. } => "ExprStmt",
+            N::Begin { .. } => "Begin",
+            N::Feed { .. } => "Feed",
+            N::Define { .. } => "Define",
+            N::MutWrite { .. } => "MutWrite",
+            N::Proj(_) => "Proj",
+            N::Source(_) => "Source",
+            N::Defer => "Defer",
+            N::Error => "Error",
+        }
+    }
+
+    /// The invariant [`for_each_scoped_child_mut`] rests on: the scoped walk
+    /// yields exactly `walk_children`'s children, in order.
+    #[test]
+    fn child_enumeration_matches_walk_children() {
+        for e in corpus() {
+            let mut walked: Vec<*const TypedExpr> = Vec::new();
+            e.walk_children(|c| walked.push(c));
+            let mut scoped: Vec<*const TypedExpr> = Vec::new();
+            for_each_scoped_item(&e, &mut |item| {
+                if let ScopedItem::Child { expr, .. } = item {
+                    scoped.push(expr);
+                }
+            });
+            assert_eq!(
+                walked,
+                scoped,
+                "child enumeration diverged for `{}`",
+                variant_name(&e.node)
+            );
+        }
+    }
+
+    /// The scoped walk and [`TypedExpr::walk_binders`] must agree on which
+    /// bindings a node declares — the former by scope, the latter by slot.
+    #[test]
+    fn declared_binders_match_walk_binders() {
+        for e in corpus() {
+            let mut declared: Vec<*const TypedBinding> = Vec::new();
+            e.walk_binders(|b| declared.push(b));
+
+            // Consecutive scopes: a binder list repeats across the children it
+            // covers, so dedup adjacent repeats to recover the declaration set.
+            let mut scoped: Vec<*const TypedBinding> = Vec::new();
+            let mut prev: Vec<*const TypedBinding> = Vec::new();
+            for_each_scoped_item(&e, &mut |item| {
+                if let ScopedItem::Child { binders, .. } = item {
+                    let here: Vec<*const TypedBinding> =
+                        binders.iter().map(|b| *b as *const _).collect();
+                    if here != prev {
+                        scoped.extend(here.iter().copied());
+                        prev = here;
+                    }
+                }
+            });
+            assert_eq!(
+                declared,
+                scoped,
+                "binder declaration diverged for `{}`",
+                variant_name(&e.node)
+            );
+        }
+    }
+
+    /// The consecutiveness invariant, which two things rest on:
+    /// `declared_binders_match_walk_binders` above recovers the declaration set
+    /// by deduping *adjacent* binder lists, and a consumer that carries
+    /// per-scope state may rebuild it only when the list changes. A node that
+    /// interleaved two scopes would break both. The ambient (empty) list is
+    /// exempt — it is not a scope the node opens, and a `Case` returns to it
+    /// whenever a branch binds no payload.
+    #[test]
+    fn scopes_are_consecutive_and_entered_once() {
+        for e in corpus() {
+            let mut runs: Vec<Vec<*const TypedBinding>> = Vec::new();
+            for_each_scoped_item(&e, &mut |item| {
+                if let ScopedItem::Child { binders, .. } = item {
+                    let here: Vec<*const TypedBinding> =
+                        binders.iter().map(|b| *b as *const _).collect();
+                    if runs.last() != Some(&here) {
+                        runs.push(here);
+                    }
+                }
+            });
+            let mut scoped: Vec<Vec<*const TypedBinding>> =
+                runs.into_iter().filter(|r| !r.is_empty()).collect();
+            let entered = scoped.len();
+            scoped.sort();
+            scoped.dedup();
+            assert_eq!(
+                entered,
+                scoped.len(),
+                "a scope was re-entered after being left in `{}`",
+                variant_name(&e.node)
+            );
+        }
+    }
+
+    /// The mutable adapter must hand each child the same binder names the
+    /// immutable walk scopes over it.
+    #[test]
+    fn mut_adapter_pairs_the_same_binders() {
+        for e in corpus() {
+            let expected: Vec<Vec<Name>> = {
+                let mut v = Vec::new();
+                for_each_scoped_item(&e, &mut |item| {
+                    if let ScopedItem::Child { binders, .. } = item {
+                        v.push(binders.iter().map(|b| b.name.clone()).collect());
+                    }
+                });
+                v
+            };
+            let mut actual: Vec<Vec<Name>> = Vec::new();
+            let mut e = e;
+            for_each_scoped_child_mut(&mut e, &mut |_, binders| actual.push(binders.to_vec()));
+            assert_eq!(
+                expected,
+                actual,
+                "mut adapter diverged for `{}`",
+                variant_name(&e.node)
+            );
+        }
+    }
+
+    /// Spot-check the rules that are easy to get backwards.
+    #[test]
+    fn the_scoping_rules() {
+        let binders_of = |e: &TypedExpr| -> Vec<Vec<String>> {
+            let mut v = Vec::new();
+            for_each_scoped_item(e, &mut |item| {
+                if let ScopedItem::Child { binders, .. } = item {
+                    v.push(binders.iter().map(|b| b.name.base().to_string()).collect());
+                }
+            });
+            v
+        };
+
+        // Let: `bound_expr` outside, `body` inside.
+        assert_eq!(
+            binders_of(&TypedExpr::let_bind("l", var("a"), var("b"))),
+            vec![Vec::<String>::new(), vec!["l".to_string()]],
+        );
+        // Lambda: the one child is under the param.
+        assert_eq!(
+            binders_of(&TypedExpr::lambda("p", Type::Hole, var("p"))),
+            vec![vec!["p".to_string()]],
+        );
+        // For: `iter` outside, `body` under the target.
+        assert_eq!(
+            binders_of(&node(N::For {
+                target: bind("t"),
+                iter: Box::new(var("xs")),
+                body: Box::new(var("t")),
+            })),
+            vec![Vec::<String>::new(), vec!["t".to_string()]],
+        );
+        // LetRec: the whole group over every definition and the body.
+        let group = vec!["f".to_string(), "g".to_string()];
+        assert_eq!(
+            binders_of(&TypedExpr::letrec(
+                vec![(bind("f"), var("g")), (bind("g"), var("f"))],
+                var("f"),
+            )),
+            vec![group.clone(), group.clone(), group],
+        );
+        // Case: the pattern binder covers its own branch only.
+        assert_eq!(
+            binders_of(&node(N::Case {
+                scrutinee: Some(Box::new(var("s"))),
+                branches: vec![
+                    Branch {
+                        pattern: Some(Pattern {
+                            tag: "T".into(),
+                            binding: bind("payload"),
+                        }),
+                        guard: var("g0"),
+                        body: var("payload"),
+                    },
+                    Branch {
+                        pattern: None,
+                        guard: var("g1"),
+                        body: var("b1"),
+                    },
+                ],
+            })),
+            vec![
+                Vec::<String>::new(),
+                vec!["payload".to_string()],
+                vec!["payload".to_string()],
+                Vec::<String>::new(),
+                Vec::<String>::new(),
+            ],
+        );
+    }
+
+    /// A `Feed` target is a variable use; a `Transact` key is a label. Both are
+    /// name occurrences, and the distinction is exactly what lets a
+    /// free-variable walker skip the latter.
+    #[test]
+    fn name_occurrences_are_classified() {
+        let mut vars = Vec::new();
+        let mut keys = Vec::new();
+        let mut record = |e: &TypedExpr| {
+            for_each_scoped_item(e, &mut |item| match item {
+                ScopedItem::VarRef(n) => vars.push(n.base().to_string()),
+                ScopedItem::KeyRef(n) => keys.push(n.base().to_string()),
+                ScopedItem::Child { .. } => {}
+            });
+        };
+        record(&TypedExpr::feed("d", var("v")));
+        record(&node(N::Transact {
+            keys: vec![crate::ccl::TransactKey {
+                name: Name::raw("k"),
+                init: int(0),
+            }],
+            writers: vec![WriterSite {
+                read_keys: vec![Name::raw("k")],
+                write_keys: vec![Name::raw("k")],
+                source: var("src"),
+                body: var("wbody"),
+            }],
+            domain: Type::Txn,
+        }));
+        assert_eq!(vars, vec!["d".to_string()]);
+        assert_eq!(
+            keys,
+            vec!["k".to_string(), "k".to_string(), "k".to_string()]
+        );
+    }
+}

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -57,7 +57,9 @@ use std::rc::Rc;
 
 use crate::ccl::ccl_utils::{PredMemo, is_free};
 use crate::ccl::provenance::NodeId;
-use crate::ccl::scope::{ScopedItem, for_each_scoped_child_mut, for_each_scoped_item};
+use crate::ccl::scope::{
+    ScopedItem, ScopedItemMut, for_each_scoped_item, for_each_scoped_item_mut,
+};
 use crate::ccl::{Branch, Name, PredicateId, Type, TypedExpr, TypedExprNode};
 
 /// A term binder name.
@@ -573,18 +575,30 @@ impl Subst {
         (self.handle_target(name), Box::new(self.apply_expr(value)))
     }
 
-    /// The handle-rename half of [`Self::apply_handle_use`], shared with the
-    /// in-place mode: rename through var-shaped mappings, keep the name on a
-    /// non-variable discharge.
-    fn handle_target(&self, name: &Name) -> Name {
-        match self.0.get(name) {
-            None => name.clone(),
-            Some(Mapping::Rename(to)) => to.clone(),
-            Some(Mapping::Discharge(t)) => match &t.node {
-                TypedExprNode::Var(n) => n.clone(),
-                _ => name.clone(),
+    /// The name this substitution retargets a *name position* to, or `None` when
+    /// it leaves the position alone: an unmapped name, or one mapped to a
+    /// non-variable term (a handle or a channel domain can only hold a name, so
+    /// a compound discharge has nothing to write there — see the `Feed` arm of
+    /// [`Self::apply_expr_inner`]).
+    ///
+    /// Distinguishing "unchanged" from "changed to the same thing" is what lets
+    /// the in-place mode visit every name occurrence in the tree without a
+    /// [`Name`] clone per node.
+    fn retarget(&self, name: &Name) -> Option<Name> {
+        match self.0.get(name)? {
+            Mapping::Rename(to) => Some(to.clone()),
+            Mapping::Discharge(t) => match &t.node {
+                TypedExprNode::Var(n) => Some(n.clone()),
+                _ => None,
             },
         }
+    }
+
+    /// The handle-rename half of [`Self::apply_handle_use`], shared with the
+    /// type-slot walks: [`Self::retarget`] with the unchanged case spelled out
+    /// as the original name, for the rebuilding callers that need a value.
+    fn handle_target(&self, name: &Name) -> Name {
+        self.retarget(name).unwrap_or_else(|| name.clone())
     }
 
     /// Apply this substitution to a term **in place** — the pass-level mode
@@ -662,36 +676,49 @@ impl Subst {
         // unrestricted substitution is the right one for it, and the binder
         // crossings below still only guard the children.
         e.walk_type_slots_mut(|ty| self.rewrite_type_go(ty, memo));
-        // The one node-local slot the type walk and the generic child descent
-        // both miss: the write target of a handle node, which is a *use* of a
-        // binder (see `crate::ccl::scope`, which declares it as such) rather
-        // than a type or a child, so a var-shaped mapping retargets it.
-        match &mut e.node {
-            TypedExprNode::Feed { name, .. }
-            | TypedExprNode::Define { name, .. }
-            | TypedExprNode::MutWrite { name, .. } => *name = self.handle_target(name),
-            _ => {}
-        }
 
-        // Capture-avoiding descent: each child is rewritten under the
-        // substitution restricted by the binders that scope over it. Which
-        // binders those are is not decided here — `for_each_scoped_child_mut`
-        // is the crate's one statement of CCL's binding structure. An empty
-        // binder list needs no special case: `shadow_all` borrows and the
-        // recursive call is the unrestricted one.
+        // Capture-avoiding descent, plus the node's own name occurrences. Which
+        // children a binder scopes over, and which names a node mentions of its
+        // own, are not decided here — `crate::ccl::scope` is the crate's one
+        // statement of CCL's binding structure, and folding over it is what
+        // keeps a newly-added node from silently escaping both.
+        //
+        // The restriction and its Barendregt check are per *scope*, not per
+        // child: the walk opens a scope once for the whole run of children it
+        // covers, so a `LetRec` group of n binders pays n checks rather than
+        // n * (n + 1). Each check walks every `Discharge` replacement term, so
+        // per-child would be quadratic in the group's width. An ambient scope
+        // needs no special case: `shadow_all` borrows and the recursive call is
+        // the unrestricted one.
         //
         // Inertness is *not* pre-tested here. The recursive call opens with the
         // same test against the same substitution, so testing it here would walk
         // every child subtree twice — and returning early on it would skip the
-        // Barendregt assertion below, which is the tripwire for a broken
+        // Barendregt assertion, which is the tripwire for a broken
         // uid-preservation invariant and should fire wherever the binder is
         // crossed, not only where the substitution happens to be live.
-        for_each_scoped_child_mut(e, &mut |child, binders| {
-            let inner = self.shadow_all(binders);
-            for b in binders {
-                inner.assert_no_capture(b);
+        let mut scoped: Cow<'_, Subst> = Cow::Borrowed(self);
+        for_each_scoped_item_mut(e, &mut |item| match item {
+            ScopedItemMut::Scope(binders) => {
+                scoped = self.shadow_all(binders);
+                for b in binders {
+                    scoped.assert_no_capture(b);
+                }
             }
-            inner.rewrite_expr_go(child, memo);
+            ScopedItemMut::Child(child) => scoped.rewrite_expr_go(child, memo),
+            // A handle node's write target is a *use* of the binder that
+            // introduced it, so a var-shaped mapping retargets it. (A `Var`
+            // occurrence the substitution maps never reaches here — it was
+            // replaced wholesale above — and `retarget` leaves an unmapped one
+            // alone without so much as a clone.)
+            ScopedItemMut::VarRef(name) => {
+                if let Some(to) = self.retarget(name) {
+                    *name = to;
+                }
+            }
+            // A register key is a field label, not a variable occurrence:
+            // nothing a term substitution acts on.
+            ScopedItemMut::KeyRef(_) => {}
         });
 
         // `Compose`'s type is derived from its elements, so rewriting them can
@@ -707,6 +734,8 @@ impl Subst {
     /// The Barendregt no-capture invariant at a binder crossing (see
     /// [`Self::under_binder`] for why capture is impossible by convention).
     fn assert_no_capture(&self, binder: &Name) {
+        #[cfg(test)]
+        capture_assert_probe::bump();
         assert!(
             !self.range_mentions(binder),
             "Barendregt violation: substitution range mentions binder `{binder:?}` it passes \
@@ -898,11 +927,14 @@ impl Subst {
     ///
     /// Returns a borrow when the restriction is vacuous, which is the common
     /// case: a substitution's domain is usually a single binder and the scope
-    /// being crossed usually does not name it. That matters because a scope's
-    /// children are yielded consecutively (see [`crate::ccl::scope`]), so the
-    /// restriction is recomputed once per child — folding [`Self::shadow`] over
-    /// the list instead would clone the map once per binder per child, since
-    /// `shadow` returns an owned `Subst` and so clones even on a miss.
+    /// being crossed usually does not name it. Folding [`Self::shadow`] over the
+    /// group instead would clone the map once per binder even on a miss, since
+    /// `shadow` returns an owned `Subst`.
+    ///
+    /// The `contains_key` guard is what makes that true and is therefore
+    /// load-bearing, not a micro-optimization: `to_mut()` on a `Cow::Borrowed`
+    /// clones unconditionally, so calling it before knowing there is something to
+    /// remove would allocate on every crossing and the `Cow` would buy nothing.
     pub fn shadow_all<'a>(&self, binders: impl IntoIterator<Item = &'a Name>) -> Cow<'_, Subst> {
         let mut out = Cow::Borrowed(self);
         for b in binders {
@@ -1141,6 +1173,33 @@ pub fn well_formed(ty: &Type, ctx: &BTreeSet<Binder>) -> bool {
     type_free_vars(ty).is_subset(ctx)
 }
 
+/// Counts [`Subst::assert_no_capture`] calls, so a test can assert *how many
+/// times* a descent pays for the Barendregt check rather than only that it
+/// passes. The check is release-active and walks every replacement term, so
+/// "once per scope crossed" is a cost invariant, not a detail — see
+/// `letrec_pays_the_capture_check_once_per_binder_not_once_per_child`.
+///
+/// Thread-local, because `cargo test` runs tests concurrently in one process.
+#[cfg(test)]
+mod capture_assert_probe {
+    use std::cell::Cell;
+
+    thread_local! {
+        static COUNT: Cell<usize> = const { Cell::new(0) };
+    }
+
+    pub fn bump() {
+        COUNT.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Run `body`, returning how many capture assertions it performed.
+    pub fn count(body: impl FnOnce()) -> usize {
+        COUNT.with(|c| c.set(0));
+        body();
+        COUNT.with(Cell::get)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1363,7 +1422,7 @@ mod tests {
 mod rewrite_tests {
     use super::*;
     use crate::ccl::ccl_utils::is_free;
-    use crate::ccl::{BinOpKind, CompareKind, Lit, Refinement};
+    use crate::ccl::{BinOpKind, CompareKind, Lit, Refinement, TypedBinding};
     use std::rc::Rc;
 
     fn var(s: &str) -> TypedExpr {
@@ -1509,5 +1568,139 @@ mod rewrite_tests {
             &Name::raw("d"),
             "a non-variable discharge keeps the handle for UnboundDeferHandle to report"
         );
+    }
+
+    // ---- Barendregt-check cost at a binder crossing -------------------------
+    //
+    // `assert_no_capture` is a *release-active* `assert!` whose `range_mentions`
+    // does a full `is_free` walk of every `Discharge` replacement term, so what
+    // it is paid *per* is a cost invariant. The scoped walk opens a scope once
+    // for the whole run of children it covers, and the descent restricts and
+    // checks there; asserting inside a per-child callback instead is quadratic
+    // in a scope's width, which is what these pin.
+
+    /// A `LetRec` group of *n* binders opens **one** scope covering *n*+1
+    /// children (each definition, plus the body), so the no-capture check is
+    /// owed *n* times — once per binder of the one scope crossed.
+    #[test]
+    fn letrec_pays_the_capture_check_once_per_binder_not_once_per_child() {
+        for n in [1usize, 4, 8] {
+            let bindings: Vec<_> = (0..n)
+                .map(|i| {
+                    (
+                        TypedBinding::new_unannotated(format!("f{i}")),
+                        int(i as i64),
+                    )
+                })
+                .collect();
+            let mut e = TypedExpr::letrec(bindings, var("x"));
+            let subst = Subst::discharge("x", int(0));
+
+            let asserts = capture_assert_probe::count(|| subst.rewrite_expr(&mut e));
+
+            assert_eq!(
+                asserts,
+                n,
+                "a {n}-binder letrec crosses one scope, so it owes {n} capture checks; \
+                 checking per child instead costs n*(n+1) = {}",
+                n * (n + 1)
+            );
+        }
+    }
+
+    /// A `Case` branch's payload binder opens one scope covering the branch's
+    /// guard *and* body — one scope, so one check, not one per child.
+    #[test]
+    fn case_pays_the_capture_check_once_per_branch_not_once_per_child() {
+        let branch = |tag: &str, payload: &str| Branch {
+            pattern: Some(crate::ccl::Pattern {
+                tag: tag.into(),
+                binding: TypedBinding::new_unannotated(payload),
+            }),
+            guard: int(1),
+            body: int(2),
+        };
+        let mut e = TypedExpr::new(TypedExprNode::Case {
+            scrutinee: Some(Box::new(var("x"))),
+            branches: vec![branch("A", "pa"), branch("B", "pb")],
+        });
+        let subst = Subst::discharge("x", int(0));
+
+        let asserts = capture_assert_probe::count(|| subst.rewrite_expr(&mut e));
+
+        assert_eq!(
+            asserts, 2,
+            "two payload-binding branches cross two scopes, so two capture checks; \
+             checking per child costs four (guard + body each)"
+        );
+    }
+
+    /// The descent does not pre-test inertness before crossing a binder, so the
+    /// crossing is checked wherever the binder is crossed and not only where the
+    /// substitution is still live in the body. `for y in x do 1` is live at the
+    /// node (`x` is in `iter`) and inert in the body, and the range mentions
+    /// `y`, so the tripwire must fire.
+    #[test]
+    #[should_panic(expected = "Barendregt violation")]
+    fn a_binder_crossing_is_checked_even_when_the_body_is_inert() {
+        let mut e = TypedExpr::new(TypedExprNode::For {
+            target: TypedBinding::new_unannotated("y"),
+            iter: Box::new(var("x")),
+            body: Box::new(int(1)),
+        });
+        Subst::discharge("x", var("y")).rewrite_expr(&mut e);
+    }
+
+    /// Substitution retargets every variable occurrence the scoped walk
+    /// surfaces. `crate::ccl::scope`'s corpus test checks the two walks agree on
+    /// what those occurrences *are*; this checks the descent acts on all of
+    /// them — the end-to-end half, across `Var` and the three handle nodes.
+    #[test]
+    fn a_rename_retargets_every_varref_the_scoped_walk_surfaces() {
+        use crate::ccl::scope::{ScopedItem, for_each_scoped_item};
+
+        let handle_nodes = [
+            TypedExpr::new(TypedExprNode::Feed {
+                name: Name::raw("h"),
+                value: Box::new(int(1)),
+            }),
+            TypedExpr::new(TypedExprNode::Define {
+                name: Name::raw("h"),
+                value: Box::new(int(1)),
+            }),
+            TypedExpr::new(TypedExprNode::MutWrite {
+                name: Name::raw("h"),
+                value: Box::new(int(1)),
+            }),
+            var("h"),
+        ];
+
+        for original in handle_nodes {
+            let before: Vec<Name> = varrefs(&original);
+            assert!(
+                before.contains(&Name::raw("h")),
+                "corpus node must surface `h` as a VarRef"
+            );
+
+            let mut renamed = original.clone();
+            Subst::rename("h", "h2").rewrite_expr(&mut renamed);
+
+            assert!(
+                !varrefs(&renamed).contains(&Name::raw("h")),
+                "a rename left an occurrence of `h` behind in `{:?}` — the scoped walk \
+                 declares it a variable use, so substitution must retarget it",
+                original.node
+            );
+        }
+
+        fn varrefs(e: &TypedExpr) -> Vec<Name> {
+            let mut out = Vec::new();
+            for_each_scoped_item(e, &mut |item| {
+                if let ScopedItem::VarRef(n) = item {
+                    out.push(n.clone());
+                }
+            });
+            out
+        }
     }
 }

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -51,11 +51,13 @@
 //! correct — acting differently in different scopes is the whole job of a
 //! substitution, so scope cannot be left out of the key.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
 use crate::ccl::ccl_utils::{PredMemo, is_free};
 use crate::ccl::provenance::NodeId;
+use crate::ccl::scope::{ScopedItem, for_each_scoped_child_mut, for_each_scoped_item};
 use crate::ccl::{Branch, Name, PredicateId, Type, TypedExpr, TypedExprNode};
 
 /// A term binder name.
@@ -506,9 +508,7 @@ impl Subst {
                 // Mutual recursion: every group binder is in scope in every
                 // binding body AND the letrec body, so all of them shadow the
                 // substitution throughout the group.
-                let inner = bindings
-                    .iter()
-                    .fold(self.clone(), |s, (b, _)| s.shadow(&b.name));
+                let inner = self.shadow_all(bindings.iter().map(|(b, _)| &b.name));
                 LetRec {
                     bindings: bindings
                         .iter()
@@ -527,11 +527,9 @@ impl Subst {
                     .iter()
                     .map(|b| {
                         // A structural pattern binds its payload name inside the
-                        // branch's guard and body.
-                        let inner = match &b.pattern {
-                            Some(p) => self.shadow(&p.binding.name),
-                            None => self.clone(),
-                        };
+                        // branch's guard and body; a guard-only branch binds
+                        // nothing, which `shadow_all` handles as the empty scope.
+                        let inner = self.shadow_all(b.pattern.iter().map(|p| &p.binding.name));
                         Branch {
                             pattern: b.pattern.clone(),
                             guard: inner.apply_expr(&b.guard),
@@ -664,105 +662,46 @@ impl Subst {
         // unrestricted substitution is the right one for it, and the binder
         // crossings below still only guard the children.
         e.walk_type_slots_mut(|ty| self.rewrite_type_go(ty, memo));
+        // The one node-local slot the type walk and the generic child descent
+        // both miss: the write target of a handle node, which is a *use* of a
+        // binder (see `crate::ccl::scope`, which declares it as such) rather
+        // than a type or a child, so a var-shaped mapping retargets it.
         match &mut e.node {
-            TypedExprNode::Var(_) => {}
-
-            TypedExprNode::Cast { value, .. } => {
-                self.rewrite_expr_go(value, memo);
-            }
-
-            TypedExprNode::Feed { name, value }
-            | TypedExprNode::Define { name, value }
-            | TypedExprNode::MutWrite { name, value } => {
-                *name = self.handle_target(name);
-                self.rewrite_expr_go(value, memo);
-            }
-
-            TypedExprNode::Lambda { param, body } => {
-                // `param.ty` was rewritten with the node's other type slots above
-                // — it is an independent `Rc` from the one on `e.ty`'s `Fun`
-                // domain, so it needs its own visit. Only the body is under the
-                // binder.
-                self.under_binder_mut(&param.name, body, memo);
-            }
-
-            TypedExprNode::For { target, iter, body } => {
-                self.rewrite_expr_go(iter, memo);
-                self.under_binder_mut(&target.name, body, memo);
-            }
-
-            TypedExprNode::Let {
-                binding,
-                bound_expr,
-                body,
-            } => {
-                self.rewrite_expr_go(bound_expr, memo);
-                self.under_binder_mut(&binding.name, body, memo);
-            }
-
-            TypedExprNode::LetRec { bindings, body } => {
-                // Every group binder scopes every binding body and the letrec
-                // body (mutual recursion) — shadow them all before descending
-                // anywhere inside the group.
-                let inner = bindings
-                    .iter()
-                    .fold(self.clone(), |s, (b, _)| s.shadow(&b.name));
-                for (b, _) in bindings.iter() {
-                    inner.assert_no_capture(&b.name);
-                }
-                for (_, def) in bindings.iter_mut() {
-                    inner.rewrite_expr_go(def, memo);
-                }
-                inner.rewrite_expr_go(body, memo);
-            }
-
-            TypedExprNode::Case {
-                scrutinee,
-                branches,
-            } => {
-                if let Some(sc) = scrutinee {
-                    self.rewrite_expr_go(sc, memo);
-                }
-                for b in branches.iter_mut() {
-                    let inner = match &b.pattern {
-                        Some(p) => self.shadow(&p.binding.name),
-                        None => self.clone(),
-                    };
-                    if let Some(p) = &b.pattern {
-                        inner.assert_no_capture(&p.binding.name);
-                    }
-                    inner.rewrite_expr_go(&mut b.guard, memo);
-                    inner.rewrite_expr_go(&mut b.body, memo);
-                }
-            }
-
-            TypedExprNode::Compose(elts) => {
-                for el in elts.iter_mut() {
-                    self.rewrite_expr_go(el, memo);
-                }
-                // Recompute the chain type from the rewritten ends, when both
-                // are concrete enough to read.
-                if let (Some(first), Some(last)) = (elts.first(), elts.last())
-                    && let (Some(d), Some(c)) = (first.ty.domain(), last.ty.codomain())
-                {
-                    e.ty = Type::fun(d, c);
-                }
-            }
-
-            // No binders introduced: recurse structurally into child terms.
-            _ => e.walk_children_mut(|c| self.rewrite_expr_go(c, memo)),
+            TypedExprNode::Feed { name, .. }
+            | TypedExprNode::Define { name, .. }
+            | TypedExprNode::MutWrite { name, .. } => *name = self.handle_target(name),
+            _ => {}
         }
-    }
 
-    /// In-place analogue of [`Self::under_binder`]: shadow, assert
-    /// no-capture, recurse into the binder's scope.
-    fn under_binder_mut(&self, binder: &Name, body: &mut TypedExpr, memo: &PredMemo<Subst>) {
-        let restricted = self.shadow(binder);
-        if !restricted.0.keys().any(|k| is_free(k, body)) {
-            return;
+        // Capture-avoiding descent: each child is rewritten under the
+        // substitution restricted by the binders that scope over it. Which
+        // binders those are is not decided here — `for_each_scoped_child_mut`
+        // is the crate's one statement of CCL's binding structure. An empty
+        // binder list needs no special case: `shadow_all` borrows and the
+        // recursive call is the unrestricted one.
+        //
+        // Inertness is *not* pre-tested here. The recursive call opens with the
+        // same test against the same substitution, so testing it here would walk
+        // every child subtree twice — and returning early on it would skip the
+        // Barendregt assertion below, which is the tripwire for a broken
+        // uid-preservation invariant and should fire wherever the binder is
+        // crossed, not only where the substitution happens to be live.
+        for_each_scoped_child_mut(e, &mut |child, binders| {
+            let inner = self.shadow_all(binders);
+            for b in binders {
+                inner.assert_no_capture(b);
+            }
+            inner.rewrite_expr_go(child, memo);
+        });
+
+        // `Compose`'s type is derived from its elements, so rewriting them can
+        // concretize it (substituting a `Var` whose type was a placeholder).
+        if let TypedExprNode::Compose(elts) = &e.node
+            && let (Some(first), Some(last)) = (elts.first(), elts.last())
+            && let (Some(d), Some(c)) = (first.ty.domain(), last.ty.codomain())
+        {
+            e.ty = Type::fun(d, c);
         }
-        restricted.assert_no_capture(binder);
-        restricted.rewrite_expr_go(body, memo);
     }
 
     /// The Barendregt no-capture invariant at a binder crossing (see
@@ -950,6 +889,28 @@ impl Subst {
         let mut m = self.0.clone();
         m.remove(binder);
         Subst(m)
+    }
+
+    /// This substitution restricted so it acts on **none** of `binders` — the
+    /// whole-scope form of [`Self::shadow`], for the nodes whose binders scope
+    /// over a child as a group (a `LetRec`'s mutual-recursion group, a `Case`
+    /// branch's payload, an empty list for a child in the node's own scope).
+    ///
+    /// Returns a borrow when the restriction is vacuous, which is the common
+    /// case: a substitution's domain is usually a single binder and the scope
+    /// being crossed usually does not name it. That matters because a scope's
+    /// children are yielded consecutively (see [`crate::ccl::scope`]), so the
+    /// restriction is recomputed once per child — folding [`Self::shadow`] over
+    /// the list instead would clone the map once per binder per child, since
+    /// `shadow` returns an owned `Subst` and so clones even on a miss.
+    pub fn shadow_all<'a>(&self, binders: impl IntoIterator<Item = &'a Name>) -> Cow<'_, Subst> {
+        let mut out = Cow::Borrowed(self);
+        for b in binders {
+            if out.0.contains_key(b) {
+                out.to_mut().0.remove(b);
+            }
+        }
+        out
     }
 
     /// Apply this substitution to a **type**, rewriting the term binders that
@@ -1142,11 +1103,11 @@ fn collect_type_fv(
     }
 }
 
-/// Collect the free term-variable names of an expression, respecting the
-/// binders introduced by lambdas / `let`s / loops / match arms (mirrors the
-/// shadowing rules of [`crate::ccl::ccl_utils::count_free`]). Also descends
-/// into each sub-expression's type slot, since predicate sub-terms may carry
-/// further refinements.
+/// Collect the free term-variable names of an expression — the accumulating
+/// dual of [`crate::ccl::ccl_utils::count_free`]'s by-name query, and the same
+/// fold over [`crate::ccl::scope::for_each_scoped_item`], so the two cannot
+/// disagree about what binds where. Also descends into each sub-expression's
+/// type slot, since predicate sub-terms may carry further refinements.
 fn collect_expr_fv(
     e: &TypedExpr,
     bound: &mut BTreeSet<Binder>,
@@ -1154,72 +1115,23 @@ fn collect_expr_fv(
     out: &mut BTreeSet<Binder>,
 ) {
     collect_type_fv(&e.ty, bound, visited, out);
-    match &e.node {
-        TypedExprNode::Var(n) => {
+    for_each_scoped_item(e, &mut |item| match item {
+        ScopedItem::VarRef(n) => {
             if !bound.contains(n) {
                 out.insert(n.clone());
             }
         }
-        TypedExprNode::Lambda { param, body } => {
-            with_binders(bound, [param.name.clone()], |bnd| {
-                collect_expr_fv(body, bnd, visited, out)
-            });
-        }
-        TypedExprNode::Let {
-            binding,
-            bound_expr,
-            body,
+        // A register key is a field label, not a variable occurrence.
+        ScopedItem::KeyRef(_) => {}
+        ScopedItem::Child {
+            expr: child,
+            binders,
         } => {
-            collect_expr_fv(bound_expr, bound, visited, out);
-            with_binders(bound, [binding.name.clone()], |bnd| {
-                collect_expr_fv(body, bnd, visited, out)
+            with_binders(bound, binders.iter().map(|b| b.name.clone()), |bnd| {
+                collect_expr_fv(child, bnd, visited, out)
             });
         }
-        // Mutual recursion: every group binder is bound in every binding
-        // body and in the letrec body.
-        TypedExprNode::LetRec { bindings, body } => {
-            with_binders(bound, bindings.iter().map(|(b, _)| b.name.clone()), |bnd| {
-                for (_, def) in bindings {
-                    collect_expr_fv(def, bnd, visited, out);
-                }
-                collect_expr_fv(body, bnd, visited, out);
-            });
-        }
-        // The `name` of Feed/Define/MutWrite is a *use* of the defer handle
-        // / mutable variable.
-        TypedExprNode::Feed { name, value }
-        | TypedExprNode::Define { name, value }
-        | TypedExprNode::MutWrite { name, value } => {
-            if !bound.contains(name) {
-                out.insert(name.clone());
-            }
-            collect_expr_fv(value, bound, visited, out);
-        }
-        // The loop target binds only in the body.
-        TypedExprNode::For { target, iter, body } => {
-            collect_expr_fv(iter, bound, visited, out);
-            with_binders(bound, [target.name.clone()], |bnd| {
-                collect_expr_fv(body, bnd, visited, out);
-            });
-        }
-        TypedExprNode::Case {
-            scrutinee,
-            branches,
-        } => {
-            if let Some(s) = scrutinee {
-                collect_expr_fv(s, bound, visited, out);
-            }
-            for b in branches {
-                let payload = b.pattern.iter().map(|p| p.binding.name.clone());
-                with_binders(bound, payload, |bnd| {
-                    collect_expr_fv(&b.guard, bnd, visited, out);
-                    collect_expr_fv(&b.body, bnd, visited, out);
-                });
-            }
-        }
-        // No binders introduced: recurse structurally into child terms.
-        _ => e.walk_children(|c| collect_expr_fv(c, bound, visited, out)),
-    }
+    });
 }
 
 /// A type is well-formed in context `ctx` iff every free term variable of its

--- a/src/ccl/uniquify.rs
+++ b/src/ccl/uniquify.rs
@@ -18,10 +18,25 @@
 //! (discharges, `let`-closing, monomorphization splices) copy minted names
 //! verbatim, so copies compare equal by construction.
 //!
-//! Scope rules mirror the freeness walkers in [`crate::ccl::ccl_utils`]:
-//! lambda params, `let` bindings (non-recursive: the bound expression sees
-//! the outer scope), loop accumulators, and case-pattern payloads bind;
-//! `Feed`/`Define` target names are *uses* of the defer-handle binder.
+//! Scope rules are the ones declared in [`crate::ccl::scope`]: lambda params,
+//! `let` bindings (non-recursive: the bound expression sees the outer scope),
+//! loop accumulators, `letrec` groups, and case-pattern payloads bind;
+//! `Feed`/`Define`/`MutWrite` target names are *uses* of the binder they name.
+//!
+//! This is the one scope-aware pass that does **not** fold over
+//! [`crate::ccl::scope::for_each_scoped_item`], and the reason is that it does
+//! not merely *observe* binders — it mints them. A scoped walk hands out the
+//! binders covering each child; this pass needs `&mut` access to the binding
+//! *slot* in order to rewrite the name, has to mint before descending anywhere
+//! it scopes over (`LetRec` must mint the whole group before walking any
+//! definition), and must unwind its environment stack in step. What it can and
+//! does share is the binder *enumeration*: [`assert_all_binders_minted`] checks
+//! its output through [`crate::ccl::TypedExpr::walk_binders`], which is
+//! exhaustive over [`crate::ccl::TypedExprNode`] for exactly this reason — so a
+//! binding form this pass forgets to mint cannot be invisible to the post-pass
+//! assertion, and fails it rather than passing silently. (That the enumeration
+//! and the scoping rules agree on the declaration set is a test in
+//! `crate::ccl::scope`.)
 //!
 //! Type-borne refinement predicates are full terms and are walked under the
 //! environment of their syntactic origin (a `Cast` target or a user
@@ -368,27 +383,17 @@ fn collect_node_ids(expr: &Expr) -> Vec<crate::ccl::provenance::NodeId> {
 #[cfg(debug_assertions)]
 fn assert_all_binders_minted(expr: &Expr) {
     fn go(e: &Expr) {
-        let check = |b: &TypedBinding| {
+        // `walk_binders` is the exhaustive enumeration of binding *slots* (kept
+        // in step with `crate::ccl::scope`'s scoping rules by that module's
+        // corpus test), so this check covers a newly-added binding form for
+        // free — it cannot fall through a wildcard arm.
+        e.walk_binders(|b| {
             assert!(
                 matches!(b.name, Name::Unique { .. }),
                 "uniquify must mint every binding site to a Unique name; `{:?}` is not",
                 b.name
             );
-        };
-        match &e.node {
-            TypedExprNode::Lambda { param, .. } => check(param),
-            TypedExprNode::Let { binding, .. } => check(binding),
-            TypedExprNode::LetRec { bindings, .. } => bindings.iter().for_each(|(b, _)| check(b)),
-            TypedExprNode::For { target, .. } => check(target),
-            TypedExprNode::Case { branches, .. } => {
-                for b in branches {
-                    if let Some(p) = &b.pattern {
-                        check(&p.binding);
-                    }
-                }
-            }
-            _ => {}
-        }
+        });
         e.walk_children(go);
     }
     go(expr);

--- a/tests/scope_walk_allocations.rs
+++ b/tests/scope_walk_allocations.rs
@@ -1,0 +1,87 @@
+//! The scoped-children walk sits under `is_free`, which capture-avoiding
+//! substitution consults once per mapped binder per node. That makes it one of
+//! the hottest paths in the compiler, and it must stay allocation-free — which
+//! is why `Binders` borrows a `LetRec` group in place instead of collecting it
+//! into a `Vec` so every child can be handed one slice. Collecting would be an
+//! allocation per `LetRec` node *per query*, and nothing in a freeness query's
+//! signature would show it.
+//!
+//! `is_free_in_value` is the right probe — unlike `is_free` it threads no
+//! `visited` set, so nothing but the walk itself can allocate.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use cambra::ccl::TypedBinding;
+use cambra::ccl::ccl_utils::is_free_in_value;
+use cambra::ccl::{Name, TypedExpr};
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static COUNTING: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) != 0 {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) != 0 {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static A: Counting = Counting;
+
+/// Allocations performed while running `body`. Single-threaded by construction —
+/// this file holds one test so no other thread is inside the window.
+fn allocations(body: impl FnOnce()) -> usize {
+    ALLOCS.store(0, Ordering::Relaxed);
+    COUNTING.store(1, Ordering::Relaxed);
+    body();
+    COUNTING.store(0, Ordering::Relaxed);
+    ALLOCS.load(Ordering::Relaxed)
+}
+
+#[test]
+fn a_freeness_query_over_a_letrec_spine_does_not_allocate() {
+    // `letrec f0 = 0; ..; fn = n in x`, nested `depth` deep so the walk visits
+    // `depth` LetRec nodes in one query.
+    const GROUP: usize = 4;
+    const DEPTH: usize = 10;
+
+    let mut e = TypedExpr::var("x");
+    for _ in 0..DEPTH {
+        let bindings: Vec<_> = (0..GROUP)
+            .map(|i| {
+                (
+                    TypedBinding::new_unannotated(format!("f{i}")),
+                    TypedExpr::var("x"),
+                )
+            })
+            .collect();
+        e = TypedExpr::letrec(bindings, e);
+    }
+
+    let probe = Name::raw("x");
+    let mut found = false;
+    let allocs = allocations(|| found = is_free_in_value(&probe, &e));
+
+    assert!(found, "`x` is free in the spine");
+    assert_eq!(
+        allocs, 0,
+        "the scoped walk allocated {allocs} times for a {DEPTH}-deep letrec spine — \
+         a freeness query is consulted once per mapped binder per node during \
+         substitution, so the walk must borrow its binder group rather than \
+         collecting it into a Vec"
+    );
+}


### PR DESCRIPTION
Five independent walkers each encoded "which children does this node's binder scope over": `count_free_with_visited` and `count_free_in_value` (`ccl_utils.rs`), `collect_expr_fv` and `Subst::rewrite_expr_go` (`subst.rs`), and `Uniquifier::expr` (`uniquify.rs`). They agreed, but every one of them ended in `_ => walk_children(…)`, so adding a binding form to `TypedExprNode` compiled clean in all five and silently got the wrong scope in each. `LetRec`, `For`, and `MutWrite` are all recent additions, so this is a path the codebase demonstrably walks.

New `src/ccl/scope.rs` states the rules once. `for_each_scoped_item` visits each direct child paired with the binders in scope for it, plus the name *occurrences* the node makes itself, and its `match` is **exhaustive with no wildcard arm** — a new variant must declare its scope before the crate compiles.

Four of the five are now folds over it:

- `count_free_with_visited` / `count_free_in_value` — shadowed if the scope shadows the name, else recurse.
- `collect_expr_fv` — the same fold, accumulating instead of counting.
- `Subst::rewrite_expr_go` — folds over `for_each_scoped_item_mut`, an adapter *derived* from the same walk (a `&mut` traversal cannot hold borrows into the node it mutates, so binder names are cloned and children are enumerated by `walk_children_mut`; a node that declares no binder skips the collection pass entirely, so only binder-introducing nodes pay for it). It has no arms left of its own: with the handle-target retarget folded in as well, the descent decides nothing about binding structure.

`TypedExpr::walk_binders` — the enumeration of binding *slots*, which `uniquify`'s post-pass mint assertion runs on — loses its `_ => {}` arm for the same reason the scoped walk never had one. A wildcard there would let a newly-added binding form be invisible to the assertion meant to catch a forgotten mint: the identical failure mode, one layer down. Adding a dummy binding variant now fails to compile in five places — `walk_children`, `walk_children_mut`, `walk_binders`/`walk_binders_mut`, `for_each_scoped_item`, and the `&mut` walk's name half — which together are the whole guarantee.

### A scope is a type

`Binders` is the scope a node opens over a child: `Ambient`, `One(&binding)`, or `Group(&bindings)`. It borrows the node's binder slots **in place**, so the walk allocates nothing — which matters because it sits under `is_free`, which capture-avoiding substitution consults once per mapped binder per node, so collecting a `LetRec` group into a `Vec` would be an allocation per group *per query*. `tests/scope_walk_allocations.rs` pins that with a counting allocator.

It also owns `Binders::shadows` — "does this scope shadow this name", the question every consumer actually asks, and the one that would otherwise be re-spelled as `binders.iter().any(|b| &b.name == name)` once per fold.

The `&mut` walk yields **scopes**, not per-child binder lists: `ScopedItemMut::Scope` comes once ahead of the run of children a scope covers, which is well-defined exactly because of the consecutiveness invariant this module documents and tests. So a consumer builds per-scope state once per scope, and the binder-name clones the `&mut` side cannot avoid are one per scope rather than one per child.

Substitution needs both halves of that. `Subst::shadow_all` returns a `Cow` and so borrows outright when the scope names nothing the substitution acts on — the common case, since a substitution's domain is usually a single binder; folding `shadow` over a group cloned the map once per binder even on a miss. And `assert_no_capture` is a release-active `assert!` whose `range_mentions` walks every `Discharge` replacement term, so a `LetRec` group of `n` binders owes `n` checks — one per binder of the one scope it opens — where a per-child callback performs `n * (n + 1)`. Release, 40-deep letrec spine, 32-node discharge term, per rewrite:

| group width | per child | per scope |
| --- | --- | --- |
| 1 | 355µs | 302µs |
| 8 | 4.62ms | 2.18ms |
| 32 | 44.5ms | 11.8ms |
| 64 | 152ms | 26.6ms |

`capture_assert_probe` counts the calls, so "once per scope crossed" is a test and not a comment.

`rewrite_expr_go` no longer pre-tests inertness before descending under a binder. The recursive call opens with the same test against the same substitution, so the pre-test walked every child subtree twice; and returning early on it skipped `assert_no_capture`, which is the tripwire for a broken uid-preservation invariant and belongs at every binder crossing, not only the ones where the substitution happens to still be live. That deliberately widens where the assertion fires, and it stays an `assert!` rather than a `debug_assert!`: what it catches is a uid minted outside lowering or a copy that broke uid preservation, whose consequence is silently-wrong output. Per-scope checking is what makes keeping it release-active cheap.

### Name occurrences

Two name-occurrence kinds are distinguished rather than left implicit. `ScopedItem::VarRef` is a variable use — a `Var`, or a `Feed`/`Define`/`MutWrite` write target. `ScopedItem::KeyRef` is a `Transact` register key: a label of the record the node denotes, not a variable, so free-*variable* analyses skip it. That was already the de-facto split; naming it is what lets one walk serve consumers that disagree about it. It is not hypothetical — `planning::run` calls `simplify`, which substitutes, *after* `plan_loops` has produced `Transact`, so post-planning trees do reach `Subst` and `is_free`.

The `&mut` walk surfaces them too, from its own wildcard-free match, and that is what retires substitution's last node-local `_ => {}`: the set of names a node mentions of its own was declared in `scope.rs` and then re-derived behind a wildcard in `subst.rs`, which is the shape this change exists to remove, one field over. `mut_walk_surfaces_the_same_names` checks the two walks agree over the whole corpus, and `Subst::retarget` splits "unchanged" out of `handle_target` so visiting every name occurrence in the tree costs no `Name` clone.

### What stays outside

`uniquify` does not fold over the walk, and its module docs say why: it does not observe binders, it *mints* them — it needs `&mut` access to the binding slot, must mint a whole `LetRec` group before descending into any definition, and unwinds its own environment stack. What it does now share is the binder enumeration: `assert_all_binders_minted` checks its output through the exhaustive `TypedExpr::walk_binders`, whose agreement with the scoping rules is a test in `scope.rs`, so a binding form the pass forgets to mint fails the post-pass assertion instead of passing silently.

Substitution's transport mode, `Subst::apply_expr_inner`, rebuilds nodes rather than walking them: folding it in would mean cloning each subtree at every binding node, turning substitution down a `let` spine quadratic in its depth.

Both walks are generic in their callback rather than taking `&mut dyn FnMut`. `for_each_scoped_item` sits under `is_free`, so the fold body wants to inline; neither walk is itself recursive — the recursion lives in the consumers, one closure type each — so monomorphization stays flat.

### Tests

`scope.rs` carries a corpus with one instance of every `TypedExprNode` variant, and its completeness is *checked*, not prompted: a macro declares `variant_name`'s arms and derives `VARIANT_COUNT` from that same list, so a new variant makes the match non-exhaustive, adding the arm bumps the count, and the bumped count fails `corpus_covers_every_variant` until the corpus gains an instance. Two instances of one variant fail it too — that is what would otherwise mask a missing one.

Over that corpus: the scoped walk's child sequence is pointer-identical to `walk_children`'s, the binders it declares match `walk_binders`, a binder-introducing scope's children are consecutive and the scope is never re-entered once left (the ambient scope recurs freely — a `Case` returns to it for every payload-free branch), the `&mut` walk pairs the same binder names and opens one `Scope` per run, both walks surface the same name occurrences, and the seven rules come out as written.

`ir.md` gains "Binding structure lives in one place" — the rules, the three matches that are exhaustive and why, the three invariants a consumer may rely on, and the two passes that stay outside the fold.
