### PR TITLE
Pin two review findings on literal singletons: a `Case`-arm regression and the newly-hot inline assert

### DIFF
--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -1104,6 +1104,38 @@ pub(super) fn emit_case<C: Typing>(
         };
         match &result_ty {
             None => result_ty = Some(strip_refinements(&body_ty)),
+            // BUG (pinned failing by
+            // `type_check::test_case_with_filtered_comprehension_arms_passes_consistency_wall`):
+            // the two sides of this relation are stripped *asymmetrically* — `prev` was
+            // stripped when it was stored, `body_ty` is not stripped here. For a scalar
+            // arm that is harmless, since a singleton is a subtype of its base
+            // (`{Int | __elem == 2} <: Int`). For an arm whose type is a **collection**
+            // it is not: a filtered comprehension is
+            // `{[0, N] | __elem ▷ p} ⇒ elem`, carrying its refinement on the `Fun`
+            // *domain*, and function subtyping is **contravariant** there — so relating
+            // a refined-domain arm to a stripped-domain `prev` demands
+            // `[0, N] <: {[0, N] | p}`, which does not hold. Two arms that are literally
+            // the same expression are rejected, and because this rule re-runs in Check
+            // mode over concrete recorded types the rejection lands on the
+            // post-inference consistency wall as an internal "compiler bug" panic
+            // (`ccl/context.rs`) rather than a user diagnostic.
+            //
+            // The fix is to strip **both** sides, making this the symmetric
+            // compare-modulo-refinements the rule intends (the same relation
+            // `check_node`'s reconcile and `channelize`'s feed-operand assert already
+            // use):
+            //
+            //     Some(prev) => ctx.require_sub(&strip_refinements(&body_ty), prev, &|| {
+            //         "Case arm".to_string()
+            //     })?,
+            //
+            // That also settles a second defect the asymmetry causes. With arms carrying
+            // *different* predicates the unstripped side deposits its witness on the
+            // shared variable and the stripped side deposits none, so the `Case` claims
+            // one arm's filter: `if c: [x for x in xs if x > 1] else: [x for x in xs if
+            // x < 3]` infers `{[0, 2] | x < 3} ⇒ Int`, an extent excluding `3` when the
+            // true branch contains it. Stripping both sides intersects the witnesses to
+            // none and yields `[0, 2] ⇒ Int` — the join, and sound.
             Some(prev) => ctx.require_sub(&body_ty, prev, &|| "Case arm".to_string())?,
         }
     }

--- a/src/ccl/inline.rs
+++ b/src/ccl/inline.rs
@@ -1131,6 +1131,72 @@ mod tests {
         assert_eq!(result, shadowed);
     }
 
