### PR TITLE
Positional tuple access `t.0`; `[…]` is lookup, not projection

### DIFF
--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -324,7 +324,7 @@ noted:
 | 12 | `+` `-` | additive |
 | 13 | `*` `//` | multiplicative |
 | 14 | unary `-` | prefix |
-| 15 | postfix: `f(args)`, `x[i]`, `x.attr` | left-fold |
+| 15 | postfix: `f(args)`, `x[i]`, `x.attr`, `x.0` | left-fold |
 | 16 | atom | literal, name, `(...)`, `[...]`, `{...}`, comprehension |
 
 ```ebnf
@@ -764,7 +764,8 @@ error.
 
 ```
 target[index]    -- subscript: list element or map lookup
-target.attr      -- attribute: record field access
+target.attr      -- attribute: record field by name
+target.0         -- attribute: tuple field by position
 ```
 
 - **Subscript** on a list with integer index `i` denotes the i-th
@@ -774,13 +775,24 @@ target.attr      -- attribute: record field access
 - **Subscript** on a map with key `k` denotes the value associated
   with `k`. Looking up a missing key is not defined (see *Partiality*,
   §3).
-- **Attribute** on a record denotes the value of the named field. The
-  field must exist; missing fields are a compile-time type error.
+- **Attribute** denotes the value of a field of a product (§3.11),
+  keyed either by **name** (`r.age`, on a record) or by **position**
+  (`t.0`, on a tuple). The field must exist; a missing one is a
+  compile-time type error. An identifier cannot begin with a digit, so
+  the two forms never collide. The forms compose freely, since they are
+  one operation differing only in the key: `r.p.1`, `t.0.b`.
 
-Lists, maps, and records all denote *finite functions* from their
-respective index domains (`UInt`, `K`, field-name) to their element /
-value type — so subscript and attribute access are uniformly
-"evaluate the finite function at a point," just spelt differently.
+Lists and maps denote *finite functions* from their index domains
+(`UInt`, `K`) to their element / value type, so a subscript is
+"evaluate the finite function at a point" — the same operation as a
+call, `c[k]` and `c(k)` alike.
+
+**`[…]` is lookup and `.` is projection — they are not
+interchangeable.** A product is heterogeneous, so it is not a finite
+function and has no domain to look up in: `t[0]` is an error pointing
+at `t.0`. Conversely `.` does not index a collection. The distinction
+is by *spelling*, not by whether the index happens to be a literal, so
+the meaning of `xs[0]` does not depend on what `xs` turns out to be.
 
 > **Direction [Tentative].** The collections sketch
 > (2026-06-29 §2, §6.3
@@ -831,6 +843,8 @@ A trailing comma is allowed in every form (and required to disambiguate
 **Tuple vs. record.** Both use `( … )`: a comma-list of bare expressions is
 a tuple (`(1, 2)`), a comma-list of `name=value` fields is a record
 (`(x=1, y=2)`). `(e)` (no field, no trailing comma) is a parenthesised `e`.
+Both are projected with `.` (§3.9), keyed by position for a tuple (`t.0`)
+and by name for a record (`r.x`); neither is subscripted.
 
 **Records are not braces.** `{...}` is type syntax (§6.1) — a record *type*
 `{name: T}` or a tuple type `{T, U}`. A `{...}` in value position is a

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -1085,11 +1085,20 @@ A CHL record value is a parenthesised list of `name=value` fields:
 ```python
 r = (x=1, y="hello")   # Record([("x", 1), ("y", "hello")])
 r.x                        # Apply(r, Proj(ProjKey::Field("x"))) → 1
