### PR TITLE
Add program diffing: content addressing modulo α plus a GumTree matcher

### DIFF
--- a/src/ccl/CLAUDE.md
+++ b/src/ccl/CLAUDE.md
@@ -16,7 +16,7 @@ If you find yourself adding a new `TypedExprNode` variant that "does something" 
 ## General Instructions
 
 ### Workflow
-When planning, include updates to the appropriate docs to reflect the changes; validate the docs are up to date before creating a PR. This includes the CCL design docs in `design/` (`ir.md`, `type-inference.md`, `lowering.md`, `optimization.md`, `mutability.md`, `provenance.md`) and other `*/design-*.md` files close to source files that were changed.
+When planning, include updates to the appropriate docs to reflect the changes; validate the docs are up to date before creating a PR. This includes the CCL design docs in `design/` (`ir.md`, `type-inference.md`, `lowering.md`, `optimization.md`, `mutability.md`, `provenance.md`, `diffing.md`) and other `*/design-*.md` files close to source files that were changed.
 
 ### Node identity and provenance
 Every pass rebuilds IR nodes, and every rebuild must carry the node's `NodeId` (or record the mint/copy it performs). This is not incidental bookkeeping: the always-on lowering projection is what turns an inference error into a source span, so a pass that mints where it should preserve degrades release diagnostics. Read `design/provenance.md` before changing how a pass constructs, clones, or discards nodes.

--- a/src/ccl/content_hash.rs
+++ b/src/ccl/content_hash.rs
@@ -1,0 +1,840 @@
+//! Content-addressing of CCL terms, modulo α-equivalence.
+//!
+//! Assigns every subterm a [`ContentHash`] such that two subterms hash equal
+//! **iff** they are structurally identical up to (a) consistent renaming of
+//! variables *bound within the subterm* and (b) the identity of variables that
+//! are *free* in the subterm. This is the primitive the program-differ is built
+//! on: equal hash ⇒ "the same computation", which the GumTree matcher (see
+//! [`crate::ccl::diff`]) turns into the shared / moved / updated / new /
+//! deleted classification. See `src/ccl/design/diffing.md`, "Content addressing
+//! modulo α".
+//!
+//! The hash is **type-aware**: a node's inferred type, user annotations, binder
+//! types, and cast targets all participate ([`hash_type`]) — two terms that
+//! differ only in a type (a refinement predicate, a base type, an annotation)
+//! are *not* the same computation. Types are hashed with the same uid-robust
+//! discipline as terms; the one thing skipped is *unresolved* type structure
+//! (`Hole`/`Infer`), which carries no identity. (Pre-inference most `ty`s are
+//! `Hole`, so type sensitivity there comes from annotations and lowering-built
+//! types like cast refinements; the full payoff lands once types are inferred.)
+//!
+//! # Why α-invariance is the whole problem
+//!
+//! Two independently-lowered programs that share a subexpression do not share
+//! its binders' identities. Pre-uniquify, a source binder is a
+//! [`Name::Raw`](crate::ccl::Name) spelling, so the *same* source binder yields
+//! the *same* name across versions — but post-uniquify every binder carries a
+//! globally-fresh `uid`, so even identical code compares unequal. A hash that
+//! is to recognize "the same computation" across versions therefore cannot hash
+//! a bound variable by its name/uid. It hashes it **positionally**:
+//!
+//! * A variable whose binder lies *inside* the subterm being hashed contributes
+//!   its De Bruijn index — invisible to α-renaming.
+//! * A variable that is *free* in the subterm contributes an identity supplied
+//!   by [`hash_free_var`] — the one place the hash's meaning is a choice
+//!   rather than a consequence of the term (see below).
+//!
+//! Lexical shadowing falls out for free: [`hash_rel`] resolves a name against
+//! the *innermost* enclosing binder, so a shadowed `Raw` name resolves to the
+//! binder a reader would pick.
+//!
+//! # Two hashes, one traversal
+//!
+//! The free-variable seam ([`FreeVars`]) is the one place the hash's meaning is
+//! a choice, and the two choices answer different questions:
+//!
+//! * [`content_hash`] identifies a free variable by its **spelling**. That is
+//!   context-free — a subterm hashes the same wherever it sits and in whichever
+//!   program — which is exactly the property a matcher looking for a subterm's
+//!   twin needs.
+//! * [`resolved_hash`] identifies it by **which binder it resolves to**, taken
+//!   up to a correspondence between the two programs. That is what "the same
+//!   computation" actually means, but it presupposes a correspondence, so it is
+//!   for classifying a matching rather than producing one.
+//!
+//! Everything else — the traversal, the De Bruijn treatment of bound variables,
+//! the type-awareness — is shared. See `src/ccl/design/diffing.md`, "Two
+//! hashes, two questions".
+//!
+//! # Stage-agnostic by construction
+//!
+//! The hash is a pure function of a [`TypedExpr`] plus the binder-scoping rules
+//! of [`crate::ccl::scope`], which cover **every** [`TypedExprNode`] variant —
+//! including the ones (`LetRec`, `Transact`) that exist only below the
+//! mutability phases. Nothing else is stage-sensitive, so one hash serves every
+//! [`CompileStage`](crate::ccl::context::CompileStage).
+//!
+//! # Complexity
+//!
+//! [`hash_all`] recomputes each subterm's standalone hash with a fresh binder
+//! environment, which is `O(n · depth)`. That is comfortable for real Cambra
+//! programs even with their deep `let`-spine. The asymptotically-tight scheme
+//! (Maziarz et al., *Hashing Modulo Alpha-Equivalence*, PLDI 2021 — `O(n
+//! log²n)` via per-subterm free-variable summaries and a commutative position
+//! combiner) slots in behind this same interface if a program ever grows large
+//! enough to feel it.
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use super::scope::{ScopedItem, for_each_scoped_item};
+use super::{FunKind, Lit, Name, ProjKey, Type, TypedBinding, TypedExpr, TypedExprNode};
+
+/// The α-invariant content hash of a (sub)term. Two terms with equal
+/// `ContentHash` are α-equivalent up to free-variable identity (modulo the
+/// negligible collision probability of a 64-bit hash).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ContentHash(pub u64);
+
+/// Pointer identity of a node within a borrowed tree, used as a side-table key
+/// — the same convention as [`crate::ccl::PredicateId`]. Valid only for the
+/// lifetime of the borrow the hashes were computed from; never dereferenced.
+pub type NodeId = *const TypedExpr;
+
+/// The standalone α-invariant content hash of a single (sub)term.
+///
+/// "Standalone" means free variables are resolved against the empty
+/// environment: a variable bound *above* `e` is treated as free and hashed by
+/// [`hash_free_var`]. This is what makes a subterm match its twin in another
+/// program regardless of how deeply each sits — the GumTree precondition.
+pub fn content_hash(e: &TypedExpr) -> ContentHash {
+    ContentHash(hash_rel(e, &mut Vec::new(), FreeVars::BySpelling))
+}
+
+/// The α-invariant hash of `e` with its free variables resolved **through the
+/// enclosing scope** rather than by spelling — the classification counterpart
+/// to [`content_hash`]. See `src/ccl/design/diffing.md`, "Two hashes, two
+/// questions".
+///
+/// `scope` lists the binders `e` sits under, innermost last, each paired with a
+/// *class* token that corresponding binders of the two programs share. A free
+/// variable then hashes to the class of the binder it resolves to, so a binding
+/// renamed between versions is invisible, and a same-spelled binding of
+/// something else is not mistaken for it.
+pub fn resolved_hash(e: &TypedExpr, scope: &[(&Name, u64)]) -> ContentHash {
+    ContentHash(hash_rel(e, &mut Vec::new(), FreeVars::ByBinder(scope)))
+}
+
+/// How a variable that is *free* in the subterm being hashed is identified —
+/// the one place the hash's meaning is a choice rather than a consequence of
+/// the term.
+#[derive(Clone, Copy)]
+pub enum FreeVars<'r> {
+    /// By the binder's stable spelling ([`Name::base`]). Context-free: a
+    /// subterm hashes the same wherever it sits and in whichever program, which
+    /// is exactly what a matcher looking for a subterm's twin needs.
+    BySpelling,
+    /// By the identity of the binder it resolves to, taken up to a
+    /// correspondence between the two programs — `(name, class)` innermost
+    /// last. Context-sensitive, and only meaningful once a correspondence
+    /// exists, so this is for classifying a matching, not for producing one.
+    ByBinder(&'r [(&'r Name, u64)]),
+}
+
+/// The standalone [`content_hash`] of every subterm of `root`, keyed by node
+/// pointer identity ([`NodeId`]). The returned map borrows nothing but its keys
+/// are addresses into `root`, so it must not outlive `root`.
+pub fn hash_all(root: &TypedExpr) -> HashMap<NodeId, ContentHash> {
+    let mut out = HashMap::new();
+    collect(root, &mut out);
+    out
+}
+
+fn collect(e: &TypedExpr, out: &mut HashMap<NodeId, ContentHash>) {
+    out.insert(e as NodeId, content_hash(e));
+    e.walk_children(|c| collect(c, out));
+}
+
+/// Hash the identity of a variable that is *free* in the subterm under
+/// consideration, per [`FreeVars`].
+///
+/// Never hash the whole `Name`. A binder may be `Raw` in one lowering and
+/// `Unique`/`Synthetic` — carrying a globally-fresh, run-varying `uid` — in
+/// another: lowering uniquifies some subexpressions in place (e.g.
+/// comprehension sources via `uniquify::run`), and uids are non-deterministic
+/// *by design*.
+///
+/// Under [`FreeVars::BySpelling`] the identity is the spelling, which is what
+/// survives independent compilation. Its imprecision — two distinct binders
+/// sharing a spelling compare equal — is why [`FreeVars::ByBinder`] exists.
+/// Under that variant a variable still free in the *whole program* (a source
+/// name, say) has nothing to resolve to, so it falls back to its spelling.
+fn hash_free_var(name: &Name, free: FreeVars<'_>, state: &mut DefaultHasher) {
+    match free {
+        FreeVars::BySpelling => name.base().hash(state),
+        FreeVars::ByBinder(scope) => match scope.iter().rev().find(|(n, _)| *n == name) {
+            Some((_, class)) => {
+                0u8.hash(state);
+                class.hash(state);
+            }
+            None => {
+                1u8.hash(state);
+                name.base().hash(state);
+            }
+        },
+    }
+}
+
+/// The domain-refinement predicate **term** carried by a cast `target` type,
+/// if any — the borrowing companion to
+/// [`crate::ccl::ccl_utils::cast_target_refinement`] (which clones).
+///
+/// A refinement predicate is a *term* (`Rc<TypedExpr>` — the filter/join logic
+/// a comprehension lowers to), embedded in a type position. `hash_type` already
+/// folds it into a cast's hash; this borrowing accessor is what lets the
+/// *differ* descend into the predicate as a tree child (so an edit localizes to
+/// it), rather than only flagging the enclosing cast as changed.
+pub(crate) fn cast_target_predicate(target: &Type) -> Option<&TypedExpr> {
+    let Type::Fun { domain, .. } = target else {
+        return None;
+    };
+    let Type::Refinement(_, refinement) = domain.as_ref() else {
+        return None;
+    };
+    Some(refinement.predicate.as_ref())
+}
+
+/// Resolve and hash a variable *reference* (a use site, not a binder): a De
+/// Bruijn index if its binder is in `env` (bound within the subterm), else a
+/// free-variable identity. `env` holds the in-scope binders, innermost last, so
+/// the first match scanning from the back is the lexically-closest binder —
+/// this is what makes shadowing resolve correctly.
+fn hash_name_ref(name: &Name, env: &[&Name], free: FreeVars<'_>, state: &mut DefaultHasher) {
+    match env.iter().rev().position(|b| *b == name) {
+        Some(debruijn) => {
+            0u8.hash(state); // tag: bound
+            debruijn.hash(state);
+        }
+        None => {
+            1u8.hash(state); // tag: free
+            hash_free_var(name, free, state);
+        }
+    }
+}
+
+/// Structurally hash a [`Type`] — the type-level companion to [`hash_rel`].
+/// The two are mutually recursive because terms carry types (a node's `ty`,
+/// annotations, cast targets) and types carry terms (refinement predicates).
+///
+/// Like the term hash, this is **uid-robust**: refinement predicates go through
+/// [`hash_rel`] (free names by spelling), `Fun` Pi-binder names are ignored — a
+/// `Some`-binder unreferenced by its codomain is observationally `None`, and a
+/// referenced one is matched through the spelling of its `Var` occurrences in
+/// the codomain's refinement — a [`Type::ChanDom`]'s channel name is folded by
+/// spelling, and `Variant` tags are [`FieldKey`]s (string/index, never a uid).
+/// `Record`/`Variant` fields are folded order-insensitively, mirroring the
+/// term-level record rule.
+///
+/// `Hole` and `Infer` hash to a bare discriminant tag: pre-inference every type
+/// is `Hole`, and a resolved AST contains no `Infer`, so collapsing all
+/// unresolved types to one value is a safe fallback rather than a determinism
+/// hazard (the diff never runs mid-inference).
+///
+/// [`FieldKey`]: crate::ccl::FieldKey
+fn hash_type<'a>(
+    ty: &'a Type,
+    env: &mut Vec<&'a Name>,
+    free: FreeVars<'_>,
+    state: &mut DefaultHasher,
+) {
+    use Type as T;
+    std::mem::discriminant(ty).hash(state);
+    match ty {
+        T::Base(b) => b.hash(state),
+        T::UIntRange(n) => n.hash(state),
+        T::DataSource(s) => s.hash(state),
+        // The channel domain's identity *is* its name (its `ChanLevel` is
+        // deliberately identity-transparent and hashes to nothing). Fold the
+        // spelling, not the whole `Name`: a channel binder carries a
+        // run-varying `uid`, exactly like a free term variable.
+        T::ChanDom(name, _level) => name.base().hash(state),
+        // `SharedHole`'s id joins `Infer`'s uid as an identity that is only
+        // meaningful inside the tree that minted it (ids are per
+        // `LoweringContext`), so it says nothing about content: two programs
+        // that differ only in how many holes were minted before this one are
+        // the same program here. The discriminant, hashed above, still
+        // separates a shared hole from a plain one.
+        T::Txn | T::Hole | T::SharedHole(_) | T::Infer(_) => {}
+        // A bounded annotation's ceiling is content, not an identity: `x <: Int`
+        // and `x <: Str` state different obligations. The discriminant separates
+        // it from a plain `Hole`.
+        T::BoundedHole(bound) => hash_type(bound, env, free, state),
+        // The kind is content: a data function's domain *is* its data and its
+        // joins have to be lossless, so `A ⇒ B` and `A ⤇ B` are not the same
+        // computation. A `FunKind::Var`'s `uid` is a per-compilation identity
+        // like `Infer`'s, so only its pin participates — what the one value
+        // reaching it fixed it to. The Pi binder `name` stays out: it is bound
+        // in `codomain`, and α-invariance is the point of this hash.
+        T::Fun {
+            domain,
+            codomain,
+            kind,
+            name: _,
+        } => {
+            std::mem::discriminant(kind).hash(state);
+            if let FunKind::Var(v) = kind {
+                std::mem::discriminant(&v.pin()).hash(state);
+            }
+            hash_type(domain, env, free, state);
+            hash_type(codomain, env, free, state);
+        }
+        T::Tuple(tys) => {
+            tys.len().hash(state);
+            for t in tys {
+                hash_type(t, env, free, state);
+            }
+        }
+        T::Record(fields) => hash_type_fields(fields, env, free, state),
+        // Openness is not decoration: an open arm set commits only to the arms it
+        // lists, so a closed and an open type over the same arms make different
+        // demands and are not the same computation.
+        T::Variant(fields, openness) => {
+            openness.hash(state);
+            hash_type_fields(fields, env, free, state);
+        }
+        T::Refinement(base, refinement) => {
+            hash_type(base, env, free, state);
+            hash_rel(&refinement.predicate, env, free).hash(state);
+        }
+        T::History {
+            value,
+            domain,
+            kind,
+        } => {
+            kind.hash(state);
+            hash_type(value, env, free, state);
+            hash_type(domain, env, free, state);
+        }
+    }
+}
+
+/// Fold named/tagged type fields into `state` order-insensitively: each
+/// `(key, type)` is finalized to its own hash, then the set is sorted before
+/// folding, so field declaration order does not matter.
+fn hash_type_fields<'a, K: Hash>(
+    fields: &'a [(K, Type)],
+    env: &mut Vec<&'a Name>,
+    free: FreeVars<'_>,
+    state: &mut DefaultHasher,
+) {
+    let mut hs: Vec<u64> = fields
+        .iter()
+        .map(|(key, t)| {
+            let mut h = DefaultHasher::new();
+            key.hash(&mut h);
+            hash_type(t, env, free, &mut h);
+            h.finish()
+        })
+        .collect();
+    hs.sort_unstable();
+    hs.hash(state);
+}
+
+/// Hash an optional type, with a leading tag distinguishing `Some` from `None`.
+fn hash_opt_type<'a>(
+    ty: Option<&'a Type>,
+    env: &mut Vec<&'a Name>,
+    free: FreeVars<'_>,
+    state: &mut DefaultHasher,
+) {
+    match ty {
+        Some(t) => {
+            1u8.hash(state);
+            hash_type(t, env, free, state);
+        }
+        None => 0u8.hash(state),
+    }
+}
+
+/// Hash a binder's declared type and user annotation. The binder's *name* is
+/// folded into the De Bruijn environment by the caller, not hashed here.
+fn hash_binding<'a>(
+    b: &'a TypedBinding,
+    env: &mut Vec<&'a Name>,
+    free: FreeVars<'_>,
+    state: &mut DefaultHasher,
+) {
+    hash_type(&b.ty, env, free, state);
+    hash_opt_type(b.user_annotation.as_ref(), env, free, state);
+}
+
+/// Hash a register-key *label* occurrence — a [`TypedExprNode::Transact`] key
+/// or writer footprint entry.
+///
+/// A key names a field of the mutable variable record the node denotes, not a
+/// variable,
+/// so it never resolves against the binder environment; its identity is its
+/// spelling, exactly like a free variable's (and inherits that seam's
+/// crudeness). The distinct tag keeps a label from colliding with a free
+/// variable of the same spelling.
+fn hash_key_ref(name: &Name, state: &mut DefaultHasher) {
+    2u8.hash(state); // tag: register-key label
+    hash_free_var(name, FreeVars::BySpelling, state);
+}
+
+/// Hash everything about a node that is **not** a child term and not a name
+/// occurrence: literal payloads, operator kinds, variant tags, binder types,
+/// a cast's target type, and the arities that make variable-width nodes
+/// unambiguous.
+///
+/// The split exists so the child traversal below can be a fold over
+/// [`for_each_scoped_item`] instead of a second copy of the binding rules. The
+/// `match` is exhaustive on purpose: a new variant's payload must be declared
+/// here, or two nodes differing only in it would hash equal.
+///
+/// Binder types are hashed *before* `env` is extended, because a binder's
+/// declared type lives in the enclosing scope.
+fn hash_payload<'a>(
+    e: &'a TypedExpr,
+    env: &mut Vec<&'a Name>,
+    free: FreeVars<'_>,
+    h: &mut DefaultHasher,
+) {
+    use TypedExprNode as N;
+    match &e.node {
+        N::Lit(Lit::Int(n)) => n.hash(h),
+        N::Lit(Lit::String(s)) => s.hash(h),
+        N::Lit(Lit::Bool(b)) => b.hash(h),
+        N::Lit(Lit::Unit) => {}
+        N::Builtin(b) => b.hash(h),
+        N::Source(s) => s.hash(h),
+        N::Proj(ProjKey::Index(i)) => i.hash(h),
+        N::Proj(ProjKey::Field(f)) => f.hash(h),
+
+        // Fully described by their children and/or name occurrences.
+        N::Var(_)
+        | N::Defer
+        | N::Error
+        | N::Apply { .. }
+        | N::ExprStmt { .. }
+        | N::Begin { .. }
+        | N::List(_)
+        | N::Tuple(_)
+        | N::Compose(_)
+        | N::Copair(_)
+        | N::DisjointJoin(_)
+        | N::Feed { .. }
+        | N::Define { .. }
+        | N::MutWrite { .. } => {}
+
+        // The cast's `target` is hashed in full, which includes any
+        // domain-refinement predicate — a load-bearing term (a comprehension's
+        // filter/join condition). A cast is precisely a type-level change, so
+        // the target must participate.
+        N::Cast { target, .. } => hash_type(target, env, free, h),
+        N::BinOp { op, .. } => op.hash(h),
+        N::UnaryOp(kind, _) => kind.hash(h),
+        N::Aggregate { kind, .. } => kind.hash(h),
+        N::VariantCtor { tag, .. } => tag.hash(h),
+        // Field *names* are folded together with their values in `hash_rel`,
+        // which is what keeps `(a: 1, b: 2)` distinct from `(a: 2, b: 1)` under
+        // the order-insensitive fold.
+        N::Record(fields) => fields.len().hash(h),
+
+        N::Lambda { param, .. } => hash_binding(param, env, free, h),
+        N::Let { binding, .. } => hash_binding(binding, env, free, h),
+        // A mutable variable introduction binds exactly as a `let` does — the
+        // history `Mut(V, D)` rides the binder's `ty`, so hashing the binding
+        // covers the declaration's whole type-level content.
+        N::MutDecl { binding, .. } => hash_binding(binding, env, free, h),
+        N::For { target, .. } => hash_binding(target, env, free, h),
+        N::LetRec { bindings, .. } => {
+            bindings.len().hash(h);
+            for (b, _) in bindings {
+                hash_binding(b, env, free, h);
+            }
+        }
+        N::Case {
+            scrutinee,
+            branches,
+        } => {
+            scrutinee.is_some().hash(h);
+            branches.len().hash(h);
+            for br in branches {
+                match &br.pattern {
+                    Some(p) => {
+                        1u8.hash(h);
+                        p.tag.hash(h);
+                        hash_binding(&p.binding, env, free, h);
+                    }
+                    None => 0u8.hash(h),
+                }
+            }
+        }
+        N::Transact {
+            keys,
+            writers,
+            domain,
+        } => {
+            hash_type(domain, env, free, h);
+            keys.len().hash(h);
+            writers.len().hash(h);
+            for w in writers {
+                w.read_keys.len().hash(h);
+                w.write_keys.len().hash(h);
+            }
+        }
+    }
+}
+
+/// Hash `e` relative to the binder environment `env` (in-scope binders,
+/// innermost last) and return a finalized 64-bit hash. Child contributions are
+/// finalized recursively and folded into this node's hasher; ordered children
+/// are folded in position order, unordered children (records, collection
+/// unions) are sorted first so the hash is permutation-invariant.
+///
+/// The scoping — which binders `env` is extended by over which child — is not
+/// decided here. It comes from [`for_each_scoped_item`], the crate's single
+/// statement of CCL's binding structure, which the free-variable walkers fold
+/// over too. That shared source is what makes a divergence impossible; a
+/// divergence would be a correctness bug rather than a style difference,
+/// because it would make the hash disagree with α-equivalence.
+///
+/// What *is* decided here is the associative–commutative folding of the
+/// set-shaped nodes (`Record`, `DisjointJoin`), which is a property of their
+/// algebra rather than of their scoping.
+fn hash_rel<'a>(e: &'a TypedExpr, env: &mut Vec<&'a Name>, free: FreeVars<'_>) -> u64 {
+    use TypedExprNode as N;
+    let mut h = DefaultHasher::new();
+    std::mem::discriminant(&e.node).hash(&mut h);
+    hash_payload(e, env, free, &mut h);
+
+    // Name occurrences fold as they are met; child hashes are collected in walk
+    // order so the AC nodes below can canonicalize theirs first.
+    let mut children: Vec<u64> = Vec::new();
+    for_each_scoped_item(e, &mut |item| match item {
+        ScopedItem::VarRef(name) => hash_name_ref(name, env, free, &mut h),
+        ScopedItem::KeyRef(name) => hash_key_ref(name, &mut h),
+        ScopedItem::Child {
+            expr: child,
+            binders,
+        } => {
+            let depth = env.len();
+            env.extend(binders.iter().map(|b| &b.name));
+            let hashed = hash_rel(child, env, free);
+            env.truncate(depth);
+            children.push(hashed);
+        }
+    });
+
+    match &e.node {
+        // Records are unordered by field name; field names are unique, so
+        // sorting the (name, child-hash) pairs yields a canonical order.
+        N::Record(fields) => {
+            let mut entries: Vec<(&str, u64)> = fields
+                .iter()
+                .map(|(n, _)| n.as_str())
+                .zip(children)
+                .collect();
+            entries.sort_unstable();
+            entries.hash(&mut h);
+        }
+        // A disjoint join is the join in the partial-function order: associative
+        // and commutative, so sorting the child hashes canonicalizes it. A
+        // `Copair` is only associative — operand position picks the coproduct
+        // tag, so `a ++ b` and `b ++ a` land on different domains — and folds in
+        // position order with the ordered nodes below.
+        N::DisjointJoin(_) => {
+            children.sort_unstable();
+            children.hash(&mut h);
+        }
+        _ => children.hash(&mut h),
+    }
+
+    // The node's own inferred type and user annotation. Types are meaningful,
+    // so the hash is type-aware — refinements participate via `hash_rel` (see
+    // `hash_type`). Pre-inference these `ty`s are `Hole` (a constant tag);
+    // post-inference they carry the resolved type.
+    hash_type(&e.ty, env, free, &mut h);
+    hash_opt_type(e.user_annotation.as_ref(), env, free, &mut h);
+    h.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccl::{ArithmeticKind, BaseType, BinOpKind, CompareKind, Refinement, Type};
+    use std::rc::Rc;
+
+    fn var(name: &str) -> TypedExpr {
+        TypedExpr::var(name)
+    }
+    fn int(n: i64) -> TypedExpr {
+        TypedExpr::lit(Lit::Int(n))
+    }
+    fn lam(param: &str, body: TypedExpr) -> TypedExpr {
+        TypedExpr::lambda(param, Type::Hole, body)
+    }
+    fn add(l: TypedExpr, r: TypedExpr) -> TypedExpr {
+        TypedExpr::binop(l, BinOpKind::Arithmetic(ArithmeticKind::Add), r)
+    }
+    fn mul(l: TypedExpr, r: TypedExpr) -> TypedExpr {
+        TypedExpr::binop(l, BinOpKind::Arithmetic(ArithmeticKind::Mul), r)
+    }
+    fn h(e: &TypedExpr) -> ContentHash {
+        content_hash(e)
+    }
+
+    #[test]
+    fn bound_renaming_is_invisible() {
+        // λx → x  ≡α  λy → y
+        assert_eq!(h(&lam("x", var("x"))), h(&lam("y", var("y"))));
+    }
+
+    #[test]
+    fn bound_var_distinct_from_free_var_of_same_shape() {
+        // λx → x   (x bound)   is not   λx → y   (y free)
+        assert_ne!(h(&lam("x", var("x"))), h(&lam("x", var("y"))));
+    }
+
+    #[test]
+    fn renaming_under_a_free_context_is_invisible() {
+        // λx → x + index  ≡α  λy → y + index   (the free `index` matches by name)
+        assert_eq!(
+            h(&lam("x", add(var("x"), var("index")))),
+            h(&lam("y", add(var("y"), var("index")))),
+        );
+    }
+
+    #[test]
+    fn differing_free_var_breaks_the_match() {
+        // λx → x + index  ≠  λx → x + count
+        assert_ne!(
+            h(&lam("x", add(var("x"), var("index")))),
+            h(&lam("x", add(var("x"), var("count")))),
+        );
+    }
+
+    #[test]
+    fn shadowing_resolves_to_the_innermost_binder() {
+        // λx → λx → x   (inner binds the use)  ≡α  λa → λb → b
+        assert_eq!(
+            h(&lam("x", lam("x", var("x")))),
+            h(&lam("a", lam("b", var("b"))))
+        );
+        // ...and is distinct from λa → λb → a (outer-bound use).
+        assert_ne!(
+            h(&lam("x", lam("x", var("x")))),
+            h(&lam("a", lam("b", var("a"))))
+        );
+    }
+
+    #[test]
+    fn free_subterm_matches_across_versions() {
+        // The GumTree precondition: the same subterm in two versions hashes
+        // equal even when its enclosing binder is bound to different things.
+        // `x + y` is standalone-free in both, so it must match.
+        let v1 = TypedExpr::let_bind("x", var("a"), add(var("x"), var("y")));
+        let v2 = TypedExpr::let_bind("x", var("b"), add(var("x"), var("y")));
+        let (TypedExprNode::Let { body: b1, .. }, TypedExprNode::Let { body: b2, .. }) =
+            (&v1.node, &v2.node)
+        else {
+            unreachable!()
+        };
+        assert_eq!(h(b1), h(b2));
+        // The whole `let`s differ, because the bound expressions differ.
+        assert_ne!(h(&v1), h(&v2));
+    }
+
+    #[test]
+    fn motivating_example_isolates_one_divergence() {
+        // v1 writes `index`; v2 writes `2 * index`. The value subterm diverges;
+        // an unchanged sibling (the key string) stays shared.
+        let v1_val = var("index");
+        let v2_val = mul(int(2), var("index"));
+        assert_ne!(h(&v1_val), h(&v2_val));
+
+        let key = TypedExpr::lit(Lit::String("idx".into()));
+        assert_eq!(h(&key), h(&TypedExpr::lit(Lit::String("idx".into()))));
+    }
+
+    #[test]
+    fn records_are_order_insensitive_tuples_are_not() {
+        let rec_ab = TypedExpr::new(TypedExprNode::Record(vec![
+            ("a".into(), int(1)),
+            ("b".into(), int(2)),
+        ]));
+        let rec_ba = TypedExpr::new(TypedExprNode::Record(vec![
+            ("b".into(), int(2)),
+            ("a".into(), int(1)),
+        ]));
+        assert_eq!(h(&rec_ab), h(&rec_ba));
+
+        let tup_12 = TypedExpr::tuple(vec![int(1), int(2)]);
+        let tup_21 = TypedExpr::tuple(vec![int(2), int(1)]);
+        assert_ne!(h(&tup_12), h(&tup_21));
+    }
+
+    #[test]
+    fn disjoint_join_is_order_insensitive() {
+        let j_ab = TypedExpr::disjoint_join(vec![var("a"), var("b")]);
+        let j_ba = TypedExpr::disjoint_join(vec![var("b"), var("a")]);
+        assert_eq!(h(&j_ab), h(&j_ba));
+    }
+
+    #[test]
+    fn copair_is_order_sensitive() {
+        let c_ab = TypedExpr::copair(vec![var("a"), var("b")]);
+        let c_ba = TypedExpr::copair(vec![var("b"), var("a")]);
+        assert_ne!(h(&c_ab), h(&c_ba));
+    }
+
+    #[test]
+    fn hash_all_covers_every_node() {
+        let e = TypedExpr::let_bind("x", var("a"), add(var("x"), var("y")));
+        let map = hash_all(&e);
+        // Let, bound_expr Var(a), body BinOp, BinOp's Var(x), Var(y) = 5 nodes.
+        assert_eq!(map.len(), 5);
+        assert_eq!(map[&(&e as NodeId)], content_hash(&e));
+    }
+
+    /// A `Var(x)` node carrying type `ty` — for exercising type-awareness with
+    /// the term structure held fixed.
+    fn typed(ty: Type) -> TypedExpr {
+        TypedExpr::new(TypedExprNode::Var("x".into())).with_ty(ty)
+    }
+
+    #[test]
+    fn inferred_type_participates_in_the_hash() {
+        // Identical term, different inferred type → different hash.
+        assert_ne!(
+            h(&typed(Type::Base(BaseType::Int))),
+            h(&typed(Type::Base(BaseType::Bool))),
+        );
+        assert_eq!(
+            h(&typed(Type::Base(BaseType::Int))),
+            h(&typed(Type::Base(BaseType::Int))),
+        );
+    }
+
+    #[test]
+    fn fun_kind_participates_in_the_hash() {
+        // A data function and a compute function over the same domain and
+        // codomain are different computations: `⤇` says the domain *is* the
+        // data, which is what drives iteration and forces joins to be lossless.
+        let int = || Type::Base(BaseType::Int);
+        assert_ne!(
+            h(&typed(Type::fun(int(), int()))),
+            h(&typed(Type::data_fun(int(), int()))),
+        );
+        // An unresolved kind is a third state, not a synonym for either point.
+        let unpinned = || {
+            typed(Type::Fun {
+                name: None,
+                kind: FunKind::fresh_var(),
+                domain: Box::new(int()),
+                codomain: Box::new(int()),
+            })
+        };
+        assert_ne!(h(&unpinned()), h(&typed(Type::fun(int(), int()))));
+        // Two fresh variables differ only in `uid`, a per-compilation identity,
+        // so they agree — the property the whole hash rests on.
+        assert_eq!(h(&unpinned()), h(&unpinned()));
+
+        // What a variable was pinned to *is* content, and it is the one part of
+        // a `FunKindVar` that a program determines rather than allocation order.
+        let pinned = |data: bool| {
+            let kind = FunKind::fresh_var();
+            let FunKind::Var(v) = &kind else {
+                unreachable!()
+            };
+            if data {
+                v.pin_data()
+            } else {
+                v.pin_compute()
+            }
+            typed(Type::Fun {
+                name: None,
+                kind,
+                domain: Box::new(int()),
+                codomain: Box::new(int()),
+            })
+        };
+        assert_ne!(h(&pinned(true)), h(&pinned(false)));
+        assert_ne!(h(&pinned(false)), h(&unpinned()));
+        assert_eq!(h(&pinned(true)), h(&pinned(true)));
+    }
+
+    #[test]
+    fn refinement_predicate_participates_in_the_hash() {
+        // `{Int | __elem == n}` for two different `n`. The refinement predicate
+        // is a *term* embedded in the type; changing it must change the hash.
+        let refined = |n: i64| {
+            let pred = TypedExpr::binop(
+                TypedExpr::var(Name::elem()),
+                BinOpKind::Compare(CompareKind::Equals),
+                int(n),
+            );
+            typed(Type::Refinement(
+                Box::new(Type::Base(BaseType::Int)),
+                Refinement {
+                    predicate: Rc::new(pred),
+                },
+            ))
+        };
+        assert_ne!(
+            h(&refined(0)),
+            h(&refined(5)),
+            "differing predicate differs"
+        );
+        assert_eq!(h(&refined(0)), h(&refined(0)), "same predicate matches");
+        // The refinement is also distinct from its bare base type.
+        assert_ne!(h(&refined(0)), h(&typed(Type::Base(BaseType::Int))));
+    }
+
+    #[test]
+    fn resolved_hash_follows_the_binder_not_the_spelling() {
+        // Two occurrences of a free variable agree iff the binders they resolve
+        // to correspond — whatever those binders happen to be called.
+        let x = Name::raw("x");
+        let y = Name::raw("y");
+        let (e_x, e_y) = (add(var("x"), int(1)), add(var("y"), int(1)));
+
+        // Same binder class, different spellings: the same computation.
+        assert_eq!(
+            resolved_hash(&e_x, &[(&x, 7)]),
+            resolved_hash(&e_y, &[(&y, 7)]),
+        );
+        // Same spelling, different binder classes: not the same computation.
+        assert_ne!(
+            resolved_hash(&e_x, &[(&x, 7)]),
+            resolved_hash(&e_x, &[(&x, 8)]),
+        );
+        // Unresolvable in either scope: falls back to the spelling, so these
+        // still differ from one another and agree with themselves.
+        assert_eq!(resolved_hash(&e_x, &[]), resolved_hash(&e_x, &[]));
+        assert_ne!(resolved_hash(&e_x, &[]), resolved_hash(&e_y, &[]));
+        // A binder in scope is not the same as no binder at all.
+        assert_ne!(resolved_hash(&e_x, &[(&x, 7)]), resolved_hash(&e_x, &[]));
+    }
+
+    #[test]
+    fn resolved_hash_still_resolves_inner_binders_positionally() {
+        // Binders *inside* the subterm keep their De Bruijn treatment — the
+        // scope only supplies what is free.
+        assert_eq!(
+            resolved_hash(&lam("x", var("x")), &[]),
+            resolved_hash(&lam("y", var("y")), &[]),
+        );
+    }
+
+    #[test]
+    fn user_annotation_participates_in_the_hash() {
+        let annotated = |ann: Option<Type>| {
+            let e = TypedExpr::new(TypedExprNode::Var("x".into()));
+            match ann {
+                Some(ty) => e.with_user_annotation(ty),
+                None => e,
+            }
+        };
+        assert_ne!(
+            h(&annotated(Some(Type::Base(BaseType::Int)))),
+            h(&annotated(Some(Type::Base(BaseType::Bool)))),
+        );
+        assert_ne!(
+            h(&annotated(Some(Type::Base(BaseType::Int)))),
+            h(&annotated(None))
+        );
+    }
+}

--- a/src/ccl/content_hash.rs
+++ b/src/ccl/content_hash.rs
@@ -38,7 +38,7 @@
 //! the *innermost* enclosing binder, so a shadowed `Raw` name resolves to the
 //! binder a reader would pick.
 //!
-//! # Two hashes, one traversal
+//! # Three hashes, one traversal
 //!
 //! The free-variable seam ([`FreeVars`]) is the one place the hash's meaning is
 //! a choice, and the two choices answer different questions:
@@ -52,9 +52,16 @@
 //!   computation" actually means, but it presupposes a correspondence, so it is
 //!   for classifying a matching rather than producing one.
 //!
+//! [`own_hash`] answers a third question over the same traversal: not "is this
+//! the same computation" but "did this node change", which a differ needs to
+//! report a disagreement at the node that owns it rather than at every ancestor.
+//! It resolves free variables like [`resolved_hash`] and folds only what is
+//! authored at the node — dropping its children, its inferred `ty`, and a
+//! binder's declared type, all three of which are derived from the first two.
+//!
 //! Everything else — the traversal, the De Bruijn treatment of bound variables,
-//! the type-awareness — is shared. See `src/ccl/design/diffing.md`, "Two
-//! hashes, two questions".
+//! the type-awareness — is shared. See `src/ccl/design/diffing.md`, "Three
+//! hashes, three questions".
 //!
 //! # Stage-agnostic by construction
 //!
@@ -62,7 +69,7 @@
 //! of [`crate::ccl::scope`], which cover **every** [`TypedExprNode`] variant —
 //! including the ones (`LetRec`, `Transact`) that exist only below the
 //! mutability phases. Nothing else is stage-sensitive, so one hash serves every
-//! [`CompileStage`](crate::ccl::context::CompileStage).
+//! [`Phase`](crate::ccl::context::Phase).
 //!
 //! # Complexity
 //!
@@ -104,16 +111,62 @@ pub fn content_hash(e: &TypedExpr) -> ContentHash {
 
 /// The α-invariant hash of `e` with its free variables resolved **through the
 /// enclosing scope** rather than by spelling — the classification counterpart
-/// to [`content_hash`]. See `src/ccl/design/diffing.md`, "Two hashes, two
+/// to [`content_hash`]. See `src/ccl/design/diffing.md`, "Three hashes, three
 /// questions".
 ///
-/// `scope` lists the binders `e` sits under, innermost last, each paired with a
-/// *class* token that corresponding binders of the two programs share. A free
-/// variable then hashes to the class of the binder it resolves to, so a binding
-/// renamed between versions is invisible, and a same-spelled binding of
-/// something else is not mistaken for it.
+/// `scope` lists the binders `e` sits under, innermost last, each paired with its
+/// *correspondent* — a token that corresponding binders of the two programs
+/// share. A free variable then hashes to the correspondent of the binder it
+/// resolves to, so a binding renamed between versions is invisible, and a
+/// same-spelled binding of something else is not mistaken for it.
 pub fn resolved_hash(e: &TypedExpr, scope: &[(&Name, u64)]) -> ContentHash {
     ContentHash(hash_rel(e, &mut Vec::new(), FreeVars::ByBinder(scope)))
+}
+
+/// The α-invariant hash of what is **authored at** `e`: everything the node
+/// carries that is not derived from something else in the tree.
+///
+/// [`resolved_hash`] answers "is this the same computation", which a change
+/// anywhere below also answers no to. This answers the narrower question a
+/// differ needs to keep its set of disagreement sites minimal: did this node
+/// change, or is it only reflecting a change in a child that is already
+/// reported on its own?
+///
+/// Folds the node's discriminant, its payload ([`hash_payload`] under
+/// [`Fold::Own`]: a literal's value, an operator, a variant tag, a record's
+/// labels), the binders its variable occurrences resolve to, and its
+/// `user_annotation`. `scope` has the same meaning as in [`resolved_hash`].
+///
+/// Three things are left out, and derivedness rather than child-ness is what
+/// they have in common:
+///
+/// 1. the children's hashes, which is the point;
+/// 2. the node's inferred `ty`, computed from the payload and the children —
+///    folding it would report `let a = 1` → `let a = 2` at the `Let` as well as
+///    at the literal, since the `Let`'s type is the literal's singleton;
+/// 3. a binder's declared `ty`, on the same ground, and a `Cast`'s target,
+///    whose refinement predicate the differ reaches as a child of the cast.
+///
+/// A type change with no payload or child change still surfaces: the content
+/// hash sees it, at the node whose type it is.
+///
+/// A container therefore has close to no own content — a `Let`'s is its
+/// discriminant plus two `user_annotation`s, since its binder's name is De
+/// Bruijn and its type is skipped. That is the design working: a container is
+/// never a disagreement site on its own.
+pub fn own_hash(e: &TypedExpr, scope: &[(&Name, u64)]) -> ContentHash {
+    let free = FreeVars::ByBinder(scope);
+    let env = &mut Vec::new();
+    let mut h = DefaultHasher::new();
+    std::mem::discriminant(&e.node).hash(&mut h);
+    hash_payload(e, env, free, Fold::Own, &mut h);
+    for_each_scoped_item(e, &mut |item| match item {
+        ScopedItem::VarRef(name) => hash_name_ref(name, env, free, &mut h),
+        ScopedItem::KeyRef(name) => hash_key_ref(name, &mut h),
+        ScopedItem::Child { .. } => {}
+    });
+    hash_opt_type(e.user_annotation.as_ref(), env, free, &mut h);
+    ContentHash(h.finish())
 }
 
 /// How a variable that is *free* in the subterm being hashed is identified —
@@ -126,9 +179,10 @@ pub enum FreeVars<'r> {
     /// is exactly what a matcher looking for a subterm's twin needs.
     BySpelling,
     /// By the identity of the binder it resolves to, taken up to a
-    /// correspondence between the two programs — `(name, class)` innermost
-    /// last. Context-sensitive, and only meaningful once a correspondence
-    /// exists, so this is for classifying a matching, not for producing one.
+    /// correspondence between the two programs — `(name, correspondent)`
+    /// innermost last. Context-sensitive, and only meaningful once a
+    /// correspondence exists, so this is for classifying a matching, not for
+    /// producing one.
     ByBinder(&'r [(&'r Name, u64)]),
 }
 
@@ -164,9 +218,9 @@ fn hash_free_var(name: &Name, free: FreeVars<'_>, state: &mut DefaultHasher) {
     match free {
         FreeVars::BySpelling => name.base().hash(state),
         FreeVars::ByBinder(scope) => match scope.iter().rev().find(|(n, _)| *n == name) {
-            Some((_, class)) => {
+            Some((_, correspondent)) => {
                 0u8.hash(state);
-                class.hash(state);
+                correspondent.hash(state);
             }
             None => {
                 1u8.hash(state);
@@ -176,23 +230,32 @@ fn hash_free_var(name: &Name, free: FreeVars<'_>, state: &mut DefaultHasher) {
     }
 }
 
-/// The domain-refinement predicate **term** carried by a cast `target` type,
-/// if any — the borrowing companion to
-/// [`crate::ccl::ccl_utils::cast_target_refinement`] (which clones).
+/// The domain-refinement predicate **terms** carried by a cast `target` type —
+/// the borrowing companion to
+/// [`crate::ccl::ccl_utils::cast_target_refinement`] (which clones the set).
 ///
 /// A refinement predicate is a *term* (`Rc<TypedExpr>` — the filter/join logic
 /// a comprehension lowers to), embedded in a type position. `hash_type` already
-/// folds it into a cast's hash; this borrowing accessor is what lets the
-/// *differ* descend into the predicate as a tree child (so an edit localizes to
+/// folds them into a cast's hash; this borrowing accessor is what lets the
+/// *differ* descend into each predicate as a tree child (so an edit localizes to
 /// it), rather than only flagging the enclosing cast as changed.
-pub(crate) fn cast_target_predicate(target: &Type) -> Option<&TypedExpr> {
+///
+/// A refined domain carries a [`RefinementSet`], whose physical order is
+/// meaningless by contract, so the predicates are returned in ascending
+/// [`content_hash`] order. A differ pairs a node's children by position, and
+/// one built off the set's own order would report two compilations of one
+/// program as disagreeing on which predicate is which.
+pub(crate) fn cast_target_predicates(target: &Type) -> Vec<&TypedExpr> {
     let Type::Fun { domain, .. } = target else {
-        return None;
+        return Vec::new();
     };
-    let Type::Refinement(_, refinement) = domain.as_ref() else {
-        return None;
+    let Type::Refinement(_, refinements) = domain.as_ref() else {
+        return Vec::new();
     };
-    Some(refinement.predicate.as_ref())
+    let mut predicates: Vec<&TypedExpr> =
+        refinements.iter().map(|r| r.predicate.as_ref()).collect();
+    predicates.sort_unstable_by_key(|p| content_hash(p).0);
+    predicates
 }
 
 /// Resolve and hash a variable *reference* (a use site, not a binder): a De
@@ -293,9 +356,17 @@ fn hash_type<'a>(
             openness.hash(state);
             hash_type_fields(fields, env, free, state);
         }
-        T::Refinement(base, refinement) => {
+        // A refinement set is a set: its physical order carries nothing, so the
+        // predicate hashes sort before they fold — the canonicalization
+        // `hash_rel` applies to its AC nodes.
+        T::Refinement(base, refinements) => {
             hash_type(base, env, free, state);
-            hash_rel(&refinement.predicate, env, free).hash(state);
+            let mut predicates: Vec<u64> = refinements
+                .iter()
+                .map(|r| hash_rel(&r.predicate, env, free))
+                .collect();
+            predicates.sort_unstable();
+            predicates.hash(state);
         }
         T::History {
             value,
@@ -349,14 +420,34 @@ fn hash_opt_type<'a>(
 
 /// Hash a binder's declared type and user annotation. The binder's *name* is
 /// folded into the De Bruijn environment by the caller, not hashed here.
+///
+/// Under [`Fold::Own`] the inferred `ty` is skipped: for a `let` it is the bound
+/// expression's type, so folding it would report `let a = 1` → `let a = 2` at
+/// the `Let` as well as at the literal. The `user_annotation` is authored and
+/// stays either way.
 fn hash_binding<'a>(
     b: &'a TypedBinding,
     env: &mut Vec<&'a Name>,
     free: FreeVars<'_>,
+    fold: Fold,
     state: &mut DefaultHasher,
 ) {
-    hash_type(&b.ty, env, free, state);
+    if fold == Fold::Whole {
+        hash_type(&b.ty, env, free, state);
+    }
     hash_opt_type(b.user_annotation.as_ref(), env, free, state);
+}
+
+/// How much of a node's payload a fold takes in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Fold {
+    /// Everything the node carries — what [`hash_rel`] wants, since the whole
+    /// subtree's identity is the question.
+    Whole,
+    /// Only what is authored at this node and not derived from anything else
+    /// in the tree — what [`own_hash`] wants. Three exclusions, not one: the
+    /// children, the node's inferred `ty`, and a binder's declared `ty`.
+    Own,
 }
 
 /// Hash a register-key *label* occurrence — a [`TypedExprNode::Transact`] key
@@ -389,6 +480,7 @@ fn hash_payload<'a>(
     e: &'a TypedExpr,
     env: &mut Vec<&'a Name>,
     free: FreeVars<'_>,
+    fold: Fold,
     h: &mut DefaultHasher,
 ) {
     use TypedExprNode as N;
@@ -422,27 +514,48 @@ fn hash_payload<'a>(
         // domain-refinement predicate — a load-bearing term (a comprehension's
         // filter/join condition). A cast is precisely a type-level change, so
         // the target must participate.
-        N::Cast { target, .. } => hash_type(target, env, free, h),
+        //
+        // It stays out of an [`Fold::Own`] fold: the differ hands that same
+        // predicate to its walk as a *child* (the one place its child set
+        // departs from `walk_children`), so folding the target here too would
+        // report one threshold edit twice — at the literal, and at the cast
+        // above it. A change confined to the rest of the target still surfaces
+        // at the cast, with nothing below it to explain it.
+        N::Cast { target, .. } => {
+            if fold == Fold::Whole {
+                hash_type(target, env, free, h);
+            }
+        }
         N::BinOp { op, .. } => op.hash(h),
         N::UnaryOp(kind, _) => kind.hash(h),
         N::Aggregate { kind, .. } => kind.hash(h),
         N::VariantCtor { tag, .. } => tag.hash(h),
         // Field *names* are folded together with their values in `hash_rel`,
         // which is what keeps `(a: 1, b: 2)` distinct from `(a: 2, b: 1)` under
-        // the order-insensitive fold.
-        N::Record(fields) => fields.len().hash(h),
+        // the order-insensitive fold. An [`Fold::Own`] fold has no children to
+        // pair them with, so it takes the names alone, sorted: a record's
+        // labels are its own content, and a rename over an edited sibling would
+        // otherwise go unreported.
+        N::Record(fields) => {
+            fields.len().hash(h);
+            if fold == Fold::Own {
+                let mut names: Vec<&str> = fields.iter().map(|(n, _)| n.as_str()).collect();
+                names.sort_unstable();
+                names.hash(h);
+            }
+        }
 
-        N::Lambda { param, .. } => hash_binding(param, env, free, h),
-        N::Let { binding, .. } => hash_binding(binding, env, free, h),
+        N::Lambda { param, .. } => hash_binding(param, env, free, fold, h),
+        N::Let { binding, .. } => hash_binding(binding, env, free, fold, h),
         // A mutable variable introduction binds exactly as a `let` does — the
         // history `Mut(V, D)` rides the binder's `ty`, so hashing the binding
         // covers the declaration's whole type-level content.
-        N::MutDecl { binding, .. } => hash_binding(binding, env, free, h),
-        N::For { target, .. } => hash_binding(target, env, free, h),
+        N::MutDecl { binding, .. } => hash_binding(binding, env, free, fold, h),
+        N::For { target, .. } => hash_binding(target, env, free, fold, h),
         N::LetRec { bindings, .. } => {
             bindings.len().hash(h);
             for (b, _) in bindings {
-                hash_binding(b, env, free, h);
+                hash_binding(b, env, free, fold, h);
             }
         }
         N::Case {
@@ -456,7 +569,7 @@ fn hash_payload<'a>(
                     Some(p) => {
                         1u8.hash(h);
                         p.tag.hash(h);
-                        hash_binding(&p.binding, env, free, h);
+                        hash_binding(&p.binding, env, free, fold, h);
                     }
                     None => 0u8.hash(h),
                 }
@@ -498,7 +611,7 @@ fn hash_rel<'a>(e: &'a TypedExpr, env: &mut Vec<&'a Name>, free: FreeVars<'_>) -
     use TypedExprNode as N;
     let mut h = DefaultHasher::new();
     std::mem::discriminant(&e.node).hash(&mut h);
-    hash_payload(e, env, free, &mut h);
+    hash_payload(e, env, free, Fold::Whole, &mut h);
 
     // Name occurrences fold as they are met; child hashes are collected in walk
     // order so the AC nodes below can canonicalize theirs first.
@@ -554,7 +667,9 @@ fn hash_rel<'a>(e: &'a TypedExpr, env: &mut Vec<&'a Name>, free: FreeVars<'_>) -
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ccl::{ArithmeticKind, BaseType, BinOpKind, CompareKind, Refinement, Type};
+    use crate::ccl::{
+        ArithmeticKind, BaseType, BinOpKind, CompareKind, Refinement, RefinementSet, Type,
+    };
     use std::rc::Rc;
 
     fn var(name: &str) -> TypedExpr {
@@ -768,9 +883,9 @@ mod tests {
             );
             typed(Type::Refinement(
                 Box::new(Type::Base(BaseType::Int)),
-                Refinement {
+                RefinementSet::one(Refinement {
                     predicate: Rc::new(pred),
-                },
+                }),
             ))
         };
         assert_ne!(
@@ -791,12 +906,12 @@ mod tests {
         let y = Name::raw("y");
         let (e_x, e_y) = (add(var("x"), int(1)), add(var("y"), int(1)));
 
-        // Same binder class, different spellings: the same computation.
+        // Same binder correspondent, different spellings: the same computation.
         assert_eq!(
             resolved_hash(&e_x, &[(&x, 7)]),
             resolved_hash(&e_y, &[(&y, 7)]),
         );
-        // Same spelling, different binder classes: not the same computation.
+        // Same spelling, different binder correspondents: not the same computation.
         assert_ne!(
             resolved_hash(&e_x, &[(&x, 7)]),
             resolved_hash(&e_x, &[(&x, 8)]),

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -3,6 +3,8 @@
 // builtins
 // ---------------------------------------------------------------------------
 
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
 use std::{cell::RefCell, rc::Rc};
 
 use crate::chl_parser;
@@ -11,7 +13,7 @@ use log::debug;
 
 use crate::{
     ccl::{
-        Expr, channelize,
+        Expr, Name, channelize,
         infer::{
             InferError, TypeInferenceContext, check_mut_discipline, check_mut_write_targets,
             check_pre_channelize, infer, typecheck,
@@ -29,7 +31,7 @@ use crate::{
         transact_phase, uniquify,
     },
     interpreter::{
-        Consumer, DataSourceDomainExtentImpl, Scheduler, StdinDataSource,
+        Consumer, DataSink, DataSourceDomainExtentImpl, Scheduler, StdinDataSource,
         operator_conversion::{
             ConversionError, OpConversionContext, convert_record_fields_to_operators,
             convert_to_operators,
@@ -778,12 +780,12 @@ pub(crate) fn predicate_id_collisions(expr: &Expr) -> Vec<(NodeId, &'static str)
 /// narrow live set, planning's *main-tree* output is essentially fully explained
 /// and the residue is entirely inside refinement predicates, which is the
 /// measurement that says where the remaining work is.
-pub(crate) fn collect_main_tree_ids(expr: &Expr) -> std::collections::HashSet<NodeId> {
-    fn go(e: &Expr, acc: &mut std::collections::HashSet<NodeId>) {
+pub(crate) fn collect_main_tree_ids(expr: &Expr) -> HashSet<NodeId> {
+    fn go(e: &Expr, acc: &mut HashSet<NodeId>) {
         acc.insert(e.node_id());
         e.walk_children(|c| go(c, acc));
     }
-    let mut acc = std::collections::HashSet::new();
+    let mut acc = HashSet::new();
     go(expr, &mut acc);
     acc
 }
@@ -795,11 +797,11 @@ pub(crate) fn collect_main_tree_ids(expr: &Expr) -> std::collections::HashSet<No
 /// Deliberately wider than `assert_unique_node_ids`, which walks children only.
 /// Explanation and uniqueness are two questions with two answers; see
 /// `design/provenance.md`, "Walking the ids".
-pub(crate) fn collect_tree_ids(expr: &Expr) -> std::collections::HashSet<NodeId> {
+pub(crate) fn collect_tree_ids(expr: &Expr) -> HashSet<NodeId> {
     use crate::ccl::TypedExprNode;
     use crate::ccl::ty::Type;
 
-    fn from_ty(t: &Type, acc: &mut std::collections::HashSet<NodeId>) {
+    fn from_ty(t: &Type, acc: &mut HashSet<NodeId>) {
         if let Type::Refinement(_, refinements) = t {
             // Every refinement's predicate rides the slot, so every one of them
             // carries ids the projections must explain.
@@ -810,7 +812,7 @@ pub(crate) fn collect_tree_ids(expr: &Expr) -> std::collections::HashSet<NodeId>
         t.walk_children(|c| from_ty(c, acc));
     }
 
-    fn from_expr(e: &Expr, acc: &mut std::collections::HashSet<NodeId>) {
+    fn from_expr(e: &Expr, acc: &mut HashSet<NodeId>) {
         acc.insert(e.node_id());
         from_ty(&e.ty, acc);
         if let Some(ann) = &e.user_annotation {
@@ -838,7 +840,7 @@ pub(crate) fn collect_tree_ids(expr: &Expr) -> std::collections::HashSet<NodeId>
         e.walk_children(|c| from_expr(c, acc));
     }
 
-    let mut acc = std::collections::HashSet::new();
+    let mut acc = HashSet::new();
     from_expr(expr, &mut acc);
     acc
 }
@@ -851,17 +853,13 @@ pub(crate) fn collect_tree_ids(expr: &Expr) -> std::collections::HashSet<NodeId>
 /// many times over, so a second sighting of an id is not yet a collision;
 /// [`predicate_id_collisions`] answers that domain, dedupping by `Rc` first.
 fn duplicate_node_ids(expr: &Expr) -> Vec<(NodeId, &'static str)> {
-    fn walk(
-        e: &Expr,
-        seen: &mut std::collections::HashSet<NodeId>,
-        dups: &mut Vec<(NodeId, &'static str)>,
-    ) {
+    fn walk(e: &Expr, seen: &mut HashSet<NodeId>, dups: &mut Vec<(NodeId, &'static str)>) {
         if !seen.insert(e.node_id()) {
             dups.push((e.node_id(), e.node.kind_name()));
         }
         e.walk_children(|c| walk(c, seen, dups));
     }
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = HashSet::new();
     let mut dups = Vec::new();
     walk(expr, &mut seen, &mut dups);
     dups
@@ -926,180 +924,6 @@ pub(crate) fn assert_unique_node_ids(expr: &Expr, boundary: &str) {
         !placeholder,
         "Default/mem::take placeholder node persisted into the tree at `{boundary}`"
     );
-}
-
-/// A pipeline stage a program can be compiled to for diffing; the differ
-/// ([`crate::ccl::diff`]) accepts an [`Expr`] at any of them. See
-/// `src/ccl/design/diffing.md`, "Which stage to diff".
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CompileStage {
-    /// Lowered CCL: `Raw` names, pre-α-uniquification, pre-inference. Closest
-    /// to source; most node types are still `Type::Hole`.
-    Lowered,
-    /// Type-inferred CCL: α-uniquified, every node annotated with its resolved
-    /// type — reflects type-level differences a `Lowered` diff cannot see.
-    /// Still carries the transient surface nodes (`Defer`/`Feed`/`For`/
-    /// `Begin`) and their `History` types, which the mutability and
-    /// channelization phases below this stage erase.
-    Inferred,
-    /// Type-inferred, then **UDF-inlined**: every call to a user-defined
-    /// function is replaced by its beta-reduced body, so function boundaries
-    /// stop being part of the program's identity.
-    ///
-    /// This is the pipeline's own [`inline`] pass used as a normalization, and
-    /// it is a deliberate trade, not a strict improvement. Extracting a
-    /// subexpression into a `def` (or inlining one back) becomes invisible —
-    /// the two versions compile to the same tree. In exchange, an edit *inside*
-    /// a function called `n` times is reported `n` times, because the body it
-    /// changed now appears `n` times. Pick this stage when refactoring across
-    /// function boundaries is the noise you want gone; pick [`Inferred`] when
-    /// locality inside shared helpers matters more.
-    ///
-    /// That last recommendation is weaker than it sounds. Monomorphization runs
-    /// inside `infer`, so [`Inferred`] has *already* cloned a definition once
-    /// per distinct instantiation identity: two calls that key apart — literal
-    /// arguments do, since a `SpecKey` sees their singletons — are two bodies
-    /// before inlining is even reached. `Inferred` preserves locality across
-    /// call sites that share a specialization, not across call sites generally.
-    /// Measured both ways in `src/ccl/design/diffing.md`, "How much to
-    /// normalize".
-    ///
-    /// [`Inferred`]: CompileStage::Inferred
-    Inlined,
-    /// Mutability eliminated: `with begin():` blocks and mutation loops have
-    /// become causal `LetRec` recurrences over their sequencing domain, and
-    /// feeds have been routed into channels. `For`/`MutWrite`/`Begin`/`Defer`
-    /// are gone.
-    Channelized,
-    /// Point-free: lambdas replaced by combinators, so binders no longer appear
-    /// in the term at all.
-    LambdaElim,
-    /// Recurrences lowered onto the `Transact` carrier and joins planned — the
-    /// shape operator conversion consumes. The last stage before the tile
-    /// graph, and the one where compute sharing is decided.
-    Planned,
-}
-
-/// Compile `code` to the given [`CompileStage`], ready to pass to
-/// [`crate::ccl::diff::diff`]. Sources — the pre-registered `stdin()` and any
-/// discovered during lowering — are registered for inference, so the result is
-/// reachable end-to-end from source.
-///
-/// Pair two results for a program diff (each tree must outlive the borrow), or
-/// use [`crate::ccl::diff::diff_programs`] for the common case:
-/// ```ignore
-/// let (a, b) = (compile_to(s1, CompileStage::Inferred)?, compile_to(s2, CompileStage::Inferred)?);
-/// let d = crate::ccl::diff::diff(&a, &b);
-/// ```
-///
-/// The prefix here mirrors [`compile_program`]'s frontend, stopping at the
-/// requested stage rather than continuing to the operator graph.
-///
-/// Choosing a stage is choosing how much of the compiler's own rewriting to
-/// diff through, and it is a trade in both directions — a later stage
-/// normalizes more away but spreads a single edit over more of the tree. See
-/// [`CompileStage`] and `src/ccl/design/diffing.md`, "How much to normalize".
-///
-/// The transaction, mutability and channelization phases are not separately
-/// selectable: they are one rewrite of the user's loops and feeds into `LetRec`
-/// recurrences, and stopping between them exposes a half-rewritten tree no
-/// consumer wants. [`Channelized`] is the point where that rewrite is complete.
-///
-/// [`Channelized`]: CompileStage::Channelized
-pub fn compile_to(code: &str, stage: CompileStage) -> Result<Expr, Vec<CompileError>> {
-    let mut ctx = GlobalContext::new();
-    let mut errors: Vec<CompileError> = Vec::new();
-
-    let parse_result = chl_parser::parse_module(code);
-    errors.extend(parse_result.errors.into_iter().map(CompileError::Parse));
-    let Some(module) = parse_result.value else {
-        return Err(errors);
-    };
-    if module.body.is_empty() {
-        errors.push(CompileError::Lower(LoweringError::unsupported(
-            chl_parser::ast::Span::new(0, code.len()),
-            "empty program: file contains no top-level statements",
-        )));
-        return Err(errors);
-    }
-
-    let lower_result = lower_stmts(&module.body, ctx.lowering_ctx());
-    errors.extend(lower_result.errors.into_iter().map(CompileError::Lower));
-    let Some(mut expr) = lower_result.value else {
-        return Err(errors);
-    };
-    // `Error` placeholders make the tree unfit for inference (and meaningless
-    // to diff), so bail on any earlier-stage error even at the `Lowered` stage.
-    if !errors.is_empty() {
-        return Err(errors);
-    }
-    if stage == CompileStage::Lowered {
-        return Ok(expr);
-    }
-
-    expr = uniquify::run(expr);
-    for (_name, source) in ctx.lowering_ctx().take_sources() {
-        let name = source.borrow().get_id().to_string();
-        let output_type = source.borrow().output_type();
-        // The source's data-function type is constructed inside
-        // `register_source_type` from the element type — the `Data` kind is
-        // intrinsic, not stamped here.
-        ctx.inference_ctx().register_source_type(&name, output_type);
-    }
-    // No lowering projection is threaded here — this entry point exists to hand a
-    // tree to the differ, not to render diagnostics — so an inference error keeps
-    // its blame node but degrades to a span-less `CompileError`.
-    if let Err(errors) = infer(&mut expr, ctx.inference_ctx()) {
-        return Err(errors
-            .into_iter()
-            .map(|located| CompileError::Infer {
-                error: located.error,
-                span: None,
-            })
-            .collect());
-    }
-    if stage == CompileStage::Inferred {
-        return Ok(expr);
-    }
-
-    let expr = inline::inline_capability_lambdas(expr);
-    if stage == CompileStage::Inlined {
-        return Ok(expr);
-    }
-
-    // The staged path exists to hand the differ a tree the real pipeline would
-    // also have produced, so it runs the transact phase's rejection checks too:
-    // a program `compile_program` refuses must not yield a stage snapshot here.
-    let txn_mut_vars = transact_phase::collect_txn_mut_vars(&expr);
-    transact_phase::check_no_nested_transactions(&expr, &txn_mut_vars)
-        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
-    transact_phase::check_no_induction_only_transactions(&expr, &txn_mut_vars)
-        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
-    transact_phase::check_no_guarded_induction_write_in_block(&expr, &txn_mut_vars)
-        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
-    transact_phase::check_await_final_linearity(&expr)
-        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
-    let expr = transact_phase::run(expr, &txn_mut_vars)
-        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
-    let expr = mut_elim::run(expr);
-    let mut expr = channelize::run(expr).errs()?;
-    transact_phase::rewrite_as_of_reads(&mut expr)
-        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
-    if stage == CompileStage::Channelized {
-        return Ok(expr);
-    }
-
-    let expr = lambda_elim::run(expr).errs()?;
-    if stage == CompileStage::LambdaElim {
-        return Ok(expr);
-    }
-
-    debug_assert_eq!(
-        stage,
-        CompileStage::Planned,
-        "every CompileStage must be handled before this point",
-    );
-    Ok(planning::run(planning::plan_loops(expr)))
 }
 
 // ---------------------------------------------------------------------------
@@ -1229,7 +1053,7 @@ fn recorded<R>(capture: bool, phase: Phase, f: impl FnOnce() -> R) -> R {
 /// retires when the last phase records".
 struct ProvenanceAudit {
     span: &'static str,
-    state: Option<(PhaseScope, std::collections::HashSet<NodeId>)>,
+    state: Option<(PhaseScope, HashSet<NodeId>)>,
 }
 
 impl ProvenanceAudit {
@@ -1248,7 +1072,7 @@ impl ProvenanceAudit {
     /// this switch inert (both arms computing the same set) and its own doc
     /// comment false. Keeping a named narrow walk is what makes the comparison
     /// measurable rather than a no-op.
-    fn live_ids(expr: &Expr) -> std::collections::HashSet<NodeId> {
+    fn live_ids(expr: &Expr) -> HashSet<NodeId> {
         if provenance_predicates_live() {
             collect_tree_ids(expr)
         } else {
@@ -1291,7 +1115,7 @@ impl ProvenanceAudit {
         else {
             return;
         };
-        let mut counts = std::collections::BTreeMap::<&str, usize>::new();
+        let mut counts = BTreeMap::<&str, usize>::new();
         for l in &leaks {
             *counts
                 .entry(match l {
@@ -1312,37 +1136,146 @@ impl ProvenanceAudit {
     }
 }
 
-/// Compile a CHL program and return its operator graph plus subscribed outputs.
+/// `check_pre_channelize` as a wall between two phases. It is the relaxed
+/// pre-channelize check, which permits the transient `Feed` /
+/// `Infer`-channel-domain types only channelization erases.
 ///
-/// Returns a [`CompiledProgram`] whose `outputs` vector contains one entry
-/// per "output" of the program:
+/// A failure is a compiler bug, with one exception: residual `Type::Infer`
+/// variables, which inference deliberately tolerates for a generalized
+/// definition the program never exercises at a concrete type (see
+/// `Type::Infer`'s invariant). That residue is an *ambiguous program* — a user
+/// error — so it is rendered as a diagnostic; anything else panics, naming
+/// `produced_by`.
+fn pre_channelize_wall(expr: &Expr, produced_by: &str) -> Result<(), Vec<CompileError>> {
+    check_pre_channelize(expr).map_err(|errs| {
+        if errs
+            .iter()
+            .all(|e| matches!(e, InferError::UnresolvedInfer { .. }))
+        {
+            errs.into_compile_errors()
+        } else {
+            panic!("{produced_by} created invalid expr: {errs:?}")
+        }
+    })
+}
+
+/// The two user-facing mutability rules, checked on the fully-typed,
+/// still-`Mut`-bearing tree — after [`pre_channelize_wall`], before inlining.
 ///
-/// - **Pure programs** (no sinks): a single `("main", op)` entry whose
-///   producer is subscribed to `main_consumer`.  The caller drives the main
-///   loop by repeatedly calling [`TileProducer::get`] on that producer.
-/// - **Sink programs** (e.g. `http_serve`): one entry per sink field of the
-///   trailing `Record{…}`, each wired to a [`SinkConsumer`] that dispatches
-///   to the registered [`DataSink`](crate::interpreter::DataSink).  For
-///   sink-only programs the supplied `main_consumer` is dropped before
-///   returning.
-pub fn compile_program(
+/// Both need the pre-inline `Apply`/parameter structure and the coalesced `.ty`
+/// slots and `user_annotation`s. Unlike the surrounding [`pre_channelize_wall`]
+/// calls (compiler-bug backstops), these are user errors:
+///
+/// - `check_mut_discipline` — the second-class `Mut` discipline
+///   (`src/ccl/design/mutability.md`, "No aliasing: `Mut` values are second-class
+///   (downward-only)"): no aliasing or nesting a mutable reference.
+/// - `check_mut_write_targets` — every `:=` / `+=` write targets a mutable
+///   variable, never a shadowing rebind of an immutable. Load-bearing rather
+///   than a formality: lowering emits a `MutWrite` for any `x := e` whose name is
+///   already in scope, mutable variable or not (see `src/ccl/design/mutability.md`,
+///   "Mutability is the type (no lowering registry)"), so this is what rejects a
+///   write to an immutable binding — or to one monomorphization has since dropped.
+fn check_mut_rules(expr: &Expr) -> Result<(), Vec<CompileError>> {
+    check_mut_discipline(expr).map_err(|errs| errs.into_compile_errors())?;
+    check_mut_write_targets(expr).map_err(|errs| errs.into_compile_errors())
+}
+
+/// The transact phase's four rejections, run on the inlined, typed tree before
+/// [`transact_phase::run`] strips the sites they inspect.
+///
+/// - `check_no_nested_transactions` — a transactional writer reaching a `with
+///   begin():` block via a function call. The callee's inlined `For` would
+///   otherwise be silently absorbed into the outer block's read-your-writes env,
+///   dropping its commit.
+/// - `check_no_induction_only_transactions` — an induction accumulator written
+///   inside a block with no mutable variable write is a no-atomicity transaction.
+/// - `check_no_guarded_induction_write_in_block` — a *guarded* induction write
+///   inside a committing block (`balance := …; if p: cnt += 1`) is not liftable
+///   and would be silently dropped from the decision record. A debug-only assert
+///   would miss it in release.
+/// - `check_await_final_linearity` — `await_final` consumes its mutable variable:
+///   no mention may follow its await. A statement-order rule lowering cannot see,
+///   since it builds its chain right-to-left, and a callee's mention only becomes
+///   a read, a write, or a `Begin` once inlined.
+fn check_transact_rejections(
+    expr: &Expr,
+    txn_mut_vars: &HashSet<Name>,
+) -> Result<(), Vec<CompileError>> {
+    let reject = |msg: String| vec![CompileError::Unsupported(msg)];
+    transact_phase::check_no_nested_transactions(expr, txn_mut_vars).map_err(reject)?;
+    transact_phase::check_no_induction_only_transactions(expr, txn_mut_vars).map_err(reject)?;
+    transact_phase::check_no_guarded_induction_write_in_block(expr, txn_mut_vars)
+        .map_err(reject)?;
+    transact_phase::check_await_final_linearity(expr).map_err(reject)
+}
+
+/// What a frontend run hands back besides the tree it stopped at.
+struct Frontend {
+    /// The tree at the requested stop [`Phase`]'s output.
+    expr: Expr,
+    /// The tree at each requested phase output, keyed by the phase whose output
+    /// it is. A **pane** is exactly this: a captured phase output that outlives
+    /// the run.
+    panes: BTreeMap<Phase, Expr>,
+    /// The surface AST lowering consumed, retained for source-level queries.
+    module: chl_parser::ast::Module,
+    /// Sink bindings discovered during lowering. Drained before the sources,
+    /// which is the order [`LoweringContext`] requires.
+    sink_bindings: HashMap<String, Arc<dyn DataSink>>,
+    /// Every lowered node's `SourceAttribution`, the base every later fold
+    /// bottoms out in and the source release `InferError` diagnostics resolve
+    /// against one-hop.
+    lowering_projection: SourceProjection,
+    /// Open when the run recorded. The caller drains it once nothing else will
+    /// record, so the timing matches a compile that never split.
+    table_session: Option<TableSession>,
+}
+
+/// Capture `phase`'s output if asked for, and say whether the run stops here.
+///
+/// The one place a phase boundary is expressed, so "capture a pane" and "stop
+/// for a diff" are the same event at the same position. The stop test is `>=`
+/// over [`Phase`]'s declaration order, which is pipeline order.
+fn at_phase_output(
+    phase: Phase,
+    expr: &Expr,
+    stop: Phase,
+    capture: &[Phase],
+    panes: &mut BTreeMap<Phase, Expr>,
+) -> bool {
+    if capture.contains(&phase) {
+        // A pane observes the live tree at a point in time, so it preserves ids.
+        // A freshening clone would hand the pane a structurally identical
+        // program sharing no identity with the one it is meant to snapshot.
+        panes.insert(phase, expr.clone_preserving_ids());
+    }
+    phase >= stop
+}
+
+/// The compiler frontend: source in, a CCL tree at `stop`'s output out.
+///
+/// **This is the only place the phase sequence and its checks are written.**
+/// [`compile_program`] runs it to [`Phase::Planning`] and continues into
+/// operator conversion; [`compile_to`] runs it to whichever phase a diff is
+/// being taken at and stops. A check added here therefore lands on both, which
+/// is what keeps a stopped tree from being one the real pipeline would have
+/// rejected.
+///
+/// `capture` names the phase outputs to retain as panes; `record` selects
+/// whether the run installs the provenance table and opens the per-phase
+/// recorder scopes. Nothing else about the two callers differs.
+fn run_frontend(
     ctx: &mut GlobalContext,
     code: &str,
-    main_consumer: Box<dyn Consumer>,
-) -> Result<CompiledProgram, Vec<CompileError>> {
-    // ---- User-facing failure points ----
-    //
-    // The pipeline now accumulates errors across the *parse* and *lower*
-    // stages before bailing: when the parser recovers from a syntax error
-    // it still produces a partial AST, which lowering can run on and report
-    // its own errors against. The combined list is returned in one phase so
-    // the user sees everything at once. Inference and downstream stages
-    // skip when anything earlier produced an error — they assume a well-
-    // typed CCL tree without `Error` placeholders.
-    //
-    // Stage-internal consistency checks (`typecheck`, `check_fully_typed`)
-    // keep their `.expect` because firing them means the compiler itself is
-    // wrong, not the user's input.
+    stop: Phase,
+    capture: &[Phase],
+    record: bool,
+) -> Result<Frontend, Vec<CompileError>> {
+    // The parse and lower stages accumulate errors before bailing: when the
+    // parser recovers from a syntax error it still produces a partial AST, which
+    // lowering can run on and report its own errors against, so the user sees
+    // everything at once. Inference and below assume a well-typed tree with no
+    // `Error` placeholders, so they are skipped when anything earlier failed.
     let mut errors: Vec<CompileError> = Vec::new();
 
     // The node table spans the **whole compile**, not a phase: its rows are keyed
@@ -1350,7 +1283,7 @@ pub fn compile_program(
     // session's flushes mirror into one table with no possibility of collision.
     // Installed before the first session opens (the lowering one) and drained
     // below; every early return drops it, clearing the slot.
-    let table_session = TableSession::install();
+    let table_session = record.then(TableSession::install);
 
     let parse_result = chl_parser::parse_module(code);
     errors.extend(parse_result.errors.into_iter().map(CompileError::Parse));
@@ -1390,7 +1323,7 @@ pub fn compile_program(
     }
 
     // Drain sink bindings discovered during lowering before taking sources.
-    let sink_bindings_registry = ctx.lowering_ctx().take_sink_bindings();
+    let sink_bindings = ctx.lowering_ctx().take_sink_bindings();
 
     // Drain the lowering log and fold it once, at the lowering→pipeline
     // handoff (before uniquify/inference, so the release `InferError` read timing
@@ -1422,6 +1355,18 @@ pub fn compile_program(
 
     debug!("Lowered (pre-channelize):\n{}", symbolic(&expr));
 
+    let mut panes = BTreeMap::new();
+    if at_phase_output(Phase::Lower, &expr, stop, capture, &mut panes) {
+        return Ok(Frontend {
+            expr,
+            panes,
+            module,
+            sink_bindings,
+            lowering_projection,
+            table_session,
+        });
+    }
+
     // α-uniquify all binders (Barendregt convention): every binding site gets
     // a globally fresh `Name` uid, so shadowing ceases to exist before any
     // phase that compares names. Must run before channelization — channelize's
@@ -1429,21 +1374,48 @@ pub fn compile_program(
     // binders are distinct names. (Channelize now runs after inference; see below.)
     expr = uniquify::run(expr);
 
-    // Retain the pre-inference IR for the inspector's upstream pane before
-    // `infer` mutates `expr` in place. This is the source-shaped, pre-mono,
-    // still-hole-typed tree. Its ids resolve against the `lowering_projection`
-    // (the pre-mono originals). See `CompiledProgram::pre_inference_ir`.
-    // A pane snapshot: the same nodes as the live tree, observed at a point in
-    // time, so it preserves ids. A freshening clone would hand the pane a
-    // structurally identical program sharing no identity with the one it is meant
-    // to snapshot, and these ids must resolve against the `lowering_projection`,
-    // which is keyed by the originals.
-    let pre_inference_ir = expr.clone_preserving_ids();
+    let expr = run_passes(
+        ctx,
+        expr,
+        stop,
+        capture,
+        record,
+        &lowering_projection,
+        &mut panes,
+    )?;
+    Ok(Frontend {
+        expr,
+        panes,
+        module,
+        sink_bindings,
+        lowering_projection,
+        table_session,
+    })
+}
 
-    // Phase recording for the rows the two pane pairs' folds read. One scope per
-    // phase, opened and closed in place: a phase scope is per-thread and
+/// The phase sequence, from the α-uniquified tree to `stop`'s output.
+///
+/// Split out of [`run_frontend`] only so each phase boundary can `return` the
+/// tree; the two are one pipeline. Every phase ends with one
+/// [`at_phase_output`] call, which is both where a pane is taken and where a
+/// stop happens.
+fn run_passes(
+    ctx: &mut GlobalContext,
+    mut expr: Expr,
+    stop: Phase,
+    capture: &[Phase],
+    record: bool,
+    lowering_projection: &SourceProjection,
+    panes: &mut BTreeMap<Phase, Expr>,
+) -> Result<Expr, Vec<CompileError>> {
+    // Phase recording for the rows the pane folds read. One scope per phase,
+    // opened and closed in place: a phase scope is per-thread and
     // non-reentrant, so the scopes are sequential, never nested.
-    let capture_provenance = provenance_capture_enabled();
+    let capture_provenance = record && provenance_capture_enabled();
+
+    if at_phase_output(Phase::Uniquify, &expr, stop, capture, panes) {
+        return Ok(expr);
+    }
 
     // Register every source (pre-registered + discovered during lowering) with
     // inference and operator-conversion now that the full source set is known.
@@ -1497,16 +1469,7 @@ pub fn compile_program(
     // definition the program never exercises at a concrete type (see
     // `Type::Infer`'s invariant). That residue is an *ambiguous program* — a
     // user error — so it is rendered as a diagnostic; anything else panics.
-    check_pre_channelize(&expr).map_err(|errs| {
-        if errs
-            .iter()
-            .all(|e| matches!(e, InferError::UnresolvedInfer { .. }))
-        {
-            errs.into_compile_errors()
-        } else {
-            panic!("Inference created invalid expr: {errs:?}")
-        }
-    })?;
+    pre_channelize_wall(&expr, "Inference")?;
 
     // Enforce the second-class `Mut` discipline (`src/ccl/design/mutability.md`,
     // "No aliasing: `Mut` values are second-class (downward-only)") on the
@@ -1516,7 +1479,7 @@ pub fn compile_program(
     // `user_annotation`s. Unlike the surrounding `check_pre_channelize` walls
     // (compiler-bug backstops), these are user errors: aliasing or nesting a
     // mutable reference.
-    check_mut_discipline(&expr).map_err(|errs| errs.into_compile_errors())?;
+    check_mut_rules(&expr)?;
 
     // Enforce that every `:=` / `+=` write targets a mutable variable (a write is
     // never a shadowing rebind of an immutable). Post-inference so binder types
@@ -1526,7 +1489,6 @@ pub fn compile_program(
     // scope, mutable variable or not (see `src/ccl/design/mutability.md`, "Mutability is the
     // type (no lowering registry)"), so this is what rejects a write to an immutable
     // binding — or to one monomorphization has since dropped.
-    check_mut_write_targets(&expr).map_err(|errs| errs.into_compile_errors())?;
 
     // Inline UDFs *before* channelize: a defer-mediating UDF (`λ out → out << e`)
     // or a cross-function writer is beta-reduced to its call site before
@@ -1549,7 +1511,9 @@ pub fn compile_program(
     // view — `lambda_elim`/`planning` re-mint ids and produce execution shape.
     // See `CompiledProgram::post_inference_ir`.
     // A pane snapshot; see `pre_inference_ir`.
-    let post_inference_ir = expr.clone_preserving_ids();
+    if at_phase_output(Phase::Infer, &expr, stop, capture, panes) {
+        return Ok(expr);
+    }
 
     // Driver-capture audit span: post-inference pane in, and out at the **last
     // instrumented pane** — currently `post-lambda-elim`, covering inline,
@@ -1568,31 +1532,20 @@ pub fn compile_program(
     // that instruments it** — to `join-planned` when planning records. Leaving
     // it behind understates coverage; moving it ahead reintroduces the
     // unreachable-zero problem.
-    let audit = ProvenanceAudit::start(
-        "full",
-        "post-inference..post-lambda-elim",
-        &post_inference_ir,
-    );
+    let audit = ProvenanceAudit::start("full", "post-inference..post-lambda-elim", &expr);
     // A narrower pane pair over just the mutability phases (inline, transact,
     // mut_elim), which is where the fate-prediction question lives.
-    let audit_letrec =
-        ProvenanceAudit::start("letrec", "post-inference..post-letrec", &post_inference_ir);
+    let audit_letrec = ProvenanceAudit::start("letrec", "post-inference..post-letrec", &expr);
 
     expr = recorded(capture_provenance, Phase::Inline, || {
         inline::inline_capability_lambdas(expr)
     });
     assert_unique_node_ids(&expr, "post-inline");
     debug!("UDFs inlined CCL:\n{}", symbolic(&expr));
-    check_pre_channelize(&expr).map_err(|errs| {
-        if errs
-            .iter()
-            .all(|e| matches!(e, InferError::UnresolvedInfer { .. }))
-        {
-            errs.into_compile_errors()
-        } else {
-            panic!("UDF inlining created invalid expr: {errs:?}")
-        }
-    })?;
+    pre_channelize_wall(&expr, "UDF inlining")?;
+    if at_phase_output(Phase::Inline, &expr, stop, capture, panes) {
+        return Ok(expr);
+    }
 
     // Transactional slice of the unified phase: rewrite every `with begin():`
     // writer of a `Mut(_, Txn)` mutable variable into a `get_prev_txn`-guarded `LetRec`
@@ -1614,25 +1567,8 @@ pub fn compile_program(
     // is a nested transaction — the callee's inlined `For` would otherwise be
     // silently absorbed into the outer block's read-your-writes env, dropping its
     // commit. Reject it before the phase strips the sites.
-    transact_phase::check_no_nested_transactions(&expr, &txn_mut_vars)
-        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
-    // An induction accumulator written inside a block with no mutable variable write is a
-    // no-atomicity transaction — rejected here (type-aware), not at lowering.
-    transact_phase::check_no_induction_only_transactions(&expr, &txn_mut_vars)
-        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
-    // A *guarded* induction write inside a committing block (`balance := …; if p:
-    // cnt += 1`) is not liftable and would be silently dropped from the decision
-    // record — reject it before the phase runs (a debug-only assert would miss it
-    // in release).
-    transact_phase::check_no_guarded_induction_write_in_block(&expr, &txn_mut_vars)
-        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
-    // `await_final` consumes its mutable variable: no mention may follow its await. A
-    // statement-order rule lowering cannot see — it builds its chain right-to-left —
-    // and a callee's mention only becomes a read, a write, or a `Begin` once inlined.
-    // (The companion rule, that a commit store may not depend on the completion of
-    // that same store, is decided per store and so lives inside the phase.)
-    transact_phase::check_await_final_linearity(&expr)
-        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
+    check_transact_rejections(&expr, &txn_mut_vars)?;
+
     expr = recorded(capture_provenance, Phase::Transact, || {
         transact_phase::run(expr, &txn_mut_vars)
     })
@@ -1640,6 +1576,9 @@ pub fn compile_program(
     assert_unique_node_ids(&expr, "post-transact");
     debug!("Transact phase CCL:\n{}", symbolic(&expr));
     check_pre_channelize(&expr).expect("transact phase produced an inconsistent tree");
+    if at_phase_output(Phase::Transact, &expr, stop, capture, panes) {
+        return Ok(expr);
+    }
 
     // The unified letrec phase: direct-mirror mutation loops (`For` /
     // `MutWrite`) become causal `LetRec` groups — mutable histories over
@@ -1658,6 +1597,9 @@ pub fn compile_program(
     audit_letrec.finish(&phase_out);
     debug!("Letrec phase CCL:\n{}", symbolic(&phase_out));
     check_pre_channelize(&phase_out).expect("letrec phase produced an inconsistent tree");
+    if at_phase_output(Phase::Letrec, &phase_out, stop, capture, panes) {
+        return Ok(phase_out);
+    }
 
     // Feed channelization — the feed-routing step of the unified phase, run on
     // the phase-emitted `LetRec` tree (recognition happens *after*
@@ -1682,7 +1624,9 @@ pub fn compile_program(
     // `post_inference_ir` (post-inline/transact/letrec/channelize); see the doc
     // comment on `post_channelize_ir`.
     // A pane snapshot; see `pre_inference_ir`.
-    let post_channelize_ir = channelized.clone_preserving_ids();
+    if at_phase_output(Phase::Channelize, &channelized, stop, capture, panes) {
+        return Ok(channelized);
+    }
 
     // Fed-out mutable variable reads: rewrite a read-only reply that reads a mutable variable out of
     // its block into an outer-indexed as-of join (an as-of read at the reading
@@ -1697,8 +1641,9 @@ pub fn compile_program(
     .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
     assert_unique_node_ids(&channelized, "post-as-of-read");
     typecheck(&channelized).expect("as-of-read rewrite produced an ill-typed tree");
-    // A pane snapshot; see `pre_inference_ir`.
-    let post_as_of_read_ir = channelized.clone_preserving_ids();
+    if at_phase_output(Phase::AsOfRead, &channelized, stop, capture, panes) {
+        return Ok(channelized);
+    }
 
     let lambda_elim = recorded(capture_provenance, Phase::LambdaElim, || {
         lambda_elim::run(channelized)
@@ -1707,14 +1652,15 @@ pub fn compile_program(
     assert_unique_node_ids(&lambda_elim, "post-lambda-elim");
     // The last instrumented pane: see the span's own note at `ProvenanceAudit::start`.
     audit.finish(&lambda_elim);
-    // A pane snapshot; see `pre_inference_ir`.
-    let post_lambda_elim_ir = lambda_elim.clone_preserving_ids();
     debug!("λ-eliminated CCL:\n{}", symbolic(&lambda_elim));
     debug!("λ-eliminated typed CCL:\n{}", symbolic_typed(&lambda_elim));
 
     // `typecheck` enforces hole-freeness as its first phase, so this call
     // alone covers both checks.
     typecheck(&lambda_elim).expect("type error after lambda elimination");
+    if at_phase_output(Phase::LambdaElim, &lambda_elim, stop, capture, panes) {
+        return Ok(lambda_elim);
+    }
 
     // Recognition: lower each causal group — now in its point-free normal
     // form — onto the domain-parameterized `Transact` carrier (a
@@ -1759,6 +1705,87 @@ pub fn compile_program(
     // domain) is unsupported and must surface loudly, not miscompile.
     #[cfg(debug_assertions)]
     crate::ccl::ccl_utils::debug_assert_no_iteration_markers(&join_planned);
+
+    at_phase_output(Phase::Planning, &join_planned, stop, capture, panes);
+    Ok(join_planned)
+}
+
+/// Compile `code` through `phase`, ready to pass to [`crate::ccl::diff::diff`].
+///
+/// Runs [`run_frontend`] — the same phases and the same checks
+/// [`compile_program`] runs — stopping at `phase`'s output rather than
+/// continuing into the operator graph, and retaining no panes and no provenance.
+/// A program `compile_program` refuses therefore yields no tree here.
+///
+/// Every phase output is a consistent tree (each has a wall after it), so any
+/// `Phase` is a legal stop. Which ones answer which question — and which ones a
+/// diff should be taken at — is `src/ccl/design/diffing.md`, "Which phase to diff".
+pub fn compile_to(code: &str, phase: Phase) -> Result<Expr, Vec<CompileError>> {
+    let mut ctx = GlobalContext::new();
+    Ok(run_frontend(&mut ctx, code, phase, &[], false)?.expr)
+}
+
+/// Compile a CHL program and return its operator graph plus subscribed outputs.
+///
+/// Returns a [`CompiledProgram`] whose `outputs` vector contains one entry
+/// per "output" of the program:
+///
+/// - **Pure programs** (no sinks): a single `("main", op)` entry whose
+///   producer is subscribed to `main_consumer`.  The caller drives the main
+///   loop by repeatedly calling [`TileProducer::get`] on that producer.
+/// - **Sink programs** (e.g. `http_serve`): one entry per sink field of the
+///   trailing `Record{…}`, each wired to a [`SinkConsumer`] that dispatches
+///   to the registered [`DataSink`](crate::interpreter::DataSink).  For
+///   sink-only programs the supplied `main_consumer` is dropped before
+///   returning.
+pub fn compile_program(
+    ctx: &mut GlobalContext,
+    code: &str,
+    main_consumer: Box<dyn Consumer>,
+) -> Result<CompiledProgram, Vec<CompileError>> {
+    // The frontend is [], shared with []: parse through
+    // join planning, every check between, and the three panes the inspector
+    // reads — each of which is a captured phase output.
+    //
+    // Phase-internal consistency checks (, )
+    // keep their  inside the frontend because firing them means the
+    // compiler itself is wrong, not the user's input.
+    const PANES: [Phase; 5] = [
+        Phase::Uniquify,
+        Phase::Infer,
+        Phase::Channelize,
+        Phase::AsOfRead,
+        Phase::LambdaElim,
+    ];
+    let Frontend {
+        expr: join_planned,
+        mut panes,
+        module,
+        sink_bindings: sink_bindings_registry,
+        lowering_projection,
+        table_session,
+    } = run_frontend(ctx, code, Phase::Planning, &PANES, true)?;
+    // The frontend ran to , which is past every pane boundary.
+    let mut pane = |phase: Phase| {
+        panes
+            .remove(&phase)
+            .unwrap_or_else(|| unreachable!("a run to  passes {phase:?}'s output"))
+    };
+    let (
+        pre_inference_ir,
+        post_inference_ir,
+        post_channelize_ir,
+        post_as_of_read_ir,
+        post_lambda_elim_ir,
+    ) = (
+        pane(Phase::Uniquify),
+        pane(Phase::Infer),
+        pane(Phase::Channelize),
+        pane(Phase::AsOfRead),
+        pane(Phase::LambdaElim),
+    );
+    let table_session =
+        table_session.unwrap_or_else(|| unreachable!("a recording run installs the table"));
 
     // Compile to one operator per field of the trailing record.  Pure
     // programs (no sinks) end up at this point with a bare expression at the

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -928,6 +928,180 @@ pub(crate) fn assert_unique_node_ids(expr: &Expr, boundary: &str) {
     );
 }
 
+/// A pipeline stage a program can be compiled to for diffing; the differ
+/// ([`crate::ccl::diff`]) accepts an [`Expr`] at any of them. See
+/// `src/ccl/design/diffing.md`, "Which stage to diff".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompileStage {
+    /// Lowered CCL: `Raw` names, pre-α-uniquification, pre-inference. Closest
+    /// to source; most node types are still `Type::Hole`.
+    Lowered,
+    /// Type-inferred CCL: α-uniquified, every node annotated with its resolved
+    /// type — reflects type-level differences a `Lowered` diff cannot see.
+    /// Still carries the transient surface nodes (`Defer`/`Feed`/`For`/
+    /// `Begin`) and their `History` types, which the mutability and
+    /// channelization phases below this stage erase.
+    Inferred,
+    /// Type-inferred, then **UDF-inlined**: every call to a user-defined
+    /// function is replaced by its beta-reduced body, so function boundaries
+    /// stop being part of the program's identity.
+    ///
+    /// This is the pipeline's own [`inline`] pass used as a normalization, and
+    /// it is a deliberate trade, not a strict improvement. Extracting a
+    /// subexpression into a `def` (or inlining one back) becomes invisible —
+    /// the two versions compile to the same tree. In exchange, an edit *inside*
+    /// a function called `n` times is reported `n` times, because the body it
+    /// changed now appears `n` times. Pick this stage when refactoring across
+    /// function boundaries is the noise you want gone; pick [`Inferred`] when
+    /// locality inside shared helpers matters more.
+    ///
+    /// That last recommendation is weaker than it sounds. Monomorphization runs
+    /// inside `infer`, so [`Inferred`] has *already* cloned a definition once
+    /// per distinct instantiation identity: two calls that key apart — literal
+    /// arguments do, since a `SpecKey` sees their singletons — are two bodies
+    /// before inlining is even reached. `Inferred` preserves locality across
+    /// call sites that share a specialization, not across call sites generally.
+    /// Measured both ways in `src/ccl/design/diffing.md`, "How much to
+    /// normalize".
+    ///
+    /// [`Inferred`]: CompileStage::Inferred
+    Inlined,
+    /// Mutability eliminated: `with begin():` blocks and mutation loops have
+    /// become causal `LetRec` recurrences over their sequencing domain, and
+    /// feeds have been routed into channels. `For`/`MutWrite`/`Begin`/`Defer`
+    /// are gone.
+    Channelized,
+    /// Point-free: lambdas replaced by combinators, so binders no longer appear
+    /// in the term at all.
+    LambdaElim,
+    /// Recurrences lowered onto the `Transact` carrier and joins planned — the
+    /// shape operator conversion consumes. The last stage before the tile
+    /// graph, and the one where compute sharing is decided.
+    Planned,
+}
+
+/// Compile `code` to the given [`CompileStage`], ready to pass to
+/// [`crate::ccl::diff::diff`]. Sources — the pre-registered `stdin()` and any
+/// discovered during lowering — are registered for inference, so the result is
+/// reachable end-to-end from source.
+///
+/// Pair two results for a program diff (each tree must outlive the borrow), or
+/// use [`crate::ccl::diff::diff_programs`] for the common case:
+/// ```ignore
+/// let (a, b) = (compile_to(s1, CompileStage::Inferred)?, compile_to(s2, CompileStage::Inferred)?);
+/// let d = crate::ccl::diff::diff(&a, &b);
+/// ```
+///
+/// The prefix here mirrors [`compile_program`]'s frontend, stopping at the
+/// requested stage rather than continuing to the operator graph.
+///
+/// Choosing a stage is choosing how much of the compiler's own rewriting to
+/// diff through, and it is a trade in both directions — a later stage
+/// normalizes more away but spreads a single edit over more of the tree. See
+/// [`CompileStage`] and `src/ccl/design/diffing.md`, "How much to normalize".
+///
+/// The transaction, mutability and channelization phases are not separately
+/// selectable: they are one rewrite of the user's loops and feeds into `LetRec`
+/// recurrences, and stopping between them exposes a half-rewritten tree no
+/// consumer wants. [`Channelized`] is the point where that rewrite is complete.
+///
+/// [`Channelized`]: CompileStage::Channelized
+pub fn compile_to(code: &str, stage: CompileStage) -> Result<Expr, Vec<CompileError>> {
+    let mut ctx = GlobalContext::new();
+    let mut errors: Vec<CompileError> = Vec::new();
+
+    let parse_result = chl_parser::parse_module(code);
+    errors.extend(parse_result.errors.into_iter().map(CompileError::Parse));
+    let Some(module) = parse_result.value else {
+        return Err(errors);
+    };
+    if module.body.is_empty() {
+        errors.push(CompileError::Lower(LoweringError::unsupported(
+            chl_parser::ast::Span::new(0, code.len()),
+            "empty program: file contains no top-level statements",
+        )));
+        return Err(errors);
+    }
+
+    let lower_result = lower_stmts(&module.body, ctx.lowering_ctx());
+    errors.extend(lower_result.errors.into_iter().map(CompileError::Lower));
+    let Some(mut expr) = lower_result.value else {
+        return Err(errors);
+    };
+    // `Error` placeholders make the tree unfit for inference (and meaningless
+    // to diff), so bail on any earlier-stage error even at the `Lowered` stage.
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+    if stage == CompileStage::Lowered {
+        return Ok(expr);
+    }
+
+    expr = uniquify::run(expr);
+    for (_name, source) in ctx.lowering_ctx().take_sources() {
+        let name = source.borrow().get_id().to_string();
+        let output_type = source.borrow().output_type();
+        // The source's data-function type is constructed inside
+        // `register_source_type` from the element type — the `Data` kind is
+        // intrinsic, not stamped here.
+        ctx.inference_ctx().register_source_type(&name, output_type);
+    }
+    // No lowering projection is threaded here — this entry point exists to hand a
+    // tree to the differ, not to render diagnostics — so an inference error keeps
+    // its blame node but degrades to a span-less `CompileError`.
+    if let Err(errors) = infer(&mut expr, ctx.inference_ctx()) {
+        return Err(errors
+            .into_iter()
+            .map(|located| CompileError::Infer {
+                error: located.error,
+                span: None,
+            })
+            .collect());
+    }
+    if stage == CompileStage::Inferred {
+        return Ok(expr);
+    }
+
+    let expr = inline::inline_capability_lambdas(expr);
+    if stage == CompileStage::Inlined {
+        return Ok(expr);
+    }
+
+    // The staged path exists to hand the differ a tree the real pipeline would
+    // also have produced, so it runs the transact phase's rejection checks too:
+    // a program `compile_program` refuses must not yield a stage snapshot here.
+    let txn_mut_vars = transact_phase::collect_txn_mut_vars(&expr);
+    transact_phase::check_no_nested_transactions(&expr, &txn_mut_vars)
+        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
+    transact_phase::check_no_induction_only_transactions(&expr, &txn_mut_vars)
+        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
+    transact_phase::check_no_guarded_induction_write_in_block(&expr, &txn_mut_vars)
+        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
+    transact_phase::check_await_final_linearity(&expr)
+        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
+    let expr = transact_phase::run(expr, &txn_mut_vars)
+        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
+    let expr = mut_elim::run(expr);
+    let mut expr = channelize::run(expr).errs()?;
+    transact_phase::rewrite_as_of_reads(&mut expr)
+        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
+    if stage == CompileStage::Channelized {
+        return Ok(expr);
+    }
+
+    let expr = lambda_elim::run(expr).errs()?;
+    if stage == CompileStage::LambdaElim {
+        return Ok(expr);
+    }
+
+    debug_assert_eq!(
+        stage,
+        CompileStage::Planned,
+        "every CompileStage must be handled before this point",
+    );
+    Ok(planning::run(planning::plan_loops(expr)))
+}
+
 // ---------------------------------------------------------------------------
 // Provenance measurement switches
 //

--- a/src/ccl/design/README.md
+++ b/src/ccl/design/README.md
@@ -30,6 +30,7 @@ CHL source
 | [lowering.md](lowering.md) | CHL → CCL lowering: how comprehensions, lambdas, `def`s, and generators become CCL shapes, and the surface syntax of the deferred-collection operators. |
 | [optimization.md](optimization.md) | The optimization/compilation passes: inlining, lambda elimination, join/aggregate planning, algebraic simplification, and conversion to tile operators. |
 | [provenance.md](provenance.md) | How a node keeps its link to the source the user wrote across the whole pipeline: the `NodeId`/`Phase` identity primitives, the `ProvenanceTable` model and its fold, the recorder, the always-on lowering projection release diagnostics read, and what the inspector consumes. |
+| [diffing.md](diffing.md) | Program diffing: α-invariant content addressing of CCL terms and the GumTree correspondence between two compiled programs. |
 
 Provenance is the one cross-cutting concern in the table: every pass above both
 preserves node identity and records what it rewrote, so

--- a/src/ccl/design/diffing.md
+++ b/src/ccl/design/diffing.md
@@ -1,0 +1,608 @@
+# Program diffing — content addressing and correspondence
+
+For two compiled programs, this analysis decides which parts are **the same
+computation** and where they diverge. Running two versions concurrently with
+their storage and compute shared rests on it, as does a denotationally precise
+transition between them. Neither is built; the model they need is recorded
+below.
+
+Implemented by [`ccl/content_hash.rs`](../content_hash.rs) (the equivalence) and
+[`ccl/diff.rs`](../diff.rs) (the correspondence). Neither is wired into
+[`compile_program`](../context.rs) — the analysis is a library the versioning
+work will consume, not a pipeline pass.
+
+---
+
+## Why the diff is semantic, not operational
+
+Standard deployment treats a new version as opaque: old code stops, new code
+starts, state migration is ad hoc. Cambra programs are pure functions of
+time-indexed tilings ([mutability.md](mutability.md)), so both versions are
+denotations over the same time domain and the diff between them is tractable at
+the semantic level — it is *the set of points in the computation graph where the
+denotations diverge*.
+
+That buys three things:
+
+- **Sharing.** Unchanged parts of the computation have the same inputs and the
+  same code, so they can be one execution and one storage entry.
+- **Retroactive change.** A branch point in the past is expressible in the same
+  framework as one in the future; both are statements about which version's
+  denotation applies at which commit timestamps.
+- **Branching as the user story.** v1 and v2 are sibling branches of a shared
+  history: old clients stay on v1, new clients move to v2, v1 eventually drains.
+
+---
+
+## Content addressing modulo α
+
+The whole analysis rests on one primitive: a hash under which two subterms
+collide **iff** they are the same computation. `content_hash` assigns every
+subterm a 64-bit `ContentHash` such that two subterms hash equal iff they are
+structurally identical up to (a) consistent renaming of variables *bound within*
+the subterm and (b) the identity of variables *free* in it.
+
+### Why α-invariance is the problem
+
+Two independently compiled programs do not share their binders' identities.
+Before uniquification a source binder is a `Name::Raw` spelling, so the same
+source binder yields the same name in both versions — but after uniquification
+every binder carries a globally fresh `uid`, and identical code compares
+unequal. A hash meant to recognize "the same computation" across versions
+therefore cannot hash a bound variable by its name at all. It hashes it
+positionally:
+
+- a variable whose binder lies *inside* the subterm contributes its De Bruijn
+  index, which is invisible to α-renaming;
+- a variable *free* in the subterm contributes its stable **spelling**
+  (`Name::base`), which is what survives independent compilation.
+
+Lexical shadowing then falls out for free: a name resolves against the innermost
+enclosing binder, which is the one a reader would pick.
+
+The free-variable rule is crude: two distinct binders that share a spelling
+compare equal. It is isolated in one function (`hash_free_var`) so a finer
+cross-version binder correspondence can replace it without touching anything
+else.
+
+### Two hashes, two questions
+
+The free-variable rule is the one place the hash's meaning is a choice rather
+than a consequence of the term, and two different questions want two different
+answers.
+
+**Matching** asks *where else does this subterm appear?* — of two programs that
+do not share binder identities. That needs a **context-free** answer, so a
+subterm hashes the same wherever it sits: free variables go by **spelling**
+(`content_hash`). Everything the matcher does is built on this.
+
+**Classification** asks *is this the same computation?* — of two nodes already
+known to correspond. Spelling is both too strict and too loose for that. Too
+strict: renaming a binding is a denotational no-op, but every subterm mentioning
+it hashes differently, so `x = 1; x + 2` → `y = 1; y + 2` reports every mention
+changed even though the two roots hash equal. Too loose: two same-spelled
+variables bound to different things hash the same, so the hash has to be taken
+over the subterm together with its resolved bindings rather than over its AST
+text alone.
+
+So classification uses `resolved_hash`, which identifies a free variable by
+**which binder it resolves to**, taken up to the correspondence: each binder
+carries a *class* token shared by its counterpart in the other program, and a
+free variable hashes to its binder's class. A renamed binding is then invisible,
+and a same-spelled binding of something else is not confused with it. This
+presupposes a correspondence, which is why it classifies a matching rather than
+producing one.
+
+*What this is not.* Threading the binder chain from the root and using raw De
+Bruijn indices throughout looks equivalent and is not: inserting a binder
+*above* a subterm shifts the index of every reference that reaches past it, so
+adding one statement would report the entire tail below it as changed.
+Binder classes are stable under that, because they name the binder rather than
+the distance to it.
+
+*Direction of error.* Where the matching itself is suboptimal, resolved hashing
+reports change rather than sharing. Reordering two independent bindings, for
+instance, pairs the spine positionally, so the bindings genuinely do differ
+under the correspondence produced and the uses read as changed. That is the safe
+direction: over-reporting change costs a sharing opportunity, under-reporting it
+would make an unsound share.
+
+### Standalone hashing is the matcher's precondition
+
+Every subterm is hashed *standalone*: free variables are resolved against the
+empty environment, so a variable bound above the subterm counts as free. This is
+what lets a subterm match its twin in the other program regardless of how deeply
+each one sits — which is exactly what the top-down matcher needs.
+
+The cost is `O(𝑛 · depth)`, since each subterm's hash is recomputed with a fresh
+binder environment. That is comfortable for real programs even with their deep
+`let`-spine; the asymptotically tight scheme (Maziarz et al., *Hashing Modulo
+Alpha-Equivalence*, PLDI 2021 — `O(𝑛 log²𝑛)`) slots in behind the same interface
+if a program ever grows large enough to feel it.
+
+### The hash is type-aware
+
+A node's inferred type, its user annotation, its binders' types, and a `Cast`'s
+target all participate. Two terms differing only in a type are not the same
+computation — a change from `{Int | __elem >= 18}` to `{Int | __elem >= 21}` is
+a change to the program even though the term structure is untouched. Types are
+hashed with the same uid-robust discipline: refinement predicates (which are
+*terms* living in type positions) go back through the term hasher, `Fun`
+Pi-binder names are ignored, and a `ChanDom`'s channel name folds by spelling.
+
+A `Fun`'s `FunKind` participates. `A ⇒ B` and `A ⤇ B` are different
+computations — a data function's domain is its data, which is what drives
+iteration and forces its joins to be lossless — so the two must not collide. A
+`FunKind::Var` contributes what it was pinned to and not its `uid`, on the same
+grounds as `Infer`: the pin is determined by the one value that reaches the
+variable, the `uid` by allocation order.
+
+`Hole` and `Infer` hash to a bare tag. Before inference every type is `Hole`,
+and a resolved tree contains no `Infer`, so collapsing unresolved structure to
+one value is a safe fallback rather than a determinism hazard — the diff never
+runs mid-inference.
+
+### A rendered name is a hash the seam cannot reach
+
+Uid-robustness lives in exactly one place: a free variable is identified by
+`Name::base()`, never by its `uid`. That holds as long as a name is a `Name`.
+Once a pass renders one into a `String`, the hash sees an ordinary string and
+the seam no longer applies — nothing downstream can tell a run-varying identity
+from a user-written one.
+
+Loop planning is where this bites. The mutable variable record a `Transact`
+denotes is typed with `Name::field_key()` labels, and folding the binder uid in
+would type the node `{acc#9: ([0, 2] ⇒ Int)}` in one compilation and `{acc#19:
+…}` in the next, with `.acc#9` against `.acc#19` reading it — two compilations
+of the same source diffing as different, and every stage from planning down
+unusable.
+
+The label has no need of a uid. It must be distinct only among the keys of one
+mutable variable record: every consumer resolves it against a `keys_map` built
+per `Transact` node, so accumulators in sibling loops live in different records
+and cannot collide. `field_key` is therefore the plain spelling, and that
+distinctness holds by construction — a key is either the user's own variable
+name, distinct within its block, or a label planning mints indexed by position
+(`acc0`, `acc1`).
+
+The general rule this leaves: **a name rendered into a string is an identity the
+hash cannot normalize**, so a pass that needs a label should derive it from
+something already stable, and state where its uniqueness is enforced.
+
+### Order-insensitivity where the language is
+
+A record's fields and a `DisjointJoin`'s operands are sets, not sequences, so
+their child hashes are sorted before folding and a reorder is a no-op. Tuples,
+lists, `Compose` chains, and `Copair` operands are ordered and fold in position
+order. The differ mirrors this exactly: a record field swap is not reported as a
+move.
+
+`Copair` sits on the ordered side because operand position picks the coproduct
+tag: `a ++ b` has domain `A + B` and `b ++ a` has `B + A`, so the two are not the
+same computation. `DisjointJoin` is the join in the partial-function order, which
+is associative and commutative outright
+([ir.md](ir.md#copair-and-disjointjoin--two-collection-combining-operations-not-one)
+separates the two operations).
+
+### Scoping comes from one place
+
+`hash_rel` extends the binder environment over exactly the scoped children, and
+which children those are is not decided in `content_hash.rs`. It folds over
+[`ccl/scope.rs`](../scope.rs)'s `for_each_scoped_item`, the crate's single
+statement of CCL's binding structure, which the free-variable walkers
+(`ccl_utils`'s `count_free` / `count_free_in_value`, `subst`'s `collect_expr_fv`)
+and capture-avoiding substitution (`Subst::rewrite_expr`) fold over too. The
+sharing matters most for the hash: a divergence would be a **correctness bug**,
+not a style question, because the hash would stop agreeing with α-equivalence
+and the differ would silently report identical programs as different.
+
+`content_hash.rs` keeps the two things that are not scoping — a node's
+non-child payload (`hash_payload`, exhaustive so a new variant's payload must be
+declared) and the associative–commutative folding of `Record` / `DisjointJoin`,
+which is a property of their algebra.
+
+---
+
+## The correspondence: a GumTree matcher
+
+`diff` computes a node correspondence between two trees and classifies it. It is
+a GumTree-style matcher (Falleri et al., *Fine-grained and accurate source code
+differencing*, ASE 2014) run over the content hash, in five phases.
+
+**1. Top-down anchoring.** Map the largest subtrees whose content hash is equal.
+Equal hash means isomorphic modulo α, so the whole subtree is shared and its
+descendants are mapped along with it (paired by hash, not position, so the
+order-insensitive nodes come out right). Tallest-first, so a big anchor claims
+its descendants before anything inside it is considered separately.
+
+*Duplicate resolution.* Small subtrees always repeat — `0`, `true`, `x`. Every
+equal-hash pairing is an equally valid "shared" classification, but not an
+equally *useful* one: the copy chosen decides whether the node reads as sitting
+still or as having moved, and which siblings are left over for the later phases.
+Among free candidates the matcher takes the one in the most structurally
+corresponding position — parent already matched to this node's parent, then the
+longest agreeing chain of ancestor node kinds, then the closest depth. An
+arbitrary choice here manufactures a spurious move and a spurious delete/insert
+pair for the copy it displaced.
+
+**2. Root anchoring.** Two programs being diffed are two versions of one
+program, so their roots correspond by construction and are anchored to each
+other if phase 1 has not already done it. Nothing else can establish that: a
+root that gained a statement fails phase 3's similarity test (see below), and
+the result is that the entire program reads as deleted-and-reinserted for a
+one-statement edit. The anchor requires the two roots to be the same node kind,
+so two genuinely unrelated programs still correspond nowhere.
+
+**3. Bottom-up container recovery.** An interior node left unmatched is paired
+with the best same-kind candidate in the other tree that *contains* enough of
+its already-matched descendants, processed children-before-parents. This is what
+keeps an inserted statement from desynchronizing the whole `let`-spine below it:
+the unchanged tail anchors in phase 1, and the containers above it are recovered
+here instead of being reported as wholesale rewrites.
+
+*Containment and tightness are separate questions.* GumTree gates this on the
+Dice coefficient, `2·common / (|desc 𝑢| + |desc 𝑤|)`, which asks "how much of
+these two subtrees is shared" — and that is the wrong question when one side is
+the side that grew. A container that gained a statement has its own
+contribution swamped by the new material and scores below the threshold, so the
+very edit the phase exists to absorb is the one it rejects. The gate is
+therefore the **overlap coefficient**, `common / min(|desc 𝑢|, |desc 𝑤|)`: "is
+one of these essentially inside the other", which is exactly the insertion (and,
+symmetrically, the deletion) question. Dice stays as the *ranking* among
+candidates that pass — the candidates all contain the same matched descendants
+and so are nested in one another, and Dice's growing denominator picks the
+innermost, the container that fits tightest.
+
+**4. Optimal recovery inside a paired container.** Phases 1–3 match by
+whole-subtree equality and by container similarity; neither can pair two
+subtrees that are nearly identical but differ somewhere inside. That gap is what
+makes a one-token edit read as a delete plus an insert. This phase closes it: as
+each container pair is established, compute the minimum-cost edit mapping between the
+two subtrees and adopt every pair it aligns whose nodes are same-kind and still
+unmatched. Node labels are content hashes, so relabelling is free when the
+hashes agree and costs one otherwise. Pairs from phases 2 and 3 are the only
+ones that need this — a phase-1 pair is isomorphic by construction, so there is
+nothing left unmatched beneath it.
+
+The mapping is optimal under unit edit costs, computed with the Zhang–Shasha
+dynamic program. GumTree reaches for RTED, which computes the same optimal
+mapping faster by choosing a better decomposition strategy — the difference is
+asymptotic cost, not the result. Pairs above a size ceiling (100 nodes,
+GumTree's default) are skipped, since tree edit distance is `O(𝑛²𝑚²)` in the
+worst case; those keep only what phases 1–3 found.
+
+**5. Classification along two axes.** Every correspondence is labelled with
+whether its **content** changed and whether its **placement** did. These are
+independent: a node can keep its content and move, or stay put and change.
+
+- *Content* is just hash equality: `Same` (identical computation, reusable
+  wholesale) or `Changed` (the same place in both programs with different
+  content — the divergence lives in the children).
+- *Placement* is the child-alignment step from Chawathe et al.'s edit-script
+  derivation, which GumTree inherits. A node is `InPlace` iff it hangs off the
+  corresponding parent and did not cross any of its matched siblings. Within
+  one matched container pair, "did not cross" is decided by taking a longest
+  increasing subsequence of the matched children's destination slots: the
+  children on it kept their relative order, and the rest are the minimum set of
+  moves that explains the permutation. Order-insensitive containers skip the
+  test entirely.
+
+A source-only node is **deleted**; a target-only node is **new**. A relocated
+subtree is reported as moved once, at its root — its descendants stay in place
+relative to it.
+
+### The actionable form: divergences and shared roots
+
+The classification is complete but not minimal. Every *ancestor* of an edit has
+changed content, and every *descendant* of an inserted subtree is itself new —
+one literal edited at the bottom of a forty-binding spine leaves forty-two
+changed nodes, of which exactly one is the edit. A consumer that read `matched`
+directly would have to re-derive the interesting set every time, so the differ
+derives it once.
+
+**`divergences()`** is the minimal set of places the two programs disagree, at
+the granularity a version guard is placed. No divergence contains another,
+so the set partitions the disagreement: everything not under one corresponds.
+Three kinds —
+
+- *Changed* — both programs have a node here, its content differs, and nothing
+  below it differs. A changed node with a changed descendant is not a site: the
+  deeper node is the better explanation. Insertions and deletions do not
+  suppress it: a node whose own payload changed and which gained a child has
+  two separate things to say.
+- *Inserted* — the root of a subtree the new program has and the old does not.
+  Reported where the new region begins, not once per node in it. The walk
+  continues underneath: a matched node can sit inside a new region — a new
+  expression wrapping content that survived — and what diverges under it still
+  counts.
+- *Deleted* — the mirror image, at the root of what the old program had.
+
+**`shared_roots()`** is the other side: every node whose content is unchanged
+and whose parent's is not — the largest subtrees the two versions have in
+common, and so the units of reuse. A `Same` node's whole subtree is `Same`, so
+its descendants add nothing.
+
+Reuse here means *the term is the same term*, which is what a unified tree
+needs. It does not mean the term evaluates to the same value in both versions:
+`let x = 1 in x` and `let x = 2 in x` share the body `x`, and that is right —
+the two `let`s are the divergence, and it is the binding that differs, not the
+read. Value-level sharing is the key-level storage question, decided at
+runtime, not a property of the tree.
+
+### Reading a diff
+
+A [`Diff`](../diff.rs) renders itself: it prints as an annotated tree of the
+**new** program, followed by whatever the old program had that the new one
+dropped.
+
+```text
+2 shared · 1 changed · 1 moved · 0 deleted · 16 new
+
+~ let a = 1…
+  = 1
+  + let b = Sum(λ __iter_record → __iter_record ▷ [1, 2, 3] ▷ (λ i → i *…
+    + Sum(λ __iter_record → __iter_record ▷ [1, 2, 3] ▷ (λ i → i * 2))    (+12 nodes)
+    + a + b
+      = a »
+      + b
+```
+
+Markers are `=` unchanged, `~` content changed, `+` new, `-` deleted, and a
+trailing `»` for a node whose placement changed. Two rules keep it readable:
+an unchanged subtree is not descended into (it is unchanged all the way down),
+and a wholly-new or wholly-deleted region collapses to its root with a node
+count. A node that gained or lost only *itself* — a wrapper around content that
+survived — is not collapsed: above, the new `a + b` is shown with the reused
+`a` under it, because claiming that `a` changed would be false.
+
+Each node is shown by rendering its subterm with `symbolic` and keeping the
+first line, cut to a fixed width. A leaf prints exactly; an interior node prints
+its head. That costs `O(𝑛²)` text and is an inspection surface, not a hot path —
+but it means the rendering cannot drift out of step with the AST the way a
+second, shallow node vocabulary would.
+
+### Worked example
+
+`v = 5` followed by `1 if v > 0 else 2`, with the guard threshold edited to
+`1`, diffed at the lowered stage. The ternary lowers to a guard-based `Case`,
+so both trees contain a literal `1` (the then-branch value) and, in the new
+version, a second literal `1` (the guard threshold):
+
+```
+Changed/InPlace   let v = 5
+Same/InPlace      5      ->  5
+Changed/InPlace   { v > 0 → 1; true → 2 }  ->  { v > 1 → 1; true → 2 }
+Changed/InPlace   v > 0  ->  v > 1
+Same/InPlace      v      ->  v
+Changed/InPlace   0      ->  1
+Same/InPlace      1      ->  1
+Same/InPlace      true   ->  true
+Same/InPlace      2      ->  2
+```
+
+Nothing deleted, nothing new, nothing moved: one literal changed and the
+containers above it are marked as the places that changed with it. Both of the
+gap-closing phases are load-bearing here — duplicate resolution keeps the
+branch-body `1` matched to the branch-body `1` rather than to the new guard
+threshold, and optimal recovery pairs `0` with `1` instead of reporting a
+delete and an insert.
+
+---
+
+## Which stage to diff
+
+`compile_to(code, stage)` compiles to a nominated pipeline stage and hands back
+the tree. Every stage runs through one `diff` core — nothing in the matcher is
+stage-specific, because the content hash is uid-robust and type-aware, which is
+exactly what one core needs to handle all of them.
+
+| Stage | Tree | What it shows |
+| --- | --- | --- |
+| `Lowered` | `Raw` names, pre-uniquify, pre-inference; most types `Hole` | Closest to source, minimal diffs. Type sensitivity comes only from annotations and lowering-built types (cast refinements). |
+| `Inferred` | α-uniquified, every node carrying its resolved type | Everything above, plus type-level divergence the earlier stage cannot see. |
+| `Inlined` | inferred, then UDF-inlined | Everything above, with function boundaries erased — see "How much to normalize". |
+| `Channelized` | mutability eliminated: `LetRec` recurrences, feeds routed | The compiler's shape rather than the user's — `For`/`MutWrite`/`Begin`/`Defer` are gone. |
+| `LambdaElim` | point-free combinators | No binders in the term at all. |
+| `Planned` | recurrences on the `Transact` carrier, joins planned | The shape operator conversion consumes, and where compute sharing is decided. |
+
+A later stage carries signal the term structure alone does not: in `x = 1` /
+`(x, x)` versus `x = "a"` / `(x, x)` the bodies are structurally identical and
+hash equal before inference, and after inference the element type diverges so
+the same subterm no longer matches (`inference_adds_type_signal`).
+
+Pipeline positions between these six are not selectable. The transaction,
+mutability and channelization phases are one rewrite of the user's loops and
+feeds into `LetRec` recurrences; stopping partway through exposes a
+half-rewritten tree no consumer wants, so `Channelized` is the point at which
+that rewrite is complete. `LetRec` and `Transact` appear from there down, and a
+diff at those stages reports the compiler's shape rather than the user's.
+
+## How much to normalize
+
+Two programs can be the same computation written differently. The more of that
+the diff sees through, the more the two versions share — and the less
+localized the answer becomes when they genuinely differ. Choosing a stage is
+choosing where on that curve to sit; the compiler's own passes do the work, so
+there is no separate rewriting system to keep honest.
+
+Divergences reported, measured on the refactors that occur. The counts are
+measurements rather than invariants: `inlining_erases_function_boundaries` and
+`inlining_costs_locality_in_a_shared_helper` pin the direction of each contrast,
+not the numbers.
+
+| Edit | `Inferred` | `Inlined` |
+| --- | --- | --- |
+| rename a binding | 0 | 0 |
+| extract a subexpression into a `def` | 6 | **0** |
+| edit a body inside a `def` called once | 1 | 1 |
+| edit a body inside a `def` called **twice**, one specialization | 1 | **2** |
+| edit a body inside a `def` called **twice**, two specializations | **2** | 4 |
+| reorder two independent bindings | 2 | 2 |
+| extract a subexpression into a `let` | 5 | 5 |
+
+Inlining is a trade, not an improvement: it makes moving code across a function
+boundary invisible, and in exchange reports an edit inside a shared helper once
+per call site, because the body it changed now appears once per call site. It is
+the stage to pick when refactoring across function boundaries is the noise to
+remove.
+
+### `Inferred` has already spent some of that locality
+
+The two "called twice" rows are the *same edit to the same helper*, and they
+differ only in whether the two call sites share a specialization. That is the
+whole content of the second row's `Inferred` cell being 2 rather than 1:
+**monomorphization runs inside `infer`**, so a definition used at two distinct
+instantiation identities is already two clones before the differ sees it, and
+the edit is reported at both.
+
+Whether two uses share a specialization is decided by a
+[`SpecKey`](type-inference.md#keying-a-specialization), which is
+polarity-complete and therefore sees an argument's *lower-bound* refinements. A
+literal argument carries its singleton, so `g(1)` and `g(2)` key apart and split
+the helper; `g(a)` and `g(b)` for two computed `Int`s key together and do not.
+Inlining then costs one further duplication per call site on top of whatever
+monomorphization already did — 1 → 2 in the shared row, 2 → 4 in the split one.
+
+`Inferred` is therefore the earliest stage this differ offers, not a stage that
+has normalized nothing: the curve starts before its column.
+
+Below `Inlined` the trade continues — every pass that rewrites the user's shape
+spreads one edit over more of the tree. No test pins these counts either:
+
+| Edit | `Inlined` | `Channelized` | `LambdaElim` | `Planned` |
+| --- | --- | --- | --- | --- |
+| a literal | 1 | 1 | 1 | 1 |
+| a comprehension's filter threshold | 1 | 1 | 2 | 4 |
+| an accumulator loop's body | 2 (2 new) | 2 (2 new) | 2 (**14 new**) | 2 (14 new) |
+| a transactional register's write | 2 (2 new) | 2 (2 new) | 3 (8 new) | 3 (8 new) |
+
+So the default is the earliest stage that answers the question. The reason to
+reach past `Inlined` is not a better diff of the source — it is that `Planned`
+is the shape operator conversion consumes, so it is where a claim about *sharing
+compute* is actually a claim about the graph that runs. Diffing there answers a
+different question, not the same question better.
+
+### What is not normalized
+
+**Extracting a subexpression into a `let`.** `(a + 2) * (a + 2)` and
+`let t = a + 2 in t * t` have the same value and are not the same program
+here: naming a subexpression is how CCL says "compute this once". The two
+compile to different operator graphs — one shared node against two — so for a
+system that shares compute between versions this is a real change, and
+reporting it is correct. (Which is also why the `Inlined` stage stops at UDFs:
+`inline` beta-reduces *function* bindings, not value bindings.)
+
+**Commutativity.** `a + b` and `b + a` differ by one divergence. Normalizing
+them would need type direction, because `+` is string concatenation as well as
+addition and is not commutative there — so it is available only post-inference,
+for a rare edit, at the cost of making the hash type-conditional. Not worth it.
+
+**Constant folding, β/η reduction beyond UDF inlining.** Each widens the
+equivalence class and costs locality the same way inlining does. Nothing
+observed yet asks for them; the roadmap is driven by missed sharing that shows
+up in practice, not by completeness.
+
+### The one that needs more than a stage
+
+Reordering two independent bindings is a true no-op — CCL's `let` is
+non-recursive and pure, so the operator graph depends on the dependency DAG, not
+on the written order — and no stage fixes it, because the nesting is the order.
+See "Open threads".
+
+---
+
+## Beyond the analysis: branching
+
+The analysis stops at the classification. What gets built from it is running two
+versions with their common work shared, and upgrading one to the next without
+rewriting the history the old one produced. Three constraints follow.
+
+*The divergence frontier is the input.* `divergences()` says where a version
+guard goes; `shared_roots()` says what the two versions can compute once. That
+is why both are derived here rather than left to the consumer.
+
+*A guard needs a clock, and the domain says whether there is one.* A divergence
+inside a domain that is both ordered and event-anchored (`Txn`, a live source)
+can be guarded; one inside a batch region — literal data, a finite loop — cannot,
+because there is no position at which its answer changes. Neither property is
+carried in the type today, so this is an approximation read off the domain of
+the enclosing function rather than something checkable.
+
+*A branch needs no new node.* It is an ordinary `Case` on the sequencing
+domain, so nothing in the diff's output has to be a construct the rest of the
+pipeline does not already understand.
+
+### The next analysis: divergence reachability
+
+Running two versions side by side means giving each its own copy of any state
+they could disagree about, and of no other state. The question is per mutable
+variable and per sink: **is any divergence upstream of it in the dataflow
+graph?** If none is, the two versions provably write it identically and it needs
+one store; if one is, it needs a store per version (or copy-on-write, where the
+values happen to agree anyway — a runtime concern, not this one).
+
+It is a reachability query over `divergences()` rather than new matching work,
+and it is what makes a second version cost the diff rather than 2×. Not built.
+
+---
+
+## Open threads
+
+**Substitution's transport mode still restates the scoping rules.**
+[`ccl/scope.rs`](../scope.rs) now holds them once and every *observing* walk
+folds over it, but `subst`'s `Subst::apply_expr_inner` — the mode that returns a
+rewritten copy rather than mutating in place — cannot: it rebuilds each node,
+and a rebuild is a per-variant `match` by construction. Folding it over the
+shared walk would mean cloning the whole subtree at every binding node (clone
+the node, then overwrite its children), which turns substitution down a `let`
+spine from linear into quadratic in the spine's depth — the one shape Cambra
+programs are reliably deep in. Its arms are guarded only by review; if a binding
+form is ever added, `scope.rs` is the compile error that should prompt a look
+here.
+
+**Child enumeration is written out twice.** `diff`'s `child_exprs` mirrors
+`TypedExpr::walk_children` arm for arm, differing only in that it descends into
+a `Cast` target's refinement predicate (a load-bearing term that
+`walk_children` treats as a type child). Both matches are exhaustive, so a new
+node variant is a compile error in both places — the duplication is visible
+rather than silent, which is why it stands.
+
+**A `let`-spine encodes an order it does not have.** A run of independent
+bindings is a dependency DAG, but CCL spells it as nested `Let`s, so reordering
+two of them changes the tree shape and the matcher pairs the spine by depth.
+The reads underneath then resolve to non-corresponding binders and report as
+changed — conservative, but noise (two divergences for two reordered bindings).
+**Decided: leave it.**
+
+*It is not a matcher-tuning problem.* Three plausible fixes were tried and
+measured, and none moved the reordering case:
+
+- running bottom-up container recovery *before* the root edit-distance step, so
+  a content-aware phase gets first refusal on container pairings — made it
+  worse (three reordered bindings went from two divergences to three);
+- ranking candidates by how many of their children are already matched to each
+  other — byte-identical results on every case in the corpus;
+- a rule that a `Let`'s identity is its *binding* rather than its body, pairing
+  each `Let` with the one whose bound expression its own matched — no change to
+  reordering, and worse on three bindings.
+
+The consistency is the finding: the nesting is the order, so no amount of
+matcher tuning recovers what the representation does not distinguish.
+
+*The two real options both cost more than the noise.* A canonical pre-diff
+reordering needs a sort key stable under ordinary edits, and neither candidate
+is: sorting by content hash is chaotic — editing one literal permutes the spine,
+trading reorder noise for value-edit noise, which is far more common — and
+sorting by binder spelling is stable under value edits but makes a rename that
+crosses another binding alphabetically produce exactly the noise being removed.
+Either way it moves noise rather than removing it. The other option is to stop
+spelling a binding group as a nest: an n-ary group node would make the order
+disappear at the source and give `Record`-style order-insensitivity for free,
+but it is a new concept threaded through parse, lowering, inference and every
+pass. That cost is only worth paying if something other than diffing wants it
+too — which is the trigger to revisit this.
+
+**The free-variable seam is crude.** Two distinct binders sharing a spelling
+compare equal. A real cross-version binder correspondence — matching v1's binder
+to v2's by position in the correspondence being computed — is circular with the
+matcher and needs thought.

--- a/src/ccl/design/diffing.md
+++ b/src/ccl/design/diffing.md
@@ -13,6 +13,66 @@ work will consume, not a pipeline pass.
 
 ---
 
+## Inputs, output, and what holds of it
+
+**In**: two [`TypedExpr`](../expr.rs) trees, each a whole program compiled to the
+same [`Phase`](../context.rs). They are taken to be two versions of one program;
+nothing requires that, and unrelated programs share little.
+
+**Out**: a [`Diff`](../diff.rs) — a correspondence between the two trees' nodes,
+each pair classified on content and on placement, plus the nodes of each side
+left unpaired. Two derived forms are what a consumer reads: `divergences()`, the
+places the two programs disagree, and `shared_roots()`, the largest subtrees they
+compute the same way.
+
+What holds of the output, and the test that holds it:
+
+| | Held by |
+| --- | --- |
+| Two compilations of one source diff as identical, at every phase | `every_stage_diffs_identical_source_as_identical` |
+| Identical trees have no divergences, and one shared root: the program | `identical_programs_have_no_divergences` |
+| An identity that varies between compilations (a `Name` uid) never reaches the result | `diff_is_robust_to_uid_nondeterminism` |
+| Renaming a binding is not a change | `renaming_a_binding_is_not_a_change` |
+| One edit is one divergence, however deep in the `let` spine it sits | `one_edit_is_one_divergence` |
+| Shared roots are pairwise disjoint, each the top of its region | `shared_roots_are_maximal_and_disjoint` |
+| Two terms differing only in an inferred type hash apart | `inference_adds_type_signal` |
+
+Two properties are absent, and stated as absent rather than approximated.
+`divergences()` is not minimal: it is small on the shapes the tests measure, and
+the two reduction rules are not a minimality theorem
+([The actionable form](#the-actionable-form-divergences-and-shared-roots)).
+Sharing is not maximal: where the matching is suboptimal the result reports
+change, which costs a sharing opportunity rather than producing an unsound share
+([Direction of error](#direction-of-error)).
+
+---
+
+## Diffing at a glance
+
+Two compiled trees in, a classified node correspondence out, in four steps.
+
+1. **Hash every subterm by content, modulo α** (`content_hash`). A variable free
+   in the subterm is identified by its spelling, so a subterm hashes the same
+   wherever it sits and in whichever program.
+2. **Match the two trees on those hashes**, GumTree-style: anchor equal-hash
+   subtrees largest-first, anchor the two roots to each other, recover the
+   containers above an anchor by how much of it they hold, then close the
+   remaining gaps inside a paired container with tree edit distance.
+3. **Re-hash every matched node against the correspondence.** `resolved_hash`
+   identifies a free variable by which binder it resolves to, so a binding
+   renamed between versions is invisible; `own_hash` takes what is authored at
+   the node alone, which separates "this node changed" from "something under it
+   did".
+4. **Classify** each correspondence on two axes, content and placement, and
+   reduce the result to `divergences()` — where the two programs disagree — and
+   `shared_roots()` — what they can compute once.
+
+The order is fixed: step 2 has no correspondence to resolve names through, and
+step 3 exists only because step 2 produced one. Matching never consults a
+classification.
+
+---
+
 ## Why the diff is semantic, not operational
 
 Standard deployment treats a new version as opaque: old code stops, new code
@@ -26,11 +86,17 @@ That buys three things:
 
 - **Sharing.** Unchanged parts of the computation have the same inputs and the
   same code, so they can be one execution and one storage entry.
-- **Retroactive change.** A branch point in the past is expressible in the same
-  framework as one in the future; both are statements about which version's
-  denotation applies at which commit timestamps.
-- **Branching as the user story.** v1 and v2 are sibling branches of a shared
-  history: old clients stay on v1, new clients move to v2, v1 eventually drains.
+- **A version's extent is a predicate over commit positions**, and the predicate
+  is not required to start at the present one. Applying v2 from a commit
+  timestamp already in the past is the same statement as applying it from a
+  future one, so a correction to history and a forward deployment are one
+  mechanism.
+- **Two versions run at once**, over overlapping ranges of the commit domain:
+  clients holding v1 keep being answered by v1 while new clients are answered by
+  v2, until nothing selects v1 any more. There is no branch *structure* — no
+  parent version, no ordering between v1 and v2 beyond the predicates each one
+  carries — so which version was written first says nothing about which applies
+  where.
 
 ---
 
@@ -46,9 +112,10 @@ the subterm and (b) the identity of variables *free* in it.
 
 Two independently compiled programs do not share their binders' identities.
 Before uniquification a source binder is a `Name::Raw` spelling, so the same
-source binder yields the same name in both versions — but after uniquification
-every binder carries a globally fresh `uid`, and identical code compares
-unequal. A hash meant to recognize "the same computation" across versions
+source binder yields the same name in both versions. After uniquification every
+binder carries a globally fresh **`uid`**, allocated in traversal order, so the
+same source binder gets a different one in each compilation and identical code
+compares unequal. A hash meant to recognize "the same computation" across versions
 therefore cannot hash a bound variable by its name at all. It hashes it
 positionally:
 
@@ -60,16 +127,33 @@ positionally:
 Lexical shadowing then falls out for free: a name resolves against the innermost
 enclosing binder, which is the one a reader would pick.
 
-The free-variable rule is crude: two distinct binders that share a spelling
-compare equal. It is isolated in one function (`hash_free_var`) so a finer
-cross-version binder correspondence can replace it without touching anything
-else.
+Under this rule a rename is a change: `x = 1; x + 2` → `y = 1; y + 2` hashes
+every mention of the binding differently, even though the two programs denote
+the same thing. That is correct for the matcher, which is looking for a
+subterm's twin and has no correspondence to consult, and wrong for the
+classifier, which does — hence the second hash below. Reordering two independent
+bindings is a separate problem, in the representation rather than the hash; see
+[Open threads](#open-threads).
 
-### Two hashes, two questions
+The free-variable rule is also crude in the other direction: two distinct
+binders that share a spelling compare equal. It is isolated in one function
+(`hash_free_var`) so a finer cross-version binder correspondence can replace it
+without touching anything else.
 
-The free-variable rule is the one place the hash's meaning is a choice rather
-than a consequence of the term, and two different questions want two different
-answers.
+### Three hashes, three questions
+
+Three questions come up, and each wants a different answer to "what is this
+node's identity". Everything else about the fold — the traversal, the De Bruijn
+treatment of bound variables, the type-awareness, the order-insensitivity — is
+shared, so the table below is the whole difference between them.
+
+| | `content_hash` | `resolved_hash` | `own_hash` |
+| --- | --- | --- | --- |
+| Question | where else does this subterm appear? | is this the same computation? | did *this node* change? |
+| Used by | matching (phases 1–4) | classification (phase 5) | classification (phase 5) |
+| A **free variable** identified by | its spelling (`Name::base`) | the binder it resolves to | the binder it resolves to |
+| The node's **children** | fold in | fold in | left out |
+| Needs a correspondence | no | yes | yes |
 
 **Matching** asks *where else does this subterm appear?* — of two programs that
 do not share binder identities. That needs a **context-free** answer, so a
@@ -78,45 +162,75 @@ subterm hashes the same wherever it sits: free variables go by **spelling**
 
 **Classification** asks *is this the same computation?* — of two nodes already
 known to correspond. Spelling is both too strict and too loose for that. Too
-strict: renaming a binding is a denotational no-op, but every subterm mentioning
-it hashes differently, so `x = 1; x + 2` → `y = 1; y + 2` reports every mention
-changed even though the two roots hash equal. Too loose: two same-spelled
-variables bound to different things hash the same, so the hash has to be taken
-over the subterm together with its resolved bindings rather than over its AST
-text alone.
+strict: a rename hashes every mention differently, as above. Too loose: two
+same-spelled variables bound to different things hash the same, so the hash has
+to be taken over the subterm together with its resolved bindings rather than
+over its AST text alone.
 
 So classification uses `resolved_hash`, which identifies a free variable by
-**which binder it resolves to**, taken up to the correspondence: each binder
-carries a *class* token shared by its counterpart in the other program, and a
-free variable hashes to its binder's class. A renamed binding is then invisible,
-and a same-spelled binding of something else is not confused with it. This
-presupposes a correspondence, which is why it classifies a matching rather than
-producing one.
+**which binder it resolves to**, taken up to the correspondence. Each binder
+carries a **correspondent**: a 64-bit token naming the binder it corresponds to
+in the other program, minted from the correspondence itself. A src binder's is
+the index of the dst node its owner matched; an unmatched binder gets a token
+outside dst's index range, so it corresponds to nothing and can never look like a
+match. A free variable hashes to the correspondent of the binder it resolves to.
+A renamed binding is then invisible, and a same-spelled binding of something else
+is not confused with it. A node introducing several binders at once — a `LetRec`
+group — gives each its own correspondent, keyed by position within the group,
+since they are distinct binders.
 
-*What this is not.* Threading the binder chain from the root and using raw De
-Bruijn indices throughout looks equivalent and is not: inserting a binder
-*above* a subterm shifts the index of every reference that reaches past it, so
-adding one statement would report the entire tail below it as changed.
-Binder classes are stable under that, because they name the binder rather than
-the distance to it.
+**Localizing** asks *did this node change, or only something under it?* — of a
+node already known to differ. `own_hash` answers it by folding what is authored
+at the node and stopping there: its discriminant, its literal value, operator,
+variant tag, binder annotation or record labels, and the correspondents its
+variable occurrences resolve to.
 
-*Direction of error.* Where the matching itself is suboptimal, resolved hashing
-reports change rather than sharing. Reordering two independent bindings, for
-instance, pairs the spine positionally, so the bindings genuinely do differ
-under the correspondence produced and the uses read as changed. That is the safe
-direction: over-reporting change costs a sharing opportunity, under-reporting it
-would make an unsound share.
+Derivedness, not child-ness, is the boundary, and three things fall outside it.
+The children, which is the point. The node's inferred `ty`, computed from the
+node and its children — folding it would report `let a = 1` → `let a = 2` at the
+`Let` as well as at the literal, since the `Let`'s type is the literal's
+singleton. And a binder's declared `ty`, on the same ground. A reader who takes
+the boundary to be children alone gets the two type exclusions wrong, and those
+are where the design decision sits.
+
+A container therefore has close to no own content. A `Let`'s is its discriminant
+plus two `user_annotation`s — the binder's name is De Bruijn and its type is
+skipped — so `let a = 1 in a`, `let a = 2 in a`, `let b = 1 in b` and
+`let a = 1 + 5 in a` all share one own hash at the `Let`, and only an annotation
+moves it. A container is never a disagreement site on its own, which is what
+puts the site on the literal that changed.
+
+*What a correspondent is not.* Threading the binder chain from the root and
+using raw De Bruijn indices throughout looks equivalent and is not: inserting a
+binder above a subterm shifts the index of every reference that reaches past it,
+so adding one statement would report the entire tail below it as changed. A
+correspondent is stable under that, because it names the binder rather than the
+distance to it.
+
+#### Direction of error
+
+Where the matching itself is suboptimal, resolved hashing reports change rather
+than sharing. Reordering two independent bindings, for instance, pairs the `let`
+**spine** — the chain of nested `Let` nodes a run of statements lowers to —
+positionally, so the bindings genuinely do differ under the correspondence
+produced and the uses read as changed. That is the safe direction:
+over-reporting change costs a sharing opportunity, under-reporting it makes an
+unsound share.
 
 ### Standalone hashing is the matcher's precondition
 
-Every subterm is hashed *standalone*: free variables are resolved against the
+Every node of the tree gets a hash, and each one is computed over that node's
+whole subterm: a node's hash folds its children's, so the root's hash covers the
+program. `hash_all` walks the tree once and returns the map.
+
+Each of those hashes is *standalone*: free variables are resolved against the
 empty environment, so a variable bound above the subterm counts as free. This is
 what lets a subterm match its twin in the other program regardless of how deeply
 each one sits — which is exactly what the top-down matcher needs.
 
 The cost is `O(𝑛 · depth)`, since each subterm's hash is recomputed with a fresh
 binder environment. That is comfortable for real programs even with their deep
-`let`-spine; the asymptotically tight scheme (Maziarz et al., *Hashing Modulo
+`let` spine; the asymptotically tight scheme (Maziarz et al., *Hashing Modulo
 Alpha-Equivalence*, PLDI 2021 — `O(𝑛 log²𝑛)`) slots in behind the same interface
 if a program ever grows large enough to feel it.
 
@@ -125,10 +239,21 @@ if a program ever grows large enough to feel it.
 A node's inferred type, its user annotation, its binders' types, and a `Cast`'s
 target all participate. Two terms differing only in a type are not the same
 computation — a change from `{Int | __elem >= 18}` to `{Int | __elem >= 21}` is
-a change to the program even though the term structure is untouched. Types are
-hashed with the same uid-robust discipline: refinement predicates (which are
-*terms* living in type positions) go back through the term hasher, `Fun`
-Pi-binder names are ignored, and a `ChanDom`'s channel name folds by spelling.
+a change to the program even though the term structure is untouched.
+
+This section describes `content_hash` and `resolved_hash`, which agree on all of
+it. `own_hash` keeps the user annotation and drops the rest: a node's `ty`
+and a binder's `ty` because both are derived from the node and its children,
+and a `Cast`'s target because the differ reaches that target's refinement
+predicate as a *child* of the cast — the one place `diff`'s child enumeration
+departs from `TypedExpr::walk_children` — so folding it here too would report one
+threshold edit at the literal and again at the cast above it.
+
+Types are hashed with the same **uid-robust** discipline as terms: no identity
+that varies between two compilations of one source reaches the hash. Refinement
+predicates (which are *terms* living in type positions) go back through the term
+hasher, `Fun` Pi-binder names are ignored, and a `ChanDom`'s channel name
+contributes its spelling rather than its `Name`.
 
 A `Fun`'s `FunKind` participates. `A ⇒ B` and `A ⤇ B` are different
 computations — a data function's domain is its data, which is what drives
@@ -142,13 +267,13 @@ and a resolved tree contains no `Infer`, so collapsing unresolved structure to
 one value is a safe fallback rather than a determinism hazard — the diff never
 runs mid-inference.
 
-### A rendered name is a hash the seam cannot reach
+### A name rendered into a string is past the point uid-robustness applies
 
-Uid-robustness lives in exactly one place: a free variable is identified by
-`Name::base()`, never by its `uid`. That holds as long as a name is a `Name`.
-Once a pass renders one into a `String`, the hash sees an ordinary string and
-the seam no longer applies — nothing downstream can tell a run-varying identity
-from a user-written one.
+Uid-robustness is enforced in exactly one place: a free variable is identified by
+`Name::base()`, never by its `uid`. That works only while the name is still a
+`Name`. Once a pass renders one into a `String` — a record label, a key — the
+hash sees an ordinary string, and nothing downstream can tell a run-varying
+identity from a user-written one.
 
 Loop planning is where this bites. The mutable variable record a `Transact`
 denotes is typed with `Name::field_key()` labels, and folding the binder uid in
@@ -160,22 +285,31 @@ unusable.
 The label has no need of a uid. It must be distinct only among the keys of one
 mutable variable record: every consumer resolves it against a `keys_map` built
 per `Transact` node, so accumulators in sibling loops live in different records
-and cannot collide. `field_key` is therefore the plain spelling, and that
-distinctness holds by construction — a key is either the user's own variable
-name, distinct within its block, or a label planning mints indexed by position
-(`acc0`, `acc1`).
+and cannot collide. `field_key` is therefore the plain spelling. That leaves the
+distinctness as a property of spellings rather than of construction — a key is
+the user's own variable name, distinct within its block; a label planning mints
+indexed by position (`acc0`, `acc1`); or a writer's reply tap (`to_<base>_<n>`),
+which shares the record with both — so each site that builds a record from these
+labels asserts it in debug (`hist_record` in `planning/loops.rs`, the two
+`keys_map` inserts in `interpreter/operator_conversion.rs`).
 
 The general rule this leaves: **a name rendered into a string is an identity the
-hash cannot normalize**, so a pass that needs a label should derive it from
-something already stable, and state where its uniqueness is enforced.
+hash cannot normalize**, so a pass that needs a label derives it from something
+already stable and states where its uniqueness is enforced.
 
 ### Order-insensitivity where the language is
 
-A record's fields and a `DisjointJoin`'s operands are sets, not sequences, so
-their child hashes are sorted before folding and a reorder is a no-op. Tuples,
-lists, `Compose` chains, and `Copair` operands are ordered and fold in position
-order. The differ mirrors this exactly: a record field swap is not reported as a
-move.
+A record's fields, a `DisjointJoin`'s operands and a refined type's
+[`RefinementSet`](../ty.rs) are sets, not sequences, so their child hashes are
+sorted before folding and a reorder is a no-op. Tuples, lists, `Compose` chains,
+and `Copair` operands are ordered and fold in position order. The differ mirrors
+this exactly: a record field swap is not reported as a move.
+
+A refinement set is where the mirroring takes work rather than falling out. The
+differ descends into a cast target's predicates as children of the cast, and
+children are paired by position, so the enumeration is sorted by `content_hash`
+(`cast_target_predicates`) — the set's physical order is meaningless by contract,
+and `CAMBRA_REFINEMENT_ORDER=reverse` flips it globally to prove that.
 
 `Copair` sits on the ordered side because operand position picks the coproduct
 tag: `a ++ b` has domain `A + B` and `b ++ a` has `B + A`, so the two are not the
@@ -187,14 +321,15 @@ separates the two operations).
 ### Scoping comes from one place
 
 `hash_rel` extends the binder environment over exactly the scoped children, and
-which children those are is not decided in `content_hash.rs`. It folds over
+which children those are is not decided in `content_hash.rs`. It reads them from
 [`ccl/scope.rs`](../scope.rs)'s `for_each_scoped_item`, the crate's single
 statement of CCL's binding structure, which the free-variable walkers
 (`ccl_utils`'s `count_free` / `count_free_in_value`, `subst`'s `collect_expr_fv`)
-and capture-avoiding substitution (`Subst::rewrite_expr`) fold over too. The
-sharing matters most for the hash: a divergence would be a **correctness bug**,
-not a style question, because the hash would stop agreeing with α-equivalence
-and the differ would silently report identical programs as different.
+and capture-avoiding substitution (`Subst::rewrite_expr`) read from too. A
+divergence between the hash's idea of the binding structure and the language's
+would be a **correctness bug** rather than a style question: the hash would stop
+agreeing with α-equivalence, and the differ would report identical programs as
+different.
 
 `content_hash.rs` keeps the two things that are not scoping — a node's
 non-child payload (`hash_payload`, exhaustive so a new variant's payload must be
@@ -209,11 +344,26 @@ which is a property of their algebra.
 a GumTree-style matcher (Falleri et al., *Fine-grained and accurate source code
 differencing*, ASE 2014) run over the content hash, in five phases.
 
+Two words recur below and mean different things. A **subtree** is a node
+together with everything under it. A **container** is a node considered as the
+thing that holds other nodes — the word is used where the point is what a node
+contains rather than what it is, and every container is the root of a subtree.
+
 **1. Top-down anchoring.** Map the largest subtrees whose content hash is equal.
-Equal hash means isomorphic modulo α, so the whole subtree is shared and its
-descendants are mapped along with it (paired by hash, not position, so the
-order-insensitive nodes come out right). Tallest-first, so a big anchor claims
-its descendants before anything inside it is considered separately.
+Equal hash means isomorphic modulo α, so a single hash comparison at the root
+settles the whole subtree: the two are the same computation node for node, and
+the matcher maps the descendants along with it in one pass without comparing
+them again. Tallest-first, so a big anchor claims its descendants before
+anything inside it is considered separately.
+
+Equal hash does not fix child order. The hash canonicalizes the nodes whose
+order carries nothing — a `Record`'s fields fold sorted by label, a
+`DisjointJoin`'s operands and a refinement set's members fold by sorted child
+hash — so two subtrees can hash equal while holding the same children in
+different physical positions. The descent within an anchor therefore pairs each
+child with an equal-hash child still free on the other side (`map_isomorphic`),
+not with the child at the same index, which would pair a record's field `a`
+against its field `b`.
 
 *Duplicate resolution.* Small subtrees always repeat — `0`, `true`, `x`. Every
 equal-hash pairing is an equally valid "shared" classification, but not an
@@ -236,7 +386,7 @@ so two genuinely unrelated programs still correspond nowhere.
 **3. Bottom-up container recovery.** An interior node left unmatched is paired
 with the best same-kind candidate in the other tree that *contains* enough of
 its already-matched descendants, processed children-before-parents. This is what
-keeps an inserted statement from desynchronizing the whole `let`-spine below it:
+keeps an inserted statement from desynchronizing the whole `let` spine below it:
 the unchanged tail anchors in phase 1, and the containers above it are recovered
 here instead of being reported as wholesale rewrites.
 
@@ -257,35 +407,50 @@ innermost, the container that fits tightest.
 whole-subtree equality and by container similarity; neither can pair two
 subtrees that are nearly identical but differ somewhere inside. That gap is what
 makes a one-token edit read as a delete plus an insert. This phase closes it: as
-each container pair is established, compute the minimum-cost edit mapping between the
-two subtrees and adopt every pair it aligns whose nodes are same-kind and still
-unmatched. Node labels are content hashes, so relabelling is free when the
-hashes agree and costs one otherwise. Pairs from phases 2 and 3 are the only
-ones that need this — a phase-1 pair is isomorphic by construction, so there is
-nothing left unmatched beneath it.
+each container pair is established, compute the **tree** edit distance between
+the two subtrees — Zhang–Shasha, the tree analogue of Levenshtein, over trees
+rather than strings — and adopt every pair its minimum-cost script aligns whose
+nodes are same-kind and still unmatched. The **label** the distance compares at
+each node is that node's content hash, so relabelling is free when the hashes
+agree and costs one otherwise, alongside unit costs for deleting and inserting a
+node. Pairs from phases 2 and 3 are the only ones that need this — a phase-1
+pair is isomorphic by construction, so there is nothing left unmatched beneath
+it.
 
-The mapping is optimal under unit edit costs, computed with the Zhang–Shasha
-dynamic program. GumTree reaches for RTED, which computes the same optimal
-mapping faster by choosing a better decomposition strategy — the difference is
-asymptotic cost, not the result. Pairs above a size ceiling (100 nodes,
-GumTree's default) are skipped, since tree edit distance is `O(𝑛²𝑚²)` in the
-worst case; those keep only what phases 1–3 found.
+GumTree reaches for RTED, which computes the same optimal mapping faster by
+choosing a better decomposition strategy — the difference is asymptotic cost,
+not the result. Recovery declines when either subtree holds more than 100 nodes
+(GumTree's default), since tree edit distance is `O(𝑛²𝑚²)` in the worst case;
+those pairs keep only what phases 1–3 found, and their still-unmatched interiors
+are reported as deleted and new rather than aligned.
 
 **5. Classification along two axes.** Every correspondence is labelled with
 whether its **content** changed and whether its **placement** did. These are
 independent: a node can keep its content and move, or stay put and change.
 
-- *Content* is just hash equality: `Same` (identical computation, reusable
-  wholesale) or `Changed` (the same place in both programs with different
-  content — the divergence lives in the children).
-- *Placement* is the child-alignment step from Chawathe et al.'s edit-script
-  derivation, which GumTree inherits. A node is `InPlace` iff it hangs off the
-  corresponding parent and did not cross any of its matched siblings. Within
-  one matched container pair, "did not cross" is decided by taking a longest
-  increasing subsequence of the matched children's destination slots: the
-  children on it kept their relative order, and the rest are the minimum set of
-  moves that explains the permutation. Order-insensitive containers skip the
-  test entirely.
+*Content* compares two hashes, giving three outcomes:
+
+| `resolved_hash` | `own_hash` | | |
+| --- | --- | --- | --- |
+| equal | equal | `Same` | identical computation, reusable wholesale |
+| differs | equal | `ChangedBelow` | the node's own content is intact; what differs is under it |
+| differs | differs | `Changed` | the node itself differs, whatever its children did |
+
+*Placement* is the child-alignment step from Chawathe et al.'s edit-script
+derivation, which GumTree inherits. A node is `InPlace` iff it hangs off the
+corresponding parent and kept its order relative to its matched siblings.
+Order-insensitive containers skip the test.
+
+Ordering is decided per matched container pair. Number the container's matched
+children by where their counterparts sit under the corresponding container in
+the other tree — a child's **destination position**. Taking the children in
+source order gives a sequence of destination positions, and a *longest
+increasing subsequence* of it is the largest set of children whose relative
+order both versions agree on. Those are `InPlace`; every child left off it is
+`Moved`, and the set left off is minimal, so the classification names the fewest
+moves that account for the permutation. Two children **cross** when one precedes
+the other in the source container and follows it in the destination; a
+crossing is what forces at least one of the pair off the subsequence.
 
 A source-only node is **deleted**; a target-only node is **new**. A relocated
 subtree is reported as moved once, at its root — its descendants stay in place
@@ -293,29 +458,42 @@ relative to it.
 
 ### The actionable form: divergences and shared roots
 
-The classification is complete but not minimal. Every *ancestor* of an edit has
-changed content, and every *descendant* of an inserted subtree is itself new —
-one literal edited at the bottom of a forty-binding spine leaves forty-two
-changed nodes, of which exactly one is the edit. A consumer that read `matched`
-directly would have to re-derive the interesting set every time, so the differ
-derives it once.
+The classification is complete but says the same thing many times. `Diff::matched`
+holds every node correspondence and `deleted` / `new` hold the unmatched nodes of each side, so
+every *ancestor* of an edit is in `matched` with changed content and every
+*descendant* of an inserted subtree is in `new` — one literal edited at the
+bottom of a forty-binding spine leaves forty-two changed correspondences, of
+which exactly one is the edit. A consumer reading `matched` directly would have
+to re-derive the interesting set every time, so the differ derives it once.
 
-**`divergences()`** is the minimal set of places the two programs disagree, at
-the granularity a version guard is placed. No divergence contains another,
-so the set partitions the disagreement: everything not under one corresponds.
-Three kinds —
+**`divergences()`** is the set of places the two programs disagree, at the
+granularity a version guard is placed. Three kinds —
 
-- *Changed* — both programs have a node here, its content differs, and nothing
-  below it differs. A changed node with a changed descendant is not a site: the
-  deeper node is the better explanation. Insertions and deletions do not
-  suppress it: a node whose own payload changed and which gained a child has
-  two separate things to say.
+- *Changed* — both programs have a node here and it is the node that changed.
+  Reported when the node's own content differs (`Content::Changed`), and also
+  when only its subtree differs (`Content::ChangedBelow`) and nothing under it
+  was reported — a reordering of unchanged children, or a type resolved from
+  outside the subtree, has nowhere deeper to point.
 - *Inserted* — the root of a subtree the new program has and the old does not.
   Reported where the new region begins, not once per node in it. The walk
   continues underneath: a matched node can sit inside a new region — a new
   expression wrapping content that survived — and what diverges under it still
   counts.
 - *Deleted* — the mirror image, at the root of what the old program had.
+
+Those two rules cut the set in each direction, and neither is a minimality
+theorem: the result is small on the shapes the tests measure, not provably
+smallest. A node whose own content is intact is not reported beside the child
+that explains it, so a container that only gained a statement yields one site,
+the insertion, rather than two. A node whose own content changed is reported
+even when a child changed too, so a record that relabelled one field and edited
+another yields both. Suppressing the second would be the unsound direction: a
+real change left with no site, hidden behind the one below it.
+
+Each kind is reported at its own root, so no two divergences of the same kind
+nest. Across kinds they can: a `Changed` may sit inside an `Inserted` or a
+`Deleted`, because the walk descends under a new region to find what survived
+inside it. A consumer placing one guard per divergence gets nested guards there.
 
 **`shared_roots()`** is the other side: every node whose content is unchanged
 and whose parent's is not — the largest subtrees the two versions have in
@@ -326,14 +504,26 @@ Reuse here means *the term is the same term*, which is what a unified tree
 needs. It does not mean the term evaluates to the same value in both versions:
 `let x = 1 in x` and `let x = 2 in x` share the body `x`, and that is right —
 the two `let`s are the divergence, and it is the binding that differs, not the
-read. Value-level sharing is the key-level storage question, decided at
-runtime, not a property of the tree.
+read. Whether the two versions' *values* can share one storage entry is decided
+per store key at runtime, by comparing what each version wrote; nothing in the
+tree answers it. See
+[The next analysis: divergence reachability](#the-next-analysis-divergence-reachability).
 
 ### Reading a diff
 
-A [`Diff`](../diff.rs) renders itself: it prints as an annotated tree of the
-**new** program, followed by whatever the old program had that the new one
-dropped.
+A [`Diff`](../diff.rs) renders itself as an annotated tree of the **new**
+program, followed by whatever the old program had that the new one dropped.
+
+Take these two versions:
+
+```
+# v1                      # v2
+a = 1                     a = 1
+a                         b = sum([i * 2 for i in [1,2,3]])
+                          a + b
+```
+
+Diffed at the lowered stage they render as:
 
 ```text
 2 shared · 1 changed · 1 moved · 0 deleted · 16 new
@@ -347,80 +537,147 @@ dropped.
       + b
 ```
 
-Markers are `=` unchanged, `~` content changed, `+` new, `-` deleted, and a
-trailing `»` for a node whose placement changed. Two rules keep it readable:
-an unchanged subtree is not descended into (it is unchanged all the way down),
-and a wholly-new or wholly-deleted region collapses to its root with a node
-count. A node that gained or lost only *itself* — a wrapper around content that
-survived — is not collapsed: above, the new `a + b` is shown with the reused
-`a` under it, because claiming that `a` changed would be false.
+Every line of the tree is one node of v2, indented by its depth, and the marker
+in the first column says what the diff concluded about it. The `-` lines after
+the tree are v1 nodes, which is why the program above — it deletes nothing —
+shows none:
 
-Each node is shown by rendering its subterm with `symbolic` and keeping the
-first line, cut to a fixed width. A leaf prints exactly; an interior node prints
-its head. That costs `O(𝑛²)` text and is an inspection surface, not a hot path —
-but it means the rendering cannot drift out of step with the AST the way a
-second, shallow node vocabulary would.
+| Marker | Meaning |
+| --- | --- |
+| `=` | matched, content unchanged |
+| `~` | matched, content changed — the node itself, or something under it |
+| `+` | in v2 only |
+| `-` | in v1 only, listed after the tree since it has no place in v2 |
+| `»` | suffix: this node's placement changed |
 
-### Worked example
+A node carries a column marker and, when it moved, the suffix: `= a »` is v1's
+`a` unchanged but relocated, which is what happens when `a` becomes the left
+operand of `a + b`. Only v2's side of a move is shown, because the rendering is
+v2's tree; the node's position in v1 is reached through `Match::src`.
 
-`v = 5` followed by `1 if v > 0 else 2`, with the guard threshold edited to
-`1`, diffed at the lowered stage. The ternary lowers to a guard-based `Case`,
-so both trees contain a literal `1` (the then-branch value) and, in the new
-version, a second literal `1` (the guard threshold):
+The trailing `…` is truncation, not a marker. Each line renders that node's
+subterm with `symbolic` and keeps the first line, cut to a fixed width, so a
+leaf prints exactly and an interior node prints its head — `let a = 1…` is the
+whole `let`, elided after its bound expression. That costs `O(𝑛²)` text and is
+an inspection surface rather than a hot path, but it keeps the rendering from
+drifting out of step with the AST the way a second, shallow node vocabulary
+would.
+
+Two rules keep the tree short. An unchanged subtree is not descended into, since
+it is unchanged all the way down. A wholly-new or wholly-deleted region collapses
+to its root with a node count — `(+12 nodes)` above. A node that appeared or
+vanished *around* content that survived does not collapse: the new `a + b` is
+shown with the reused `a` under it, because claiming `a` changed would be false.
+
+### Worked example: one literal, and the duplicates around it
+
+A changed literal with the guard threshold edited to `1`, diffed at the lowered
+stage:
 
 ```
-Changed/InPlace   let v = 5
-Same/InPlace      5      ->  5
-Changed/InPlace   { v > 0 → 1; true → 2 }  ->  { v > 1 → 1; true → 2 }
-Changed/InPlace   v > 0  ->  v > 1
-Same/InPlace      v      ->  v
-Changed/InPlace   0      ->  1
-Same/InPlace      1      ->  1
-Same/InPlace      true   ->  true
-Same/InPlace      2      ->  2
+# v1                      # v2
+v = 5                     v = 5
+1 if v > 0 else 2         1 if v > 1 else 2
 ```
 
-Nothing deleted, nothing new, nothing moved: one literal changed and the
-containers above it are marked as the places that changed with it. Both of the
-gap-closing phases are load-bearing here — duplicate resolution keeps the
+The ternary lowers to a guard-based `Case`, so v1 already contains a literal `1`
+as the then-branch value, and v2 contains a second one as the guard threshold.
+
+| v1 | | v2 | Content / Placement |
+| --- | --- | --- | --- |
+| `let v = 5` | ~ | `let v = 5` | `ChangedBelow` / `InPlace` |
+| `5` | = | `5` | `Same` / `InPlace` |
+| `{ v > 0 → 1; true → 2 }` | ~ | `{ v > 1 → 1; true → 2 }` | `ChangedBelow` / `InPlace` |
+| `v > 0` | ~ | `v > 1` | `ChangedBelow` / `InPlace` |
+| `v` | = | `v` | `Same` / `InPlace` |
+| `0` | ~ | `1` | `Changed` / `InPlace` |
+| `1` | = | `1` | `Same` / `InPlace` |
+| `true` | = | `true` | `Same` / `InPlace` |
+| `2` | = | `2` | `Same` / `InPlace` |
+
+Nothing deleted, nothing new, nothing moved. One node is `Changed` — the
+literal — and `divergences()` reports that one; the three `ChangedBelow`
+containers above it are reflecting it, not adding to it.
+
+Both gap-closing phases are load-bearing here. Duplicate resolution keeps the
 branch-body `1` matched to the branch-body `1` rather than to the new guard
-threshold, and optimal recovery pairs `0` with `1` instead of reporting a
-delete and an insert.
+threshold, and optimal recovery pairs `0` with `1` instead of reporting a delete
+and an insert.
 
 ---
 
-## Which stage to diff
+## Which phase to diff
 
-`compile_to(code, stage)` compiles to a nominated pipeline stage and hands back
-the tree. Every stage runs through one `diff` core — nothing in the matcher is
-stage-specific, because the content hash is uid-robust and type-aware, which is
-exactly what one core needs to handle all of them.
+`compile_to(code, phase)` runs the pipeline to `phase`'s output and hands back
+the tree. It runs `run_frontend`, the same function `compile_program` runs, with
+a stop phase instead of a continuation into operator conversion — so the tree a
+diff is taken over is the tree the real pipeline produces, and a program
+`compile_program` refuses yields no tree. `both_entry_points_compile_to_one_tree`
+pins that at `Planning` using this differ.
 
-| Stage | Tree | What it shows |
+The axis is [`Phase`](../context.rs), the compiler's own enumeration of its
+phases, whose declaration order is pipeline order. A **position** in the pipeline
+is a phase's output, and there is exactly one vocabulary for it: a stop for a
+diff, a pane the inspector retains, and the range endpoint
+`ProvenanceTable::deaths` reads are the same thing named the same way. `run_passes`
+expresses each one as a single `at_phase_output` call.
+
+Every phase output is a legal stop — each has a consistency wall after it, so
+none of them is a half-formed tree. What follows is which ones answer which
+question, not which ones are well-formed.
+
+| Phase output | Tree | What it shows |
 | --- | --- | --- |
-| `Lowered` | `Raw` names, pre-uniquify, pre-inference; most types `Hole` | Closest to source, minimal diffs. Type sensitivity comes only from annotations and lowering-built types (cast refinements). |
-| `Inferred` | α-uniquified, every node carrying its resolved type | Everything above, plus type-level divergence the earlier stage cannot see. |
-| `Inlined` | inferred, then UDF-inlined | Everything above, with function boundaries erased — see "How much to normalize". |
-| `Channelized` | mutability eliminated: `LetRec` recurrences, feeds routed | The compiler's shape rather than the user's — `For`/`MutWrite`/`Begin`/`Defer` are gone. |
+| `Lower` | `Raw` names, pre-uniquify, pre-inference; most types `Hole` | Closest to source, minimal diffs. Type sensitivity comes only from annotations and lowering-built types (cast refinements). |
+| `Uniquify` | the same tree with every binder α-renamed | Nothing a diff can see: the hash is uid-robust, so this diffs identically to `Lower`. It is a position because the inspector's upstream pane is taken here. |
+| `Infer` | every node carrying its resolved type | Everything above, plus type-level divergence the earlier positions cannot see. |
+| `Inline` | inferred, then UDF-inlined | Everything above, with function boundaries erased — see "How much to normalize". |
+| `Transact` | `with begin():` writers rewritten to `LetRec` | Half of the mutability rewrite. Diffing here reports a shape no source construct corresponds to; the position exists for provenance and debugging. |
+| `Letrec` | induction loops folded to `LetRec` too | The other half. Same caveat. |
+| `Channelize` | mutability eliminated, feeds routed | The compiler's shape rather than the user's — `For`/`MutWrite`/`Begin`/`Defer` are gone. Taken *before* the as-of-read rewrite. |
+| `AsOfRead` | fed-out mutable reads rewritten to as-of joins | **The last tree that still has binders**, and the one `lambda_elim` consumes. Fully typed and fully mutability-eliminated, while an edit still localizes the way it does at the phases above — see below. |
 | `LambdaElim` | point-free combinators | No binders in the term at all. |
-| `Planned` | recurrences on the `Transact` carrier, joins planned | The shape operator conversion consumes, and where compute sharing is decided. |
+| `Planning` | recurrences on the `Transact` carrier, joins planned | The shape operator conversion consumes, and where compute sharing is decided. |
 
-A later stage carries signal the term structure alone does not: in `x = 1` /
+A later phase carries signal the term structure alone does not: in `x = 1` /
 `(x, x)` versus `x = "a"` / `(x, x)` the bodies are structurally identical and
 hash equal before inference, and after inference the element type diverges so
 the same subterm no longer matches (`inference_adds_type_signal`).
 
-Pipeline positions between these six are not selectable. The transaction,
-mutability and channelization phases are one rewrite of the user's loops and
-feeds into `LetRec` recurrences; stopping partway through exposes a
-half-rewritten tree no consumer wants, so `Channelized` is the point at which
-that rewrite is complete. `LetRec` and `Transact` appear from there down, and a
-diff at those stages reports the compiler's shape rather than the user's.
+`AsOfRead` is the position to reach for when the question is about a compiled
+program rather than a source edit. It is the last point before the term goes
+point-free — measured on a transaction program, three `Lambda` nodes survive
+there and none survive `LambdaElim` — so it is the deepest tree in which a
+binder still names something the user wrote. An edit costs the same there as at
+`Channelize` and less than below it: a filter-threshold change is one site at
+`AsOfRead`, two at `LambdaElim`, ten at `Planning`.
+
+`Transact` and `Letrec` are the two positions to avoid for a source-level diff.
+They are one rewrite of the user's loops and feeds into `LetRec` recurrences, and
+stopping between them reports the compiler's shape mid-rewrite; `Channelize` is
+where that rewrite is complete. The tree is consistent at both, which is why they
+are reachable at all — a caller debugging a phase wants them.
 
 ## How much to normalize
 
-Two programs can be the same computation written differently. The more of that
-the diff sees through, the more the two versions share — and the less
+Two questions want two different stages, and neither one dominates.
+
+**What runs together** is a question about the operator graph, so it is asked at
+`Planning` — the shape operator conversion consumes, and therefore the only stage
+where a claim about sharing compute is a claim about what executes. Anything a
+version guard or a shared store is derived from is read there.
+
+**Which source edit is this** is a question about the program the user wrote, so
+it is asked at the earliest stage that can see the edit at all. Every pass
+between the two rewrites the user's shape, and a rewrite spreads one edit over
+more of the tree: at `Planning` a comprehension's threshold change is four sites
+rather than one, and an accumulator's body change carries fourteen new nodes
+rather than two. Those extra sites are the same edit, reported once per place
+the compiler copied it to, which is signal about the graph and noise about the
+source.
+
+Two programs can also be the same computation written differently. The more of
+that the diff sees through, the more the two versions share — and the less
 localized the answer becomes when they genuinely differ. Choosing a stage is
 choosing where on that curve to sit; the compiler's own passes do the work, so
 there is no separate rewriting system to keep honest.
@@ -428,17 +685,18 @@ there is no separate rewriting system to keep honest.
 Divergences reported, measured on the refactors that occur. The counts are
 measurements rather than invariants: `inlining_erases_function_boundaries` and
 `inlining_costs_locality_in_a_shared_helper` pin the direction of each contrast,
-not the numbers.
+not the numbers. Each row names the pair it was measured on, so the numbers can
+be reproduced and a drift in them is visible.
 
-| Edit | `Inferred` | `Inlined` |
-| --- | --- | --- |
-| rename a binding | 0 | 0 |
-| extract a subexpression into a `def` | 6 | **0** |
-| edit a body inside a `def` called once | 1 | 1 |
-| edit a body inside a `def` called **twice**, one specialization | 1 | **2** |
-| edit a body inside a `def` called **twice**, two specializations | **2** | 4 |
-| reorder two independent bindings | 2 | 2 |
-| extract a subexpression into a `let` | 5 | 5 |
+| Edit | Measured on | `Infer` | `Inline` |
+| --- | --- | --- | --- |
+| rename a binding | `x = 1; y = x + 2; y` → `q = 1; y = q + 2; y` | 0 | 0 |
+| extract a subexpression into a `def` | `a = 1; (a + 2) * 3` → the same via `def g(y): y + 2` | 5 | **0** |
+| edit a body inside a `def` called once | `y + 2` → `y + 5`, one call site | 1 | 1 |
+| edit a body inside a `def` called **twice**, one specialization | the same edit, called at `a = 1 + 1` and `b = 2 + 2` | 1 | **2** |
+| edit a body inside a `def` called **twice**, two specializations | the same edit, called at `g(1)` and `g(2)` | **2** | 3 |
+| reorder two independent bindings | `a = 1; b = 2; a + b` → `b = 2; a = 1; a + b` | 2 | 2 |
+| extract a subexpression into a `let` | `(a + 2) * (a + 2)` → `t = a + 2; t * t` | 6 | 6 |
 
 Inlining is a trade, not an improvement: it makes moving code across a function
 boundary invisible, and in exchange reports an edit inside a shared helper once
@@ -446,11 +704,11 @@ per call site, because the body it changed now appears once per call site. It is
 the stage to pick when refactoring across function boundaries is the noise to
 remove.
 
-### `Inferred` has already spent some of that locality
+### `Infer` has already spent some of that locality
 
 The two "called twice" rows are the *same edit to the same helper*, and they
 differ only in whether the two call sites share a specialization. That is the
-whole content of the second row's `Inferred` cell being 2 rather than 1:
+whole content of the second row's `Infer` cell being 2 rather than 1:
 **monomorphization runs inside `infer`**, so a definition used at two distinct
 instantiation identities is already two clones before the differ sees it, and
 the edit is reported at both.
@@ -461,36 +719,64 @@ polarity-complete and therefore sees an argument's *lower-bound* refinements. A
 literal argument carries its singleton, so `g(1)` and `g(2)` key apart and split
 the helper; `g(a)` and `g(b)` for two computed `Int`s key together and do not.
 Inlining then costs one further duplication per call site on top of whatever
-monomorphization already did — 1 → 2 in the shared row, 2 → 4 in the split one.
+monomorphization already did — 1 → 2 in the shared row, 2 → 3 in the split one.
 
-`Inferred` is therefore the earliest stage this differ offers, not a stage that
+`Infer` is therefore the earliest stage this differ offers, not a stage that
 has normalized nothing: the curve starts before its column.
 
-Below `Inlined` the trade continues — every pass that rewrites the user's shape
+Below `Inline` the trade continues — every pass that rewrites the user's shape
 spreads one edit over more of the tree. No test pins these counts either:
 
-| Edit | `Inlined` | `Channelized` | `LambdaElim` | `Planned` |
-| --- | --- | --- | --- | --- |
-| a literal | 1 | 1 | 1 | 1 |
-| a comprehension's filter threshold | 1 | 1 | 2 | 4 |
-| an accumulator loop's body | 2 (2 new) | 2 (2 new) | 2 (**14 new**) | 2 (14 new) |
-| a transactional register's write | 2 (2 new) | 2 (2 new) | 3 (8 new) | 3 (8 new) |
+| Edit | Measured on | `Inline` | `Channelize` | `LambdaElim` | `Planning` |
+| --- | --- | --- | --- | --- | --- |
+| a literal | `a = 1; b = 2; a + b` → `b = 3` | 2 | 2 | 3 | 3 |
+| a comprehension's filter threshold | `FILTER_AGG` → `FILTER_AGG_21` (`>= 18` → `>= 21`) | 1 | 1 | 2 | **10** |
+| an accumulator loop's body | `ACCUM` → `acc + i * 2` | 1 (2 new) | 1 (2 new) | 1 (**14 new**) | 1 (14 new) |
+| a transactional register's write | `TXN` → `pool - r - 1` | 1 (2 new) | 1 (2 new) | 2 (8 new) | 2 (8 new) |
 
-So the default is the earliest stage that answers the question. The reason to
-reach past `Inlined` is not a better diff of the source — it is that `Planned`
-is the shape operator conversion consumes, so it is where a claim about *sharing
-compute* is actually a claim about the graph that runs. Diffing there answers a
-different question, not the same question better.
+Two of those columns need reading carefully.
+
+**A literal edit is two sites, not one, from `Infer` down.** A literal's type
+is its singleton (`Int@2`), and that singleton rides the type of every *read* of
+the binding, so editing `b = 2` to `b = 3` changes the literal and every `b`
+that mentions it. Both are real: a consumer sharing the read would be sharing a
+value that differs.
+
+**The `Planning` cell for the filter threshold is 10 because a term inside a type
+is reported wherever that type is mentioned.** A comprehension filter lowers to
+a refinement predicate, which is a term living in a type. The differ gives that
+term one home — the `Cast` whose target holds it, reached as a child — but by
+`Planning` the same predicate rides the type of every operator the refined domain
+flows through: `sum`, `restrict`, and a `zip`/`const`/`ge` triple per leg. Each
+of those is a leaf, so each is its own site, and the count scales with how far
+the domain travels rather than with the size of the edit. Eight of the ten carry
+the *same* predicate term. Collapsing them is a real option — `Refinement`'s
+predicate is a shared `Rc` by design (`src/ccl/ty.rs`), so the mentions are
+identifiable — and it is not done here. See
+[Open threads](#open-threads).
+
+The rule this leaves: diff at the earliest stage that can see the edit, unless
+the answer is about the graph that runs, in which case diff at `Planning`.
+Reaching past `Inline` is not a better diff of the source; it is a diff of a
+different object.
 
 ### What is not normalized
 
 **Extracting a subexpression into a `let`.** `(a + 2) * (a + 2)` and
-`let t = a + 2 in t * t` have the same value and are not the same program
-here: naming a subexpression is how CCL says "compute this once". The two
-compile to different operator graphs — one shared node against two — so for a
-system that shares compute between versions this is a real change, and
-reporting it is correct. (Which is also why the `Inlined` stage stops at UDFs:
-`inline` beta-reduces *function* bindings, not value bindings.)
+`let t = a + 2 in t * t` have the same value and are not the same program here:
+naming a subexpression is how CCL says "compute this once".
+
+The two compile to different operator graphs. A `Let` binding compiles to
+`FanOut(Memo(bound_op))` and every use of the binder branches that one fan
+([`operator_conversion.rs`](../../interpreter/operator_conversion.rs)), while a
+repeated subterm is converted once per occurrence — operator conversion has no
+common-subexpression pass. So `a = 5; (a + 2) * (a + 2)` builds two `BinOp(+)`
+operators over one shared `a`, and `a = 5; t = a + 2; t * t` builds one, with the
+second use a back-reference to its fan. For a system that shares compute between
+versions that difference is the change, and reporting it is correct.
+
+The `Inline` phase does not erase it: `inline` beta-reduces function bindings,
+not value bindings.
 
 **Commutativity.** `a + b` and `b + a` differ by one divergence. Normalizing
 them would need type direction, because `+` is string concatenation as well as
@@ -550,9 +836,9 @@ and it is what makes a second version cost the diff rather than 2×. Not built.
 
 **Substitution's transport mode still restates the scoping rules.**
 [`ccl/scope.rs`](../scope.rs) now holds them once and every *observing* walk
-folds over it, but `subst`'s `Subst::apply_expr_inner` — the mode that returns a
+reads from it, but `subst`'s `Subst::apply_expr_inner` — the mode that returns a
 rewritten copy rather than mutating in place — cannot: it rebuilds each node,
-and a rebuild is a per-variant `match` by construction. Folding it over the
+and a rebuild is a per-variant `match` by construction. Routing it through the
 shared walk would mean cloning the whole subtree at every binding node (clone
 the node, then overwrite its children), which turns substitution down a `let`
 spine from linear into quadratic in the spine's depth — the one shape Cambra
@@ -560,19 +846,50 @@ programs are reliably deep in. Its arms are guarded only by review; if a binding
 form is ever added, `scope.rs` is the compile error that should prompt a look
 here.
 
+**A term inside a type is reported at every node whose type mentions it.** A
+refinement predicate is a term, and the same predicate `Rc` rides the type of
+every node the refined domain reaches. The differ gives the term one home — the
+`Cast` whose target holds it — but the other mentions are leaves, so each is its
+own divergence, and one threshold edit is ten sites at `Planning` (measured in
+"How much to normalize"). Eight of those ten carry one predicate.
+
+The direction of a fix is available rather than speculative: `Refinement`'s
+predicate is a shared `Rc` by design (`src/ccl/ty.rs`), so a mention is
+identifiable by pointer, and a node whose only change is a predicate already
+reported at its home need not be its own site. What that costs is a
+correspondence between the two versions' predicates — `Rc` identity is
+per-compilation, so the two sides have to be related through the matching, which
+is the same circularity the free-variable seam has. Not attempted.
+
+Separately, the `sum` and `restrict` mentions in that measurement carry *three*
+distinct `Rc`s holding one predicate, where `Refinement::predicate`'s own doc
+comment says a predicate rides many slots as one shared `Rc`. Whether some pass
+rebuilds per occurrence there, or those are legitimately independent mints, is
+unexamined.
+
 **Child enumeration is written out twice.** `diff`'s `child_exprs` mirrors
 `TypedExpr::walk_children` arm for arm, differing only in that it descends into
 a `Cast` target's refinement predicate (a load-bearing term that
 `walk_children` treats as a type child). Both matches are exhaustive, so a new
-node variant is a compile error in both places — the duplication is visible
-rather than silent, which is why it stands.
+node variant is a compile error in both places.
 
-**A `let`-spine encodes an order it does not have.** A run of independent
-bindings is a dependency DAG, but CCL spells it as nested `Let`s, so reordering
-two of them changes the tree shape and the matcher pairs the spine by depth.
-The reads underneath then resolve to non-corresponding binders and report as
-changed — conservative, but noise (two divergences for two reordered bindings).
-**Decided: leave it.**
+The exhaustiveness is not the whole risk, and one defect has already come from
+the other half: nothing checks that a given walk picks the *right* one of the
+two. `subtree_entirely_in` and `size_note` walked `walk_children` while their
+callers walked `child_exprs`, so a deleted `Cast` whose predicate still held a
+matched node tested as wholly deleted. Both now walk `child_exprs`
+(`a_deleted_cast_with_a_surviving_predicate_is_not_wholly_deleted`), and the
+selection stays a review-time judgment at each call site.
+
+**A `let` spine encodes an order it does not have.** A run of independent
+bindings is a dependency DAG, but CCL spells it as nested `Let`s. Order
+insensitivity does not reach it: that rule is about the *children of one node* —
+a `Record`'s fields, a `DisjointJoin`'s operands — and a run of bindings is not
+one node's children but a chain of nodes, each the body of the one above. So
+reordering two bindings changes the tree's shape rather than a child order, the
+matcher pairs the spine by depth, and the reads underneath resolve to
+non-corresponding binders and report as changed. Conservative, but noise: two
+divergences for two reordered bindings. **Decided: leave it.**
 
 *It is not a matcher-tuning problem.* Three plausible fixes were tried and
 measured, and none moved the reordering case:

--- a/src/ccl/diff.rs
+++ b/src/ccl/diff.rs
@@ -1,0 +1,2288 @@
+//! Structural diff of two CCL programs — the shared / new / deleted analysis
+//! that whole-program branching is built on. See `src/ccl/design/diffing.md`.
+//!
+//! Given two [`TypedExpr`] trees, [`diff`] computes a node correspondence and
+//! classifies it. It is a GumTree-style matcher (Falleri et al., *Fine-grained
+//! and accurate source code differencing*, ASE 2014) over the α-invariant
+//! [`content_hash`](super::content_hash::content_hash):
+//!
+//! 1. **Top-down anchors.** Map the *largest* subtrees whose content hash is
+//!    equal — equal hash means isomorphic modulo α, so the whole subtree is
+//!    *shared*. Larger subtrees are claimed first; once a node is matched its
+//!    descendants are matched with it (paired by hash, which is correct for the
+//!    order-insensitive nodes too).
+//! 2. **Root anchoring.** Two programs being diffed are two versions of *one*
+//!    program, so their roots correspond by construction ([`anchor_roots`]).
+//!    Nothing else can establish that — a root that gained a statement scores
+//!    too low for step 3 to pair it, and the whole program would read as
+//!    deleted-and-reinserted for a one-statement edit.
+//! 3. **Bottom-up container recovery.** An interior node left unmatched is
+//!    paired with the best same-kind candidate in the other tree that
+//!    *contains* enough of its already-matched descendants. This is what keeps
+//!    an inserted statement from desynchronizing the whole `let`-spine below
+//!    it: the unchanged tail anchors in step 1, and the containers above it are
+//!    recovered here rather than reported as wholesale rewrites.
+//! 4. **Optimal recovery inside a paired container.** Two containers paired in
+//!    step 2 or 3 still have unmatched descendants — near-identical subtrees
+//!    whose hashes differ somewhere inside. [`recover`] maps those *optimally*,
+//!    by tree edit distance ([`ted`]), so an edit deep inside a large subtree
+//!    does not read as a wholesale replacement of everything around it.
+//!
+//! The result is then classified along two independent axes ([`Match`]):
+//! whether the node's **content** changed ([`Content`]) and whether its
+//! **placement** did ([`Placement`]). A source-only node is **deleted**; a
+//! target-only node is **new**.
+//!
+//! That classification is complete but not minimal — every *ancestor* of an
+//! edit has changed content, and every *descendant* of an inserted subtree is
+//! new. [`Diff::divergences`] reduces it to the places the programs actually
+//! disagree, and [`Diff::shared_roots`] to the largest pieces they have in
+//! common. Those two are the actionable form: the first says where a version
+//! guard goes, the second says what the two versions can compute once.
+//!
+//! # Stage-agnostic
+//!
+//! [`diff`] is a pure function of two [`TypedExpr`] trees and does not care
+//! which pipeline stage produced them, so one implementation serves every
+//! [`CompileStage`]: the caller chooses how much of the compiler's own
+//! rewriting to diff through by choosing which trees to pass. Nothing in the
+//! matcher is stage-specific — [`content_hash`] is uid-robust (free names by
+//! spelling) and type-aware, which is what lets one core cover the lot,
+//! including the `LetRec` and `Transact` shapes that exist only below the
+//! mutability phases. Which stage answers which question is
+//! `src/ccl/design/diffing.md`, "Which stage to diff".
+//!
+//! # Scope of this implementation
+//!
+//! This is the analysis, not a rewrite: it computes a correspondence and says
+//! nothing about what to build from it. The one place it departs from full
+//! GumTree is candidate selection in step 3, which picks the best-scoring
+//! container greedily rather than solving a global assignment — GumTree does
+//! the same.
+
+use std::cmp::Reverse;
+use std::collections::{HashMap, HashSet};
+use std::mem::Discriminant;
+
+use super::content_hash::{cast_target_predicate, content_hash, resolved_hash};
+use super::context::{CompileError, CompileStage, compile_to};
+use super::scope::{ScopedItem, for_each_scoped_item};
+use super::{Name, TypedExpr};
+
+/// How much of the smaller of two subtrees must be common before container
+/// recovery will pair them — see the containment gate in [`bottom_up`]. The
+/// GumTree default, applied to a different measure than GumTree's.
+const SIMILARITY_THRESHOLD: f64 = 0.5;
+
+/// Subtree-size ceiling for the optimal recovery step ([`recover`]). Tree edit
+/// distance is `O(n²m²)` in the worst case, so a pair of containers larger than
+/// this keeps only the matches steps 1–3 found; their unmatched interiors are
+/// reported as deleted/new rather than aligned. GumTree's default, for the same
+/// reason.
+const MAX_RECOVERY_SIZE: u32 = 100;
+
+/// Whether a matched node's *content* changed. Orthogonal to [`Placement`]: a
+/// node can keep its content and move, or stay put and change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Content {
+    /// Equal content hash — identical computation, reusable wholesale.
+    Same,
+    /// The node corresponds but its content differs. The actual divergence is
+    /// in the children — see [`Diff::divergences`] for the minimal set.
+    Changed,
+}
+
+/// Whether a matched node's *position in the tree* changed. Orthogonal to
+/// [`Content`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Placement {
+    /// The node hangs off the corresponding parent, in a corresponding
+    /// position among its matched siblings.
+    InPlace,
+    /// The node was relocated: either its parent does not correspond, or it
+    /// crossed one of its matched siblings within an order-sensitive parent.
+    /// Reported once, at the root of the relocated subtree — a moved subtree's
+    /// descendants stay `InPlace` relative to it.
+    Moved,
+}
+
+/// One node correspondence between the two programs, classified along both
+/// axes.
+#[derive(Debug, Clone, Copy)]
+pub struct Match<'a> {
+    /// The node in the old program.
+    pub src: &'a TypedExpr,
+    /// The node it corresponds to in the new program.
+    pub dst: &'a TypedExpr,
+    /// Did the content change?
+    pub content: Content,
+    /// Did the position change?
+    pub placement: Placement,
+}
+
+/// The classified correspondence between two programs. All references borrow
+/// the two input trees.
+#[derive(Debug)]
+pub struct Diff<'a> {
+    /// Every node correspondence, in source pre-order.
+    pub matched: Vec<Match<'a>>,
+    /// Source-only nodes: present in the old program, gone in the new.
+    pub deleted: Vec<&'a TypedExpr>,
+    /// Target-only nodes: introduced by the new program.
+    pub new: Vec<&'a TypedExpr>,
+    /// The old program's root — retained so a [`Diff`] can render itself.
+    pub src_root: &'a TypedExpr,
+    /// The new program's root.
+    pub dst_root: &'a TypedExpr,
+}
+
+impl<'a> Diff<'a> {
+    /// Correspondences whose content is identical ([`Content::Same`]) — the
+    /// computation the two versions share, whether or not it moved.
+    pub fn shared(&self) -> impl Iterator<Item = &Match<'a>> {
+        self.matched.iter().filter(|m| m.content == Content::Same)
+    }
+
+    /// Correspondences that changed ([`Content::Changed`]) — "the same place in
+    /// both programs, different content".
+    pub fn updated(&self) -> impl Iterator<Item = &Match<'a>> {
+        self.matched
+            .iter()
+            .filter(|m| m.content == Content::Changed)
+    }
+
+    /// Correspondences that were relocated ([`Placement::Moved`]), independent
+    /// of whether their content also changed.
+    pub fn moved(&self) -> impl Iterator<Item = &Match<'a>> {
+        self.matched
+            .iter()
+            .filter(|m| m.placement == Placement::Moved)
+    }
+
+    /// `true` when the two programs correspond node-for-node with no change in
+    /// content or placement anywhere — the "these are the same program" test.
+    pub fn is_identical(&self) -> bool {
+        self.deleted.is_empty()
+            && self.new.is_empty()
+            && self
+                .matched
+                .iter()
+                .all(|m| m.content == Content::Same && m.placement == Placement::InPlace)
+    }
+
+    /// The **minimal** set of places the two programs disagree, in new-program
+    /// order (deletions, which have no place there, come last).
+    ///
+    /// This is the actionable form of the diff, and where a version guard would
+    /// be placed. `matched`/`deleted`/`new` are complete but not
+    /// minimal: every *ancestor* of an edit has changed content too, and every
+    /// *descendant* of an inserted subtree is itself new. One literal edited at
+    /// the bottom of a forty-binding spine leaves forty-two changed nodes, of
+    /// which exactly one is the edit. Divergences report that one.
+    ///
+    /// No divergence contains another, so the set partitions the disagreement
+    /// between the two programs: everything not under a divergence corresponds.
+    pub fn divergences(&self) -> Vec<Divergence<'a>> {
+        let by_dst: HashMap<*const TypedExpr, &Match<'a>> = self
+            .matched
+            .iter()
+            .map(|m| (m.dst as *const TypedExpr, m))
+            .collect();
+        let mut out = Vec::new();
+
+        // A changed node is a site only when nothing *below* it changed — the
+        // deeper node is the better explanation. Insertions and deletions are
+        // reported at their own roots and do not suppress it: a node whose
+        // payload changed *and* which gained a child has two things to say.
+        /// Returns whether anything in this subtree reported a change.
+        fn walk<'a>(
+            e: &'a TypedExpr,
+            parent_matched: bool,
+            by_dst: &HashMap<*const TypedExpr, &Match<'a>>,
+            out: &mut Vec<Divergence<'a>>,
+        ) -> bool {
+            let Some(m) = by_dst.get(&(e as *const TypedExpr)) else {
+                // Target-only. It is the *root* of an inserted region exactly
+                // when the node above it is not also new. Keep descending
+                // regardless: a matched node can sit inside a new region — the
+                // new expression wrapping content that survived — and whatever
+                // diverges under it still has to be reported.
+                if parent_matched {
+                    out.push(Divergence::Inserted(e));
+                }
+                let mut changed = false;
+                for c in child_exprs(e) {
+                    changed |= walk(c, false, by_dst, out);
+                }
+                return changed;
+            };
+            let mut changed_below = false;
+            for c in child_exprs(e) {
+                changed_below |= walk(c, true, by_dst, out);
+            }
+            if m.content == Content::Changed && !changed_below {
+                out.push(Divergence::Changed(**m));
+                return true;
+            }
+            changed_below || m.content == Content::Changed
+        }
+        walk(self.dst_root, true, &by_dst, &mut out);
+
+        let gone: HashSet<*const TypedExpr> = self
+            .deleted
+            .iter()
+            .map(|e| *e as *const TypedExpr)
+            .collect();
+        let mut roots: Vec<(&TypedExpr, bool)> = Vec::new();
+        collect_deleted_roots(self.src_root, &gone, &mut roots);
+        out.extend(roots.into_iter().map(|(e, _)| Divergence::Deleted(e)));
+        out
+    }
+
+    /// The largest subtrees the two programs have in common: every node whose
+    /// content is unchanged and whose parent's is not, in new-program order.
+    ///
+    /// These are the units of reuse — a `Same` node's whole subtree is `Same`,
+    /// so reporting the descendants as well would say nothing more.
+    ///
+    /// Reuse here means *the term is the same term*, which is what a unified
+    /// tree needs. It does **not** mean the term evaluates to the same value in
+    /// both versions: `let x = 1 in x` and `let x = 2 in x` share the body `x`,
+    /// and that is right — the two `let`s are a divergence, and it is the
+    /// binding that differs, not the read.
+    pub fn shared_roots(&self) -> Vec<&Match<'a>> {
+        let by_dst: HashMap<*const TypedExpr, &Match<'a>> = self
+            .matched
+            .iter()
+            .map(|m| (m.dst as *const TypedExpr, m))
+            .collect();
+        let mut out = Vec::new();
+        fn walk<'a, 'm>(
+            e: &TypedExpr,
+            by_dst: &HashMap<*const TypedExpr, &'m Match<'a>>,
+            out: &mut Vec<&'m Match<'a>>,
+        ) {
+            if let Some(m) = by_dst.get(&(e as *const TypedExpr))
+                && m.content == Content::Same
+            {
+                out.push(m);
+                return;
+            }
+            for c in child_exprs(e) {
+                walk(c, by_dst, out);
+            }
+        }
+        walk(self.dst_root, &by_dst, &mut out);
+        out
+    }
+}
+
+/// One place the two programs disagree, at the granularity a version guard is
+/// placed. Minimal by construction: no divergence contains another.
+#[derive(Debug, Clone, Copy)]
+pub enum Divergence<'a> {
+    /// Both programs have a node here and its content differs, with nothing
+    /// below it differing — this is where the change actually is.
+    Changed(Match<'a>),
+    /// A subtree the new program has and the old one does not, at its root.
+    Inserted(&'a TypedExpr),
+    /// A subtree the old program had and the new one does not, at its root.
+    Deleted(&'a TypedExpr),
+}
+
+/// Diff two programs (`src` = old, `dst` = new). See the module docs.
+pub fn diff<'a>(src: &'a TypedExpr, dst: &'a TypedExpr) -> Diff<'a> {
+    let s = Indexed::build(src);
+    let d = Indexed::build(dst);
+    let mut m = Matching::new(s.len(), d.len());
+
+    top_down(&s, &d, &mut m);
+    anchor_roots(&s, &d, &mut m);
+    bottom_up(&s, &d, &mut m);
+
+    classify(&s, &d, &m)
+}
+
+/// Anchor the two roots to each other when phase 1 has not already.
+///
+/// Two programs being diffed are two *versions of one program*, so their roots
+/// correspond by construction — neither has anywhere else to go. [`bottom_up`]
+/// cannot reach that on its own because it is seeded by already-matched
+/// descendants and gives up when a node has none, which is exactly the case
+/// where two roots correspond but nothing *inside* them does: `Some(1)` against
+/// `Some(2)` would otherwise be a wholesale rebuild rather than an edited
+/// payload. Anchoring also hands step 4 a pair to align the interiors within.
+///
+/// Requiring the same node kind keeps the anchor honest: two genuinely
+/// unrelated programs (a `BinOp` against a `Lit`) still correspond nowhere.
+fn anchor_roots(s: &Indexed, d: &Indexed, m: &mut Matching) {
+    const ROOT: usize = 0;
+    if m.src_matched(ROOT) || m.dst_matched(ROOT) || s.nodes[ROOT].kind != d.nodes[ROOT].kind {
+        return;
+    }
+    m.map(ROOT, ROOT);
+    recover(s, d, ROOT, ROOT, m);
+}
+
+/// Compile two source programs to `stage` and diff them — the end-to-end entry
+/// point from source. The classified [`Diff`] borrows the two compiled trees,
+/// which live only for the duration of this call, so the result is delivered to
+/// `f`; return out of it whatever you need to keep (e.g. counts, cloned nodes).
+///
+/// ```ignore
+/// let (shared, new) = diff_programs(v1_src, v2_src, CompileStage::Inferred,
+///     |d| (d.shared().count(), d.new.len()))?;
+/// ```
+pub fn diff_programs<R>(
+    src: &str,
+    dst: &str,
+    stage: CompileStage,
+    f: impl FnOnce(&Diff) -> R,
+) -> Result<R, Vec<CompileError>> {
+    let a = compile_to(src, stage)?;
+    let b = compile_to(dst, stage)?;
+    Ok(f(&diff(&a, &b)))
+}
+
+// ---------------------------------------------------------------------------
+// Flattened tree index
+// ---------------------------------------------------------------------------
+
+/// One node of a tree, flattened into pre-order. The subtree rooted at index
+/// `i` occupies the contiguous range `[i, i + size)`, so descendants of `i` are
+/// exactly the indices in `(i, i + size)`.
+struct NodeInfo<'a> {
+    expr: &'a TypedExpr,
+    kind: Discriminant<super::TypedExprNode>,
+    hash: u64,
+    /// Subtree node count, self included.
+    size: u32,
+    /// Leaf = 1; interior = 1 + max child height.
+    height: u32,
+    /// Root = 0; a child is its parent's depth plus one.
+    depth: u32,
+    /// `None` at the root.
+    parent: Option<usize>,
+    children: Vec<usize>,
+    /// `true` for the nodes whose children are a *set*, not a sequence
+    /// (`Record`, `DisjointJoin`) — the content hash folds them
+    /// permutation-invariantly, so reordering them is not a move.
+    unordered: bool,
+}
+
+struct Indexed<'a> {
+    nodes: Vec<NodeInfo<'a>>,
+}
+
+impl<'a> Indexed<'a> {
+    fn build(root: &'a TypedExpr) -> Self {
+        let mut nodes = Vec::new();
+        Self::add(root, None, 0, &mut nodes);
+        Indexed { nodes }
+    }
+
+    /// Append `e`'s subtree in pre-order, returning `e`'s index.
+    fn add(
+        e: &'a TypedExpr,
+        parent: Option<usize>,
+        depth: u32,
+        nodes: &mut Vec<NodeInfo<'a>>,
+    ) -> usize {
+        let idx = nodes.len();
+        nodes.push(NodeInfo {
+            expr: e,
+            kind: std::mem::discriminant(&e.node),
+            hash: content_hash(e).0,
+            size: 1,
+            height: 1,
+            depth,
+            parent,
+            children: Vec::new(),
+            unordered: has_unordered_children(e),
+        });
+        let child_refs = child_exprs(e);
+        let mut children = Vec::with_capacity(child_refs.len());
+        let (mut size, mut max_h) = (1u32, 0u32);
+        for c in child_refs {
+            let ci = Self::add(c, Some(idx), depth + 1, nodes);
+            size += nodes[ci].size;
+            max_h = max_h.max(nodes[ci].height);
+            children.push(ci);
+        }
+        nodes[idx].size = size;
+        nodes[idx].height = 1 + max_h;
+        nodes[idx].children = children;
+        idx
+    }
+
+    fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Exclusive upper bound of the subtree rooted at `i`.
+    fn subtree_end(&self, i: usize) -> usize {
+        i + self.nodes[i].size as usize
+    }
+
+    /// `true` if `node` lies strictly inside the subtree rooted at `root`.
+    fn is_descendant(&self, node: usize, root: usize) -> bool {
+        root < node && node < self.subtree_end(root)
+    }
+}
+
+/// Do this node's children denote a set rather than a sequence? Mirrors the
+/// `unordered` fold in `content_hash`'s `hash_rel`: if the hash is
+/// permutation-invariant over these children, the differ must not call a
+/// permutation of them a move.
+fn has_unordered_children(e: &TypedExpr) -> bool {
+    use super::TypedExprNode as N;
+    matches!(e.node, N::Record(_) | N::DisjointJoin(_))
+}
+
+/// The direct child expressions of `e`, borrowed for `e`'s lifetime.
+///
+/// The lifetime-preserving companion to [`TypedExpr::walk_children`], which it
+/// mirrors arm-for-arm **except for `Cast`**: a cast-target domain-refinement
+/// predicate is a load-bearing term (a comprehension filter/join condition), so
+/// the differ descends into it; `walk_children` excludes it (a type child,
+/// reached via type walks). The match is exhaustive — no wildcard — so adding a
+/// `TypedExprNode` variant is a compile error here until its children are
+/// declared.
+//
+// NOTE (recurring shape): this duplicates `walk_children`'s child enumeration.
+// The two could share a private `for_each_child<'a>(&'a self, &mut dyn
+// FnMut(&'a TypedExpr))`, but that adds dynamic dispatch to the hot
+// `walk_children` traversal, so it isn't folded in here.
+fn child_exprs(e: &TypedExpr) -> Vec<&TypedExpr> {
+    use super::TypedExprNode as N;
+    match &e.node {
+        N::Lit(_) | N::Var(_) | N::Builtin(_) | N::Proj(_) | N::Source(_) | N::Defer | N::Error => {
+            vec![]
+        }
+        N::Apply { function, argument } => vec![function, argument],
+        N::Cast { value, target } => match cast_target_predicate(target) {
+            Some(pred) => vec![value, pred],
+            None => vec![value],
+        },
+        N::BinOp { left, right, .. } => vec![left, right],
+        N::UnaryOp(_, inner) => vec![inner],
+        N::Lambda { body, .. } => vec![body],
+        N::Aggregate { input, .. } => vec![input],
+        N::Let {
+            bound_expr, body, ..
+        } => vec![bound_expr, body],
+        N::List(xs) | N::Tuple(xs) | N::Compose(xs) | N::Copair(xs) | N::DisjointJoin(xs) => {
+            xs.iter().collect()
+        }
+        N::Case {
+            scrutinee,
+            branches,
+        } => {
+            let mut v: Vec<&TypedExpr> = scrutinee.as_deref().into_iter().collect();
+            for b in branches {
+                v.push(&b.guard);
+                v.push(&b.body);
+            }
+            v
+        }
+        N::VariantCtor { payload, .. } => vec![payload],
+        N::Record(fields) => fields.iter().map(|(_, e)| e).collect(),
+        N::Transact { keys, writers, .. } => {
+            let mut v: Vec<&TypedExpr> = keys.iter().map(|k| &k.init).collect();
+            for w in writers {
+                v.push(&w.source);
+                v.push(&w.body);
+            }
+            v
+        }
+        N::LetRec { bindings, body } => {
+            let mut v: Vec<&TypedExpr> = bindings.iter().map(|(_, def)| def).collect();
+            v.push(body);
+            v
+        }
+        N::MutDecl { init, body, .. } => vec![init, body],
+        N::For { iter, body, .. } => vec![iter, body],
+        N::Begin { body } => vec![body],
+        N::ExprStmt { expr, body } => vec![expr, body],
+        N::Feed { value, .. } | N::Define { value, .. } | N::MutWrite { value, .. } => vec![value],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Matching state
+// ---------------------------------------------------------------------------
+
+struct Matching {
+    src_to_dst: Vec<Option<usize>>,
+    dst_to_src: Vec<Option<usize>>,
+}
+
+impl Matching {
+    fn new(n_src: usize, n_dst: usize) -> Self {
+        Matching {
+            src_to_dst: vec![None; n_src],
+            dst_to_src: vec![None; n_dst],
+        }
+    }
+
+    fn map(&mut self, s: usize, d: usize) {
+        self.src_to_dst[s] = Some(d);
+        self.dst_to_src[d] = Some(s);
+    }
+
+    fn src_matched(&self, s: usize) -> bool {
+        self.src_to_dst[s].is_some()
+    }
+
+    fn dst_matched(&self, d: usize) -> bool {
+        self.dst_to_src[d].is_some()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: top-down isomorphic anchoring
+// ---------------------------------------------------------------------------
+
+fn top_down(s: &Indexed, d: &Indexed, m: &mut Matching) {
+    // Index dst nodes by hash for candidate lookup.
+    let mut dst_by_hash: HashMap<u64, Vec<usize>> = HashMap::new();
+    for (i, n) in d.nodes.iter().enumerate() {
+        dst_by_hash.entry(n.hash).or_default().push(i);
+    }
+
+    // Tallest (and, tie-broken, largest) subtrees first, so a big anchor claims
+    // its descendants before any smaller subtree inside it is considered. For
+    // identical trees the root (a unique hash) is anchored first and maps
+    // everything in one pass.
+    let mut order: Vec<usize> = (0..s.len()).collect();
+    order.sort_by_key(|&i| Reverse((s.nodes[i].height, s.nodes[i].size)));
+
+    // Anchor each unmatched src subtree to an unmatched dst subtree of equal
+    // hash. Equal hash means isomorphic-modulo-α, so *every* such pairing is a
+    // valid "shared" classification — but not every one is equally *useful*:
+    // when a subtree shape repeats (and small ones always do — `0`, `true`,
+    // `x`), the copy we pick decides whether the node reads as sitting still or
+    // as having moved, and it decides which of its siblings are left over for
+    // the later phases to pair. So among equal-hash candidates, take the one in
+    // the most structurally corresponding position ([`best_candidate`]).
+    // Refusing to anchor ambiguous duplicates at all would instead strand them
+    // with no bottom-up seed, which is strictly worse.
+    for u in order {
+        if m.src_matched(u) {
+            continue;
+        }
+        let Some(cands) = dst_by_hash.get(&s.nodes[u].hash) else {
+            continue;
+        };
+        if let Some(w) = best_candidate(s, d, u, cands, m) {
+            map_isomorphic(s, d, u, w, m);
+        }
+    }
+}
+
+/// Pick the free candidate in `cands` (all of which are isomorphic to `u`) that
+/// sits in the most structurally corresponding position, by three criteria in
+/// descending priority:
+///
+/// 1. **Its parent already corresponds to `u`'s.** Exact information, when the
+///    enclosing structure happens to be matched already.
+/// 2. **The longest agreeing chain of ancestor kinds.** `1` in a branch body
+///    and `1` in that branch's guard are indistinguishable as subtrees; their
+///    ancestor chains (`Case, Let` vs `BinOp, Case, Let`) are not.
+/// 3. **The closest depth**, then source order, as a deterministic tie-break.
+///
+/// Without this the choice is arbitrary, and an arbitrary choice manufactures a
+/// spurious move plus a spurious delete/insert pair for the copy it displaced.
+fn best_candidate(
+    s: &Indexed,
+    d: &Indexed,
+    u: usize,
+    cands: &[usize],
+    m: &Matching,
+) -> Option<usize> {
+    let mut free = cands.iter().copied().filter(|&w| !m.dst_matched(w));
+    let first = free.next()?;
+    let Some(second) = free.next() else {
+        return Some(first); // unambiguous: no scoring needed
+    };
+
+    let parent_corresponds = |w: usize| match (s.nodes[u].parent, d.nodes[w].parent) {
+        (Some(pu), Some(pw)) => m.src_to_dst[pu] == Some(pw),
+        (None, None) => true,
+        _ => false,
+    };
+    let u_ancestors = ancestor_kinds(s, u);
+    let score = |w: usize| {
+        let agree = ancestor_kinds(d, w)
+            .iter()
+            .zip(&u_ancestors)
+            .take_while(|(a, b)| a == b)
+            .count();
+        let depth_gap = s.nodes[u].depth.abs_diff(d.nodes[w].depth);
+        (parent_corresponds(w), agree, Reverse(depth_gap))
+    };
+    [first, second]
+        .into_iter()
+        .chain(free)
+        .max_by_key(|&w| (score(w), Reverse(w)))
+}
+
+/// The kinds of `n`'s ancestors, innermost (its parent) first.
+fn ancestor_kinds(t: &Indexed, n: usize) -> Vec<Discriminant<super::TypedExprNode>> {
+    let mut out = Vec::new();
+    let mut cur = t.nodes[n].parent;
+    while let Some(p) = cur {
+        out.push(t.nodes[p].kind);
+        cur = t.nodes[p].parent;
+    }
+    out
+}
+
+/// Map two subtrees known to be isomorphic (equal content hash). Children are
+/// paired by hash, not position, so the correspondence is correct even for the
+/// order-insensitive nodes (`Record`, `DisjointJoin`), whose children may be
+/// stored in a different order despite equal hashes. Already-matched nodes are
+/// skipped so a recursive mapping can never overwrite an existing pairing —
+/// reachable when a subtree shape repeats and two separate anchors descend into
+/// overlapping dst regions.
+fn map_isomorphic(s: &Indexed, d: &Indexed, u: usize, w: usize, m: &mut Matching) {
+    m.map(u, w);
+    let wc = &d.nodes[w].children;
+    let mut used = vec![false; wc.len()];
+    for &cu in &s.nodes[u].children {
+        if m.src_matched(cu) {
+            continue;
+        }
+        let hu = s.nodes[cu].hash;
+        if let Some(pos) = wc
+            .iter()
+            .enumerate()
+            .position(|(i, &cw)| !used[i] && !m.dst_matched(cw) && d.nodes[cw].hash == hu)
+        {
+            used[pos] = true;
+            map_isomorphic(s, d, cu, wc[pos], m);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: bottom-up container recovery
+// ---------------------------------------------------------------------------
+
+fn bottom_up(s: &Indexed, d: &Indexed, m: &mut Matching) {
+    // Children before parents: process unmatched interior nodes by ascending
+    // height, so a container's similarity reflects matches already made below.
+    let mut order: Vec<usize> = (0..s.len())
+        .filter(|&i| !s.nodes[i].children.is_empty())
+        .collect();
+    order.sort_by_key(|&i| s.nodes[i].height);
+
+    for u in order {
+        if m.src_matched(u) {
+            continue;
+        }
+        // Where do u's matched descendants land in dst?
+        let targets: Vec<usize> = (u + 1..s.subtree_end(u))
+            .filter_map(|x| m.src_to_dst[x])
+            .collect();
+        if targets.is_empty() {
+            continue;
+        }
+
+        // Two questions, two measures. *Containment* decides whether `w` is a
+        // plausible counterpart at all; *tightness* picks between the plausible
+        // ones. Conflating them is what made a container that gained a
+        // statement look implausible — see the note on the two below.
+        let src_desc = f64::from(s.nodes[u].size - 1);
+        let mut best: Option<(usize, f64)> = None;
+        for w in 0..d.len() {
+            if d.nodes[w].children.is_empty()
+                || m.dst_matched(w)
+                || d.nodes[w].kind != s.nodes[u].kind
+            {
+                continue;
+            }
+            let common = targets.iter().filter(|&&t| d.is_descendant(t, w)).count();
+            if common == 0 {
+                continue;
+            }
+            let dst_desc = f64::from(d.nodes[w].size - 1);
+            // Containment (the overlap coefficient): "is one of these two
+            // essentially inside the other?" Normalizing by the *smaller*
+            // subtree is what makes it survive an edit that grows or shrinks
+            // one side — the case Dice alone gets wrong.
+            let contained = common as f64 / src_desc.min(dst_desc);
+            if contained < SIMILARITY_THRESHOLD {
+                continue;
+            }
+            // Tightness (Dice): among the plausible candidates — which are
+            // necessarily nested in one another, since they all contain the
+            // same matched descendants — the growing denominator prefers the
+            // innermost, i.e. the container that fits `u` best.
+            let dice = 2.0 * common as f64 / (src_desc + dst_desc);
+            if best.is_none_or(|(_, b)| dice > b) {
+                best = Some((w, dice));
+            }
+        }
+
+        if let Some((w, _)) = best {
+            m.map(u, w);
+            recover(s, d, u, w, m);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: optimal recovery inside a paired container
+// ---------------------------------------------------------------------------
+
+/// Optimally align the still-unmatched interiors of a freshly paired
+/// container pair `(u, w)`.
+///
+/// Steps 1–2 match by *whole-subtree* equality and by container similarity;
+/// neither can pair two subtrees that are nearly identical but differ somewhere
+/// inside. That leaves a real gap: an edit deep in a large subtree would report
+/// the whole surrounding structure as deleted-and-reinserted. This step closes
+/// it by computing the minimum-cost edit mapping between the two subtrees
+/// ([`ted::mapping`]) and adopting every pair it aligns whose nodes are
+/// same-kind and still unmatched.
+///
+/// The mapping is *optimal* under unit edit costs. (GumTree reaches for RTED,
+/// which computes the same optimal mapping as the Zhang–Shasha dynamic program
+/// used here, faster, by choosing a better decomposition strategy — the
+/// difference is asymptotic cost, not the result.) Subtrees above
+/// [`MAX_RECOVERY_SIZE`] are left to steps 1–2 alone.
+fn recover(s: &Indexed, d: &Indexed, u: usize, w: usize, m: &mut Matching) {
+    if s.nodes[u].size > MAX_RECOVERY_SIZE || d.nodes[w].size > MAX_RECOVERY_SIZE {
+        return;
+    }
+    for (x, y) in ted::mapping(s, u, d, w, m) {
+        if !m.src_matched(x) && !m.dst_matched(y) && s.nodes[x].kind == d.nodes[y].kind {
+            m.map(x, y);
+        }
+    }
+}
+
+/// Zhang–Shasha tree edit distance, specialized to recovering the *mapping*
+/// between two subtrees of already-indexed trees.
+///
+/// Node labels are content hashes: relabelling is free when the hashes agree
+/// and costs one otherwise; deleting or inserting a node costs one. The
+/// returned mapping is the node correspondence induced by a minimum-cost edit
+/// script.
+mod ted {
+    use super::Indexed;
+
+    /// A subtree flattened into post-order, the indexing Zhang–Shasha needs.
+    /// Post-order numbering is 1-based; index 0 is the empty-forest sentinel
+    /// used by the dynamic program's boundary row and column.
+    struct Post {
+        /// `global[k]` is the enclosing [`Indexed`] index of post-order node `k`.
+        global: Vec<usize>,
+        /// `leftmost[k]` is the post-order index of `k`'s leftmost-leaf
+        /// descendant. In post-order a subtree occupies a contiguous range
+        /// ending at its root, so this is just `k - size(k) + 1`.
+        leftmost: Vec<usize>,
+        /// Nodes that head a distinct `leftmost` chain — the roots of the
+        /// subproblems the dynamic program is decomposed over.
+        keyroots: Vec<usize>,
+    }
+
+    impl Post {
+        fn build(t: &Indexed, root: usize) -> Self {
+            let mut global = vec![usize::MAX]; // sentinel at index 0
+            fn walk(t: &Indexed, n: usize, global: &mut Vec<usize>) {
+                for &c in &t.nodes[n].children {
+                    walk(t, c, global);
+                }
+                global.push(n);
+            }
+            walk(t, root, &mut global);
+
+            let leftmost: Vec<usize> = (0..global.len())
+                .map(|k| {
+                    if k == 0 {
+                        0
+                    } else {
+                        k - t.nodes[global[k]].size as usize + 1
+                    }
+                })
+                .collect();
+
+            // The last node of each distinct `leftmost` chain is its keyroot.
+            let mut last_of_chain = vec![0usize; global.len()];
+            for k in 1..global.len() {
+                last_of_chain[leftmost[k]] = k;
+            }
+            let mut keyroots: Vec<usize> = last_of_chain
+                .into_iter()
+                .skip(1)
+                .filter(|&k| k > 0)
+                .collect();
+            keyroots.sort_unstable();
+            keyroots.dedup();
+
+            Post {
+                global,
+                leftmost,
+                keyroots,
+            }
+        }
+
+        fn n(&self) -> usize {
+            self.global.len() - 1
+        }
+    }
+
+    /// The forest-distance table for one keyroot pair, indexed
+    /// `[i - l(ki) + 1][j - l(kj) + 1]` with row/column 0 the empty forest.
+    struct Forest {
+        rows: usize,
+        cols: usize,
+        d: Vec<u32>,
+    }
+
+    impl Forest {
+        fn get(&self, i: usize, j: usize) -> u32 {
+            self.d[i * self.cols + j]
+        }
+        fn set(&mut self, i: usize, j: usize, v: u32) {
+            self.d[i * self.cols + j] = v;
+        }
+    }
+
+    /// Relabelling cost.
+    ///
+    /// Free when the two nodes are the same computation, or when the earlier
+    /// phases already paired them. **Prohibitive** when either node is already
+    /// paired with somebody else: the edit distance is otherwise free to invent
+    /// an alignment that contradicts an anchor, and since only its *unmatched*
+    /// pairs are adopted, the contradiction survives as a silently wrong match
+    /// — a `let` in a spine mapped to its own inner `let`, say, because the
+    /// distance was happy to shift the whole chain by one. Three exceeds the
+    /// cost of deleting and inserting instead (two), so a conflicting pair is
+    /// never on an optimal script.
+    fn relabel(a: &Indexed, ga: usize, b: &Indexed, gb: usize, m: &super::Matching) -> u32 {
+        match (m.src_to_dst[ga], m.dst_to_src[gb]) {
+            (Some(y), _) if y == gb => 0,
+            (None, None) => u32::from(a.nodes[ga].hash != b.nodes[gb].hash),
+            _ => 3,
+        }
+    }
+
+    /// Fill the forest-distance table for keyroot pair `(ki, kj)`, writing any
+    /// whole-subtree distances it settles into `tree`.
+    #[allow(clippy::too_many_arguments)]
+    fn forest_dist(
+        s: &Indexed,
+        ps: &Post,
+        d: &Indexed,
+        pd: &Post,
+        ki: usize,
+        kj: usize,
+        m: &super::Matching,
+        tree: &mut [u32],
+    ) -> Forest {
+        let (li, lj) = (ps.leftmost[ki], pd.leftmost[kj]);
+        let (rows, cols) = (ki - li + 2, kj - lj + 2);
+        let mut f = Forest {
+            rows,
+            cols,
+            d: vec![0; rows * cols],
+        };
+        for i in 1..rows {
+            f.set(i, 0, f.get(i - 1, 0) + 1);
+        }
+        for j in 1..cols {
+            f.set(0, j, f.get(0, j - 1) + 1);
+        }
+        for i in 1..rows {
+            for j in 1..cols {
+                let (pi, pj) = (li + i - 1, lj + j - 1); // post-order indices
+                let del = f.get(i - 1, j) + 1;
+                let ins = f.get(i, j - 1) + 1;
+                if ps.leftmost[pi] == li && pd.leftmost[pj] == lj {
+                    // Both are whole subtrees rooted here: this cell *is* the
+                    // tree distance, so record it for the outer decomposition.
+                    let ren = f.get(i - 1, j - 1) + relabel(s, ps.global[pi], d, pd.global[pj], m);
+                    let best = del.min(ins).min(ren);
+                    f.set(i, j, best);
+                    tree[(pi - 1) * pd.n() + (pj - 1)] = best;
+                } else {
+                    // Peel both subtrees off and reuse their settled distance.
+                    let (bi, bj) = (ps.leftmost[pi] - li, pd.leftmost[pj] - lj);
+                    let sub = f.get(bi, bj) + tree[(pi - 1) * pd.n() + (pj - 1)];
+                    f.set(i, j, del.min(ins).min(sub));
+                }
+            }
+        }
+        f
+    }
+
+    /// The node correspondence induced by a minimum-cost edit script between
+    /// the subtree of `s` rooted at `su` and the subtree of `d` rooted at `dw`.
+    /// Pairs are `(Indexed` index in `s`, `Indexed` index in `d)`.
+    pub(super) fn mapping(
+        s: &Indexed,
+        su: usize,
+        d: &Indexed,
+        dw: usize,
+        m: &super::Matching,
+    ) -> Vec<(usize, usize)> {
+        let ps = Post::build(s, su);
+        let pd = Post::build(d, dw);
+        let mut tree = vec![0u32; ps.n() * pd.n()];
+        for &ki in &ps.keyroots {
+            for &kj in &pd.keyroots {
+                forest_dist(s, &ps, d, &pd, ki, kj, m, &mut tree);
+            }
+        }
+
+        // Trace an optimal script back through the same recurrence. Each entry
+        // of `todo` is a keyroot pair whose forest table has to be re-derived;
+        // re-deriving costs one table each and there are `O(n + m)` of them,
+        // which is cheaper than retaining every table from the fill above.
+        let mut out = Vec::new();
+        let mut todo = vec![(ps.n(), pd.n())];
+        while let Some((ki, kj)) = todo.pop() {
+            let f = forest_dist(s, &ps, d, &pd, ki, kj, m, &mut tree);
+            let (li, lj) = (ps.leftmost[ki], pd.leftmost[kj]);
+            let (mut i, mut j) = (f.rows - 1, f.cols - 1);
+            while i > 0 || j > 0 {
+                if i > 0 && f.get(i, j) == f.get(i - 1, j) + 1 {
+                    i -= 1; // delete
+                } else if j > 0 && f.get(i, j) == f.get(i, j - 1) + 1 {
+                    j -= 1; // insert
+                } else {
+                    let (pi, pj) = (li + i - 1, lj + j - 1);
+                    if ps.leftmost[pi] == li && pd.leftmost[pj] == lj {
+                        out.push((ps.global[pi], pd.global[pj]));
+                        i -= 1;
+                        j -= 1;
+                    } else {
+                        todo.push((pi, pj));
+                        i = ps.leftmost[pi] - li;
+                        j = pd.leftmost[pj] - lj;
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+/// The [`resolved_hash`] of every node of `t`, indexed the same way `t` is.
+///
+/// Walks top-down carrying the binders each node sits under, each tagged with
+/// the class `class_of` gives its owner, so a free variable inside a subterm
+/// hashes to *which binder it resolves to* rather than to how that binder
+/// happens to be spelled.
+///
+/// The binders a node puts over each of its children come from
+/// [`for_each_scoped_item`], the crate's single statement of CCL's binding
+/// structure — this walk does not restate them. It is keyed by child pointer
+/// because the differ descends into one child the scope walk does not: a cast
+/// target's refinement predicate, which is a type slot. That predicate sits in
+/// its cast's own scope, so an absent entry meaning "no binders" is exactly
+/// right for it.
+fn resolved_hashes(t: &Indexed<'_>, class_of: &dyn Fn(usize) -> u64) -> Vec<u64> {
+    fn go<'a>(
+        t: &Indexed<'a>,
+        i: usize,
+        scope: &mut Vec<(&'a Name, u64)>,
+        class_of: &dyn Fn(usize) -> u64,
+        out: &mut [u64],
+    ) {
+        out[i] = resolved_hash(t.nodes[i].expr, scope).0;
+
+        let mut introduced: HashMap<*const TypedExpr, Vec<&'a Name>> = HashMap::new();
+        for_each_scoped_item(t.nodes[i].expr, &mut |item| {
+            if let ScopedItem::Child { expr, binders } = item
+                && !binders.is_empty()
+            {
+                introduced.insert(
+                    expr as *const TypedExpr,
+                    binders.iter().map(|b| &b.name).collect(),
+                );
+            }
+        });
+
+        let class = class_of(i);
+        for &c in &t.nodes[i].children {
+            let added = introduced
+                .get(&(t.nodes[c].expr as *const TypedExpr))
+                .map_or(0, |names| {
+                    for n in names {
+                        scope.push((n, class));
+                    }
+                    names.len()
+                });
+            go(t, c, scope, class_of, out);
+            scope.truncate(scope.len() - added);
+        }
+    }
+
+    let mut out = vec![0u64; t.len()];
+    go(t, 0, &mut Vec::new(), class_of, &mut out);
+    out
+}
+
+fn classify<'a>(s: &Indexed<'a>, d: &Indexed<'a>, m: &Matching) -> Diff<'a> {
+    let in_place = align_children(s, d, m);
+    // A binder's *class*: a token its counterpart in the other program shares.
+    // A src binder's class is the dst node it matched; an unmatched one gets a
+    // token out of dst's index range, so it can never look like a match.
+    let src_class = |u: usize| m.src_to_dst[u].unwrap_or(d.len() + u) as u64;
+    let dst_class = |w: usize| w as u64;
+    let src_resolved = resolved_hashes(s, &src_class);
+    let dst_resolved = resolved_hashes(d, &dst_class);
+    let mut out = Diff {
+        matched: Vec::new(),
+        deleted: Vec::new(),
+        new: Vec::new(),
+        src_root: s.nodes[0].expr,
+        dst_root: d.nodes[0].expr,
+    };
+    for (u, &dst) in m.src_to_dst.iter().enumerate() {
+        match dst {
+            Some(w) => out.matched.push(Match {
+                src: s.nodes[u].expr,
+                dst: d.nodes[w].expr,
+                content: if src_resolved[u] == dst_resolved[w] {
+                    Content::Same
+                } else {
+                    Content::Changed
+                },
+                placement: if in_place[u] {
+                    Placement::InPlace
+                } else {
+                    Placement::Moved
+                },
+            }),
+            None => out.deleted.push(s.nodes[u].expr),
+        }
+    }
+    for (w, &src) in m.dst_to_src.iter().enumerate() {
+        if src.is_none() {
+            out.new.push(d.nodes[w].expr);
+        }
+    }
+    out
+}
+
+/// Decide, for every matched src node, whether it kept its position — the
+/// child-alignment step of Chawathe et al.'s edit-script derivation, which
+/// GumTree inherits.
+///
+/// A node is in place iff it hangs off the corresponding parent **and** it did
+/// not cross any of its matched siblings. Within one matched container pair,
+/// "did not cross" is decided by taking a longest increasing subsequence of the
+/// matched children's destination positions: the children on it kept their
+/// relative order and stay put, and the rest are the minimum set of moves that
+/// explains the permutation. Order-insensitive containers skip the test —
+/// permuting their children is not an edit at all.
+fn align_children(s: &Indexed, d: &Indexed, m: &Matching) -> Vec<bool> {
+    let mut in_place = vec![false; s.len()];
+
+    for (u, &dst) in m.src_to_dst.iter().enumerate() {
+        // A matched pair of roots has no parent to disagree with.
+        if let Some(w) = dst
+            && s.nodes[u].parent.is_none()
+            && d.nodes[w].parent.is_none()
+        {
+            in_place[u] = true;
+        }
+    }
+
+    for pu in 0..s.len() {
+        let Some(pw) = m.src_to_dst[pu] else {
+            continue;
+        };
+        // Children of `pu` that matched into a child of `pw`, with the
+        // destination slot each landed in. A child matched somewhere else in
+        // the target tree is absent here, and so stays `Moved`.
+        let paired: Vec<(usize, usize)> = s.nodes[pu]
+            .children
+            .iter()
+            .filter_map(|&c| {
+                let w = m.src_to_dst[c]?;
+                let slot = d.nodes[pw].children.iter().position(|&x| x == w)?;
+                Some((c, slot))
+            })
+            .collect();
+
+        if s.nodes[pu].unordered || d.nodes[pw].unordered {
+            for (c, _) in paired {
+                in_place[c] = true;
+            }
+            continue;
+        }
+        let slots: Vec<usize> = paired.iter().map(|&(_, slot)| slot).collect();
+        for i in longest_increasing(&slots) {
+            in_place[paired[i].0] = true;
+        }
+    }
+    in_place
+}
+
+/// Indices of one longest strictly-increasing subsequence of `seq`, ascending.
+/// Patience sorting: `tails[k]` is the index of the smallest tail among the
+/// increasing subsequences of length `k + 1` found so far.
+fn longest_increasing(seq: &[usize]) -> Vec<usize> {
+    let mut tails: Vec<usize> = Vec::new();
+    let mut prev: Vec<Option<usize>> = vec![None; seq.len()];
+    for i in 0..seq.len() {
+        let pos = tails.partition_point(|&t| seq[t] < seq[i]);
+        if pos > 0 {
+            prev[i] = Some(tails[pos - 1]);
+        }
+        if pos == tails.len() {
+            tails.push(i);
+        } else {
+            tails[pos] = i;
+        }
+    }
+    let mut out = Vec::new();
+    let mut cur = tails.last().copied();
+    while let Some(i) = cur {
+        out.push(i);
+        cur = prev[i];
+    }
+    out.reverse();
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/// How wide a single node's term rendering may get before it is elided.
+const RENDER_WIDTH: usize = 68;
+
+/// One node's own line in a rendered diff: the head of its symbolic form.
+///
+/// A node is shown by rendering its whole subterm with
+/// [`symbolic`](crate::ccl::symbolic::symbolic) and keeping the first line, cut
+/// to [`RENDER_WIDTH`]. That reads naturally — a leaf prints exactly, an
+/// interior node prints its head (`let a = 1 in …`) — and it costs nothing to
+/// keep in step with the AST, which a second shallow-label vocabulary would
+/// not. The price is `O(n²)` text for the whole tree; this is a debugging and
+/// inspection surface, not a hot path.
+fn head(e: &TypedExpr) -> String {
+    let full = crate::ccl::symbolic::symbolic(e);
+    let line = full.lines().next().unwrap_or("").trim_end();
+    let mut out: String = line.chars().take(RENDER_WIDTH).collect();
+    if line.chars().count() > RENDER_WIDTH || full.lines().nth(1).is_some() {
+        out.push('…');
+    }
+    out
+}
+
+/// Renders as an annotated tree of the **new** program, plus whatever the old
+/// program had that the new one dropped.
+///
+/// Every node of the new program is marked with what the diff concluded about
+/// it. An inserted or deleted subtree is shown by its **root** only, with its
+/// node count — printing every node of a pasted-in block is noise, and the root
+/// is the actionable unit.
+///
+/// ```text
+/// 15 shared · 3 changed · 1 moved · 0 deleted · 4 new
+///
+/// ~ let a = 1 in let b = sum(…) in a + b…
+///   = 1
+///   + let b = sum([i ▷ (λ i → i * 2) for …    (+13 nodes)
+///   ~ a + b
+///     = a
+/// ```
+///
+/// Markers: `=` unchanged, `~` content changed, `+` new, `-` deleted, and a
+/// trailing `»` on a node whose placement changed.
+impl std::fmt::Display for Diff<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let by_dst: HashMap<*const TypedExpr, &Match> = self
+            .matched
+            .iter()
+            .map(|m| (m.dst as *const TypedExpr, m))
+            .collect();
+        let inserted: HashSet<*const TypedExpr> =
+            self.new.iter().map(|e| *e as *const TypedExpr).collect();
+
+        writeln!(
+            f,
+            "{} shared · {} changed · {} moved · {} deleted · {} new",
+            self.shared().count(),
+            self.updated().count(),
+            self.moved().count(),
+            self.deleted.len(),
+            self.new.len(),
+        )?;
+        writeln!(f)?;
+
+        render_node(f, self.dst_root, 0, &by_dst, &inserted)?;
+
+        // Anything the old program had that the new one does not.
+        let gone: HashSet<*const TypedExpr> = self
+            .deleted
+            .iter()
+            .map(|e| *e as *const TypedExpr)
+            .collect();
+        let mut roots: Vec<(&TypedExpr, bool)> = Vec::new();
+        collect_deleted_roots(self.src_root, &gone, &mut roots);
+        if !roots.is_empty() {
+            writeln!(f)?;
+            for (e, whole) in roots {
+                let note = if whole { size_note(e) } else { String::new() };
+                writeln!(f, "- {}{note}", head(e))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Is every node of `e`'s subtree in `set`?
+///
+/// This is what decides whether a wholly-inserted or wholly-deleted region may
+/// collapse to its root in the rendering. A node in `set` whose *interior* is
+/// still matched is a different thing entirely — a wrapper that appeared or
+/// vanished around content that survived — and collapsing it would claim its
+/// surviving children changed too.
+fn subtree_entirely_in(e: &TypedExpr, set: &HashSet<*const TypedExpr>) -> bool {
+    set.contains(&(e as *const TypedExpr)) && e.all_children(|c| subtree_entirely_in(c, set))
+}
+
+/// `    (+N nodes)` when `e` has descendants, so an elided subtree still
+/// reports how much it stands for; empty for a leaf.
+fn size_note(e: &TypedExpr) -> String {
+    let mut n = 0;
+    fn count(e: &TypedExpr, n: &mut usize) {
+        *n += 1;
+        e.walk_children(|c| count(c, n));
+    }
+    e.walk_children(|c| count(c, &mut n));
+    if n == 0 {
+        String::new()
+    } else {
+        format!("    (+{n} nodes)")
+    }
+}
+
+fn render_node(
+    f: &mut std::fmt::Formatter<'_>,
+    e: &TypedExpr,
+    depth: usize,
+    by_dst: &HashMap<*const TypedExpr, &Match>,
+    inserted: &HashSet<*const TypedExpr>,
+) -> std::fmt::Result {
+    let indent = "  ".repeat(depth);
+    match by_dst.get(&(e as *const TypedExpr)) {
+        // Target-only. A wholly-new region collapses to its root; a new node
+        // wrapping content that survived is shown with that content under it.
+        None if subtree_entirely_in(e, inserted) => {
+            writeln!(f, "{indent}+ {}{}", head(e), size_note(e))
+        }
+        None => {
+            writeln!(f, "{indent}+ {}", head(e))?;
+            for c in child_exprs(e) {
+                render_node(f, c, depth + 1, by_dst, inserted)?;
+            }
+            Ok(())
+        }
+        Some(m) => {
+            let mark = match m.content {
+                Content::Same => '=',
+                Content::Changed => '~',
+            };
+            let moved = if m.placement == Placement::Moved {
+                " »"
+            } else {
+                ""
+            };
+            writeln!(f, "{indent}{mark} {}{moved}", head(e))?;
+            // An unchanged subtree is unchanged all the way down; descending
+            // would print it verbatim for no information.
+            if m.content == Content::Changed {
+                for c in child_exprs(e) {
+                    render_node(f, c, depth + 1, by_dst, inserted)?;
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Collect the topmost deleted nodes of `root`, each flagged with whether its
+/// whole subtree went with it. A wholly-deleted region is reported once, at its
+/// root; a deleted node whose children survived is reported alone, and the walk
+/// continues through it to find whatever else was dropped further down.
+fn collect_deleted_roots<'a>(
+    e: &'a TypedExpr,
+    gone: &HashSet<*const TypedExpr>,
+    out: &mut Vec<(&'a TypedExpr, bool)>,
+) {
+    if gone.contains(&(e as *const TypedExpr)) {
+        let whole = subtree_entirely_in(e, gone);
+        out.push((e, whole));
+        if whole {
+            return;
+        }
+    }
+    for c in child_exprs(e) {
+        collect_deleted_roots(c, gone, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccl::content_hash::content_hash;
+    use crate::ccl::{ArithmeticKind, BinOpKind, Lit, TypedExpr, TypedExprNode};
+
+    fn var(name: &str) -> TypedExpr {
+        TypedExpr::var(name)
+    }
+    fn int(n: i64) -> TypedExpr {
+        TypedExpr::lit(Lit::Int(n))
+    }
+    fn str_lit(s: &str) -> TypedExpr {
+        TypedExpr::lit(Lit::String(s.into()))
+    }
+    fn add(l: TypedExpr, r: TypedExpr) -> TypedExpr {
+        TypedExpr::binop(l, BinOpKind::Arithmetic(ArithmeticKind::Add), r)
+    }
+    fn mul(l: TypedExpr, r: TypedExpr) -> TypedExpr {
+        TypedExpr::binop(l, BinOpKind::Arithmetic(ArithmeticKind::Mul), r)
+    }
+    fn let_in(name: &str, value: TypedExpr, body: TypedExpr) -> TypedExpr {
+        TypedExpr::let_bind(name, value, body)
+    }
+
+    /// The src sides of the matches whose content changed, as a convenience for
+    /// asserting "this literal is an update, not a delete+insert".
+    fn updated_pairs<'a>(d: &Diff<'a>) -> Vec<(&'a TypedExpr, &'a TypedExpr)> {
+        d.updated().map(|m| (m.src, m.dst)).collect()
+    }
+
+    #[test]
+    fn identical_programs_are_entirely_shared() {
+        let a = let_in("x", int(1), add(var("x"), var("y")));
+        let b = a.clone();
+        let r = diff(&a, &b);
+        assert!(r.is_identical());
+        // The root, and every node under it, is shared.
+        assert!(r.shared().any(|m| std::ptr::eq(m.src, &a)));
+        assert_eq!(r.shared().count(), 5); // Let, 1, BinOp, x, y
+    }
+
+    #[test]
+    fn motivating_example_isolates_one_inserted_node() {
+        // ("idx", index)  ->  ("idx", 2 * index)
+        let v1 = TypedExpr::tuple(vec![str_lit("idx"), var("index")]);
+        let v2 = TypedExpr::tuple(vec![str_lit("idx"), mul(int(2), var("index"))]);
+        let r = diff(&v1, &v2);
+
+        // Nothing is deleted: the old value `index` survives inside `2 * index`.
+        assert!(r.deleted.is_empty(), "deleted: {:?}", r.deleted);
+        // The divergence is one site: a single new *container* (the `2 * _`
+        // BinOp). Its literal `2` is also new, but `index` is reused, not
+        // re-inserted — that is the whole point of structural sharing.
+        assert_eq!(
+            r.new
+                .iter()
+                .filter(|e| matches!(e.node, TypedExprNode::BinOp { .. }))
+                .count(),
+            1,
+            "new: {:?}",
+            r.new
+        );
+        assert!(
+            !r.new
+                .iter()
+                .any(|e| matches!(&e.node, TypedExprNode::Var(_))),
+            "the shared `index` must not be re-inserted",
+        );
+        // The unchanged key and the surviving `index` are shared.
+        assert!(
+            r.shared()
+                .any(|m| content_hash(m.src) == content_hash(&str_lit("idx")))
+        );
+        assert!(
+            r.shared()
+                .any(|m| content_hash(m.src) == content_hash(&var("index")))
+        );
+        // The two tuples correspond but differ → an update.
+        assert!(
+            r.updated()
+                .any(|m| matches!(m.src.node, TypedExprNode::Tuple(_)))
+        );
+    }
+
+    #[test]
+    fn inserting_a_statement_does_not_desync_the_spine() {
+        // let a = 1 in (let b = 2 in a + b)
+        // let a = 1 in (let c = 9 in (let b = 2 in a + b))   <- middle insertion
+        let tail = || let_in("b", int(2), add(var("a"), var("b")));
+        let v1 = let_in("a", int(1), tail());
+        let v2 = let_in("a", int(1), let_in("c", int(9), tail()));
+        let r = diff(&v1, &v2);
+
+        // The unchanged tail subtree anchors as shared rather than the whole
+        // body below `a` reading as rewritten.
+        let tail_expr = tail();
+        assert!(
+            r.shared()
+                .any(|m| content_hash(m.src) == content_hash(&tail_expr)),
+            "tail subtree should be shared",
+        );
+        // Nothing deleted; the inserted `let c = 9` shows up as new.
+        assert!(r.deleted.is_empty(), "deleted: {:?}", r.deleted);
+        assert!(!r.new.is_empty());
+        assert!(
+            r.new
+                .iter()
+                .any(|e| matches!(e.node, TypedExprNode::Let { .. }))
+        );
+    }
+
+    #[test]
+    fn unrelated_programs_share_nothing_structural() {
+        let a = add(var("p"), var("q"));
+        let b = str_lit("hello");
+        let r = diff(&a, &b);
+        assert_eq!(r.shared().count(), 0);
+        // a's nodes are all deleted, b's all new.
+        assert_eq!(r.deleted.len(), 3); // BinOp, p, q
+        assert_eq!(r.new.len(), 1); // the string
+    }
+
+    #[test]
+    fn repeated_subtrees_match_without_corruption() {
+        // Two identical `x + 1` subtrees, one edited to `x + 2`. A repeated
+        // shape means top-down anchors the duplicates arbitrarily and recursive
+        // mappings can touch overlapping dst regions — the already-matched guard
+        // in `map_isomorphic` keeps that sound. The diff should localize to the
+        // edited literal, not rewrite the world.
+        let v1 = TypedExpr::tuple(vec![add(var("x"), int(1)), add(var("x"), int(1))]);
+        let v2 = TypedExpr::tuple(vec![add(var("x"), int(1)), add(var("x"), int(2))]);
+        let r = diff(&v1, &v2);
+        assert!(r.deleted.is_empty(), "deleted: {:?}", r.deleted);
+        assert!(r.new.is_empty(), "new: {:?}", r.new);
+        // The one divergence is the literal, recovered as an in-place update.
+        let lit_updates: Vec<_> = updated_pairs(&r)
+            .into_iter()
+            .filter(|(s, _)| matches!(s.node, TypedExprNode::Lit(_)))
+            .collect();
+        assert_eq!(lit_updates.len(), 1, "exactly one literal changed");
+        assert!(matches!(
+            lit_updates[0].0.node,
+            TypedExprNode::Lit(Lit::Int(1))
+        ));
+        assert!(matches!(
+            lit_updates[0].1.node,
+            TypedExprNode::Lit(Lit::Int(2))
+        ));
+        // An unchanged `x + 1` (and its operands) survive as shared.
+        assert!(
+            r.shared()
+                .any(|m| matches!(m.src.node, TypedExprNode::BinOp { .. })),
+            "an unchanged x+1 stays shared",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Placement: moves, reorders, and the order-insensitive exemption
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn relocated_subtree_is_matched_and_labelled_moved() {
+        // Content-hash matching is position-independent, so a subtree relocated
+        // to a new parent is recognized (shared content) rather than reported
+        // as a delete + insert — and the placement axis says it moved.
+        let moved = add(var("a"), var("b"));
+        let v1 = TypedExpr::tuple(vec![moved.clone(), int(9)]);
+        // `a + b` is now nested inside `(a + b) * 2`, in the other tuple slot.
+        let v2 = TypedExpr::tuple(vec![int(9), mul(moved.clone(), int(2))]);
+        let r = diff(&v1, &v2);
+
+        let relocated: Vec<_> = r
+            .moved()
+            .filter(|m| content_hash(m.src) == content_hash(&moved))
+            .collect();
+        assert_eq!(relocated.len(), 1, "`a + b` is reported moved, once");
+        assert_eq!(
+            relocated[0].content,
+            Content::Same,
+            "its content is unchanged — the two axes are independent",
+        );
+        // The move is reported at the subtree root only; `a` and `b` came along.
+        assert!(
+            !r.moved()
+                .any(|m| matches!(m.src.node, TypedExprNode::Var(_))),
+            "a moved subtree's descendants stay in place relative to it",
+        );
+        assert!(r.deleted.is_empty(), "the moved subtree is not deleted");
+    }
+
+    #[test]
+    fn sibling_swap_moves_the_minimum_number_of_children() {
+        // Tuples are ordered: swapping two elements leaves both matched, and
+        // exactly one of them has to move to explain the permutation.
+        let (tup_12, tup_21) = (
+            TypedExpr::tuple(vec![int(1), int(2)]),
+            TypedExpr::tuple(vec![int(2), int(1)]),
+        );
+        let r = diff(&tup_12, &tup_21);
+        assert!(
+            r.deleted.is_empty() && r.new.is_empty(),
+            "no element is lost"
+        );
+        assert_eq!(r.shared().count(), 2, "both elements stay shared");
+        // A tuple is ordered, so the container's own content changed too.
+        assert!(
+            r.updated()
+                .any(|m| matches!(m.src.node, TypedExprNode::Tuple(_)))
+        );
+        assert_eq!(r.moved().count(), 1, "one crossing explains the swap");
+        assert!(matches!(
+            r.moved().next().unwrap().src.node,
+            TypedExprNode::Lit(_)
+        ));
+    }
+
+    #[test]
+    fn record_field_reorder_is_not_a_move() {
+        let rec = |fields: Vec<(&str, TypedExpr)>| {
+            TypedExpr::new(TypedExprNode::Record(
+                fields
+                    .into_iter()
+                    .map(|(n, e)| (n.to_string(), e))
+                    .collect(),
+            ))
+        };
+        // Records are order-insensitive, so a field swap is a no-op to the diff
+        // — on the content axis *and* the placement axis.
+        let (rec_ab, rec_ba) = (
+            rec(vec![("a", int(1)), ("b", int(2))]),
+            rec(vec![("b", int(2)), ("a", int(1))]),
+        );
+        let r = diff(&rec_ab, &rec_ba);
+        assert!(r.is_identical(), "record field reorder is a no-op");
+    }
+
+    #[test]
+    fn shifted_siblings_are_not_moves() {
+        // Inserting a statement shifts everything after it by one slot. That is
+        // an insertion, not a pile of moves: the longest increasing subsequence
+        // keeps the untouched children in place.
+        let v1 = TypedExpr::tuple(vec![int(1), int(2), int(3)]);
+        let v2 = TypedExpr::tuple(vec![int(9), int(1), int(2), int(3)]);
+        let r = diff(&v1, &v2);
+        assert_eq!(r.moved().count(), 0, "a shift is not a move");
+        assert_eq!(r.new.len(), 1);
+        assert!(r.deleted.is_empty());
+    }
+
+    #[test]
+    fn an_ambiguous_leaf_anchors_where_it_belongs() {
+        // `(1, v > 0)` -> `(1, v > 1)`. The new version has *two* `1` leaves,
+        // so the tuple's `1` has two isomorphic candidates and the choice is
+        // not free: anchoring it to the guard's `1` would strand the tuple slot
+        // (a spurious insert), strand `0` (a spurious delete), and report a move
+        // that never happened. Structural position picks the tuple slot, and
+        // optimal recovery then reads the guard edit as `0 -> 1`.
+        let guard = |n: i64| {
+            TypedExpr::binop(
+                var("v"),
+                BinOpKind::Compare(crate::ccl::CompareKind::Greater),
+                int(n),
+            )
+        };
+        let v1 = TypedExpr::tuple(vec![int(1), guard(0)]);
+        let v2 = TypedExpr::tuple(vec![int(1), guard(1)]);
+        let r = diff(&v1, &v2);
+
+        assert!(r.deleted.is_empty(), "deleted: {:?}", r.deleted);
+        assert!(r.new.is_empty(), "new: {:?}", r.new);
+        assert_eq!(r.moved().count(), 0, "nothing actually moved");
+        assert!(
+            r.updated().any(|m| {
+                matches!(m.src.node, TypedExprNode::Lit(Lit::Int(0)))
+                    && matches!(m.dst.node, TypedExprNode::Lit(Lit::Int(1)))
+            }),
+            "the guard threshold reads as one in-place update",
+        );
+        // The tuple's own `1` kept its slot rather than being reused elsewhere.
+        assert!(
+            r.shared()
+                .any(|m| matches!(m.src.node, TypedExprNode::Lit(Lit::Int(1)))
+                    && m.placement == Placement::InPlace),
+        );
+    }
+
+    #[test]
+    fn variant_ctor_changes_are_detected() {
+        // `VariantCtor` has no surface syntax (later passes introduce it), so
+        // build it directly.
+        let some1 = TypedExpr::variant_ctor("Some", int(1));
+
+        // Payload change `1 -> 2`. Nothing under the ctor is isomorphic, so
+        // there is no seed for container recovery — but the two ctors are the
+        // two programs' *roots*, which correspond by construction, and phase 3
+        // then aligns the payloads. The edit reads as an update, not a rebuild.
+        let some2 = TypedExpr::variant_ctor("Some", int(2));
+        let r = diff(&some1, &some2);
+        assert!(r.deleted.is_empty() && r.new.is_empty(), "{r:?}");
+        assert!(r.updated().any(|m| {
+            matches!(m.src.node, TypedExprNode::Lit(Lit::Int(1)))
+                && matches!(m.dst.node, TypedExprNode::Lit(Lit::Int(2)))
+        }));
+
+        // Same one level down, where the ctor is not itself a root: the tuple
+        // roots correspond, and recovery reaches the payload through them.
+        let nested =
+            |n: i64| TypedExpr::tuple(vec![int(0), TypedExpr::variant_ctor("Some", int(n))]);
+        let (n1, n2) = (nested(1), nested(2));
+        let r = diff(&n1, &n2);
+        assert!(r.deleted.is_empty() && r.new.is_empty(), "{r:?}");
+        assert!(r.updated().any(|m| {
+            matches!(m.src.node, TypedExprNode::Lit(Lit::Int(1)))
+                && matches!(m.dst.node, TypedExprNode::Lit(Lit::Int(2)))
+        }));
+
+        // Tag change `Some -> None`: the payload `1` stays shared and seeds
+        // bottom-up recovery, so the ctor is recognized as *updated* (the tag
+        // changed in place) rather than rebuilt.
+        let none1 = TypedExpr::variant_ctor("None", int(1));
+        let r = diff(&some1, &none1);
+        assert!(
+            r.shared()
+                .any(|m| matches!(m.src.node, TypedExprNode::Lit(Lit::Int(1)))),
+            "the unchanged payload stays shared",
+        );
+        assert!(
+            r.updated()
+                .any(|m| matches!(m.src.node, TypedExprNode::VariantCtor { .. })),
+            "the tag change marks the ctor updated",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Real lowered / inferred CCL, from CHL source
+    // -----------------------------------------------------------------------
+
+    /// Pre-uniquify CCL (`Raw` names, before inference), via the public API.
+    fn lower(code: &str) -> TypedExpr {
+        compile_to(code, CompileStage::Lowered).expect("compile to lowered stage should succeed")
+    }
+
+    /// Post-inference CCL (uniquified, fully typed), via the public API.
+    fn lower_and_infer(code: &str) -> TypedExpr {
+        compile_to(code, CompileStage::Inferred).expect("compile to inferred stage should succeed")
+    }
+
+    // Realistic CHL programs exercising records, list comprehensions, filters,
+    // aggregates, projections, joins, def/yield generators, groupby, induction
+    // accumulators, and transactional registers. Between them they cover every
+    // node kind that reaches these two stages: `Defer`/`Feed` (generators),
+    // `Case` (guards), `Cast` (comprehension filters), `For`/`MutWrite`
+    // (accumulators), and `Begin` (transaction blocks). `LetRec` and `Transact`
+    // are born *below* the inferred stage — the mutability phases build them —
+    // so no source program can exercise them here; `content_hash` covers them
+    // structurally instead.
+    const FILTER_AGG: &str = "users = [\n  (name=\"alice\", age=30, score=85),\n  (name=\"bob\", age=17, score=92),\n]\nsum([u.score for u in users if u.age >= 18])\n";
+    const FILTER_AGG_21: &str = "users = [\n  (name=\"alice\", age=30, score=85),\n  (name=\"bob\", age=17, score=92),\n]\nsum([u.score for u in users if u.age >= 21])\n";
+    const GENERATORS: &str = "def positives(xs):\n    for x in xs:\n        if x > 0:\n            yield x\n\ndef squared(xs):\n    for x in xs:\n        yield x * x\n\nmax(squared(positives([-3, 4, -1, 2, 5, -7])))\n";
+    const JOIN: &str = "users = [(id=1, name=\"alice\"), (id=2, name=\"bob\")]\norders = [(user_id=1, amount=50), (user_id=2, amount=75)]\n[(customer=u.name, total=o.amount) for u in users for o in orders if u.id == o.user_id]\n";
+    const GROUPBY: &str = "sales = [(region=\"west\", amount=100), (region=\"east\", amount=50)]\n[sum([s.amount for s in g]) for g in groupby(sales, \\r -> r.region)]\n";
+    const ACCUM: &str = "acc := 0\nfor i in [1, 2, 3, 4, 5]:\n    acc := acc + i\nacc\n";
+    const TXN: &str = "pool: Mut(Int, Txn) := 100\nreqs = [1, 2, 3]\nfor r in reqs:\n    with begin():\n        pool := pool - r\n";
+
+    #[test]
+    fn lowered_source_is_stable_across_independent_compilations() {
+        // The point of diffing pre-uniquify on Raw names: lowering the same
+        // source twice, through independent contexts, yields trees that diff as
+        // identical — no spurious divergence from fresh binder identities.
+        let src = "x = 1\ny = x + 2\ny\n";
+        let (a, b) = (lower(src), lower(src));
+        let r = diff(&a, &b);
+        assert!(r.is_identical(), "{r:?}");
+        assert!(r.shared().count() > 0);
+    }
+
+    #[test]
+    fn lowered_one_literal_edit_is_localized() {
+        // A single changed literal in *real* lowered CCL. Optimal recovery pairs
+        // the changed leaf with its counterpart, so the edit reads as one
+        // in-place update rather than a delete plus an insert — and nothing
+        // around it is disturbed.
+        let v1 = lower("x = 1\ny = x + 2\ny\n");
+        let v2 = lower("x = 1\ny = x + 3\ny\n");
+        let r = diff(&v1, &v2);
+
+        assert!(r.deleted.is_empty(), "deleted: {:?}", r.deleted);
+        assert!(r.new.is_empty(), "new: {:?}", r.new);
+        assert_eq!(r.moved().count(), 0, "nothing moved");
+        let lit_updates: Vec<_> = r
+            .updated()
+            .filter(|m| matches!(m.src.node, TypedExprNode::Lit(_)))
+            .collect();
+        assert_eq!(lit_updates.len(), 1, "exactly one literal changed");
+        assert!(matches!(
+            lit_updates[0].src.node,
+            TypedExprNode::Lit(Lit::Int(2))
+        ));
+        assert!(matches!(
+            lit_updates[0].dst.node,
+            TypedExprNode::Lit(Lit::Int(3))
+        ));
+        // The unchanged `x = 1` binding value survives as shared.
+        assert!(
+            r.shared()
+                .any(|m| matches!(m.src.node, TypedExprNode::Lit(Lit::Int(1)))),
+            "the unchanged literal 1 should be shared",
+        );
+    }
+
+    #[test]
+    fn adding_a_statement_is_an_insertion_not_a_rewrite() {
+        // `a = 1; a` gains a substantial statement. The root `let` has only two
+        // descendants and the new one brings a dozen, so a similarity test that
+        // weighs the two subtrees *together* scores the root far too low to
+        // pair — and the whole program reads as deleted-and-reinserted for a
+        // one-statement edit. The roots correspond by construction instead.
+        let v1 = lower("a = 1\na\n");
+        let v2 = lower("a = 1\nb = sum([i * 2 for i in [1,2,3]])\na + b\n");
+        let r = diff(&v1, &v2);
+        assert!(
+            r.deleted.is_empty(),
+            "nothing was removed, so nothing should be deleted: {:?}",
+            r.deleted
+        );
+        assert!(
+            r.updated().any(
+                |m| std::ptr::eq(m.src, &v1) && matches!(m.src.node, TypedExprNode::Let { .. })
+            ),
+            "the root corresponds, as an update",
+        );
+        // The pre-existing `a = 1` value is still recognized.
+        assert!(
+            r.shared()
+                .any(|m| matches!(m.src.node, TypedExprNode::Lit(Lit::Int(1)))),
+        );
+    }
+
+    #[test]
+    fn a_container_that_grew_still_corresponds() {
+        // The same shape one level down, where root anchoring cannot help: a
+        // `def` body gains a statement. The enclosing container is matched on
+        // *containment* of what it already had, not on its size relative to
+        // what was added.
+        let v1 = lower("def f(x):\n    a = 1\n    a + x\nf(2)\n");
+        let v2 = lower(
+            "def f(x):\n    a = 1\n    b = sum([i * 2 for i in [1,2,3]])\n    a + x + b\nf(2)\n",
+        );
+        let r = diff(&v1, &v2);
+        assert!(
+            r.deleted.is_empty(),
+            "the grown container corresponds rather than being rebuilt: {:?}",
+            r.deleted
+        );
+        assert!(
+            r.shared().count() >= 6,
+            "the untouched body is still shared"
+        );
+    }
+
+    #[test]
+    fn render_collapses_whole_regions_but_not_wrappers() {
+        // `a = 1; a` gains a statement that both introduces new structure and
+        // reuses `a`. The wholly-new `sum(…)` subtree collapses to one line
+        // with a node count; the new `a + b` does *not*, because `a` survived
+        // underneath it and hiding that would claim it changed.
+        let v1 = lower("a = 1\na\n");
+        let v2 = lower("a = 1\nb = sum([i * 2 for i in [1,2,3]])\na + b\n");
+        let out = diff(&v1, &v2).to_string();
+
+        assert!(
+            out.starts_with("2 shared · 1 changed"),
+            "summary line: {out}"
+        );
+        assert!(
+            out.contains("(+"),
+            "a wholly-new subtree collapses with a node count:\n{out}"
+        );
+        // The surviving `a` is still shown, under the new node that wraps it.
+        assert!(
+            out.lines().any(|l| l.trim_start().starts_with("= a")),
+            "the reused `a` is rendered as shared:\n{out}"
+        );
+        // Every line after the summary carries exactly one marker.
+        for l in out.lines().skip(2).filter(|l| !l.trim().is_empty()) {
+            let m = l.trim_start().chars().next().unwrap();
+            assert!("=~+-".contains(m), "unmarked line {l:?} in:\n{out}");
+        }
+    }
+
+    #[test]
+    fn render_does_not_overstate_a_deletion() {
+        // `let c = 9 in …` is dropped, but the statements under it survive. The
+        // deleted wrapper must be reported on its own — not as a subtree of
+        // everything it used to contain.
+        let v1 = lower("a = 1\nc = 9\nb = 2\na + b + c\n");
+        let v2 = lower("a = 1\nb = 2\na + b\n");
+        let d = diff(&v1, &v2);
+        let out = d.to_string();
+
+        let deleted_lines: Vec<&str> = out.lines().filter(|l| l.starts_with("- ")).collect();
+        assert_eq!(
+            deleted_lines.len(),
+            d.deleted.len(),
+            "one line per deleted node when none of them collapse:\n{out}"
+        );
+        assert!(
+            deleted_lines.iter().all(|l| !l.contains("(+")),
+            "no deleted node claims a subtree it did not take with it:\n{out}"
+        );
+    }
+
+    #[test]
+    fn renaming_a_binding_is_not_a_change() {
+        // Renaming is a denotational no-op, and the two roots hash equal, so
+        // the diff has to agree all the way down. It only does because
+        // classification resolves a free variable to *which binder it means*
+        // rather than to how that binder is spelled.
+        for (a, b) in [
+            ("x = 1\ny = x + 2\ny\n", "q = 1\ny = q + 2\ny\n"),
+            (
+                "users = [(name=\"a\", age=30)]\nsum([u.age for u in users])\n",
+                "users = [(name=\"a\", age=30)]\nsum([q.age for q in users])\n",
+            ),
+        ] {
+            let (v1, v2) = (lower(a), lower(b));
+            assert!(
+                diff(&v1, &v2).is_identical(),
+                "a pure rename must diff as identical:\n{a}\n{}",
+                diff(&v1, &v2)
+            );
+        }
+    }
+
+    #[test]
+    fn a_binder_inserted_above_a_subterm_does_not_change_it() {
+        // The trap the binder-class scheme exists to avoid. `b`'s binding and
+        // the tail below it still reach `a` through one more enclosing `let`
+        // than before; if a free variable were identified by its distance to
+        // its binder rather than by the binder itself, every reference reaching
+        // past the new one would shift and the whole tail would read as
+        // changed.
+        let v1 = lower("a = 1\nb = 2\na + b\n");
+        let v2 = lower("a = 1\nc = 9\nb = 2\na + b\n");
+        let r = diff(&v1, &v2);
+        assert!(r.deleted.is_empty(), "{r}");
+        assert!(
+            r.shared()
+                .any(|m| matches!(m.src.node, TypedExprNode::BinOp { .. })),
+            "the untouched `a + b` tail is still shared:\n{r}",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // The divergence frontier
+    // -----------------------------------------------------------------------
+
+    /// A 40-binding `let` spine whose final expression uses a different
+    /// literal — one edit, as deep in the tree as this corpus goes.
+    fn deep_spine(tweak: bool) -> String {
+        let mut s = String::from("a0 = 1\n");
+        for i in 1..40 {
+            s.push_str(&format!("a{i} = a{} + {i}\n", i - 1));
+        }
+        s.push_str(&format!("a39 + {}\n", if tweak { 99 } else { 1 }));
+        s
+    }
+
+    #[test]
+    fn one_edit_is_one_divergence() {
+        // Every ancestor of an edit has changed content, so `matched` reports
+        // 42 changed nodes here. Exactly one of them is the edit.
+        let (v1, v2) = (lower(&deep_spine(false)), lower(&deep_spine(true)));
+        let r = diff(&v1, &v2);
+        assert!(
+            r.updated().count() > 40,
+            "the ancestors are all changed too"
+        );
+
+        let dv = r.divergences();
+        assert_eq!(dv.len(), 1, "{dv:?}");
+        let Divergence::Changed(m) = dv[0] else {
+            panic!("expected a content change, got {:?}", dv[0])
+        };
+        assert!(matches!(m.src.node, TypedExprNode::Lit(Lit::Int(1))));
+        assert!(matches!(m.dst.node, TypedExprNode::Lit(Lit::Int(99))));
+    }
+
+    #[test]
+    fn an_inserted_region_is_reported_at_its_root() {
+        // 16 new nodes, one insertion.
+        let v1 = lower("a = 1\na\n");
+        let v2 = lower("a = 1\nb = sum([i * 2 for i in [1,2,3]])\na + b\n");
+        let r = diff(&v1, &v2);
+        assert!(r.new.len() > 10, "the inserted block is substantial");
+
+        let inserted: Vec<_> = r
+            .divergences()
+            .into_iter()
+            .filter(|d| matches!(d, Divergence::Inserted(_)))
+            .collect();
+        assert_eq!(inserted.len(), 1, "{inserted:?}");
+        let Divergence::Inserted(e) = inserted[0] else {
+            unreachable!()
+        };
+        assert!(matches!(e.node, TypedExprNode::Let { .. }));
+    }
+
+    #[test]
+    fn identical_programs_have_no_divergences() {
+        let (v1, v2) = (lower(&deep_spine(false)), lower(&deep_spine(false)));
+        let r = diff(&v1, &v2);
+        assert!(r.divergences().is_empty());
+        // ...and reuse is the whole program, in one piece.
+        let roots = r.shared_roots();
+        assert_eq!(roots.len(), 1);
+        assert!(std::ptr::eq(roots[0].dst, &v2));
+    }
+
+    #[test]
+    fn shared_roots_are_maximal_and_disjoint() {
+        let v1 = lower("a = 1\nb = 2\na + b\n");
+        let v2 = lower("a = 1\nc = 9\nb = 2\na + b\n");
+        let r = diff(&v1, &v2);
+        let roots = r.shared_roots();
+        assert!(!roots.is_empty());
+
+        // No shared root sits inside another: each is the top of its region.
+        let tops: Vec<*const TypedExpr> = roots.iter().map(|m| m.dst as *const _).collect();
+        for m in &roots {
+            let mut inner = 0;
+            m.dst.walk_children(|c| {
+                fn any(e: &TypedExpr, tops: &[*const TypedExpr], n: &mut usize) {
+                    if tops.contains(&(e as *const TypedExpr)) {
+                        *n += 1;
+                    }
+                    e.walk_children(|c| any(c, tops, n));
+                }
+                any(c, &tops, &mut inner);
+            });
+            assert_eq!(inner, 0, "a shared root contains another: {}", head(m.dst));
+        }
+    }
+
+    /// Assert a construct survives the two properties that matter on real
+    /// lowered CCL: lowering the same source twice diffs as identical, and an
+    /// edit that *wraps* an existing subexpression localizes (nothing deleted,
+    /// the wrapper shows up as new, the bulk stays shared).
+    fn assert_stable_and_localizing(src: &str, edited: &str) {
+        let (a, b) = (lower(src), lower(src));
+        let stable = diff(&a, &b);
+        assert!(stable.is_identical(), "same source must diff as identical");
+
+        let v2 = lower(edited);
+        let edit = diff(&a, &v2);
+        assert!(
+            edit.deleted.is_empty(),
+            "no spurious deletions, got {}",
+            edit.deleted.len()
+        );
+        assert!(
+            edit.new
+                .iter()
+                .any(|e| matches!(e.node, TypedExprNode::BinOp { .. })),
+            "the wrapping operator should show up as new",
+        );
+        assert!(
+            edit.shared().count() > edit.new.len(),
+            "the bulk should stay shared"
+        );
+    }
+
+    #[test]
+    fn induction_accumulator_is_stable_and_localizes() {
+        // `acc := acc + i` inside a `for` lowers to a `For` carrying a
+        // `MutWrite`; the loop binder is hashed positionally, so none of the
+        // mutation machinery leaks into the diff.
+        assert_stable_and_localizing(
+            ACCUM,
+            "acc := 0\nfor i in [1, 2, 3, 4, 5]:\n    acc := acc + i * 2\nacc\n",
+        );
+    }
+
+    #[test]
+    fn transactional_register_is_stable_and_localizes() {
+        // A `Mut(Int, Txn)` register written under `with begin():` lowers to a
+        // `Begin` block wrapping the `MutWrite`. Same story: stable across
+        // compilations, and an edit inside the block localizes to it.
+        assert_stable_and_localizing(
+            TXN,
+            "pool: Mut(Int, Txn) := 100\nreqs = [1, 2, 3]\nfor r in reqs:\n    with begin():\n        pool := pool - r - 1\n",
+        );
+    }
+
+    #[test]
+    fn rich_programs_are_stable_across_lowerings() {
+        // Records, list comprehensions, filters, aggregates, projections, joins,
+        // def/yield generators, and groupby all diff as identical when the same
+        // source is lowered twice. `groupby` in particular exercises the
+        // free-variable seam: lowering uniquifies the comprehension source, so
+        // some binders carry run-varying `uid`s — matching free variables by
+        // spelling (not uid) keeps the diff stable regardless.
+        for src in [FILTER_AGG, GENERATORS, JOIN, GROUPBY, ACCUM, TXN] {
+            let (a, b) = (lower(src), lower(src));
+            let r = diff(&a, &b);
+            assert!(
+                r.is_identical(),
+                "expected identical diff for:\n{src}\n{r:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn comprehension_filter_predicate_change_is_visible() {
+        // A comprehension filter lowers into a cast-target *refinement
+        // predicate* — a term living in a type position. The content hash is
+        // type-aware (and the differ descends into refinement predicate terms),
+        // so a threshold change is visible and localizes to the threshold.
+        let (v1, v2) = (lower(FILTER_AGG), lower(FILTER_AGG_21));
+        let r = diff(&v1, &v2);
+        assert!(
+            r.updated().any(|m| {
+                matches!(m.src.node, TypedExprNode::Lit(Lit::Int(18)))
+                    && matches!(m.dst.node, TypedExprNode::Lit(Lit::Int(21)))
+            }),
+            "the threshold change should read as one in-place update: {r:?}",
+        );
+    }
+
+    #[test]
+    fn diff_is_robust_to_uid_nondeterminism() {
+        // Lowering uniquifies some subexpressions, minting globally-fresh,
+        // run-varying uids, so two lowerings of `groupby` are *structurally*
+        // unequal (`g1 != g2`) yet denote the same program. The diff must treat
+        // them as identical — matching free variables by spelling, not uid.
+        let (g1, g2) = (lower(GROUPBY), lower(GROUPBY));
+        assert_ne!(g1, g2, "precondition: lowering assigns run-varying uids");
+        assert!(diff(&g1, &g2).is_identical());
+    }
+
+    #[test]
+    fn conditional_branches_diff_cleanly() {
+        // A ternary `1 if v > 0 else 2` lowers to a guard-based `Case`.
+        let base = "v = 5\n1 if v > 0 else 2\n";
+        let (a, b) = (lower(base), lower(base));
+        assert!(diff(&a, &b).is_identical());
+
+        // Editing the else-branch value localizes to that literal.
+        let (e1, e2) = (lower(base), lower("v = 5\n1 if v > 0 else 3\n"));
+        let r = diff(&e1, &e2);
+        assert!(r.updated().any(|m| {
+            matches!(m.src.node, TypedExprNode::Lit(Lit::Int(2)))
+                && matches!(m.dst.node, TypedExprNode::Lit(Lit::Int(3)))
+        }));
+
+        // Editing the guard threshold localizes to that literal.
+        let (g1, g2) = (lower(base), lower("v = 5\n1 if v > 1 else 2\n"));
+        let r = diff(&g1, &g2);
+        assert!(r.updated().any(|m| {
+            matches!(m.src.node, TypedExprNode::Lit(Lit::Int(0)))
+                && matches!(m.dst.node, TypedExprNode::Lit(Lit::Int(1)))
+        }));
+    }
+
+    #[test]
+    fn inferred_program_is_stable_across_compilations() {
+        // The post-inference mode works and is uid/Infer-robust: lowering +
+        // uniquifying + inferring the same source twice (independent global
+        // counters) diffs as identical. Same shared `diff` core as pre-uniquify.
+        let (a, b) = (lower_and_infer(FILTER_AGG), lower_and_infer(FILTER_AGG));
+        assert_ne!(
+            a, b,
+            "precondition: independent compilations assign fresh uids"
+        );
+        assert!(diff(&a, &b).is_identical());
+    }
+
+    #[test]
+    fn inference_adds_type_signal() {
+        // The body `(x, x)` is structurally identical in both programs — `x` is
+        // free there, matched by spelling — so *pre-inference* (types still
+        // `Hole`) the two bodies hash equal. After inference the element type
+        // diverges (`x: Int` vs `x: String`), so the *same* subterm no longer
+        // matches: types carry signal the term structure alone does not. This
+        // is the payoff of diffing post-inference.
+        let prog_int = "x = 1\n(x, x)\n";
+        let prog_str = "x = \"a\"\n(x, x)\n";
+
+        // The `(x, x)` tuple is the root `let`'s body.
+        let body = |e: &TypedExpr| match &e.node {
+            TypedExprNode::Let { body, .. } => content_hash(body),
+            other => panic!("expected a top-level let, got {other:?}"),
+        };
+
+        assert_eq!(
+            body(&lower(prog_int)),
+            body(&lower(prog_str)),
+            "pre-inference: the `(x, x)` bodies are indistinguishable",
+        );
+        assert_ne!(
+            body(&lower_and_infer(prog_int)),
+            body(&lower_and_infer(prog_str)),
+            "post-inference: the element type (Int vs String) diverges",
+        );
+    }
+
+    #[test]
+    fn inlining_erases_function_boundaries() {
+        // Extracting a subexpression into a `def` is invisible once the
+        // pipeline's own inlining has run: the two versions are the same tree.
+        let plain = "a = 1\n(a + 2) * 3\n";
+        let extracted = "def g(y):\n    y + 2\na = 1\ng(a) * 3\n";
+
+        let (v1, v2) = (
+            compile_to(plain, CompileStage::Inferred).unwrap(),
+            compile_to(extracted, CompileStage::Inferred).unwrap(),
+        );
+        assert!(
+            !diff(&v1, &v2).divergences().is_empty(),
+            "the function boundary is still part of the program here",
+        );
+
+        let (v1, v2) = (
+            compile_to(plain, CompileStage::Inlined).unwrap(),
+            compile_to(extracted, CompileStage::Inlined).unwrap(),
+        );
+        assert!(
+            diff(&v1, &v2).is_identical(),
+            "inlined, the two are the same program:\n{}",
+            diff(&v1, &v2)
+        );
+    }
+
+    #[test]
+    fn inlining_costs_locality_in_a_shared_helper() {
+        // The other side of that trade, stated as a test so it cannot be
+        // mistaken for a strict improvement: a body called twice is inlined
+        // twice, so one edit inside it diverges at both call sites.
+        //
+        // The two calls pass *different* arguments that nonetheless share one
+        // specialization: monomorphization keys on instantiation identity, and
+        // a join of two singletons keeps neither refinement, so `a` and `b`
+        // both arrive as plain `Int`. Literal arguments would key apart and
+        // clone the helper during inference — the baseline would already be
+        // delocalized, and the contrast below would not be inlining's doing.
+        // See `src/ccl/design/diffing.md`, "How much to normalize".
+        let v1 = "def g(y):\n    y + 2\na = 1 + 1\nb = 2 + 2\ng(a) * g(b)\n";
+        let v2 = "def g(y):\n    y + 5\na = 1 + 1\nb = 2 + 2\ng(a) * g(b)\n";
+
+        let (a, b) = (
+            compile_to(v1, CompileStage::Inferred).unwrap(),
+            compile_to(v2, CompileStage::Inferred).unwrap(),
+        );
+        assert_eq!(
+            diff(&a, &b).divergences().len(),
+            1,
+            "one edit, one divergence, while the two calls still share one function",
+        );
+
+        let (a, b) = (
+            compile_to(v1, CompileStage::Inlined).unwrap(),
+            compile_to(v2, CompileStage::Inlined).unwrap(),
+        );
+        assert!(
+            diff(&a, &b).divergences().len() > 1,
+            "inlined, the same edit lands once per call site",
+        );
+    }
+
+    #[test]
+    fn every_stage_diffs_identical_source_as_identical() {
+        // The property the whole analysis rests on, over the shapes the corpus
+        // reaches: compiling one source twice — independent contexts, fresh
+        // binder uids — must produce trees the differ cannot tell apart. A
+        // failure means some pass has let a run-varying identity leak into the
+        // hash, which would make every real diff untrustworthy.
+        //
+        // It covers every stage because that is exactly how the leak was found:
+        // `Transact` labelled its mutable variable record with
+        // `Name::field_key()`, which folded the binder uid into a `String`, and
+        // once a name is a record label no amount of uid-robustness in the
+        // hasher can see through it.
+        let corpus = [
+            ("pure", "a = 1\nb = 2\na + b\n"),
+            ("comprehension", FILTER_AGG),
+            ("generators", GENERATORS),
+            ("join", JOIN),
+            ("groupby", GROUPBY),
+            ("accumulator", ACCUM),
+            ("transaction", TXN),
+            ("source", "[\"> \" + line for line in stdin()]\n"),
+        ];
+        for stage in [
+            CompileStage::Lowered,
+            CompileStage::Inferred,
+            CompileStage::Inlined,
+            CompileStage::Channelized,
+            CompileStage::LambdaElim,
+            CompileStage::Planned,
+        ] {
+            for (label, src) in corpus {
+                let (a, b) = (
+                    compile_to(src, stage).expect(label),
+                    compile_to(src, stage).expect(label),
+                );
+                assert!(
+                    diff(&a, &b).is_identical(),
+                    "{label} at {stage:?} is not stable across compilations:\n{}",
+                    diff(&a, &b)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn diff_programs_end_to_end_from_source() {
+        // The public single-call entry: compile both sources to a stage and
+        // diff, results delivered through the closure.
+        //
+        // A filter-threshold edit (`>= 18` → `>= 21`) is reflected at the
+        // lowered stage.
+        let changed = diff_programs(FILTER_AGG, FILTER_AGG_21, CompileStage::Lowered, |d| {
+            d.updated().count()
+        })
+        .expect("compile + diff should succeed");
+        assert!(changed > 0, "the edit is reflected");
+
+        // Identical programs diff as identical at the inferred stage.
+        let identical = diff_programs(FILTER_AGG, FILTER_AGG, CompileStage::Inferred, |d| {
+            d.is_identical()
+        })
+        .expect("compile + diff should succeed");
+        assert!(
+            identical,
+            "identical source diffs as identical post-inference"
+        );
+    }
+
+    #[test]
+    fn diff_programs_handles_source_using_programs() {
+        // A program reading `stdin()` compiles end-to-end — the source is
+        // registered for inference — and diffs cleanly against itself. Proves
+        // the public API handles sources, not just literal programs.
+        let prog = "[\"> \" + line for line in stdin()]\n";
+        let identical = diff_programs(prog, prog, CompileStage::Inferred, |d| d.is_identical())
+            .expect("stdin program should compile to the inferred stage and diff");
+        assert!(identical);
+    }
+}

--- a/src/ccl/diff.rs
+++ b/src/ccl/diff.rs
@@ -33,9 +33,9 @@
 //! **placement** did ([`Placement`]). A source-only node is **deleted**; a
 //! target-only node is **new**.
 //!
-//! That classification is complete but not minimal — every *ancestor* of an
-//! edit has changed content, and every *descendant* of an inserted subtree is
-//! new. [`Diff::divergences`] reduces it to the places the programs actually
+//! That classification is complete but says the same thing many times — every
+//! *ancestor* of an edit has changed content, and every *descendant* of an
+//! inserted subtree is new. [`Diff::divergences`] reduces it to the places the programs actually
 //! disagree, and [`Diff::shared_roots`] to the largest pieces they have in
 //! common. Those two are the actionable form: the first says where a version
 //! guard goes, the second says what the two versions can compute once.
@@ -44,13 +44,13 @@
 //!
 //! [`diff`] is a pure function of two [`TypedExpr`] trees and does not care
 //! which pipeline stage produced them, so one implementation serves every
-//! [`CompileStage`]: the caller chooses how much of the compiler's own
+//! [`Phase`]: the caller chooses how much of the compiler's own
 //! rewriting to diff through by choosing which trees to pass. Nothing in the
 //! matcher is stage-specific — [`content_hash`] is uid-robust (free names by
 //! spelling) and type-aware, which is what lets one core cover the lot,
 //! including the `LetRec` and `Transact` shapes that exist only below the
 //! mutability phases. Which stage answers which question is
-//! `src/ccl/design/diffing.md`, "Which stage to diff".
+//! `src/ccl/design/diffing.md`, "Which phase to diff".
 //!
 //! # Scope of this implementation
 //!
@@ -64,8 +64,8 @@ use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::mem::Discriminant;
 
-use super::content_hash::{cast_target_predicate, content_hash, resolved_hash};
-use super::context::{CompileError, CompileStage, compile_to};
+use super::content_hash::{cast_target_predicates, content_hash, own_hash, resolved_hash};
+use super::context::{CompileError, Phase, compile_to};
 use super::scope::{ScopedItem, for_each_scoped_item};
 use super::{Name, TypedExpr};
 
@@ -74,21 +74,30 @@ use super::{Name, TypedExpr};
 /// GumTree default, applied to a different measure than GumTree's.
 const SIMILARITY_THRESHOLD: f64 = 0.5;
 
-/// Subtree-size ceiling for the optimal recovery step ([`recover`]). Tree edit
-/// distance is `O(n²m²)` in the worst case, so a pair of containers larger than
-/// this keeps only the matches steps 1–3 found; their unmatched interiors are
-/// reported as deleted/new rather than aligned. GumTree's default, for the same
-/// reason.
+/// Node-count ceiling for the optimal recovery step ([`recover`]), applied to
+/// each of the two subtrees it is asked to align.
+///
+/// Recovery runs Zhang–Shasha tree edit distance, which is `O(n²m²)` in the
+/// worst case. When either subtree holds more than this many nodes, recovery
+/// declines: the pair keeps whatever the top-down and bottom-up phases matched,
+/// and their still-unmatched interiors are reported as deleted and new rather
+/// than aligned node-for-node. GumTree's default, for the same reason.
 const MAX_RECOVERY_SIZE: u32 = 100;
 
-/// Whether a matched node's *content* changed. Orthogonal to [`Placement`]: a
-/// node can keep its content and move, or stay put and change.
+/// Whether a matched node's *content* changed, and if so whether the change is
+/// the node's own. Orthogonal to [`Placement`]: a node can keep its content and
+/// move, or stay put and change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Content {
     /// Equal content hash — identical computation, reusable wholesale.
     Same,
-    /// The node corresponds but its content differs. The actual divergence is
-    /// in the children — see [`Diff::divergences`] for the minimal set.
+    /// The subtree differs but the node's own content does not: same literal,
+    /// operator, binder, annotation and cast target, over children that
+    /// changed. The disagreement is under it and is reported there — see
+    /// [`Diff::divergences`].
+    ChangedBelow,
+    /// The node itself differs, by [`own_hash`]. Its children may differ
+    /// too, and report separately.
     Changed,
 }
 
@@ -143,12 +152,11 @@ impl<'a> Diff<'a> {
         self.matched.iter().filter(|m| m.content == Content::Same)
     }
 
-    /// Correspondences that changed ([`Content::Changed`]) — "the same place in
-    /// both programs, different content".
+    /// Correspondences whose subtree changed — "the same place in both
+    /// programs, different content", whether the change is the node's own
+    /// ([`Content::Changed`]) or entirely below it ([`Content::ChangedBelow`]).
     pub fn updated(&self) -> impl Iterator<Item = &Match<'a>> {
-        self.matched
-            .iter()
-            .filter(|m| m.content == Content::Changed)
+        self.matched.iter().filter(|m| m.content != Content::Same)
     }
 
     /// Correspondences that were relocated ([`Placement::Moved`]), independent
@@ -170,63 +178,38 @@ impl<'a> Diff<'a> {
                 .all(|m| m.content == Content::Same && m.placement == Placement::InPlace)
     }
 
-    /// The **minimal** set of places the two programs disagree, in new-program
-    /// order (deletions, which have no place there, come last).
+    /// The places the two programs disagree, reduced to the node that owns each
+    /// disagreement, in new-program order (deletions, which have no place there,
+    /// come last).
     ///
     /// This is the actionable form of the diff, and where a version guard would
-    /// be placed. `matched`/`deleted`/`new` are complete but not
-    /// minimal: every *ancestor* of an edit has changed content too, and every
+    /// be placed. `matched`/`deleted`/`new` are complete but say the same thing
+    /// many times: every *ancestor* of an edit has changed content too, and every
     /// *descendant* of an inserted subtree is itself new. One literal edited at
     /// the bottom of a forty-binding spine leaves forty-two changed nodes, of
     /// which exactly one is the edit. Divergences report that one.
     ///
-    /// No divergence contains another, so the set partitions the disagreement
-    /// between the two programs: everything not under a divergence corresponds.
+    /// Two rules decide what is reported, and neither is a minimality theorem —
+    /// the set is small in the shapes the tests measure, not provably smallest:
+    ///
+    /// - A node whose own content is intact ([`Content::ChangedBelow`]) is
+    ///   reported only when nothing below it was, so the child that explains it
+    ///   is not joined by its container.
+    /// - A node whose own content changed ([`Content::Changed`]) is reported
+    ///   whatever its children did. Suppressing it would leave a real change with
+    ///   no site.
+    ///
+    /// Each kind is reported at its own root, so no two divergences of the same
+    /// kind nest. Across kinds they can: the walk descends under an inserted
+    /// region, because a new expression can wrap content that survived, so a
+    /// `Changed` may sit inside an `Inserted` or a `Deleted`. A consumer placing
+    /// a guard per divergence gets nested guards there.
     pub fn divergences(&self) -> Vec<Divergence<'a>> {
         let by_dst: HashMap<*const TypedExpr, &Match<'a>> = self
             .matched
             .iter()
             .map(|m| (m.dst as *const TypedExpr, m))
             .collect();
-        let mut out = Vec::new();
-
-        // A changed node is a site only when nothing *below* it changed — the
-        // deeper node is the better explanation. Insertions and deletions are
-        // reported at their own roots and do not suppress it: a node whose
-        // payload changed *and* which gained a child has two things to say.
-        /// Returns whether anything in this subtree reported a change.
-        fn walk<'a>(
-            e: &'a TypedExpr,
-            parent_matched: bool,
-            by_dst: &HashMap<*const TypedExpr, &Match<'a>>,
-            out: &mut Vec<Divergence<'a>>,
-        ) -> bool {
-            let Some(m) = by_dst.get(&(e as *const TypedExpr)) else {
-                // Target-only. It is the *root* of an inserted region exactly
-                // when the node above it is not also new. Keep descending
-                // regardless: a matched node can sit inside a new region — the
-                // new expression wrapping content that survived — and whatever
-                // diverges under it still has to be reported.
-                if parent_matched {
-                    out.push(Divergence::Inserted(e));
-                }
-                let mut changed = false;
-                for c in child_exprs(e) {
-                    changed |= walk(c, false, by_dst, out);
-                }
-                return changed;
-            };
-            let mut changed_below = false;
-            for c in child_exprs(e) {
-                changed_below |= walk(c, true, by_dst, out);
-            }
-            if m.content == Content::Changed && !changed_below {
-                out.push(Divergence::Changed(**m));
-                return true;
-            }
-            changed_below || m.content == Content::Changed
-        }
-        walk(self.dst_root, true, &by_dst, &mut out);
 
         let gone: HashSet<*const TypedExpr> = self
             .deleted
@@ -235,7 +218,91 @@ impl<'a> Diff<'a> {
             .collect();
         let mut roots: Vec<(&TypedExpr, bool)> = Vec::new();
         collect_deleted_roots(self.src_root, &gone, &mut roots);
+        // Deletions are found on the src side but suppress a site on the dst
+        // side: a node that lost a child has changed content, and the `Deleted`
+        // below it is the whole explanation. Map each deleted root's src parent
+        // to its dst counterpart so the walk can see that.
+        let deleted_roots: HashSet<*const TypedExpr> =
+            roots.iter().map(|(e, _)| *e as *const TypedExpr).collect();
+        let lost_a_child = self.parents_of(&deleted_roots);
+
+        let mut out = Vec::new();
+        /// Returns whether anything in this subtree — this node included — was
+        /// reported.
+        fn walk<'a>(
+            e: &'a TypedExpr,
+            parent_matched: bool,
+            by_dst: &HashMap<*const TypedExpr, &Match<'a>>,
+            lost_a_child: &HashSet<*const TypedExpr>,
+            out: &mut Vec<Divergence<'a>>,
+        ) -> bool {
+            let Some(m) = by_dst.get(&(e as *const TypedExpr)) else {
+                // Target-only. It is the *root* of an inserted region exactly
+                // when the node above it is not also new. Keep descending
+                // regardless: a matched node can sit inside a new region — the
+                // new expression wrapping content that survived — and whatever
+                // diverges under it still has to be reported.
+                let mut reported = parent_matched;
+                if parent_matched {
+                    out.push(Divergence::Inserted(e));
+                }
+                for c in child_exprs(e) {
+                    reported |= walk(c, false, by_dst, lost_a_child, out);
+                }
+                return reported;
+            };
+            let mut reported_below = lost_a_child.contains(&(e as *const TypedExpr));
+            for c in child_exprs(e) {
+                reported_below |= walk(c, true, by_dst, lost_a_child, out);
+            }
+            // The node's own content changed: that is a site regardless of what
+            // its children did — a renamed binder over an edited body has two
+            // things to say. A node whose own content is intact is a site only
+            // when nothing below was reported, which leaves the changes no
+            // child accounts for: a reordering, or a type resolved from outside.
+            if m.content == Content::Changed
+                || (m.content == Content::ChangedBelow && !reported_below)
+            {
+                out.push(Divergence::Changed(**m));
+                return true;
+            }
+            reported_below
+        }
+        walk(self.dst_root, true, &by_dst, &lost_a_child, &mut out);
+
         out.extend(roots.into_iter().map(|(e, _)| Divergence::Deleted(e)));
+        out
+    }
+
+    /// The dst counterparts of the src nodes that directly contain one of
+    /// `children`. Used to carry a src-side finding (a deletion) over to the
+    /// dst-side walk that decides sites.
+    fn parents_of(&self, children: &HashSet<*const TypedExpr>) -> HashSet<*const TypedExpr> {
+        let by_src: HashMap<*const TypedExpr, *const TypedExpr> = self
+            .matched
+            .iter()
+            .map(|m| (m.src as *const TypedExpr, m.dst as *const TypedExpr))
+            .collect();
+        let mut out = HashSet::new();
+        fn walk(
+            e: &TypedExpr,
+            children: &HashSet<*const TypedExpr>,
+            by_src: &HashMap<*const TypedExpr, *const TypedExpr>,
+            out: &mut HashSet<*const TypedExpr>,
+        ) {
+            let kids = child_exprs(e);
+            if kids
+                .iter()
+                .any(|c| children.contains(&(*c as *const TypedExpr)))
+                && let Some(dst) = by_src.get(&(e as *const TypedExpr))
+            {
+                out.insert(*dst);
+            }
+            for c in kids {
+                walk(c, children, by_src, out);
+            }
+        }
+        walk(self.src_root, children, &by_src, &mut out);
         out
     }
 
@@ -278,11 +345,18 @@ impl<'a> Diff<'a> {
 }
 
 /// One place the two programs disagree, at the granularity a version guard is
-/// placed. Minimal by construction: no divergence contains another.
+/// placed. Each kind is reported at its own root, so no two divergences of the
+/// same kind nest; across kinds a [`Changed`] can sit inside an [`Inserted`] or
+/// a [`Deleted`], because a new expression can wrap content that survived.
+///
+/// [`Changed`]: Divergence::Changed
+/// [`Inserted`]: Divergence::Inserted
+/// [`Deleted`]: Divergence::Deleted
 #[derive(Debug, Clone, Copy)]
 pub enum Divergence<'a> {
-    /// Both programs have a node here and its content differs, with nothing
-    /// below it differing — this is where the change actually is.
+    /// Both programs have a node here and this node is the one that changed:
+    /// either its own content differs ([`Content::Changed`]) or its subtree
+    /// differs with nothing under it reported ([`Content::ChangedBelow`]).
     Changed(Match<'a>),
     /// A subtree the new program has and the old one does not, at its root.
     Inserted(&'a TypedExpr),
@@ -330,13 +404,13 @@ fn anchor_roots(s: &Indexed, d: &Indexed, m: &mut Matching) {
 /// `f`; return out of it whatever you need to keep (e.g. counts, cloned nodes).
 ///
 /// ```ignore
-/// let (shared, new) = diff_programs(v1_src, v2_src, CompileStage::Inferred,
+/// let (shared, new) = diff_programs(v1_src, v2_src, Phase::Infer,
 ///     |d| (d.shared().count(), d.new.len()))?;
 /// ```
 pub fn diff_programs<R>(
     src: &str,
     dst: &str,
-    stage: CompileStage,
+    stage: Phase,
     f: impl FnOnce(&Diff) -> R,
 ) -> Result<R, Vec<CompileError>> {
     let a = compile_to(src, stage)?;
@@ -460,10 +534,11 @@ fn child_exprs(e: &TypedExpr) -> Vec<&TypedExpr> {
             vec![]
         }
         N::Apply { function, argument } => vec![function, argument],
-        N::Cast { value, target } => match cast_target_predicate(target) {
-            Some(pred) => vec![value, pred],
-            None => vec![value],
-        },
+        N::Cast { value, target } => {
+            let mut children = vec![&**value];
+            children.extend(cast_target_predicates(target));
+            children
+        }
         N::BinOp { left, right, .. } => vec![left, right],
         N::UnaryOp(_, inner) => vec![inner],
         N::Lambda { body, .. } => vec![body],
@@ -977,8 +1052,26 @@ mod ted {
 
 /// The [`resolved_hash`] of every node of `t`, indexed the same way `t` is.
 ///
+/// Distinguishes the `j`th binder a node introduces from its siblings, without
+/// letting two nodes' correspondents collide: the multiplier is the 64-bit
+/// golden-ratio constant, so a one-bit change in either input spreads across the
+/// result.
+fn mix(correspondent: u64, j: u64) -> u64 {
+    correspondent.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ j
+}
+
+/// A node's two scope-resolved hashes: the whole subtree's, and the node's own.
+/// Comparing both is what separates "this node changed" from "something under it
+/// changed" — see [`Content`].
+#[derive(Debug, Clone, Copy, Default)]
+struct NodeHashes {
+    resolved: u64,
+    own: u64,
+}
+
 /// Walks top-down carrying the binders each node sits under, each tagged with
-/// the class `class_of` gives its owner, so a free variable inside a subterm
+/// the correspondent `correspondent_of` gives its owner, so a free variable
+/// inside a subterm
 /// hashes to *which binder it resolves to* rather than to how that binder
 /// happens to be spelled.
 ///
@@ -989,15 +1082,18 @@ mod ted {
 /// target's refinement predicate, which is a type slot. That predicate sits in
 /// its cast's own scope, so an absent entry meaning "no binders" is exactly
 /// right for it.
-fn resolved_hashes(t: &Indexed<'_>, class_of: &dyn Fn(usize) -> u64) -> Vec<u64> {
+fn resolved_hashes(t: &Indexed<'_>, correspondent_of: &dyn Fn(usize) -> u64) -> Vec<NodeHashes> {
     fn go<'a>(
         t: &Indexed<'a>,
         i: usize,
         scope: &mut Vec<(&'a Name, u64)>,
-        class_of: &dyn Fn(usize) -> u64,
-        out: &mut [u64],
+        correspondent_of: &dyn Fn(usize) -> u64,
+        out: &mut [NodeHashes],
     ) {
-        out[i] = resolved_hash(t.nodes[i].expr, scope).0;
+        out[i] = NodeHashes {
+            resolved: resolved_hash(t.nodes[i].expr, scope).0,
+            own: own_hash(t.nodes[i].expr, scope).0,
+        };
 
         let mut introduced: HashMap<*const TypedExpr, Vec<&'a Name>> = HashMap::new();
         for_each_scoped_item(t.nodes[i].expr, &mut |item| {
@@ -1011,35 +1107,45 @@ fn resolved_hashes(t: &Indexed<'_>, class_of: &dyn Fn(usize) -> u64) -> Vec<u64>
             }
         });
 
-        let class = class_of(i);
+        let correspondent = correspondent_of(i);
         for &c in &t.nodes[i].children {
             let added = introduced
                 .get(&(t.nodes[c].expr as *const TypedExpr))
                 .map_or(0, |names| {
-                    for n in names {
-                        scope.push((n, class));
+                    // Each binder a node introduces needs its own
+                    // correspondent: they are distinct binders, and one token
+                    // for the whole node would make `letrec p = …; q = … in p`
+                    // and `… in q` hash
+                    // equal — a `Content::Same` on two different computations,
+                    // which is the unsound direction (`src/ccl/design/diffing.md`,
+                    // "Direction of error"). Position within the group is the
+                    // correspondence, matching how `child_exprs` pairs the
+                    // group's definitions.
+                    for (j, n) in names.iter().enumerate() {
+                        scope.push((n, mix(correspondent, j as u64)));
                     }
                     names.len()
                 });
-            go(t, c, scope, class_of, out);
+            go(t, c, scope, correspondent_of, out);
             scope.truncate(scope.len() - added);
         }
     }
 
-    let mut out = vec![0u64; t.len()];
-    go(t, 0, &mut Vec::new(), class_of, &mut out);
+    let mut out = vec![NodeHashes::default(); t.len()];
+    go(t, 0, &mut Vec::new(), correspondent_of, &mut out);
     out
 }
 
 fn classify<'a>(s: &Indexed<'a>, d: &Indexed<'a>, m: &Matching) -> Diff<'a> {
     let in_place = align_children(s, d, m);
-    // A binder's *class*: a token its counterpart in the other program shares.
-    // A src binder's class is the dst node it matched; an unmatched one gets a
-    // token out of dst's index range, so it can never look like a match.
-    let src_class = |u: usize| m.src_to_dst[u].unwrap_or(d.len() + u) as u64;
-    let dst_class = |w: usize| w as u64;
-    let src_resolved = resolved_hashes(s, &src_class);
-    let dst_resolved = resolved_hashes(d, &dst_class);
+    // A binder's *correspondent*: the binder it corresponds to in the other
+    // program, as a token both sides share. A src binder's is the dst node it
+    // matched; an unmatched one gets a token out of dst's index range, so it
+    // corresponds to nothing and can never look like a match.
+    let src_correspondent = |u: usize| m.src_to_dst[u].unwrap_or(d.len() + u) as u64;
+    let dst_correspondent = |w: usize| w as u64;
+    let src_resolved = resolved_hashes(s, &src_correspondent);
+    let dst_resolved = resolved_hashes(d, &dst_correspondent);
     let mut out = Diff {
         matched: Vec::new(),
         deleted: Vec::new(),
@@ -1052,10 +1158,28 @@ fn classify<'a>(s: &Indexed<'a>, d: &Indexed<'a>, m: &Matching) -> Diff<'a> {
             Some(w) => out.matched.push(Match {
                 src: s.nodes[u].expr,
                 dst: d.nodes[w].expr,
-                content: if src_resolved[u] == dst_resolved[w] {
-                    Content::Same
-                } else {
-                    Content::Changed
+                content: {
+                    // `own_hash` folds a subset of what `resolved_hash` does,
+                    // plus a record's labels — which `resolved_hash` folds
+                    // paired with the children they label. So an equal subtree
+                    // hash implies an equal own hash, and the `Same` arm below
+                    // is safe to take on the subtree hash alone. Were that to
+                    // stop holding, a node whose own content changed would
+                    // classify `Same`: an unsound share, the direction
+                    // `src/ccl/design/diffing.md`, "Direction of error" rules
+                    // out.
+                    debug_assert!(
+                        src_resolved[u].resolved != dst_resolved[w].resolved
+                            || src_resolved[u].own == dst_resolved[w].own,
+                        "own_hash must refine resolved_hash: equal subtrees, differing own content",
+                    );
+                    if src_resolved[u].resolved == dst_resolved[w].resolved {
+                        Content::Same
+                    } else if src_resolved[u].own == dst_resolved[w].own {
+                        Content::ChangedBelow
+                    } else {
+                        Content::Changed
+                    }
                 },
                 placement: if in_place[u] {
                     Placement::InPlace
@@ -1251,19 +1375,32 @@ impl std::fmt::Display for Diff<'_> {
 /// still matched is a different thing entirely — a wrapper that appeared or
 /// vanished around content that survived — and collapsing it would claim its
 /// surviving children changed too.
+///
+/// Walks [`child_exprs`], not `all_children`, because that is the child set the
+/// differ indexed: a cast target's refinement predicate is a node the matcher
+/// can match and `all_children` does not reach. Testing the narrower set would
+/// call a cast wholly-gone while a matched node still lives in its predicate.
 fn subtree_entirely_in(e: &TypedExpr, set: &HashSet<*const TypedExpr>) -> bool {
-    set.contains(&(e as *const TypedExpr)) && e.all_children(|c| subtree_entirely_in(c, set))
+    set.contains(&(e as *const TypedExpr))
+        && child_exprs(e)
+            .into_iter()
+            .all(|c| subtree_entirely_in(c, set))
 }
 
 /// `    (+N nodes)` when `e` has descendants, so an elided subtree still
-/// reports how much it stands for; empty for a leaf.
+/// reports how much it stands for; empty for a leaf. Counts over
+/// [`child_exprs`], the differ's child set, so the note matches what collapsed.
 fn size_note(e: &TypedExpr) -> String {
     let mut n = 0;
     fn count(e: &TypedExpr, n: &mut usize) {
         *n += 1;
-        e.walk_children(|c| count(c, n));
+        for c in child_exprs(e) {
+            count(c, n);
+        }
     }
-    e.walk_children(|c| count(c, &mut n));
+    for c in child_exprs(e) {
+        count(c, &mut n);
+    }
     if n == 0 {
         String::new()
     } else {
@@ -1295,7 +1432,7 @@ fn render_node(
         Some(m) => {
             let mark = match m.content {
                 Content::Same => '=',
-                Content::Changed => '~',
+                Content::ChangedBelow | Content::Changed => '~',
             };
             let moved = if m.placement == Placement::Moved {
                 " »"
@@ -1305,7 +1442,7 @@ fn render_node(
             writeln!(f, "{indent}{mark} {}{moved}", head(e))?;
             // An unchanged subtree is unchanged all the way down; descending
             // would print it verbatim for no information.
-            if m.content == Content::Changed {
+            if m.content != Content::Same {
                 for c in child_exprs(e) {
                     render_node(f, c, depth + 1, by_dst, inserted)?;
                 }
@@ -1340,7 +1477,15 @@ fn collect_deleted_roots<'a>(
 mod tests {
     use super::*;
     use crate::ccl::content_hash::content_hash;
-    use crate::ccl::{ArithmeticKind, BinOpKind, Lit, TypedExpr, TypedExprNode};
+    use crate::ccl::context::{GlobalContext, compile_program};
+    use crate::ccl::{
+        ArithmeticKind, BaseType, BinOpKind, CompareKind, FunKind, Lit, Name, Refinement,
+        RefinementSet, Type, TypedBinding, TypedExpr, TypedExprNode,
+    };
+    use indoc::indoc;
+    use std::rc::Rc;
+
+    use TypedExprNode as N;
 
     fn var(name: &str) -> TypedExpr {
         TypedExpr::var(name)
@@ -1594,13 +1739,8 @@ mod tests {
         // (a spurious insert), strand `0` (a spurious delete), and report a move
         // that never happened. Structural position picks the tuple slot, and
         // optimal recovery then reads the guard edit as `0 -> 1`.
-        let guard = |n: i64| {
-            TypedExpr::binop(
-                var("v"),
-                BinOpKind::Compare(crate::ccl::CompareKind::Greater),
-                int(n),
-            )
-        };
+        let guard =
+            |n: i64| TypedExpr::binop(var("v"), BinOpKind::Compare(CompareKind::Greater), int(n));
         let v1 = TypedExpr::tuple(vec![int(1), guard(0)]);
         let v2 = TypedExpr::tuple(vec![int(1), guard(1)]);
         let r = diff(&v1, &v2);
@@ -1676,12 +1816,12 @@ mod tests {
 
     /// Pre-uniquify CCL (`Raw` names, before inference), via the public API.
     fn lower(code: &str) -> TypedExpr {
-        compile_to(code, CompileStage::Lowered).expect("compile to lowered stage should succeed")
+        compile_to(code, Phase::Lower).expect("compile to lowered stage should succeed")
     }
 
     /// Post-inference CCL (uniquified, fully typed), via the public API.
     fn lower_and_infer(code: &str) -> TypedExpr {
-        compile_to(code, CompileStage::Inferred).expect("compile to inferred stage should succeed")
+        compile_to(code, Phase::Infer).expect("compile to inferred stage should succeed")
     }
 
     // Realistic CHL programs exercising records, list comprehensions, filters,
@@ -1693,20 +1833,65 @@ mod tests {
     // are born *below* the inferred stage — the mutability phases build them —
     // so no source program can exercise them here; `content_hash` covers them
     // structurally instead.
-    const FILTER_AGG: &str = "users = [\n  (name=\"alice\", age=30, score=85),\n  (name=\"bob\", age=17, score=92),\n]\nsum([u.score for u in users if u.age >= 18])\n";
-    const FILTER_AGG_21: &str = "users = [\n  (name=\"alice\", age=30, score=85),\n  (name=\"bob\", age=17, score=92),\n]\nsum([u.score for u in users if u.age >= 21])\n";
-    const GENERATORS: &str = "def positives(xs):\n    for x in xs:\n        if x > 0:\n            yield x\n\ndef squared(xs):\n    for x in xs:\n        yield x * x\n\nmax(squared(positives([-3, 4, -1, 2, 5, -7])))\n";
-    const JOIN: &str = "users = [(id=1, name=\"alice\"), (id=2, name=\"bob\")]\norders = [(user_id=1, amount=50), (user_id=2, amount=75)]\n[(customer=u.name, total=o.amount) for u in users for o in orders if u.id == o.user_id]\n";
-    const GROUPBY: &str = "sales = [(region=\"west\", amount=100), (region=\"east\", amount=50)]\n[sum([s.amount for s in g]) for g in groupby(sales, \\r -> r.region)]\n";
-    const ACCUM: &str = "acc := 0\nfor i in [1, 2, 3, 4, 5]:\n    acc := acc + i\nacc\n";
-    const TXN: &str = "pool: Mut(Int, Txn) := 100\nreqs = [1, 2, 3]\nfor r in reqs:\n    with begin():\n        pool := pool - r\n";
+    const FILTER_AGG: &str = indoc! {r#"
+        users = [
+          (name="alice", age=30, score=85),
+          (name="bob", age=17, score=92),
+        ]
+        sum([u.score for u in users if u.age >= 18])
+    "#};
+    const FILTER_AGG_21: &str = indoc! {r#"
+        users = [
+          (name="alice", age=30, score=85),
+          (name="bob", age=17, score=92),
+        ]
+        sum([u.score for u in users if u.age >= 21])
+    "#};
+    const GENERATORS: &str = indoc! {"
+        def positives(xs):
+            for x in xs:
+                if x > 0:
+                    yield x
+
+        def squared(xs):
+            for x in xs:
+                yield x * x
+
+        max(squared(positives([-3, 4, -1, 2, 5, -7])))
+    "};
+    const JOIN: &str = indoc! {r#"
+        users = [(id=1, name="alice"), (id=2, name="bob")]
+        orders = [(user_id=1, amount=50), (user_id=2, amount=75)]
+        [(customer=u.name, total=o.amount) for u in users for o in orders if u.id == o.user_id]
+    "#};
+    const GROUPBY: &str = indoc! {r#"
+        sales = [(region="west", amount=100), (region="east", amount=50)]
+        [sum([s.amount for s in g]) for g in groupby(sales, \r -> r.region)]
+    "#};
+    const ACCUM: &str = indoc! {"
+        acc := 0
+        for i in [1, 2, 3, 4, 5]:
+            acc := acc + i
+        acc
+    "};
+    const TXN: &str = indoc! {"
+        pool: Mut(Int, Txn) := 100
+        reqs = [1, 2, 3]
+        for r in reqs:
+            with begin():
+                pool := pool - r
+    "};
 
     #[test]
     fn lowered_source_is_stable_across_independent_compilations() {
         // The point of diffing pre-uniquify on Raw names: lowering the same
         // source twice, through independent contexts, yields trees that diff as
         // identical — no spurious divergence from fresh binder identities.
-        let src = "x = 1\ny = x + 2\ny\n";
+        let src = indoc! {"
+            x = 1
+            y = x + 2
+            y
+        "};
         let (a, b) = (lower(src), lower(src));
         let r = diff(&a, &b);
         assert!(r.is_identical(), "{r:?}");
@@ -1719,8 +1904,16 @@ mod tests {
         // the changed leaf with its counterpart, so the edit reads as one
         // in-place update rather than a delete plus an insert — and nothing
         // around it is disturbed.
-        let v1 = lower("x = 1\ny = x + 2\ny\n");
-        let v2 = lower("x = 1\ny = x + 3\ny\n");
+        let v1 = lower(indoc! {"
+            x = 1
+            y = x + 2
+            y
+        "});
+        let v2 = lower(indoc! {"
+            x = 1
+            y = x + 3
+            y
+        "});
         let r = diff(&v1, &v2);
 
         assert!(r.deleted.is_empty(), "deleted: {:?}", r.deleted);
@@ -1754,8 +1947,15 @@ mod tests {
         // weighs the two subtrees *together* scores the root far too low to
         // pair — and the whole program reads as deleted-and-reinserted for a
         // one-statement edit. The roots correspond by construction instead.
-        let v1 = lower("a = 1\na\n");
-        let v2 = lower("a = 1\nb = sum([i * 2 for i in [1,2,3]])\na + b\n");
+        let v1 = lower(indoc! {"
+            a = 1
+            a
+        "});
+        let v2 = lower(indoc! {"
+            a = 1
+            b = sum([i * 2 for i in [1,2,3]])
+            a + b
+        "});
         let r = diff(&v1, &v2);
         assert!(
             r.deleted.is_empty(),
@@ -1781,10 +1981,19 @@ mod tests {
         // `def` body gains a statement. The enclosing container is matched on
         // *containment* of what it already had, not on its size relative to
         // what was added.
-        let v1 = lower("def f(x):\n    a = 1\n    a + x\nf(2)\n");
-        let v2 = lower(
-            "def f(x):\n    a = 1\n    b = sum([i * 2 for i in [1,2,3]])\n    a + x + b\nf(2)\n",
-        );
+        let v1 = lower(indoc! {"
+            def f(x):
+                a = 1
+                a + x
+            f(2)
+        "});
+        let v2 = lower(indoc! {"
+            def f(x):
+                a = 1
+                b = sum([i * 2 for i in [1,2,3]])
+                a + x + b
+            f(2)
+        "});
         let r = diff(&v1, &v2);
         assert!(
             r.deleted.is_empty(),
@@ -1803,8 +2012,15 @@ mod tests {
         // reuses `a`. The wholly-new `sum(…)` subtree collapses to one line
         // with a node count; the new `a + b` does *not*, because `a` survived
         // underneath it and hiding that would claim it changed.
-        let v1 = lower("a = 1\na\n");
-        let v2 = lower("a = 1\nb = sum([i * 2 for i in [1,2,3]])\na + b\n");
+        let v1 = lower(indoc! {"
+            a = 1
+            a
+        "});
+        let v2 = lower(indoc! {"
+            a = 1
+            b = sum([i * 2 for i in [1,2,3]])
+            a + b
+        "});
         let out = diff(&v1, &v2).to_string();
 
         assert!(
@@ -1832,8 +2048,17 @@ mod tests {
         // `let c = 9 in …` is dropped, but the statements under it survive. The
         // deleted wrapper must be reported on its own — not as a subtree of
         // everything it used to contain.
-        let v1 = lower("a = 1\nc = 9\nb = 2\na + b + c\n");
-        let v2 = lower("a = 1\nb = 2\na + b\n");
+        let v1 = lower(indoc! {"
+            a = 1
+            c = 9
+            b = 2
+            a + b + c
+        "});
+        let v2 = lower(indoc! {"
+            a = 1
+            b = 2
+            a + b
+        "});
         let d = diff(&v1, &v2);
         let out = d.to_string();
 
@@ -1856,10 +2081,27 @@ mod tests {
         // classification resolves a free variable to *which binder it means*
         // rather than to how that binder is spelled.
         for (a, b) in [
-            ("x = 1\ny = x + 2\ny\n", "q = 1\ny = q + 2\ny\n"),
             (
-                "users = [(name=\"a\", age=30)]\nsum([u.age for u in users])\n",
-                "users = [(name=\"a\", age=30)]\nsum([q.age for q in users])\n",
+                indoc! {"
+                    x = 1
+                    y = x + 2
+                    y
+                "},
+                indoc! {"
+                    q = 1
+                    y = q + 2
+                    y
+                "},
+            ),
+            (
+                indoc! {r#"
+                    users = [(name="a", age=30)]
+                    sum([u.age for u in users])
+                "#},
+                indoc! {r#"
+                    users = [(name="a", age=30)]
+                    sum([q.age for q in users])
+                "#},
             ),
         ] {
             let (v1, v2) = (lower(a), lower(b));
@@ -1873,14 +2115,23 @@ mod tests {
 
     #[test]
     fn a_binder_inserted_above_a_subterm_does_not_change_it() {
-        // The trap the binder-class scheme exists to avoid. `b`'s binding and
+        // The trap the binder-correspondent scheme exists to avoid. `b`'s binding and
         // the tail below it still reach `a` through one more enclosing `let`
         // than before; if a free variable were identified by its distance to
         // its binder rather than by the binder itself, every reference reaching
         // past the new one would shift and the whole tail would read as
         // changed.
-        let v1 = lower("a = 1\nb = 2\na + b\n");
-        let v2 = lower("a = 1\nc = 9\nb = 2\na + b\n");
+        let v1 = lower(indoc! {"
+            a = 1
+            b = 2
+            a + b
+        "});
+        let v2 = lower(indoc! {"
+            a = 1
+            c = 9
+            b = 2
+            a + b
+        "});
         let r = diff(&v1, &v2);
         assert!(r.deleted.is_empty(), "{r}");
         assert!(
@@ -1928,8 +2179,15 @@ mod tests {
     #[test]
     fn an_inserted_region_is_reported_at_its_root() {
         // 16 new nodes, one insertion.
-        let v1 = lower("a = 1\na\n");
-        let v2 = lower("a = 1\nb = sum([i * 2 for i in [1,2,3]])\na + b\n");
+        let v1 = lower(indoc! {"
+            a = 1
+            a
+        "});
+        let v2 = lower(indoc! {"
+            a = 1
+            b = sum([i * 2 for i in [1,2,3]])
+            a + b
+        "});
         let r = diff(&v1, &v2);
         assert!(r.new.len() > 10, "the inserted block is substantial");
 
@@ -1958,8 +2216,17 @@ mod tests {
 
     #[test]
     fn shared_roots_are_maximal_and_disjoint() {
-        let v1 = lower("a = 1\nb = 2\na + b\n");
-        let v2 = lower("a = 1\nc = 9\nb = 2\na + b\n");
+        let v1 = lower(indoc! {"
+            a = 1
+            b = 2
+            a + b
+        "});
+        let v2 = lower(indoc! {"
+            a = 1
+            c = 9
+            b = 2
+            a + b
+        "});
         let r = diff(&v1, &v2);
         let roots = r.shared_roots();
         assert!(!roots.is_empty());
@@ -2016,7 +2283,12 @@ mod tests {
         // mutation machinery leaks into the diff.
         assert_stable_and_localizing(
             ACCUM,
-            "acc := 0\nfor i in [1, 2, 3, 4, 5]:\n    acc := acc + i * 2\nacc\n",
+            indoc! {"
+                acc := 0
+                for i in [1, 2, 3, 4, 5]:
+                    acc := acc + i * 2
+                acc
+            "},
         );
     }
 
@@ -2027,7 +2299,13 @@ mod tests {
         // compilations, and an edit inside the block localizes to it.
         assert_stable_and_localizing(
             TXN,
-            "pool: Mut(Int, Txn) := 100\nreqs = [1, 2, 3]\nfor r in reqs:\n    with begin():\n        pool := pool - r - 1\n",
+            indoc! {"
+                pool: Mut(Int, Txn) := 100
+                reqs = [1, 2, 3]
+                for r in reqs:
+                    with begin():
+                        pool := pool - r - 1
+            "},
         );
     }
 
@@ -2080,12 +2358,21 @@ mod tests {
     #[test]
     fn conditional_branches_diff_cleanly() {
         // A ternary `1 if v > 0 else 2` lowers to a guard-based `Case`.
-        let base = "v = 5\n1 if v > 0 else 2\n";
+        let base = indoc! {"
+            v = 5
+            1 if v > 0 else 2
+        "};
         let (a, b) = (lower(base), lower(base));
         assert!(diff(&a, &b).is_identical());
 
         // Editing the else-branch value localizes to that literal.
-        let (e1, e2) = (lower(base), lower("v = 5\n1 if v > 0 else 3\n"));
+        let (e1, e2) = (
+            lower(base),
+            lower(indoc! {"
+                v = 5
+                1 if v > 0 else 3
+            "}),
+        );
         let r = diff(&e1, &e2);
         assert!(r.updated().any(|m| {
             matches!(m.src.node, TypedExprNode::Lit(Lit::Int(2)))
@@ -2093,7 +2380,13 @@ mod tests {
         }));
 
         // Editing the guard threshold localizes to that literal.
-        let (g1, g2) = (lower(base), lower("v = 5\n1 if v > 1 else 2\n"));
+        let (g1, g2) = (
+            lower(base),
+            lower(indoc! {"
+                v = 5
+                1 if v > 1 else 2
+            "}),
+        );
         let r = diff(&g1, &g2);
         assert!(r.updated().any(|m| {
             matches!(m.src.node, TypedExprNode::Lit(Lit::Int(0)))
@@ -2122,8 +2415,14 @@ mod tests {
         // diverges (`x: Int` vs `x: String`), so the *same* subterm no longer
         // matches: types carry signal the term structure alone does not. This
         // is the payoff of diffing post-inference.
-        let prog_int = "x = 1\n(x, x)\n";
-        let prog_str = "x = \"a\"\n(x, x)\n";
+        let prog_int = indoc! {"
+            x = 1
+            (x, x)
+        "};
+        let prog_str = indoc! {r#"
+            x = "a"
+            (x, x)
+        "#};
 
         // The `(x, x)` tuple is the root `let`'s body.
         let body = |e: &TypedExpr| match &e.node {
@@ -2147,12 +2446,20 @@ mod tests {
     fn inlining_erases_function_boundaries() {
         // Extracting a subexpression into a `def` is invisible once the
         // pipeline's own inlining has run: the two versions are the same tree.
-        let plain = "a = 1\n(a + 2) * 3\n";
-        let extracted = "def g(y):\n    y + 2\na = 1\ng(a) * 3\n";
+        let plain = indoc! {"
+            a = 1
+            (a + 2) * 3
+        "};
+        let extracted = indoc! {"
+            def g(y):
+                y + 2
+            a = 1
+            g(a) * 3
+        "};
 
         let (v1, v2) = (
-            compile_to(plain, CompileStage::Inferred).unwrap(),
-            compile_to(extracted, CompileStage::Inferred).unwrap(),
+            compile_to(plain, Phase::Infer).unwrap(),
+            compile_to(extracted, Phase::Infer).unwrap(),
         );
         assert!(
             !diff(&v1, &v2).divergences().is_empty(),
@@ -2160,8 +2467,8 @@ mod tests {
         );
 
         let (v1, v2) = (
-            compile_to(plain, CompileStage::Inlined).unwrap(),
-            compile_to(extracted, CompileStage::Inlined).unwrap(),
+            compile_to(plain, Phase::Inline).unwrap(),
+            compile_to(extracted, Phase::Inline).unwrap(),
         );
         assert!(
             diff(&v1, &v2).is_identical(),
@@ -2183,12 +2490,24 @@ mod tests {
         // clone the helper during inference — the baseline would already be
         // delocalized, and the contrast below would not be inlining's doing.
         // See `src/ccl/design/diffing.md`, "How much to normalize".
-        let v1 = "def g(y):\n    y + 2\na = 1 + 1\nb = 2 + 2\ng(a) * g(b)\n";
-        let v2 = "def g(y):\n    y + 5\na = 1 + 1\nb = 2 + 2\ng(a) * g(b)\n";
+        let v1 = indoc! {"
+            def g(y):
+                y + 2
+            a = 1 + 1
+            b = 2 + 2
+            g(a) * g(b)
+        "};
+        let v2 = indoc! {"
+            def g(y):
+                y + 5
+            a = 1 + 1
+            b = 2 + 2
+            g(a) * g(b)
+        "};
 
         let (a, b) = (
-            compile_to(v1, CompileStage::Inferred).unwrap(),
-            compile_to(v2, CompileStage::Inferred).unwrap(),
+            compile_to(v1, Phase::Infer).unwrap(),
+            compile_to(v2, Phase::Infer).unwrap(),
         );
         assert_eq!(
             diff(&a, &b).divergences().len(),
@@ -2197,8 +2516,8 @@ mod tests {
         );
 
         let (a, b) = (
-            compile_to(v1, CompileStage::Inlined).unwrap(),
-            compile_to(v2, CompileStage::Inlined).unwrap(),
+            compile_to(v1, Phase::Inline).unwrap(),
+            compile_to(v2, Phase::Inline).unwrap(),
         );
         assert!(
             diff(&a, &b).divergences().len() > 1,
@@ -2220,7 +2539,14 @@ mod tests {
         // once a name is a record label no amount of uid-robustness in the
         // hasher can see through it.
         let corpus = [
-            ("pure", "a = 1\nb = 2\na + b\n"),
+            (
+                "pure",
+                indoc! {"
+                    a = 1
+                    b = 2
+                    a + b
+                "},
+            ),
             ("comprehension", FILTER_AGG),
             ("generators", GENERATORS),
             ("join", JOIN),
@@ -2230,12 +2556,16 @@ mod tests {
             ("source", "[\"> \" + line for line in stdin()]\n"),
         ];
         for stage in [
-            CompileStage::Lowered,
-            CompileStage::Inferred,
-            CompileStage::Inlined,
-            CompileStage::Channelized,
-            CompileStage::LambdaElim,
-            CompileStage::Planned,
+            Phase::Lower,
+            Phase::Uniquify,
+            Phase::Infer,
+            Phase::Inline,
+            Phase::Transact,
+            Phase::Letrec,
+            Phase::Channelize,
+            Phase::AsOfRead,
+            Phase::LambdaElim,
+            Phase::Planning,
         ] {
             for (label, src) in corpus {
                 let (a, b) = (
@@ -2252,23 +2582,326 @@ mod tests {
     }
 
     #[test]
+    fn a_container_that_only_gained_or_lost_a_child_is_not_a_site() {
+        // The insertion (or deletion) is the whole story: the container's own
+        // content — its operator, binder, annotation — did not change, so
+        // reporting it alongside would put a second guard around the first.
+        let (small, big) = (
+            TypedExpr::list(vec![var("a")]),
+            TypedExpr::list(vec![var("a"), int(7)]),
+        );
+        let grew = diff(&small, &big).divergences();
+        assert!(
+            matches!(grew.as_slice(), [Divergence::Inserted(_)]),
+            "a gained child is one site: {grew:?}",
+        );
+        let shrank = diff(&big, &small).divergences();
+        assert!(
+            matches!(shrank.as_slice(), [Divergence::Deleted(_)]),
+            "a lost child is one site: {shrank:?}",
+        );
+    }
+
+    #[test]
+    fn a_container_that_changed_and_gained_a_child_reports_both() {
+        // The suppression above is about a container whose *own* content is
+        // intact. A record that both relabelled a field and gained one has two
+        // things to say, and both are reported.
+        let rec = |fields: Vec<(&str, TypedExpr)>| {
+            TypedExpr::new(N::Record(
+                fields
+                    .into_iter()
+                    .map(|(n, e)| (n.to_string(), e))
+                    .collect(),
+            ))
+        };
+        let v1 = rec(vec![("a", var("x"))]);
+        let v2 = rec(vec![("b", var("x")), ("c", int(7))]);
+        let sites = diff(&v1, &v2).divergences();
+        assert_eq!(sites.len(), 2, "{sites:?}");
+        assert!(
+            sites
+                .iter()
+                .any(|d| matches!(d, Divergence::Changed(m) if matches!(m.dst.node, N::Record(_)))),
+            "the relabelling is a site: {sites:?}",
+        );
+        assert!(
+            sites.iter().any(|d| matches!(d, Divergence::Inserted(_))),
+            "the new field is a site: {sites:?}",
+        );
+    }
+
+    #[test]
+    fn a_relabelled_field_is_reported_beside_an_edited_sibling() {
+        // The under-report the own-content fold exists to prevent: the edited
+        // literal is a site of its own, and the record's own change — its
+        // labels — must not be swallowed by it.
+        let rec = |a: &str, n: i64| {
+            TypedExpr::new(N::Record(vec![
+                (a.to_string(), var("x")),
+                ("c".to_string(), int(n)),
+            ]))
+        };
+        let (v1, v2) = (rec("a", 1), rec("b", 2));
+        let sites = diff(&v1, &v2).divergences();
+        assert_eq!(sites.len(), 2, "{sites:?}");
+    }
+
+    #[test]
+    fn a_reordering_is_a_site_at_the_container() {
+        // Nothing below reports — every child corresponds and is unchanged —
+        // so the container is where the disagreement is.
+        let v1 = TypedExpr::tuple(vec![var("a"), var("b")]);
+        let v2 = TypedExpr::tuple(vec![var("b"), var("a")]);
+        let sites = diff(&v1, &v2).divergences();
+        assert!(
+            matches!(
+                sites.as_slice(),
+                [Divergence::Changed(m)] if matches!(m.dst.node, N::Tuple(_))
+            ),
+            "{sites:?}",
+        );
+    }
+
+    #[test]
+    fn a_deleted_cast_with_a_surviving_predicate_is_not_wholly_deleted() {
+        // `child_exprs` descends into a cast target's refinement predicate — a
+        // comprehension filter or join condition, a term the matcher can match.
+        // The collapse tests must walk that same child set: over the narrower
+        // `all_children` the cast reads as wholly gone while a matched node is
+        // still live inside it, and `divergences()` then reports `Deleted` over
+        // a subtree that survives in part.
+        let pred = || {
+            TypedExpr::binop(
+                TypedExpr::var(Name::elem()),
+                BinOpKind::Compare(CompareKind::Equals),
+                int(7),
+            )
+        };
+        let cast = TypedExpr::new(N::Cast {
+            value: Box::new(int(1)),
+            target: Type::Fun {
+                name: None,
+                kind: FunKind::Compute,
+                domain: Box::new(Type::Refinement(
+                    Box::new(Type::Base(BaseType::Int)),
+                    RefinementSet::one(Refinement {
+                        predicate: Rc::new(pred()),
+                    }),
+                )),
+                codomain: Box::new(Type::Base(BaseType::Int)),
+            },
+        });
+        // The cast goes away; its predicate term survives as a sibling.
+        let v1 = TypedExpr::tuple(vec![cast, pred(), int(0)]);
+        let v2 = TypedExpr::tuple(vec![pred(), int(0)]);
+        let r = diff(&v1, &v2);
+
+        // The matcher pairs one of the two identical predicate terms with v2's,
+        // leaving a `Cast` that is deleted at its root with a live node inside.
+        let gone: HashSet<*const TypedExpr> =
+            r.deleted.iter().map(|e| *e as *const TypedExpr).collect();
+        let mut roots = Vec::new();
+        collect_deleted_roots(&v1, &gone, &mut roots);
+        assert!(
+            roots.iter().any(|(e, _)| matches!(e.node, N::Cast { .. })),
+            "the cast is deleted:\n{r}",
+        );
+        // The invariant `subtree_entirely_in` exists to state: a root marked
+        // *whole* — the one that collapses in the rendering and stops the walk —
+        // has nothing matched under it.
+        let matched: HashSet<*const TypedExpr> = r
+            .matched
+            .iter()
+            .map(|m| m.src as *const TypedExpr)
+            .collect();
+        fn any_matched(e: &TypedExpr, matched: &HashSet<*const TypedExpr>) -> bool {
+            matched.contains(&(e as *const TypedExpr))
+                || child_exprs(e).into_iter().any(|c| any_matched(c, matched))
+        }
+        for (root, whole) in roots {
+            assert!(
+                !whole || !any_matched(root, &matched),
+                "a wholly-deleted root must not cover a matched node:\n{r}",
+            );
+        }
+    }
+
+    #[test]
+    fn distinct_binders_of_one_group_get_distinct_correspondents() {
+        // Every binder a node introduces gets its own correspondent token, so a
+        // use of one does not hash equal to a use of another. Without that, a
+        // `letrec`'s whole group collapsed to one correspondent and swapping
+        // which binding the body reads classified `Same` — an unsound share.
+        let group = |body: TypedExpr| {
+            TypedExpr::letrec(
+                vec![
+                    (TypedBinding::new_unannotated("p"), int(1)),
+                    (TypedBinding::new_unannotated("q"), int(2)),
+                ],
+                body,
+            )
+        };
+        let a = group(mul(var("p"), int(10)));
+        let b = group(mul(var("q"), int(10)));
+        let r = diff(&a, &b);
+        assert!(
+            !r.is_identical(),
+            "reading a different binding of the group is a change:\n{r}"
+        );
+        // And the divergence localizes to the variable, not to the `letrec`.
+        let sites = r.divergences();
+        assert_eq!(sites.len(), 1, "sites: {sites:?}");
+        assert!(
+            matches!(
+                &sites[0],
+                Divergence::Changed(m)
+                    if matches!(&m.dst.node, TypedExprNode::Var(n) if n.base() == "q")
+            ),
+            "sites: {sites:?}",
+        );
+    }
+
+    #[test]
+    fn a_swapped_pair_of_registers_is_not_a_shared_root() {
+        // The same defect on a real program: `channelize` emits one `LetRec`
+        // group per transaction, so two mutable registers shared one
+        // correspondent and a tuple returning them swapped claimed to be
+        // reusable wholesale.
+        let prog = |tail: &str| {
+            format!(
+                "{}{tail}\n",
+                indoc! {"
+                    a: Mut(Int, Txn) := 0
+                    b: Mut(Int, Txn) := 0
+                    for x in [1, 2]:
+                        with begin():
+                            a := a + x
+                            b := b + a
+                    "}
+            )
+        };
+        let (v1, v2) = (
+            prog("(await_final(a), await_final(b))"),
+            prog("(await_final(b), await_final(a))"),
+        );
+        for stage in [Phase::Channelize, Phase::Planning] {
+            let (a, b) = (
+                compile_to(&v1, stage).expect("v1"),
+                compile_to(&v2, stage).expect("v2"),
+            );
+            let r = diff(&a, &b);
+            assert!(
+                !r.is_identical(),
+                "a swapped pair of registers is a change at {stage:?}:\n{r}"
+            );
+            // The swap is one site — the tuple — rather than the whole
+            // recurrence: the two reads pair with their counterparts and move.
+            let sites = r.divergences();
+            assert!(
+                matches!(
+                    sites.as_slice(),
+                    [Divergence::Changed(m)] if matches!(m.dst.node, TypedExprNode::Tuple(_))
+                ),
+                "at {stage:?} the swap must localize to the tuple:\n{r}",
+            );
+            // And the tuple itself is not offered for reuse: its two elements
+            // returned swapped values.
+            assert!(
+                !r.shared_roots()
+                    .iter()
+                    .any(|m| matches!(m.src.node, TypedExprNode::Tuple(_))),
+                "at {stage:?} the swapped tuple is not reusable wholesale:\n{r}",
+            );
+        }
+    }
+
+    #[test]
+    fn compile_to_rejects_what_compile_program_rejects() {
+        // `compile_to` is a second path through the frontend, so a program the
+        // real pipeline refuses must not yield a stage snapshot: the differ
+        // would otherwise be handed a tree whose illegal construct was silently
+        // dropped, and two versions differing only in it would diff as
+        // identical. `x := 2` writes to an immutable binding, which
+        // `check_mut_write_targets` is what rejects.
+        let src = indoc! {"
+            x = 1
+            x := 2
+            x
+        "};
+        for stage in [
+            Phase::Infer,
+            Phase::Inline,
+            Phase::Channelize,
+            Phase::LambdaElim,
+            Phase::Planning,
+        ] {
+            assert!(
+                compile_to(src, stage).is_err(),
+                "a write to an immutable binding must be rejected at {stage:?}",
+            );
+        }
+        // `Lowered` is below every check by construction — it is the tree as
+        // lowering built it, and the write is still a `MutWrite` node there.
+        assert!(compile_to(src, Phase::Lower).is_ok());
+    }
+
+    #[test]
+    fn both_entry_points_compile_to_one_tree() {
+        // `compile_program` and `compile_to` run one frontend, so the tree a
+        // diff is taken over is the tree the operator graph is built from.
+        // Asserted with this differ, which is what makes it an equality modulo
+        // the uids the two runs mint independently — `assert_eq!` on the two
+        // `Expr`s would fail on those alone.
+        //
+        // Only `Phase::Planning` is checkable this way: it is the phase
+        // `compile_program` runs to, and `CompiledProgram::ast` is its output.
+        for src in [FILTER_AGG, JOIN, ACCUM, TXN] {
+            let mut ctx = GlobalContext::new();
+            let compiled = compile_program(&mut ctx, src, Box::new(|| {}))
+                .unwrap_or_else(|e| panic!("compile_program failed on {src:?}: {e:?}"));
+            let staged = compile_to(src, Phase::Planning)
+                .unwrap_or_else(|e| panic!("compile_to failed on {src:?}: {e:?}"));
+            let d = diff(&compiled.ast, &staged);
+            assert!(
+                d.is_identical(),
+                "the two entry points disagree on {src:?}: {:?}",
+                d.divergences(),
+            );
+        }
+    }
+
+    #[test]
+    fn both_entry_points_agreement_is_not_vacuous() {
+        // The agreement above would pass on any two trees the differ happened to
+        // match wholesale, so pin that a genuinely different phase output fails
+        // it. `LambdaElim`'s output is one phase above `Planning`.
+        let src = FILTER_AGG;
+        let mut ctx = GlobalContext::new();
+        let compiled = compile_program(&mut ctx, src, Box::new(|| {})).expect("compiles");
+        let earlier = compile_to(src, Phase::LambdaElim).expect("compiles");
+        assert!(
+            !diff(&compiled.ast, &earlier).is_identical(),
+            "a pre-planning tree must not read as the planned one",
+        );
+    }
+
+    #[test]
     fn diff_programs_end_to_end_from_source() {
         // The public single-call entry: compile both sources to a stage and
         // diff, results delivered through the closure.
         //
         // A filter-threshold edit (`>= 18` → `>= 21`) is reflected at the
         // lowered stage.
-        let changed = diff_programs(FILTER_AGG, FILTER_AGG_21, CompileStage::Lowered, |d| {
+        let changed = diff_programs(FILTER_AGG, FILTER_AGG_21, Phase::Lower, |d| {
             d.updated().count()
         })
         .expect("compile + diff should succeed");
         assert!(changed > 0, "the edit is reflected");
 
         // Identical programs diff as identical at the inferred stage.
-        let identical = diff_programs(FILTER_AGG, FILTER_AGG, CompileStage::Inferred, |d| {
-            d.is_identical()
-        })
-        .expect("compile + diff should succeed");
+        let identical = diff_programs(FILTER_AGG, FILTER_AGG, Phase::Infer, |d| d.is_identical())
+            .expect("compile + diff should succeed");
         assert!(
             identical,
             "identical source diffs as identical post-inference"
@@ -2281,7 +2914,7 @@ mod tests {
         // registered for inference — and diffs cleanly against itself. Proves
         // the public API handles sources, not just literal programs.
         let prog = "[\"> \" + line for line in stdin()]\n";
-        let identical = diff_programs(prog, prog, CompileStage::Inferred, |d| d.is_identical())
+        let identical = diff_programs(prog, prog, Phase::Infer, |d| d.is_identical())
             .expect("stdin program should compile to the inferred stage and diff");
         assert!(identical);
     }

--- a/src/ccl/mod.rs
+++ b/src/ccl/mod.rs
@@ -8,7 +8,9 @@
 
 pub mod ccl_utils;
 pub mod channelize;
+pub mod content_hash;
 pub mod context;
+pub mod diff;
 pub mod infer;
 pub mod inline;
 pub mod lambda_elim;

--- a/src/ccl/names.rs
+++ b/src/ccl/names.rs
@@ -324,23 +324,33 @@ impl Name {
         }
     }
 
-    /// A globally-distinct string key for this name, suitable as a **mutable variable
-    /// record field label** for a [`crate::ccl::TypedExprNode::Transact`] key.
-    /// Unlike [`base`](Self::base) it folds the `uid` in, so two distinct
-    /// binders sharing a spelling (e.g. accumulators in sibling loops) get
-    /// distinct keys. A variable read of a mutable variable key projects this field of
-    /// the history record (`__hist.field_key`).
+    /// This name as a **mutable variable record field label** for a
+    /// [`crate::ccl::TypedExprNode::Transact`] key. A variable read of a
+    /// mutable variable key projects this field of the history record
+    /// (`__hist.field_key`).
+    ///
+    /// It is the plain [`base`](Self::base) spelling, and deliberately carries
+    /// no `uid`. The label has to be distinct only among the keys of *one*
+    /// history record — every consumer resolves it against a `keys_map`
+    /// built per [`Transact`](crate::ccl::TypedExprNode::Transact) node, so
+    /// accumulators in sibling loops live in different records and cannot
+    /// collide. Folding the `uid` in would buy global distinctness nothing
+    /// needs, at the cost of rendering a run-varying identity into a `String`:
+    /// once a name is a record label, uid-robust comparison is impossible, and
+    /// two compilations of one source disagree. That made program diffing at
+    /// and below loop planning unusable — see `src/ccl/design/diffing.md`.
+    ///
+    /// The per-record uniqueness this relies on holds by construction: a key
+    /// spelling is either the user's own variable name, distinct within its
+    /// block, or a label planning mints indexed by position (`acc0`, `acc1`).
     pub fn field_key(&self) -> String {
         match self {
-            Name::Raw(s) => s.clone(),
-            Name::Unique { base, uid } => format!("{base}#{}", uid.0),
-            Name::Synthetic { kind, uid } => format!("{}#{}", kind.stem(), uid.0),
-            Name::Reserved(r) => r.spelling().to_string(),
             // Not a binder, so no mutable variable is ever declared at one and
             // no record field is ever labeled by one.
             Name::PiBound(_) => {
                 unreachable!("a PiBound is a reference, not a binder; it labels no field")
             }
+            _ => self.base().to_string(),
         }
     }
 

--- a/src/ccl/names.rs
+++ b/src/ccl/names.rs
@@ -340,9 +340,14 @@ impl Name {
     /// two compilations of one source disagree. That made program diffing at
     /// and below loop planning unusable — see `src/ccl/design/diffing.md`.
     ///
-    /// The per-record uniqueness this relies on holds by construction: a key
-    /// spelling is either the user's own variable name, distinct within its
-    /// block, or a label planning mints indexed by position (`acc0`, `acc1`).
+    /// The per-record uniqueness this relies on is a property of spellings, not
+    /// of construction: a key spelling is either the user's own variable name,
+    /// distinct within its block, or a label planning mints indexed by position
+    /// (`acc0`, `acc1`), and a writer's `to_<base>_<n>` taps share the record
+    /// with both. Nothing in the type system rules a collision out, so each site
+    /// that builds a record from these labels asserts distinctness in debug:
+    /// `hist_record` in `planning/loops.rs`, and the two `keys_map` inserts
+    /// in `interpreter/operator_conversion.rs`.
     pub fn field_key(&self) -> String {
         match self {
             // Not a binder, so no mutable variable is ever declared at one and

--- a/src/ccl/planning/loops.rs
+++ b/src/ccl/planning/loops.rs
@@ -602,13 +602,18 @@ fn recognize_group(h: TypedBinding, def: Expr, letrec_body: Expr) -> Expr {
         })
         .collect();
 
-    // One mutable variable key per accumulator. Names are fresh labels: every read is
-    // positional (`__hist ≫ .writes ≫ .i`), so only field order is
-    // load-bearing.
+    // One mutable variable key per accumulator. Every read is positional
+    // (`__hist ≫ .writes ≫ .i`), so these names carry no meaning beyond
+    // labelling the mutable variable record — but the label still has to be
+    // distinct *within* that record, and `field_key` is the plain spelling. So
+    // index by position: a shared `"acc"` base would collapse two accumulators
+    // onto one field, and position is the one distinguisher that is also stable
+    // across compilations, which uid-free labels require.
     let keys: Vec<TransactKey> = inits
         .into_iter()
-        .map(|init| TransactKey {
-            name: Name::fresh("acc"),
+        .enumerate()
+        .map(|(i, init)| TransactKey {
+            name: Name::fresh(format!("acc{i}")),
             init,
         })
         .collect();

--- a/src/ccl/planning/loops.rs
+++ b/src/ccl/planning/loops.rs
@@ -9,7 +9,7 @@
 //! `Transact{domain: Txn}`. Causality is re-checked at this wall by
 //! [`crate::ccl::letrec::check_letrec_causal`].
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::ccl::{
     Builtin, Expr, F_DECISION, F_WRITE_TARGETS, F_WRITES, Name, ProjKey, TransactKey, Type,
@@ -398,6 +398,25 @@ fn tap_field(def: &Expr) -> String {
     }
 }
 
+/// The history record type a [`TypedExprNode::Transact`] node denotes: one field
+/// per store key, then the virtual keys its writers tap.
+///
+/// The labels must be distinct within the record. [`Name::field_key`] carries no
+/// uid, so that distinctness is by spelling rather than by construction, and a
+/// duplicate would put two keys at one projection — the read rewrites below
+/// would route both reads to whichever survived.
+fn hist_record(fields: Vec<(String, Type)>) -> Type {
+    debug_assert!(
+        {
+            let mut seen = HashSet::new();
+            fields.iter().all(|(n, _)| seen.insert(n.as_str()))
+        },
+        "history record labels must be distinct within one record: {:?}",
+        fields.iter().map(|(n, _)| n).collect::<Vec<_>>(),
+    );
+    Type::Record(fields)
+}
+
 /// Destructure a transaction `LetRec` (from [`crate::ccl::transact_phase`],
 /// post-elim) into the `Transact{keys, writers, domain: Txn}` carrier. The
 /// group\'s bindings, by shape ([`classify_txn_binding`]): one **history** per
@@ -454,7 +473,7 @@ fn recognize_txn_group(bindings: Vec<(TypedBinding, Expr)>, body: Expr) -> Expr 
     for (_, field, stream_ty) in &taps {
         hist_field_tys.push((field.clone(), stream_ty.clone()));
     }
-    let hist_ty = Type::Record(hist_field_tys);
+    let hist_ty = hist_record(hist_field_tys);
 
     let mut transact = Expr::new(TypedExprNode::Transact {
         keys,
@@ -632,7 +651,7 @@ fn recognize_group(h: TypedBinding, def: Expr, letrec_body: Expr) -> Expr {
     for (f, vty) in &feed_fields {
         hist_field_tys.push((f.clone(), Type::fun(domain_ty.clone(), vty.clone())));
     }
-    let hist_ty = Type::Record(hist_field_tys);
+    let hist_ty = hist_record(hist_field_tys);
 
     let writer = WriterSite {
         read_keys: key_names.clone(),

--- a/src/interpreter/operator_conversion.rs
+++ b/src/interpreter/operator_conversion.rs
@@ -1527,7 +1527,7 @@ fn build_commit_store(
         // Seed tick 0 from the key's (literal or computed) init op.
         let init_op = convert_impl(&k.init, None, ctx)?;
         init_ops.push((runtime_key.clone(), init_op));
-        keys_map.insert(
+        let prior = keys_map.insert(
             field,
             KeyReadInfo {
                 runtime_key,
@@ -1535,6 +1535,11 @@ fn build_commit_store(
                 index: 0,            // unused for `commit` reads (keyed by `runtime_key`)
                 carry_forward: true, // mutable variable: value persists across commits
             },
+        );
+        debug_assert!(
+            prior.is_none(),
+            "commit-store key labels are distinct within one store; `Name::field_key` \
+             carries no uid, so distinctness is by spelling",
         );
     }
     let value_extent = match value_extents.len() {
@@ -1622,7 +1627,7 @@ fn build_commit_store(
         for (field, tap_ty) in taps {
             let tap_value_extent = ctx.extent_of(&tap_ty)?;
             write_keys.push(Value::String(field.clone().into()));
-            keys_map.insert(
+            let prior = keys_map.insert(
                 field.clone(),
                 KeyReadInfo {
                     runtime_key: Value::String(field.clone().into()),
@@ -1633,6 +1638,13 @@ fn build_commit_store(
                     // taps to one defer don't smear across the shared clock.
                     carry_forward: false,
                 },
+            );
+            // A tap shares this map with the mutable-variable keys, so its
+            // `to_<base>_<n>` spelling must not collide with a variable's.
+            debug_assert!(
+                prior.is_none(),
+                "commit-store key labels are distinct within one store; `Name::field_key` \
+                 carries no uid, so distinctness is by spelling",
             );
             tap_fields.push(field);
         }

--- a/tests/compilation_pipeline/transactions.rs
+++ b/tests/compilation_pipeline/transactions.rs
@@ -1676,7 +1676,10 @@ fn a_cross_domain_read_coexists_with_a_second_store() {
                 b := b + y
         (await_final(a), await_final(b))
     "#};
-    assert_eq!(commit_stores(code), vec!["[0, 1][acc]", "Txn[a]", "Txn[b]"]);
+    assert_eq!(
+        commit_stores(code),
+        vec!["[0, 1][acc0]", "Txn[a]", "Txn[b]"]
+    );
     check_tile(
         code,
         Tile::Record(std::collections::HashMap::from([
@@ -1736,7 +1739,10 @@ fn a_cross_domain_accumulator_depending_on_an_await_nests_inside_that_store() {
                 b := b + acc
         await_final(b)
     "#};
-    assert_eq!(commit_stores(code), vec!["Txn[a]", "[0, 1][acc]", "Txn[b]"]);
+    assert_eq!(
+        commit_stores(code),
+        vec!["Txn[a]", "[0, 1][acc0]", "Txn[b]"]
+    );
     check_tile(code, Tile::Scalar(ColumnValue::Ints(vec![92])));
 }
 


### PR DESCRIPTION
Running two versions of one program concurrently with their storage and compute shared needs an analysis nothing in the tree provides: for two compiled programs, which parts are the same computation and where they diverge. This adds it as a library — nothing calls it from `compile_program` — plus the one compiler fix the work forced.

New:

- `src/ccl/content_hash.rs` — content-addresses every subterm modulo α. Two hashes over one traversal, differing only in how a free variable is identified: `content_hash` by spelling (context-free, what a matcher needs), `resolved_hash` by which binder it resolves to up to a correspondence (what "the same computation" means). Type-aware, so a refinement or `FunKind` change is a change. Binder scoping is not restated — it folds over `scope.rs`.
- `src/ccl/diff.rs` — a GumTree matcher over those hashes, classifying each correspondence by whether its content changed and whether its placement did. Exposes `divergences()` (the minimal set of disagreement sites) and `shared_roots()` (the largest common subtrees), and renders itself as an annotated tree.
- `CompileStage` / `compile_to` in `src/ccl/context.rs` — compiles to any of six pipeline stages, so a diff can be taken wherever the question lives. Mirrors `compile_program`'s stage order and rejection checks.
- `src/ccl/design/diffing.md` — design of record: the equivalence, the matcher's five phases, which stage to diff and what each one normalizes away.

One fix to non-diffing code: `Name::field_key` folded the binder uid into a record label, so one compilation typed a `Transact` node `{acc#9: …}` and the next `{acc#19: …}` — two compilations of one source diffing as different from loop planning down. The uid bought nothing, since every consumer resolves a footprint key against a per-node map. `field_key` is now the plain spelling, and accumulator labels are indexed by position (`acc0`, `acc1`) so they stay distinct within one record by construction. Two `transactions.rs` store assertions move to the indexed label.

53 unit tests across the two new modules. `every_stage_diffs_identical_source_as_identical` compiles eight corpus programs twice in independent contexts and asserts an empty diff at all six stages — the property the uid defect broke.