+    // Refined outer parameter — discharged by the argument's own type
+    // -----------------------------------------------------------------------
+
+    /// A literal's singleton (`5 : {Int | __elem == 5}`) reaches the outer
+    /// lambda's `param.ty` through coalesce's `refresh_lambda_param_slot`, so
+    /// the refined-parameter branch of [`inline_and_beta_reduce`] — and its hard
+    /// `assert!` — is live on an ordinary UDF call path rather than dead. The
+    /// argument's own type *is* the demanded refinement, so the precondition is
+    /// discharged and substitution proceeds.
+    ///
+    /// Shape mirrors a list-returning UDF over a scalar parameter,
+    /// `def rep(k): for x in [1, 2, 3]: yield k` called as `rep(5)`: the outer
+    /// `λ k` takes the argument's singleton as its domain, and beta-reduction
+    /// leaves the inner iteration lambda with `5` substituted for `k`.
+    #[test]
+    fn refined_outer_param_discharged_by_literal_argument() {
+        let int = Type::Base(BaseType::Int);
+        let singleton = crate::ccl::infer::lit_singleton(&Lit::Int(5));
+        let range = Type::UIntRange(3);
+        let list = fn_ty(range.clone(), int.clone());
+        let udf_ty = fn_ty(singleton.clone(), list.clone());
+
+        // λ k : {Int | __elem == 5} → λ __iter_record : [0, 2] → k
+        let inner = TypedExpr::lambda(
+            "__iter_record",
+            range.clone(),
+            TypedExpr::var("k").with_ty(int.clone()),
+        )
+        .with_ty(list.clone());
+        let outer = TypedExpr::lambda("k", singleton.clone(), inner).with_ty(udf_ty.clone());
+
+        // 5 ▷ rep, with the argument carrying its singleton.
+        let arg = TypedExpr::lit(Lit::Int(5)).with_ty(singleton);
+        let call = TypedExpr::apply(arg.clone(), TypedExpr::var("rep").with_ty(udf_ty))
+            .with_ty(list.clone());
+        let expr = TypedExpr::let_bind("rep", outer, call);
+
+        let result = inline_non_iterable_lambdas(expr);
+
+        let expected = TypedExpr::lambda("__iter_record", range, arg).with_ty(list);
+        assert_eq!(result, expected);
+    }
+
+    /// The complement: a parameter refinement the argument does *not* carry is a
+    /// precondition beta-reduction would silently drop, so the assert fires
+    /// rather than substituting. Pins the guard that keeps
+    /// [`refinement_discharged_by`] from being weakened to "any refined param is
+    /// fine" — e.g. if specialization were ever keyed modulo refinements, one
+    /// literal's singleton could reach the param slot of a call made at another.
+    #[test]
+    #[should_panic(expected = "does not entail")]
+    fn refined_outer_param_not_entailed_by_argument_asserts() {
+        let int = Type::Base(BaseType::Int);
+        let demanded = crate::ccl::infer::lit_singleton(&Lit::Int(5));
+        let supplied = crate::ccl::infer::lit_singleton(&Lit::Int(7));
+        let udf_ty = fn_ty(demanded.clone(), int.clone());
+
+        let lambda = TypedExpr::lambda("k", demanded, TypedExpr::var("k").with_ty(int.clone()))
+            .with_ty(udf_ty.clone());
+        let arg = TypedExpr::lit(Lit::Int(7)).with_ty(supplied);
+        let call = TypedExpr::apply(arg, TypedExpr::var("f").with_ty(udf_ty)).with_ty(int.clone());
+        let expr = TypedExpr::let_bind("f", lambda, call);
+
+        let _ = inline_non_iterable_lambdas(expr);
+    }
+
     // inline_non_iterable_lambdas — end-to-end pass behaviour
     // -----------------------------------------------------------------------
 

--- a/tests/compilation_pipeline/generators_udf_poly.rs
+++ b/tests/compilation_pipeline/generators_udf_poly.rs
@@ -81,6 +81,22 @@ fn test_function_def_polymorphic_used_at_two_types() {
     "def add_to(xs, n):\n    for x in xs:\n        yield x + n\nadd_to([1, 2, 3], 10)",
     make_int_list(&[11, 12, 13])
 )]
+// A list-returning UDF over a *literal* argument, with a body that imposes
+// nothing on that parameter (`yield k`, not `yield x + k`). The UDF is
+// therefore generalized in `k`, so use-site monomorphization specializes its
+// domain to the type actually flowing in — a literal's singleton,
+// `{Int | __elem == 10}` — and coalesce's `refresh_lambda_param_slot` copies
+// that refinement into the outer lambda's `param.ty`. This is what makes the
+// refined-outer-parameter branch of `ccl::inline::inline_and_beta_reduce`
+// (and its hard, release-mode `assert!`) live on an ordinary call path: the
+// assert passes only because the argument's own type carries the very
+// refinement the parameter demands, so beta-reduction *discharges* the
+// precondition instead of dropping it. Contrast `add_to` above, where
+// `x + n` forces `n` to plain `Int` and the parameter is unrefined.
+#[case(
+    "def rep(k):\n    for x in [1, 2, 3]:\n        yield k\nrep(10)",
+    make_int_list(&[10, 10, 10])
+)]
 // Filter via if-guard. The generator body's filter-feed lowers to a
 // refined-source channel whose domain carries the bare element predicate
 // `__elem ▷ source ▷ (λ x → x > n)` (the same form a filtered comprehension

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -15,7 +15,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use cambra::ccl::{
     FieldKey, HistoryKind, Lit, Type,
-    infer::{InferError, TypeInferenceContext, infer, lit_singleton},
+    infer::{InferError, TypeInferenceContext, check_pre_desugar, infer, lit_singleton},
     lower::{LoweringContext, lower_stmts},
 };
 use cambra::chl_parser::{self, ast as chl_ast};