+t = (1, "hello")       # Tuple([1, "hello"])
+t.0                        # Apply(t, Proj(ProjKey::Index(0))) → 1
 ```
 
-**Lowering:**
+**Lowering:** the surface has one postfix form for both keyings — the parser holds the key
+verbatim in `Attribute { attr }`, and lowering resolves which `ProjKey` it is. The two are
+disjoint because an identifier cannot begin with a digit, so *leading digit* is the whole
+discriminator; nothing is inferred from context. `[…]` is collection lookup only, and
+lowers to the application it *is* (`c[k]` → `Apply(lower(k), lower(c))`), so a product —
+having no domain — is never reachable through it.
+
 - `(name=v, ...)` → `TypedExprNode::Record([(name, v), ...])`.
 - `expr.field` → `Apply(lower(expr), Proj(ProjKey::Field("field")))`.
+- `expr.n` → `Apply(lower(expr), Proj(ProjKey::Index(n)))`.
 
 **Type inference:** `Record([(k, e), ...])` infers to `Type::Record([(k, T), ...])` where each `T` is the inferred type of the corresponding value expression — identical in structure to `Tuple` inference.
 
@@ -1107,6 +1116,11 @@ A bare `Proj(key)` node — i.e. the projection morphism, not an application of 
 | `Proj(Field("x"))` | `Record([("x", ?a)]) ⇒ ?a` — a single-field record |
 
 The index domain is a `Type::Tuple` padded with fresh variables up to index `n`; the field domain is a single-field `Type::Record` (see `emit_proj`). Width-subtyping lets either unify with any concrete product carrying at least that field, constraining `?a` to the element type there.
+
+**What the padding costs the diagnostics.** `Type::Tuple` is dense, so "has position `𝑛`" is only expressible as "is `𝑛+1` wide" — a positional projection cannot state a *sparse* requirement the way the named one does. Two consequences the error path has to absorb, since both would otherwise report a shape the program never had:
+
+- A projection past the end fails as a **width** violation, and the first absent position is the value's own width rather than the one the user asked for. So the subtyping edge reports the *widest* position the requirement demands (`constrain_go`'s tuple arm), which for a projection is the only position genuinely demanded — `t.99` on a 3-tuple is missing `.99`, not `.3`. `InferError::MissingField` then states the requested position against the found width, rather than the padded 100-tuple.
+- Projecting with the *wrong keying* (`r.0`, `t.name`) is a `Record`-vs-`Tuple` constructor mismatch whose "required" side is the partial requirement (`(?31)`, `{name: ?31}`). A record/tuple mismatch is always a keying confusion, so the message carries that as a hint instead of leaving the partial shape to be read as a type.
 
 A projection's domain appears only at a negative position, so the one-way constraints leave it under-determined; its full structure (the value actually flowing in) is recovered structurally during the coalesce walk by monomorphizing the morphism to its input — see [Apply is one-way](#apply-is-one-way) and [Closing the single-sided blind spots](#closing-the-single-sided-blind-spots-no-separate-pass).
 

--- a/src/ccl/infer/api.rs
+++ b/src/ccl/infer/api.rs
@@ -27,7 +27,9 @@ use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
 
 use crate::ccl::symbolic::symbolic;
-use crate::ccl::{Expr, HistoryKind, InferVarId, Name, Type, TypedBinding, TypedExprNode};
+use crate::ccl::{
+    Expr, FieldKey, HistoryKind, InferVarId, Name, Type, TypedBinding, TypedExprNode,
+};
 use crate::util::ScopeStack;
 
 // ---------------------------------------------------------------------------
@@ -275,6 +277,26 @@ pub enum InferError {
         type_b: Box<Type>,
         ctx: String,
     },
+    /// A product type lacked a field a structural edge required — the violation of
+    /// width subtyping, whose rule is that the required shape's keys all appear in the
+    /// one that flows into it.
+    ///
+    /// Its own variant rather than a [`InferError::TypeMismatch`] because there is no
+    /// second *type* worth reporting. What failed is a shape's **field set**, and the
+    /// shape that made the demand is typically partial — a projection requires only the
+    /// one field it reads — so rendering it opposite the found type describes a type the
+    /// program never had.
+    MissingField {
+        /// The key the required shape demands and `found` does not carry. For a
+        /// positional key this is the **widest** position demanded, not the first
+        /// absent one: [`Type::Tuple`] is dense, so `.99` on a 3-tuple demands a
+        /// 100-wide tuple, and the position that is actually missing is `.99`.
+        key: FieldKey,
+        /// The product that should have carried `key`.
+        found: Type,
+        /// Display label for the message (see the type docs — not the location).
+        at: String,
+    },
     /// A [`Type::Fun`] was required — e.g. in a function-application or
     /// [`TypedExprNode::Compose`] position — but a non-function type was found.
     ExpectedFunction {
@@ -459,6 +481,28 @@ impl LocatedInferError {
     }
 }
 
+/// The hint for a mismatch between a [`Type::Record`] and a [`Type::Tuple`].
+///
+/// The two are the same thing — a product — keyed differently, by field *name* and by
+/// *position*, so a mismatch between them is never about depth: it is always that one
+/// keying was used where the other applies, which the bare shapes do not say. It is the
+/// failure `r.0` and `t.name` produce, and the required side of such an edge is a
+/// projection's *partial* shape (`(?31)` names only the position it reads), so the raw
+/// message reads as internal machinery rather than as the mistake.
+///
+/// Both messages are facts about the *pair*, true whichever side the solver reports as
+/// "expected" — an application's domain can be raised from either side of its edge.
+fn product_keying_hint(type_a: &Type, type_b: &Type) -> Option<&'static str> {
+    match (type_a, type_b) {
+        (Type::Record(_), Type::Tuple(_)) | (Type::Tuple(_), Type::Record(_)) => Some(
+            "hint: a record is keyed by field *name* and a tuple by *position* — a record \
+             has no `.0` and a tuple has no named fields, so project a record with \
+             `.name` and a tuple with `.0`",
+        ),
+        _ => None,
+    }
+}
+
 impl std::fmt::Debug for InferError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -472,10 +516,41 @@ impl std::fmt::Debug for InferError {
                     f,
                     "Type mismatch for {}: expected {}, found {}",
                     ctx, type_a, type_b
-                )
+                )?;
+                if let Some(hint) = product_keying_hint(type_a, type_b) {
+                    write!(f, "\n  {hint}")?;
+                }
+                Ok(())
             }
+            InferError::MissingField { key, found, at } => match (key, found) {
+                // A tuple's positions are its width, so that is the fact to state: the
+                // projection asked for a position past the end.
+                (FieldKey::Index(i), Type::Tuple(elems)) => write!(
+                    f,
+                    "No position .{i} for {at}: {found} is a tuple with {} position{}",
+                    elems.len(),
+                    if elems.len() == 1 { "" } else { "s" },
+                ),
+                // A record's `Display` already lists its fields, so naming the absent
+                // one against it is the whole message.
+                (FieldKey::Name(name), _) => {
+                    write!(f, "No field .{name} for {at}: {found} has no such field")
+                }
+                // `found` degraded to a shape whose keying the message cannot lean on
+                // (`coalesce_for_error` falls back to `Type::Hole`).
+                _ => write!(f, "No field .{key} for {at}: {found}"),
+            },
             InferError::ExpectedFunction { found, at } => {
-                write!(f, "Expected function type at {at}, found {found}")
+                write!(f, "Expected function type at {at}, found {found}")?;
+                if matches!(found, Type::Tuple(_) | Type::Record(_)) {
+                    write!(
+                        f,
+                        "\n  hint: a tuple or record is a heterogeneous product, not a \
+                         finite function — project it with `.0` (position) or `.name` \
+                         (field) rather than applying or subscripting it"
+                    )?;
+                }
+                Ok(())
             }
             InferError::AnnotationMismatch {
                 annotation,

--- a/src/ccl/infer/mod.rs
+++ b/src/ccl/infer/mod.rs
@@ -161,11 +161,15 @@ pub(super) fn map_constrain_err(err: ConstrainError, ctx_label: &str) -> InferEr
                 }
             }
         }
-        ConstrainError::MissingField { key, in_type } => InferError::TypeMismatch {
-            ctx: format!("{ctx_label} (missing field {key:?})"),
-            type_a: Box::new(coalesce_for_error(&in_type)),
-            type_b: Box::new(Type::Hole),
+        ConstrainError::MissingField { key, in_type } => InferError::MissingField {
+            key,
+            found: coalesce_for_error(&in_type),
+            at: ctx_label.to_string(),
         },
+        // `ExtraTag` is `MissingField`'s dual and has the same shape problem — the
+        // width violation is a *tag set*, not a second type, so `type_b` is filled
+        // with a placeholder. Naming it as its own variant is the same fix, and is
+        // left to whoever next works the variant diagnostics.
         ConstrainError::ExtraTag { tag, in_type } => InferError::TypeMismatch {
             ctx: format!("{ctx_label} (variant tag .{tag} not accepted)"),
             type_a: Box::new(coalesce_for_error(&in_type)),

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -50,7 +50,9 @@ pub enum ConstrainError {
     /// that lhs did not have. Width-subtyping says rhs's keys must be a
     /// subset of lhs's; this is the violation.
     MissingField {
-        /// The missing key.
+        /// The key rhs demands and lhs does not carry. For a **positional** key
+        /// this is the *widest* position demanded rather than the first absent one
+        /// — see the tuple arm of [`constrain_go`] for why.
         key: FieldKey,
         /// The lhs record/tuple that should have contained the key.
         in_type: Type,
@@ -524,8 +526,14 @@ fn constrain_go(
                 match a.get(i) {
                     Some(t0) => constrain_go(t0, t1, sl, sr, cache)?,
                     None => {
+                        // A `Tuple` is **dense**, so the failure here is one of *width*
+                        // and the widest position rhs demands is its sharpest witness —
+                        // report that rather than the first absent one, which is just
+                        // `lhs`'s own width restated. This is what makes a positional
+                        // projection diagnosable: `t.99` requires a 100-wide tuple, so
+                        // the demand a 3-tuple fails is `.99`, not `.3`.
                         return Err(ConstrainError::MissingField {
-                            key: FieldKey::Index(i),
+                            key: FieldKey::Index(b.len() - 1),
                             in_type: lhs.clone(),
                         });
                     }

--- a/src/ccl/lower/exprs.rs
+++ b/src/ccl/lower/exprs.rs
@@ -195,6 +195,29 @@ fn lower_call_arg(
     }
 }
 
+/// Lower a subscript `target[index]`.
+///
+/// Subscript and application are the *same* operation — evaluate a finite function at a
+/// point (`docs/chl-spec.md`, "3.9 Subscript and attribute access") — so `c[k]` lowers to
+/// exactly what the application `c(k)` does, and inherits its proof obligation: the index
+/// must lie in the collection's domain.
+///
+/// `[…]` is therefore **only** collection lookup, with no case on the index's shape. A
+/// tuple is a heterogeneous product rather than a finite function, so projecting one is a
+/// different operation with a different spelling — `t.0`, alongside `r.name` — resolved in
+/// the [`ChlExpr::Attribute`] arm of [`lower_expr`]. Deciding between the two by whether
+/// the index happened to be a literal would be a guess lowering has no types to make, and
+/// it is the wrong guess for `xs[0]`, the commonest subscript anyone writes.
+pub(super) fn lower_subscript(
+    target: &Spanned<ChlExpr>,
+    index: &Spanned<ChlExpr>,
+    ctx: &mut LoweringContext,
+) -> Result<Expr, LoweringError> {
+    // The collection is the *function* and the index the *argument*: `c[k]` is `c(k)`.
+    let collection = lower_expr(target, ctx)?;
+    Ok(Expr::apply(lower_expr(index, ctx)?, collection))
+}
+
 pub(super) fn lower_binop(
     left: &Spanned<ChlExpr>,
     op: ChlBinOp,

--- a/src/ccl/lower/mod.rs
+++ b/src/ccl/lower/mod.rs
@@ -38,6 +38,8 @@
 //! | Regular functions `def f(x, y, ...): expr` | [`TypedExprNode::Let`] + single [`TypedExprNode::Lambda`] (tupled param when multi-arg) |
 //! | Record literals `{field: expr, ...}` (identifier keys only) | [`TypedExprNode::Record`] |
 //! | Field access `r.field` | [`TypedExprNode::Apply`] with [`TypedExprNode::Proj`]`(`[`crate::ccl::ProjKey::Field`]`)` |
+//! | Positional access `t.0` | [`TypedExprNode::Apply`] with [`TypedExprNode::Proj`]`(`[`crate::ccl::ProjKey::Index`]`)` |
+//! | Collection lookup `c[k]` | [`TypedExprNode::Apply`] — the same node as the call `c(k)` |
 //!
 //! Everything else returns [`LoweringError::Unsupported`].
 //!
@@ -82,9 +84,7 @@ use crate::{
         Branch, Expr, Lit, TypedExprNode,
         lineage::{Nature, RewriteLabel},
     },
-    chl_parser::ast::{
-        Expr as ChlExpr, Lit as ChlLit, RecordField, Span, Spanned, Stmt as ChlStmt,
-    },
+    chl_parser::ast::{Expr as ChlExpr, RecordField, Span, Spanned, Stmt as ChlStmt},
     interpreter::{DataSink, DataSourceDomainExtentImpl, http_server::SharedHttpServer},
 };
 
@@ -688,21 +688,7 @@ fn lower_expr_inner(
             let items: Result<Vec<_>, _> = elts.iter().map(|e| lower_expr(e, ctx)).collect();
             Ok(Expr::tuple(items?))
         }
-        ChlExpr::Subscript { target, index } => match &index.node {
-            ChlExpr::Lit(ChlLit::Int(n)) => {
-                let idx: usize = (*n).try_into().map_err(|_| {
-                    LoweringError::unsupported(index.span, "tuple index must be non-negative")
-                })?;
-                // The `Proj` images the index token the user wrote.
-                let target_expr = lower_expr(target, ctx)?;
-                let proj = ctx.tag_image(Expr::proj_index(idx), index.span);
-                Ok(Expr::apply(target_expr, proj))
-            }
-            _ => Err(LoweringError::unsupported(
-                index.span,
-                "only integer subscripts are supported",
-            )),
-        },
+        ChlExpr::Subscript { target, index } => lower_subscript(target, index, ctx),
         // Record value `(name=expr, ...)`. Lowered to a `Record` constructor:
         // `(x=1, y="foo")` becomes `Record([("x", Lit(1)), ("y", Lit("foo"))])`.
         ChlExpr::Record(fields) => {
@@ -740,11 +726,34 @@ fn lower_expr_inner(
             "`{…}` is type syntax (a record type `{name: T}`); \
              a record value is written `(name=value)`",
         )),
-        // Attribute access `r.field` → `Apply(r, Proj(Field("field")))`. The
-        // `Proj` images the `.field` access the user wrote.
-        ChlExpr::Attribute { target, attr, .. } => {
+        // Attribute access `target.attr` → `Apply(target, Proj(k))`. The `Proj` images
+        // the `.attr` access the user wrote.
+        //
+        // This is the one place a projection key's two spellings are resolved: digits
+        // are a tuple **position**, anything else a record field **name**. The two are
+        // disjoint because an identifier cannot begin with a digit, so `starts_with` a
+        // digit *is* the discriminator — no guessing and no ambiguity.
+        ChlExpr::Attribute {
+            target,
+            attr,
+            attr_span,
+        } => {
+            let key = if attr.starts_with(|c: char| c.is_ascii_digit()) {
+                // Only magnitude can fail here: the parser admits an integer literal,
+                // so the digits are a non-negative number, but not necessarily one a
+                // `usize` position can hold.
+                let index: usize = attr.parse().map_err(|_| {
+                    LoweringError::unsupported(
+                        *attr_span,
+                        format!("tuple position `.{attr}` is too large to be an index"),
+                    )
+                })?;
+                Expr::proj_index(index)
+            } else {
+                Expr::proj_field(attr.as_str())
+            };
             let target_expr = lower_expr(target, ctx)?;
-            let proj = ctx.tag_image(Expr::proj_field(attr.as_str()), expr.span);
+            let proj = ctx.tag_image(key, expr.span);
             Ok(Expr::apply(target_expr, proj))
         }
         ChlExpr::Lambda { params, body } => lower_lambda(expr.span, params, body, ctx),

--- a/src/chl_parser/ast.rs
+++ b/src/chl_parser/ast.rs
@@ -369,13 +369,21 @@ pub enum Expr {
     /// value position.
     BraceGroup(Vec<Spanned<Expr>>),
 
-    /// Subscript: `target[index]`.
+    /// Subscript: `target[index]` — **collection lookup only**. Projecting a product
+    /// is a different operation and has its own spelling, [`Expr::Attribute`].
     Subscript {
         target: Box<Spanned<Expr>>,
         index: Box<Spanned<Expr>>,
     },
 
-    /// Attribute access: `target.attr`.
+    /// Attribute access: `target.attr` — a record field by **name** (`r.age`) or a
+    /// tuple position by **index** (`t.0`, whose digits are held here verbatim).
+    ///
+    /// One node for both because they are one operation, projecting a field; what
+    /// differs is only how the field is keyed, which
+    /// [`ProjKey`](crate::ccl::ProjKey) already models. Lowering resolves the key once,
+    /// so the distinction is stated where projection is built rather than a third time
+    /// here. An identifier cannot begin with a digit, so the forms never collide.
     Attribute {
         target: Box<Spanned<Expr>>,
         attr: SmolStr,

--- a/src/chl_parser/design-chl-parser.md
+++ b/src/chl_parser/design-chl-parser.md
@@ -95,7 +95,7 @@ highest precedence:
 12. `+`, `-`
 13. `*`, `//`
 14. unary `-`