@@ -764,6 +764,45 @@ fn test_filtered_comprehension_has_refinement_on_domain() {
     } else {
         panic!("expected Fun type, got {ty}");
     }
+}
+
+/// A `Case` whose arms are *collections* must survive the post-inference
+/// consistency wall. **Currently failing** — see the `BUG` comment on
+/// `emit_case`'s arm relation in `src/ccl/infer/emit.rs`, which carries the
+/// one-line fix.
+///
+/// `emit_case` derives the node's result type from the first arm stripped of
+/// refinements, so two arms carrying different singletons (`if c: 1 else: 2`)
+/// can share one type. But it strips the two sides of the arm relation
+/// *asymmetrically*: `prev` is stripped, the arm being related to it is not.
+/// For a scalar arm that is harmless — a singleton is a subtype of its base.
+/// For a **collection** arm it is not: a filtered comprehension is
+/// `{[0, N] | predicate} ⇒ elem`, carrying its refinement on the function's
+/// **domain**, where subtyping is contravariant. Relating a refined-domain arm
+/// to a stripped-domain `prev` therefore demands `[0, N] <: {[0, N] | p}`,
+/// which does not hold — so two arms that are *literally the same expression*
+/// are rejected. Because the rule re-runs in Check mode over concrete recorded
+/// types, that lands on `check_pre_desugar`, a wall whose failures are compiler
+/// bugs and which `compile_program` panics on.
+#[test]
+fn test_case_with_filtered_comprehension_arms_passes_consistency_wall() {
+    let code = r"
+xs = [1, 2, 3]
+c = 1 > 0
+if c:
+    [x for x in xs if x > 1]
+else:
+    [x for x in xs if x > 1]
+";
+    let mut lctx = LoweringContext::default();
+    let mut ictx = TypeInferenceContext::new();
+    let stmts = parse_module(code.trim());
+    let mut expr = lower_stmts(&stmts, &mut lctx)
+        .into_result()
+        .expect("lowering failed");
+    infer(&mut expr, &mut ictx).expect("inference failed");
+    check_pre_desugar(&expr)
+        .expect("post-inference consistency wall must accept the inferred tree");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds tests only — no behavior change. One test **fails deliberately**, pinning a regression the singleton-refinement change introduces; the fix is written out as a comment at the site rather than applied, so the failure and its remedy are reviewed together.

## The failing test: asymmetric refinement stripping in `emit_case`

`emit_case` derives a `Case`'s result type from the first arm *stripped of refinements*, so that two arms carrying different singletons (`if c: 1 else: 2`) can share one type. But it strips the two sides of the arm relation asymmetrically — `prev` is stripped when stored, the arm being related to it is not.

For a scalar arm that is harmless: a singleton is a subtype of its base, so `{Int | __elem == 2} <: Int` holds. For a **collection** arm it is not. A filtered comprehension has type `{[0, N] | __elem ▷ p} ⇒ elem`, carrying its refinement on the function's *domain*, and function subtyping is contravariant there. Relating a refined-domain arm to a stripped-domain `prev` therefore demands `[0, N] <: {[0, N] | p}`, which does not hold — so a `Case` whose two arms are *literally the same expression* is rejected.

Because the rule re-runs in Check mode over concrete recorded types, the rejection lands on `check_pre_desugar`, a wall whose failures are compiler bugs. `compile_program` panics on it (`ccl/context.rs`), turning what should be an honest "collection-armed `Case` is unsupported downstream" diagnostic into an internal panic. Six lines of ordinary CHL reach it:

```python
xs = [1, 2, 3]
c = 1 > 0
if c:
    [x for x in xs if x > 1]
else:
    [x for x in xs if x > 1]
```

This is a regression, not a pre-existing bug: restoring the previous `require_eq`-without-stripping form makes the reproducer pass.

The asymmetry causes a second, quieter defect. With arms carrying *different* predicates the unstripped side deposits its witness on the shared variable and the stripped side deposits none, so the `Case` claims one arm's filter — `if c: [x for x in xs if x > 1] else: [x for x in xs if x < 3]` infers `{[0, 2] | x < 3} ⇒ Int`, an extent excluding `3` when the true branch contains it.

### The fix, left as a comment

Strip **both** sides, making this the symmetric compare-modulo-refinements the rule intends — the same relation `check_node`'s reconcile and `channelize`'s feed-operand assert already use:

```rust
Some(prev) => ctx.require_sub(&strip_refinements(&body_ty), prev, &|| {
    "Case arm".to_string()
})?,
```

Verified against the whole suite (green, 1,470 tests) and against the cases that rule out the alternatives:

| case | with the fix | note |
| --- | --- | --- |
| identical filtered-comprehension arms | no panic | the regression |
| arms `if x > 1` / `if x < 3` | `([0, 2] ⇒ Int)` | sound — witnesses intersect to none |
| one arm filtered, one not | `([0, 2] ⇒ Int)` | sound |
| `(1, 2) if c else (3, 4)` | `(Int, Int)` | nested singletons widen |
| `((1, 2), 3) if c else ((4, 5), 6)` | `((Int, Int), Int)` | widens at depth |
| `1 if c else 2` | `Int` | unchanged |

Note that a *shallow* peel (`peel_refinements_outer`) is **not** the fix, though it also clears the panic: the deep strip is load-bearing for nested singletons, and a shallow peel rejects `(1, 2) if c else (3, 4)` with `Type mismatch for Case arm: expected 3, found 1`. Stripping both sides deeply is what satisfies every row above.

## The passing tests: the `inline.rs` assert is no longer dead

`inline_and_beta_reduce`'s hard `assert!` — a release assert, since proceeding past it would drop a precondition and miscompile to wrong results — used to test `!matches!(param.ty, Type::Refinement(..))`, a condition lowering never produced. Now that a literal carries its own singleton it fires on a common path: a generalized list-returning UDF applied to a literal argument gets its domain specialized to that argument's singleton, which `refresh_lambda_param_slot` copies into `param.ty`.

Reachability was confirmed by temporarily reinstating the old condition, which fails only on the new `rep(10)` case. Three tests pin it:

- `refined_outer_param_discharged_by_literal_argument` — builds the shape `def rep(k): for x in [1, 2, 3]: yield k; rep(5)` lowers to, and asserts it beta-reduces rather than panicking. The refinements come from the production `lit_singleton`, so the test breaks if the predicate shape or `Refinement`'s type-blind `PartialEq` stops matching.
- `refined_outer_param_not_entailed_by_argument_asserts` — `#[should_panic]`, pinning the guard itself.
- An end-to-end `#[case]` on `test_generator_function`: `rep(10)` evaluates to `[10, 10, 10]`. This is the only case in that file that reaches a refined outer param, because `rep`'s body imposes nothing on `k`; the pre-existing `add_to` case forces its param to plain `Int` through the arithmetic scheme, which no longer propagates operand refinements.

No reachable case was found where the assert *fails* — cast-derived refinements ride a `Fun` domain and take the rebuild path rather than substitution, `Mut` arguments demand nothing now that a register takes no refinement from its initializer, and a join drops refinements so a joined domain demands strictly less. The `#[should_panic]` test guards the hazard that would make it reachable: re-keying monomorphization modulo refinements without stripping the clone's domain would let one literal's singleton reach the param slot of a call made at another, turning `f(1) and f(2)` into a release-mode panic.