-15. postfix: call `f(…)`, subscript `x[…]`, attribute `x.name`
+15. postfix: call `f(…)`, subscript `x[…]`, attribute `x.name` / `x.0`
 16. atom: literal, name, parenthesised, list, dict/record, comprehension
 
 Notably absent vs. Python: `/` (true division), `%` (modulo), `**`

--- a/src/chl_parser/parser.rs
+++ b/src/chl_parser/parser.rs
@@ -159,7 +159,7 @@ type PErr<'src> = extra::Err<Rich<'src, Token, Span>>;
 /// 12. `+`, `-`
 /// 13. `*`, `//`
 /// 14. unary `-`
-/// 15. postfix: call `f(...)`, subscript `x[...]`, attribute `x.name`
+/// 15. postfix: call `f(...)`, subscript `x[...]`, attribute `x.name` / `x.0`
 /// 16. atom: literal, name, parenthesised, list, dict/record, comprehension
 fn expression<'src, I>() -> impl Parser<'src, I, Spanned<Expr>, PErr<'src>> + Clone
 where
@@ -429,8 +429,19 @@ where
                 };
                 PostfixOp::Subscript(Box::new(idx))
             });
+        // `.name` or `.0` — one operation, projecting a field keyed by name or by
+        // position. A positional key is spelled as an integer literal because an
+        // identifier can never begin with a digit, so the two forms cannot collide; the
+        // digits ride in the same `attr` slot and lowering resolves which `ProjKey` they
+        // mean. (`.0` lexes as `Dot` then `Int` — there is no float token to swallow it.)
+        let attr_key = choice((
+            ident_only,
+            select! { Token::Int(n) => n }
+                .map_with(|n, e| (SmolStr::from(n.to_string()), e.span())),
+        ))
+        .labelled("field name or index");
         let attribute = just(Token::Dot)
-            .ignore_then(ident_only)
+            .ignore_then(attr_key)
             .map(|(name, span)| PostfixOp::Attribute(name, span));
 
         let postfix = atom

--- a/tests/chl_parser_roundtrip.rs
+++ b/tests/chl_parser_roundtrip.rs
@@ -119,6 +119,27 @@ fn tuples_and_subscript() {
     "#});
 }
 
+/// `.0` is an `Attribute`, not a subscript: a positional key and a named one are one
+/// postfix form, and the digits ride in the `attr` slot verbatim for lowering to resolve.
+/// (`.0` lexes as `Dot` then `Int` — there is no float token to swallow it, so `.0.1` is
+/// two projections rather than a decimal.)
+#[test]
+fn positional_attribute_access() {
+    for (src, attr) in [("t.0", "0"), ("t.10", "10"), ("t.0.1", "1"), ("t.a.0", "0")] {
+        match must_parse_expr(src).node {
+            Expr::Attribute { attr: got, .. } => assert_eq!(got.as_str(), attr, "for `{src}`"),
+            other => panic!("expected Attribute for `{src}`, got {other:?}"),
+        }
+    }
+    // A key that is neither spelling is rejected, and the label names both.
+    let r = parse_module("t.-1\n");
+    let msg = format!("{}", r.errors.first().expect("`.-1` must not parse"));
+    assert!(
+        msg.contains("field name or index"),
+        "expected the projection-key label, got: {msg}"
+    );
+}
+
 #[test]
 fn collection_union() {
     let _ = must_parse_expr("[1, 2, 3] ++ [4, 5]");

--- a/tests/compilation_pipeline/comprehensions.rs
+++ b/tests/compilation_pipeline/comprehensions.rs
@@ -41,7 +41,7 @@ fn test_comprehensions(#[case] code: &str, #[case] expected: Tile) {
 #[timeout(Duration::from_secs(10))]
 #[case("y = 5; [x + y for x in [10, 20]]", make_int_list(&[15, 25]))]
 #[case("y = 1; z = [1,2,3]; [x + y for x in z]", make_int_list(&[2, 3, 4]))]
-#[case("y = 1; z = [(1, 'a'),(2, 'b'),(3, 'c')]; [x[0] + y for x in z]", make_int_list(&[2, 3, 4]))]
+#[case("y = 1; z = [(1, 'a'),(2, 'b'),(3, 'c')]; [x.0 + y for x in z]", make_int_list(&[2, 3, 4]))]
 fn test_comprehensions_let_capture(#[case] code: &str, #[case] expected: Tile) {
     check_tile(code, expected);
 }
@@ -52,8 +52,8 @@ fn test_comprehensions_let_capture(#[case] code: &str, #[case] expected: Tile) {
 
 #[rstest]
 #[timeout(Duration::from_secs(10))]
-#[case("[(y, y)[1] for y in [10, 20]]", make_int_list(&[10, 20]))]
-#[case("[y[0] for y in [(10, 'a'), (20, 'b')]]", make_int_list(&[10, 20]))]
+#[case("[(y, y).1 for y in [10, 20]]", make_int_list(&[10, 20]))]
+#[case("[y.0 for y in [(10, 'a'), (20, 'b')]]", make_int_list(&[10, 20]))]
 #[case(
     "[(y, 100) for y in [(10, 'a'), (20, 'b')]]",
     Tile::SealedFunction {

--- a/tests/compilation_pipeline/joins_aggregates_groupby.rs
+++ b/tests/compilation_pipeline/joins_aggregates_groupby.rs
@@ -517,11 +517,11 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
 )]
 /// Join where `y` acts as a lookup table connecting `x`-values to `z`-values via projections.
 ///
-/// Verifies that multi-site tuple-element projection constraints (`y[0]` and `y[1]`)
+/// Verifies that multi-site tuple-element projection constraints (`y.0` and `y.1`)
 /// are correctly inferred: `y` acquires type `Tuple([Int, Int])` from the list element type,
 /// enabling both projections to type-check as `Int`.
 #[case(
-    "[(x , z) for x in [1,2,3] for y in [(3, 30), (2, 20), (1, 10)] for z in [20, 10, 30] if z == y[1] and y[0] == x]",
+    "[(x , z) for x in [1,2,3] for y in [(3, 30), (2, 20), (1, 10)] for z in [20, 10, 30] if z == y.1 and y.0 == x]",
     "(iterate ≫ [1, 2, 3] ≫ ((iterate ≫ [(3, 30), (2, 20), (1, 10)] ≫ .1 ≫ (iterate ≫ [20, 10, 30]) ▷ converse) ▷ uncurry ▷ map_domain ≫ .0 ≫ [(3, 30), (2, 20), (1, 10)] ≫ .0) ▷ converse) ▷ uncurry ▷ ([1] ▷ flatten_domain) ▷ map_domain ≫ cast((.0 ≫ [1, 2, 3], .2 ≫ [20, 10, 30]) ▷ zip):(([0, 2], [0, 2], [0, 2]) ⇒ (Int, Int))",
     Tile::SealedFunction {
         domain: ColumnValue::Records(HashMap::from([

--- a/tests/compilation_pipeline/misc.rs
+++ b/tests/compilation_pipeline/misc.rs
@@ -17,7 +17,7 @@ use crate::helpers::*;
 // Test that we don't have splits in the operator graph for simple binops
 #[rstest]
 #[case("[1 + x + 1 for x in [1,2,3]]")]
-#[case("[(x, x)[0] + 2 for x in [1,2,3]]")]
+#[case("[(x, x).0 + 2 for x in [1,2,3]]")]
 #[case("[(x, 0) for x in [1,2,3]]")]
 #[case("[x for x in [1,2,3] if x + 1 < 2]")]
 #[case("1 + 2 + 3")]

--- a/tests/compilation_pipeline/scalars_collections.rs
+++ b/tests/compilation_pipeline/scalars_collections.rs
@@ -32,7 +32,7 @@ fn test_literals(#[case] code: &str, #[case] expected: Value) {
 // Record type `(name=T, …)`.
 #[case("p: {a: Int, b: Int} = (a=1, b=2)\np.a", Value::Int(1))]
 // Tuple type `{T, U}` (colon-free brace group).
-#[case("t: {Int, Bool} = (1, True)\nt[0]", Value::Int(1))]
+#[case("t: {Int, Bool} = (1, True)\nt.0", Value::Int(1))]
 fn test_type_annotation_forms(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
@@ -218,9 +218,12 @@ fn test_let_nonscalar(#[case] code: &str, #[case] expected: Tile) {
     "('a', 1)",
     make_tuple(&[Value::String("a".into()), Value::Int(1)])
 )]
-#[case("('a', 1)[0]", Value::String("a".into()))]
-#[case("('a', 1)[1]", Value::Int(1))]
-#[case("x = ('a', 1); x[0]", Value::String("a".into()))]
+#[case("('a', 1).0", Value::String("a".into()))]
+#[case("('a', 1).1", Value::Int(1))]
+#[case("x = ('a', 1); x.0", Value::String("a".into()))]
+// A positional key and a named one are the same operation, so they compose freely.
+#[case("r = (p=('a', 1), q=2); r.p.1", Value::Int(1))]
+#[case("t = ((1, 2), 3); t.0.1", Value::Int(2))]
 fn test_tuples(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }

--- a/tests/compilation_pipeline/sources_incremental.rs
+++ b/tests/compilation_pipeline/sources_incremental.rs
@@ -37,8 +37,8 @@ use smol_str::SmolStr;
 #[case("[x + '' for x in testsource1()]")]
 #[case("['' + x for x in testsource1()]")]
 #[case("y = ''; [y + x for x in testsource1()]")]
-#[case("[(x, 0)[0] for x in testsource1()]")]
-#[case("[(x, 0)[0] for x in testsource1() if True]")]
+#[case("[(x, 0).0 for x in testsource1()]")]
+#[case("[(x, 0).0 for x in testsource1() if True]")]
 fn test_test_source(#[case] code: &str) {
     let mut ctx = GlobalContext::default();
     let data_source = Rc::new(RefCell::new(TestDataSource::new(
@@ -143,9 +143,9 @@ fn test_source_filter_nonterminal() {
 // 30s: the original flake site; one of the heaviest compiles, ~9.5s wall on a slow CI VM.
 #[rstest]
 #[timeout(Duration::from_secs(30))]
-#[case("[(x[0], x[1], y[1]) for x in testsource1() for y in testsource2() if x[0] == y[0]]")]
+#[case("[(x.0, x.1, y.1) for x in testsource1() for y in testsource2() if x.0 == y.0]")]
 #[case(
-    "[(x[0], x[1], y[1]) for x in testsource1() for y in testsource2() if x[0] <= y[0] and x[0] >= y[0]]"
+    "[(x.0, x.1, y.1) for x in testsource1() for y in testsource2() if x.0 <= y.0 and x.0 >= y.0]"
 )]
 fn test_inner_join(#[case] code: &str) {
     let mut ctx = GlobalContext::default();

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -437,7 +437,7 @@ fn test_tuple() {
 
 #[test]
 fn test_tuple_index() {
-    assert_eq!(infer_program(r#"(1, "a")[0]"#), int_lit(1));
+    assert_eq!(infer_program(r#"(1, "a").0"#), int_lit(1));
 }
 
 // ---------------------------------------------------------------------------
@@ -820,8 +820,8 @@ fn test_generic_identity() {
 /// heterogeneous tuple, exercising the partial-tuple / projection rule.
 #[test]
 fn test_tuple_index_heterogeneous() {
-    assert_eq!(infer_program(r#"(1, "a")[0]"#), int_lit(1));
-    assert_eq!(infer_program(r#"(1, "a")[1]"#), str_lit("a"));
+    assert_eq!(infer_program(r#"(1, "a").0"#), int_lit(1));
+    assert_eq!(infer_program(r#"(1, "a").1"#), str_lit("a"));
 }
 
 /// An unconstrained identity applied to a concrete value must resolve all
@@ -1158,6 +1158,97 @@ b = make("s")
     // element type is the literal that was fed to it.
     assert_eq!(*feed_value(&elems[0]), int_lit(1));
     assert_eq!(*feed_value(&elems[1]), str_lit("s"));
+}
+
+// ---------------------------------------------------------------------------
+// Projection (`.`) vs. lookup (`[…]`)
+// ---------------------------------------------------------------------------
+
+/// `.` projects a product and `[…]` looks up a collection. The spellings are disjoint,
+/// so lowering never has to guess which operation a bracket was — a guess it has no
+/// types to make, and the wrong one for `xs[0]`, the commonest subscript anyone writes
+/// (`docs/chl-spec.md`, "3.9 Subscript and attribute access").
+#[test]
+fn dot_projects_and_brackets_look_up() {
+    // Both keyings project, on the shapes that have them. Projection *selects* an
+    // element rather than computing one, so the element's own singleton survives.
+    assert_eq!(infer_program("t = (1, \"a\")\nt.0"), int_lit(1));
+    assert_eq!(infer_program("t = (1, \"a\")\nt.1"), str_lit("a"));
+    assert_eq!(infer_program("r = (a=1, b=2)\nr.b"), int_lit(2));
+
+    // A tuple is a heterogeneous product, not a finite function, so it has no domain to
+    // look up in — however the index is spelled, literal or not.
+    for program in ["t = (1, \"a\")\nt[0]", "t = (1, 2)\ni = 0\nt[i]"] {
+        let errs = infer_program_err(program);
+        assert!(
+            errs.iter()
+                .any(|e| matches!(e, InferError::ExpectedFunction { .. })),
+            "a tuple has no domain to look up in: `{program}` gave {errs:?}"
+        );
+        assert!(
+            errs.iter().any(|e| format!("{e:?}").contains("`.0`")),
+            "the rejection must name the projection spelling: {errs:?}"
+        );
+    }
+}
+
+/// The two keyings are one operation differing only in the key, so they compose freely
+/// in either order and to any depth.
+#[test]
+fn positional_and_named_projection_compose() {
+    assert_eq!(infer_program("r = (p=(1, \"a\"))\nr.p.1"), str_lit("a"));
+    assert_eq!(infer_program("t = ((a=1), 2)\nt.0.a"), int_lit(1));
+    assert_eq!(infer_program("t = ((1, 2), 3)\nt.0.1"), int_lit(2));
+}
+
+/// The brace *type* forms and `.` agree on keying: `{T, U}` is a tuple type, projected
+/// positionally; `{name: T}` is a record type, projected by name.
+#[test]
+fn brace_type_annotations_project_by_their_keying() {
+    assert_eq!(infer_program("t: {Int, Bool} = (1, True)\nt.0"), int_lit(1));
+    assert_eq!(infer_program("r: {a: Int} = (a=1)\nr.a"), int_lit(1));
+}
+
+/// A projection whose target's type is still a *variable* where the projection is
+/// emitted: the node states a requirement — "a product with this key" — rather than
+/// deciding a shape, so an inferred parameter recovers its shape from the call site, and
+/// an argument with no such key is rejected there.
+#[test]
+fn projection_through_an_inferred_parameter() {
+    assert_eq!(infer_program("def f(x):\n    x.1\nf((1, 2))"), int_lit(2));
+    assert_eq!(infer_program("def f(r):\n    r.a\nf((a=7))"), int_lit(7));
+    assert!(
+        !infer_program_err("def f(x):\n    x.0\nf(1)").is_empty(),
+        "an `Int` has no positions to project"
+    );
+}
+
+/// The diagnostics for a projection that cannot land say what the shape actually has.
+///
+/// Both failures otherwise report a shape the program never had, because a positional
+/// requirement is a *dense* tuple (`.99` demands 100 positions) and a named one is a
+/// one-field record — partial shapes that read as internal machinery next to the value's
+/// own type.
+#[test]
+fn projection_diagnostics_name_the_shape() {
+    // Past the end of a tuple: the position asked for, and the width there is.
+    let errs = infer_program_err("t = (1, 2, 3)\nt.99");
+    let msg = format!("{:?}", errs[0]);
+    assert!(
+        msg.contains("No position .99") && msg.contains("3 positions"),
+        "expected the requested position and the tuple's width, got: {msg}"
+    );
+
+    // Wrong keying: a record has names and a tuple has positions, which is the whole
+    // content of the failure and what the bare shapes do not say.
+    for program in ["r = (a=1)\nr.0", "t = (1, 2, 3)\nt.b"] {
+        let errs = infer_program_err(program);
+        assert!(
+            errs.iter()
+                .any(|e| format!("{e:?}").contains("keyed by field *name*")),
+            "expected the record/tuple keying hint for `{program}`, got {errs:?}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`[0]` was the only way to reach a tuple positionally, and lowering resolved `t[0]` to a projection by *guessing* from the index's shape — a guess it has no types to make. That guess made `xs[0]`, the commonest subscript anyone writes, mean tuple projection and then fail with a structural mismatch. Positional access now has its own spelling alongside the named one, and `[…]` means collection lookup with no case on the index.

The grammar accepts an integer after `.`, held in the existing `Attribute { attr }` slot. `ProjKey` already models "keyed by name or by position", so lowering is the single place the two spellings resolve, and *leading digit* is the whole discriminator since an identifier cannot begin with one. `.0` lexes as `Dot` then `Int` — there is no float token to swallow it — so `t.0.1` is two projections rather than a decimal. A subscript lowers to the application it *is* (`c[k]` → `c(k)`), so a product, having no domain, is no longer reachable through it: `t[0]` is rejected with a hint naming `.0`.

## Diagnostics

A positional projection's requirement is a **dense** tuple, because `Type::Tuple` cannot express "has position `n`" except as "is `n + 1` wide". Two failures were consequently reported against a shape the program never had:

- `t.99` on a 3-tuple said `missing field Index(3)` — the first *absent* position, which is just the value's own width restated. The subtyping edge now reports the **widest** position the requirement demands, which for a projection is the only one genuinely demanded, and the message states it against the found width: `No position .99 for Apply: (1, 2, 3) is a tuple with 3 positions`.
- `r.0` mismatched `{a: 1}` against `(?31)` — the partial requirement, rendered as if it were a type. A `Record`-vs-`Tuple` mismatch is *always* a keying confusion, so it now carries that as a hint, as does its mirror `t.b`.

`MissingField` becomes its own `InferError` variant because there is no second *type* to report: flattening it into a `TypeMismatch` required inventing one (`type_b: Type::Hole`, rendered `_`). Its dual `ExtraTag` has the same shape and is deliberately left alone — that is variant-tag territory, not this change's — with a comment recording it.

## Coverage

Every tuple subscript in the test suite migrates to `.n`; no corpus program in `tests/programs/` used one. Pinned: both keyings project and compose to any depth (`r.p.1`, `t.0.a`, `t.0.1`); `[…]` never projects, literal index or not; `.n` recovers a shape through an inferred parameter and is rejected at the call site for a non-product; the brace type forms `{T, U}` and `{name: T}` project by their own keying; `.-1` is a parse error naming both spellings; and both diagnostics say what the shape actually has.