### PR TITLE
Stop copying the bound graph to read it

### DIFF
--- a/src/ccl/infer/api.rs
+++ b/src/ccl/infer/api.rs
@@ -123,8 +123,8 @@ impl Drop for InferArena {
         // edges, so the (otherwise cyclic) refcounts can all reach zero.
         for var in crate::ccl::arena_exit() {
             let mut bounds = var.bounds.borrow_mut();
-            bounds.lower.clear();
-            bounds.upper.clear();
+            bounds.lower_mut().clear();
+            bounds.upper_mut().clear();
         }
     }
 }

--- a/src/ccl/infer/api.rs
+++ b/src/ccl/infer/api.rs
@@ -122,9 +122,7 @@ impl Drop for InferArena {
         // Take back every variable minted during the run and sever its bound
         // edges, so the (otherwise cyclic) refcounts can all reach zero.
         for var in crate::ccl::arena_exit() {
-            let mut bounds = var.bounds.borrow_mut();
-            bounds.lower_mut().clear();
-            bounds.upper_mut().clear();
+            var.bounds.borrow_mut().clear();
         }
     }
 }

--- a/src/ccl/infer/context.rs
+++ b/src/ccl/infer/context.rs
@@ -458,7 +458,7 @@ impl Typing for InferCtx {
         };
         v.bounds
             .borrow_mut()
-            .lower
+            .lower_mut()
             .push(crate::ccl::Bound::with_subst(
                 result,
                 crate::ccl::subst::Subst::discharge(&x, argument.clone()),

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -1558,7 +1558,7 @@ mod review_tests {
                 panic!("fresh() yields a variable");
             };
             let b = v.bounds.borrow();
-            b.lower.len() + b.upper.len()
+            b.lower().len() + b.upper().len()
         };
         assert!(
             bound_count(&d1) > 0,

--- a/src/ccl/infer/solver/coalesce.rs
+++ b/src/ccl/infer/solver/coalesce.rs
@@ -729,7 +729,11 @@ mod tests {
         // the path is defensive.
         let v = fresh_var(0);
         if let Type::Infer(state) = &v {
-            state.bounds.borrow_mut().lower.push(Bound::conc(v.clone()));
+            state
+                .bounds
+                .borrow_mut()
+                .lower_mut()
+                .push(Bound::conc(v.clone()));
         }
         match coalesce_compact(&compact_type(&v)).unwrap() {
             Type::Infer(_) => {}

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -7,6 +7,7 @@
 //! sibling [`mod@super::simplify_type`] and [`super::coalesce`] modules.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::rc::Rc;
 
 use smol_str::SmolStr;
 
@@ -531,12 +532,13 @@ struct ParentPath<'a> {
 impl ParentPath<'_> {
     /// Whether `uid` is on the path. Linear in the path's depth, which is the
     /// length of one variable's bound chain.
-    fn contains(mut path: Option<&ParentPath<'_>>, uid: InferVarId) -> bool {
-        while let Some(frame) = path {
-            if frame.uid == uid {
+    fn contains(&self, uid: InferVarId) -> bool {
+        let mut frame = Some(self);
+        while let Some(f) = frame {
+            if f.uid == uid {
                 return true;
             }
-            path = frame.prev;
+            frame = f.prev;
         }
         false
     }
@@ -702,7 +704,7 @@ fn compact_go(
             let uid = state.uid;
             let key = (uid, pol);
             if st.in_process.contains(&key) {
-                if ParentPath::contains(parents, uid) {
+                if parents.is_some_and(|p| p.contains(uid)) {
                     // Spurious cycle (a <: b and b <: a with no
                     // structural intermediary). Drop the bound.
                     return CompactType::empty();
@@ -742,7 +744,9 @@ fn compact_go(
             // only those clones and the per-use instantiations reach here,
             // each fixed by a single use site.
             let s = state.bounds.borrow();
-            let primary = if pol { &s.lower } else { &s.upper };
+            // `Rc::clone`, not a copy: taking the list out of the `RefCell` is a
+            // refcount bump, and this is the walk's hot read.
+            let primary_bounds = Rc::clone(if pol { s.lower() } else { s.upper() });
             // When the polarity-correct list is empty we fall back to the
             // opposite-polarity bounds (see the rationale above). Track which
             // polarity the bounds came from so we walk + merge them at THAT
@@ -766,12 +770,7 @@ fn compact_go(
             // cover these halves); see `design/type-inference.md` ("Apply is
             // one-way" and "Closing the single-sided blind spots (no separate
             // pass)").
-            let primary_bounds = primary.clone();
-            let opposite_bounds = if pol {
-                s.upper.clone()
-            } else {
-                s.lower.clone()
-            };
+            let opposite_bounds = Rc::clone(if pol { s.upper() } else { s.lower() });
             drop(s);
             // Walk bounds, transitively expanding. We fold the bounds'
             // contributions *without* seeding from the variable's own identity

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -507,10 +507,38 @@ pub fn compact_type(ty: &Type) -> CompactGraph {
         recursive: HashMap::new(),
         rec_vars: BTreeMap::new(),
     };
-    let term = compact_go(ty, true, &Subst::id(), &BTreeSet::new(), &mut st);
+    let term = compact_go(ty, true, &Subst::id(), None, &mut st);
     CompactGraph {
         term,
         rec_vars: st.rec_vars,
+    }
+}
+
+/// The variables whose bounds the current path is walking, as a chain of stack
+/// frames rather than a set on the heap.
+///
+/// It is a **path**, not a set: one entry per variable on the current bound chain,
+/// reset at every structural boundary, and only ever asked whether a uid is on it.
+/// A `BTreeSet` answers the same question and allocates a copy of itself at every
+/// variable visit to do so — which on a bound-graph walk is millions of copies, for
+/// a path that is a handful of entries deep. Borrowing the caller's frame costs
+/// nothing and says what the thing is.
+struct ParentPath<'a> {
+    uid: InferVarId,
+    prev: Option<&'a ParentPath<'a>>,
+}
+
+impl ParentPath<'_> {
+    /// Whether `uid` is on the path. Linear in the path's depth, which is the
+    /// length of one variable's bound chain.
+    fn contains(mut path: Option<&ParentPath<'_>>, uid: InferVarId) -> bool {
+        while let Some(frame) = path {
+            if frame.uid == uid {
+                return true;
+            }
+            path = frame.prev;
+        }
+        false
     }
 }
 
@@ -555,7 +583,7 @@ fn compact_go(
     ty: &Type,
     pol: bool,
     subst_acc: &Subst,
-    parents: &BTreeSet<InferVarId>,
+    parents: Option<&ParentPath<'_>>,
     st: &mut CompactState,
 ) -> CompactType {
     match ty {
@@ -596,14 +624,14 @@ fn compact_go(
             // per child mirrors Scala's `Set.empty` argument — cycles
             // span only one variable's bound chain, not across
             // function boundaries.
-            let dom = compact_go(d, !pol, subst_acc, &BTreeSet::new(), st);
+            let dom = compact_go(d, !pol, subst_acc, None, st);
             // A Pi binder shadows the accumulated substitution inside the
             // codomain (it binds the name locally), so restrict it there.
             let cod_acc = match name {
                 Some(b) => subst_acc.shadow(b),
                 None => subst_acc.clone(),
             };
-            let cod = compact_go(c, pol, &cod_acc, &BTreeSet::new(), st);
+            let cod = compact_go(c, pol, &cod_acc, None, st);
             CompactType {
                 fun: Some(CompactFun {
                     name: name.clone(),
@@ -619,10 +647,7 @@ fn compact_go(
         Type::Tuple(ts) => {
             let mut compacted = BTreeMap::new();
             for (i, v) in ts.iter().enumerate() {
-                compacted.insert(
-                    FieldKey::Index(i),
-                    compact_go(v, pol, subst_acc, &BTreeSet::new(), st),
-                );
+                compacted.insert(FieldKey::Index(i), compact_go(v, pol, subst_acc, None, st));
             }
             CompactType {
                 rec: Some(compacted),
@@ -634,7 +659,7 @@ fn compact_go(
             for (n, v) in fs {
                 compacted.insert(
                     FieldKey::Name(SmolStr::from(n.as_str())),
-                    compact_go(v, pol, subst_acc, &BTreeSet::new(), st),
+                    compact_go(v, pol, subst_acc, None, st),
                 );
             }
             CompactType {
@@ -649,10 +674,7 @@ fn compact_go(
             // payload depth is unaffected.
             let mut compacted = BTreeMap::new();
             for (k, v) in tags {
-                compacted.insert(
-                    k.clone(),
-                    compact_go(v, pol, subst_acc, &BTreeSet::new(), st),
-                );
+                compacted.insert(k.clone(), compact_go(v, pol, subst_acc, None, st));
             }
             CompactType {
                 var: Some(compacted),
@@ -669,8 +691,8 @@ fn compact_go(
             domain,
             kind,
         } => {
-            let value = compact_go(value, pol, subst_acc, &BTreeSet::new(), st);
-            let domain = compact_go(domain, pol, subst_acc, &BTreeSet::new(), st);
+            let value = compact_go(value, pol, subst_acc, None, st);
+            let domain = compact_go(domain, pol, subst_acc, None, st);
             CompactType {
                 history_slot: Some((Box::new(value), Box::new(domain), *kind)),
                 ..Default::default()
@@ -680,7 +702,7 @@ fn compact_go(
             let uid = state.uid;
             let key = (uid, pol);
             if st.in_process.contains(&key) {
-                if parents.contains(&uid) {
+                if ParentPath::contains(parents, uid) {
                     // Spurious cycle (a <: b and b <: a with no
                     // structural intermediary). Drop the bound.
                     return CompactType::empty();
@@ -762,16 +784,15 @@ fn compact_go(
             // `rec`/`var`/`fun` get this for free from their `None` merge
             // identity, but refinement sets have no such sentinel, so we keep
             // the var out of the structural fold.
-            let mut new_parents = parents.clone();
-            new_parents.insert(uid);
+            let new_parents = ParentPath { uid, prev: parents };
             let mut bound: Option<CompactType> = None;
-            for b in &primary_bounds {
+            for b in primary_bounds.iter() {
                 // Compose this edge's morphisms onto the accumulator before
                 // descending: a bound reached transitively through `v → w → …`
                 // arrives with every edge's morphism composed (design §3.6).
                 // Identity edges leave `subst_acc` unchanged (the common case).
                 let inner_acc = Subst::then(&b.render_subst(), subst_acc);
-                let bc = compact_go(&b.ty, pol, &inner_acc, &new_parents, st);
+                let bc = compact_go(&b.ty, pol, &inner_acc, Some(&new_parents), st);
                 bound = Some(match bound {
                     None => bc,
                     Some(acc) => CompactType::merge(pol, acc, bc),
@@ -791,9 +812,9 @@ fn compact_go(
                 b.atoms.is_empty() && b.rec.is_none() && b.fun.is_none() && b.history_slot.is_none()
             });
             if no_concrete {
-                for b in &opposite_bounds {
+                for b in opposite_bounds.iter() {
                     let inner_acc = Subst::then(&b.render_subst(), subst_acc);
-                    let bc = compact_go(&b.ty, !pol, &inner_acc, &new_parents, st);
+                    let bc = compact_go(&b.ty, !pol, &inner_acc, Some(&new_parents), st);
                     bound = Some(match bound {
                         None => bc,
                         Some(acc) => CompactType::merge(!pol, acc, bc),

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -646,7 +646,7 @@ fn constrain_go_impl(
                 let mut s = lv.bounds.borrow_mut();
                 s.upper_mut()
                     .push(Bound::edge(sl.clone(), rhs.clone(), sr.clone()));
-                s.lower.clone()
+                Rc::clone(s.lower())
             };
             for low in lows.iter() {
                 let (tau_l, tau_u) = bridge_holder_gap(&low.self_subst, sl);
@@ -674,7 +674,7 @@ fn constrain_go_impl(
                 let mut s = rv.bounds.borrow_mut();
                 s.lower_mut()
                     .push(Bound::edge(sr.clone(), lhs.clone(), sl.clone()));
-                s.upper.clone()
+                Rc::clone(s.upper())
             };
             for up in ups.iter() {
                 let (tau_l, tau_u) = bridge_holder_gap(sr, &up.self_subst);
@@ -1003,17 +1003,17 @@ pub fn extrude(ty: &Type, pol: bool, target_level: Level, cache: &mut ExtrudeCac
             let nvs = InferVar::fresh(target_level);
             cache.insert((tv.uid, pol), Rc::clone(&nvs));
 
-            // Snapshot the bounds we'll need to extrude before we mutate
-            // the original; otherwise we'd race the borrow checker.
-            let (lows, ups) = {
-                let s = tv.bounds.borrow();
-                (s.lower.clone(), s.upper.clone())
-            };
-
+            // Each branch snapshots only the list it does *not* push to — the
+            // positive one seeds from `lower` and writes `upper`, the negative
+            // mirrors it — so a branch never holds the list it is about to write
+            // and its own push never forks the shared list. (The snapshot is
+            // needed regardless: the bounds are read across a `borrow_mut` and
+            // across the recursion below.)
             if pol {
                 // Positive: original flows into new var. Original gains
                 // `nvs` as an upper bound; new var inherits original's
                 // lower bounds (extruded at the same polarity).
+                let lows = Rc::clone(tv.bounds.borrow().lower());
                 tv.bounds
                     .borrow_mut()
                     .upper_mut()
@@ -1026,11 +1026,12 @@ pub fn extrude(ty: &Type, pol: bool, target_level: Level, cache: &mut ExtrudeCac
                         ty_subst: b.ty_subst.clone(),
                     })
                     .collect();
-                nvs.bounds.borrow_mut().lower = Rc::new(new_lows);
+                nvs.bounds.borrow_mut().set_lower(new_lows);
             } else {
                 // Negative: new var flows into original. Original gains
                 // `nvs` as a lower bound; new var inherits original's
                 // upper bounds.
+                let ups = Rc::clone(tv.bounds.borrow().upper());
                 tv.bounds
                     .borrow_mut()
                     .lower_mut()
@@ -1043,7 +1044,7 @@ pub fn extrude(ty: &Type, pol: bool, target_level: Level, cache: &mut ExtrudeCac
                         ty_subst: b.ty_subst.clone(),
                     })
                     .collect();
-                nvs.bounds.borrow_mut().upper = Rc::new(new_ups);
+                nvs.bounds.borrow_mut().set_upper(new_ups);
             }
             Type::Infer(nvs)
         }
@@ -1112,12 +1113,12 @@ fn extrude_invariant(ty: &Type, target_level: Level, cache: &mut ExtrudeCache) -
                 let s = tv.bounds.borrow();
                 let not_proxy = |b: &Bound| !matches!(&b.ty, Type::Infer(v) if v.uid == nvs.uid);
                 (
-                    s.lower
+                    s.lower()
                         .iter()
                         .filter(|b| not_proxy(b))
                         .cloned()
                         .collect::<Vec<_>>(),
-                    s.upper
+                    s.upper()
                         .iter()
                         .filter(|b| not_proxy(b))
                         .cloned()
@@ -1387,9 +1388,9 @@ mod tests {
         let Type::Infer(v) = &a else { unreachable!() };
         let expected = refined(prim(BaseType::Int), p);
         assert!(
-            v.bounds.borrow().upper.iter().any(|u| u.ty == expected),
+            v.bounds.borrow().upper().iter().any(|u| u.ty == expected),
             "?a should carry {{Int | p}} as an upper bound, got {:?}",
-            v.bounds.borrow().upper
+            v.bounds.borrow().upper()
         );
     }
 
@@ -1497,8 +1498,8 @@ mod tests {
         constrain_subtype(&v, &p, &mut cache).unwrap();
         if let Type::Infer(state) = &v {
             let s = state.bounds.borrow();
-            assert_eq!(s.upper.len(), 1);
-            assert!(s.lower.is_empty());
+            assert_eq!(s.upper().len(), 1);
+            assert!(s.lower().is_empty());
         } else {
             unreachable!()
         }
@@ -1513,8 +1514,8 @@ mod tests {
         constrain_subtype(&p, &v, &mut cache).unwrap();
         if let Type::Infer(state) = &v {
             let s = state.bounds.borrow();
-            assert!(s.upper.is_empty());
-            assert_eq!(s.lower.len(), 1);
+            assert!(s.upper().is_empty());
+            assert_eq!(s.lower().len(), 1);
         } else {
             unreachable!()
         }
@@ -1539,9 +1540,9 @@ mod tests {
 
         if let Type::Infer(state) = &beta {
             let s = state.bounds.borrow();
-            assert_eq!(s.upper.len(), 1);
+            assert_eq!(s.upper().len(), 1);
             // The recorded upper bound is α itself, not Int.
-            assert!(matches!(&s.upper[0].ty, Type::Infer(_)));
+            assert!(matches!(&s.upper()[0].ty, Type::Infer(_)));
         } else {
             unreachable!()
         }
@@ -1786,11 +1787,11 @@ mod tests {
         let bounds = orig.bounds.borrow();
         let proxy_ty = Type::Infer(Rc::clone(proxy));
         assert!(
-            bounds.upper.iter().any(|b| b.ty == proxy_ty),
+            bounds.upper().iter().any(|b| b.ty == proxy_ty),
             "original value var is missing the upper link to its proxy"
         );
         assert!(
-            bounds.lower.iter().any(|b| b.ty == proxy_ty),
+            bounds.lower().iter().any(|b| b.ty == proxy_ty),
             "original value var is missing the lower link to its proxy"
         );
     }
@@ -1838,11 +1839,11 @@ mod tests {
         let proxy_ty = Type::Infer(Rc::clone(feed_proxy));
         let bounds = orig.bounds.borrow();
         assert!(
-            bounds.upper.iter().any(|b| b.ty == proxy_ty),
+            bounds.upper().iter().any(|b| b.ty == proxy_ty),
             "original is missing the upper (positive) link to its proxy"
         );
         assert!(
-            bounds.lower.iter().any(|b| b.ty == proxy_ty),
+            bounds.lower().iter().any(|b| b.ty == proxy_ty),
             "original is missing the lower (negative) link after the cache hit"
         );
     }
@@ -2137,7 +2138,7 @@ mod tests {
             constrain_subtype(&app, &v, &mut cache).expect("app <: V");
         }
 
-        let lows = vv.bounds.borrow().lower.clone();
+        let lows = Rc::clone(vv.bounds.borrow().lower());
         let rendered: Vec<String> = lows
             .iter()
             .map(|b| format!("{}", b.materialize()))

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -644,11 +644,11 @@ fn constrain_go_impl(
         (Type::Infer(lv), _) if type_level(rhs) <= lv.level => {
             let lows = {
                 let mut s = lv.bounds.borrow_mut();
-                s.upper
+                s.upper_mut()
                     .push(Bound::edge(sl.clone(), rhs.clone(), sr.clone()));
                 s.lower.clone()
             };
-            for low in lows {
+            for low in lows.iter() {
                 let (tau_l, tau_u) = bridge_holder_gap(&low.self_subst, sl);
                 constrain_go(
                     &low.ty,
@@ -672,11 +672,11 @@ fn constrain_go_impl(
         (_, Type::Infer(rv)) if type_level(lhs) <= rv.level => {
             let ups = {
                 let mut s = rv.bounds.borrow_mut();
-                s.lower
+                s.lower_mut()
                     .push(Bound::edge(sr.clone(), lhs.clone(), sl.clone()));
                 s.upper.clone()
             };
-            for up in ups {
+            for up in ups.iter() {
                 let (tau_l, tau_u) = bridge_holder_gap(sr, &up.self_subst);
                 constrain_go(
                     lhs,
@@ -1016,7 +1016,7 @@ pub fn extrude(ty: &Type, pol: bool, target_level: Level, cache: &mut ExtrudeCac
                 // lower bounds (extruded at the same polarity).
                 tv.bounds
                     .borrow_mut()
-                    .upper
+                    .upper_mut()
                     .push(Bound::conc(Type::Infer(Rc::clone(&nvs))));
                 let new_lows: Vec<_> = lows
                     .iter()
@@ -1026,14 +1026,14 @@ pub fn extrude(ty: &Type, pol: bool, target_level: Level, cache: &mut ExtrudeCac
                         ty_subst: b.ty_subst.clone(),
                     })
                     .collect();
-                nvs.bounds.borrow_mut().lower = new_lows;
+                nvs.bounds.borrow_mut().lower = Rc::new(new_lows);
             } else {
                 // Negative: new var flows into original. Original gains
                 // `nvs` as a lower bound; new var inherits original's
                 // upper bounds.
                 tv.bounds
                     .borrow_mut()
-                    .lower
+                    .lower_mut()
                     .push(Bound::conc(Type::Infer(Rc::clone(&nvs))));
                 let new_ups: Vec<_> = ups
                     .iter()
@@ -1043,7 +1043,7 @@ pub fn extrude(ty: &Type, pol: bool, target_level: Level, cache: &mut ExtrudeCac
                         ty_subst: b.ty_subst.clone(),
                     })
                     .collect();
-                nvs.bounds.borrow_mut().upper = new_ups;
+                nvs.bounds.borrow_mut().upper = Rc::new(new_ups);
             }
             Type::Infer(nvs)
         }
@@ -1128,7 +1128,7 @@ fn extrude_invariant(ty: &Type, target_level: Level, cache: &mut ExtrudeCache) -
             if !has_pos_link {
                 tv.bounds
                     .borrow_mut()
-                    .upper
+                    .upper_mut()
                     .push(Bound::conc(Type::Infer(Rc::clone(&nvs))));
                 let new_lows: Vec<_> = lows
                     .iter()
@@ -1138,13 +1138,13 @@ fn extrude_invariant(ty: &Type, target_level: Level, cache: &mut ExtrudeCache) -
                         ty_subst: b.ty_subst.clone(),
                     })
                     .collect();
-                nvs.bounds.borrow_mut().lower.extend(new_lows);
+                nvs.bounds.borrow_mut().lower_mut().extend(new_lows);
             }
             // Negative link: `proxy <: tv`; proxy inherits `tv`'s upper bounds.
             if !has_neg_link {
                 tv.bounds
                     .borrow_mut()
-                    .lower
+                    .lower_mut()
                     .push(Bound::conc(Type::Infer(Rc::clone(&nvs))));
                 let new_ups: Vec<_> = ups
                     .iter()
@@ -1154,7 +1154,7 @@ fn extrude_invariant(ty: &Type, target_level: Level, cache: &mut ExtrudeCache) -
                         ty_subst: b.ty_subst.clone(),
                     })
                     .collect();
-                nvs.bounds.borrow_mut().upper.extend(new_ups);
+                nvs.bounds.borrow_mut().upper_mut().extend(new_ups);
             }
             Type::Infer(nvs)
         }
@@ -2022,10 +2022,14 @@ mod tests {
         let Type::Infer(gamma_var) = &gamma else {
             unreachable!()
         };
-        gamma_var.bounds.borrow_mut().lower.push(Bound::with_subst(
-            Type::Infer(Rc::clone(result_var)),
-            Subst::discharge("x", TypedExpr::lit(Lit::Int(0))),
-        ));
+        gamma_var
+            .bounds
+            .borrow_mut()
+            .lower_mut()
+            .push(Bound::with_subst(
+                Type::Infer(Rc::clone(result_var)),
+                Subst::discharge("x", TypedExpr::lit(Lit::Int(0))),
+            ));
 
         let app_ty = coalesce(&Type::Infer(Rc::clone(gamma_var)));
         // g(0) : {i | i > 0} ⇒ Int — both the correspondence rename and the
@@ -2075,10 +2079,14 @@ mod tests {
         let Type::Infer(gamma_var) = &gamma else {
             unreachable!()
         };
-        gamma_var.bounds.borrow_mut().lower.push(Bound::with_subst(
-            Type::Infer(Rc::clone(result_var)),
-            Subst::discharge("x", TypedExpr::lit(Lit::Int(0))),
-        ));
+        gamma_var
+            .bounds
+            .borrow_mut()
+            .lower_mut()
+            .push(Bound::with_subst(
+                Type::Infer(Rc::clone(result_var)),
+                Subst::discharge("x", TypedExpr::lit(Lit::Int(0))),
+            ));
 
         // The consumer edge first: g(0) flows into an argument slot.
         let consumer = fresh_var(0);
@@ -2122,7 +2130,7 @@ mod tests {
             let Type::Infer(av) = &app else {
                 unreachable!()
             };
-            av.bounds.borrow_mut().lower.push(Bound::with_subst(
+            av.bounds.borrow_mut().lower_mut().push(Bound::with_subst(
                 r.clone(),
                 Subst::discharge("k", TypedExpr::lit(Lit::Int(lit))),
             ));

--- a/src/ccl/infer/solver/mod.rs
+++ b/src/ccl/infer/solver/mod.rs
@@ -188,8 +188,8 @@ mod tests {
     fn fresh_var_has_no_bounds() {
         let v = InferVar::fresh(0);
         let s = v.bounds.borrow();
-        assert!(s.lower.is_empty());
-        assert!(s.upper.is_empty());
+        assert!(s.lower().is_empty());
+        assert!(s.upper().is_empty());
         assert_eq!(v.level, 0);
     }
 

--- a/src/ccl/infer/solver/scheme.rs
+++ b/src/ccl/infer/solver/scheme.rs
@@ -302,8 +302,8 @@ pub fn freshen_above(
                 .collect();
             {
                 let mut s = v.bounds.borrow_mut();
-                s.lower = new_lows;
-                s.upper = new_ups;
+                s.lower = Rc::new(new_lows);
+                s.upper = Rc::new(new_ups);
             }
             Type::Infer(v)
         }

--- a/src/ccl/infer/solver/scheme.rs
+++ b/src/ccl/infer/solver/scheme.rs
@@ -277,7 +277,7 @@ pub fn freshen_above(
             // other variables but must not see partially-mutated state.
             let (lows, ups) = {
                 let s = tv.bounds.borrow();
-                (s.lower.clone(), s.upper.clone())
+                (Rc::clone(s.lower()), Rc::clone(s.upper()))
             };
             // Freshen the bound's type *and* its edge substitutions' discharge
             // payloads: a payload is a captured argument *term* whose type
@@ -302,8 +302,8 @@ pub fn freshen_above(
                 .collect();
             {
                 let mut s = v.bounds.borrow_mut();
-                s.lower = Rc::new(new_lows);
-                s.upper = Rc::new(new_ups);
+                s.set_lower(new_lows);
+                s.set_upper(new_ups);
             }
             Type::Infer(v)
         }
@@ -411,7 +411,7 @@ fn seed_pairings_go(
         if seen.insert(dv.uid) {
             let (lows, ups) = {
                 let s = dv.bounds.borrow();
-                (s.lower.clone(), s.upper.clone())
+                (Rc::clone(s.lower()), Rc::clone(s.upper()))
             };
             for b in lows.iter().chain(ups.iter()) {
                 seed_pairings_go(use_ty, &b.ty, lim, out, seen);
@@ -423,7 +423,7 @@ fn seed_pairings_go(
         if seen.insert(uv.uid) {
             let (lows, ups) = {
                 let s = uv.bounds.borrow();
-                (s.lower.clone(), s.upper.clone())
+                (Rc::clone(s.lower()), Rc::clone(s.upper()))
             };
             for b in lows.iter().chain(ups.iter()) {
                 seed_pairings_go(&b.ty, def_ty, lim, out, seen);

--- a/src/ccl/infer/solver/spec_key.rs
+++ b/src/ccl/infer/solver/spec_key.rs
@@ -467,7 +467,7 @@ fn key_go(ty: &Type, pol: bool, subst_acc: &Subst, ctx: &mut KeyCtx) -> KeyView 
             };
             let truncations_before = ctx.truncations;
             let mut acc = KeyView::default();
-            for b in &bounds {
+            for b in bounds.iter() {
                 // Compose the edge's morphism before descending, as `compact_go`
                 // does: a bound reached transitively arrives with every edge's
                 // substitution composed.
@@ -625,7 +625,7 @@ mod tests {
             let Type::Infer(v) = var else {
                 unreachable!("fresh_var yields Type::Infer");
             };
-            v.bounds.borrow_mut().lower.push(Bound::conc(ty));
+            v.bounds.borrow_mut().lower_mut().push(Bound::conc(ty));
         }
         let a = fresh_var(0);
         let b = fresh_var(0);

--- a/src/ccl/infer/solver/spec_key.rs
+++ b/src/ccl/infer/solver/spec_key.rs
@@ -89,6 +89,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, btree_map::Entry};
 use std::fmt;
+use std::rc::Rc;
 
 use smol_str::SmolStr;
 
@@ -459,11 +460,7 @@ fn key_go(ty: &Type, pol: bool, subst_acc: &Subst, ctx: &mut KeyCtx) -> KeyView 
             }
             let bounds = {
                 let b = state.bounds.borrow();
-                if pol {
-                    b.lower.clone()
-                } else {
-                    b.upper.clone()
-                }
+                Rc::clone(if pol { b.lower() } else { b.upper() })
             };
             let truncations_before = ctx.truncations;
             let mut acc = KeyView::default();

--- a/src/ccl/infer_var.rs
+++ b/src/ccl/infer_var.rs
@@ -190,12 +190,52 @@ impl Bound {
 /// these in place via the variable's [`RefCell`]; coalescing reads them to
 /// materialize a concrete [`Type`]. Each entry is a [`Bound`] carrying the
 /// substitution on its constraint edge.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct InferBounds {
     /// Lower bounds — `L <: α`. Unioned at positive (output) positions.
-    pub lower: Vec<Bound>,
+    ///
+    /// Behind an [`Rc`] so a *reader* can take the list away from the `RefCell`
+    /// without copying it. Materialization does exactly that, once per variable
+    /// visit, and a `Bound` owns a whole [`Type`] and a `Subst` — so the copy is
+    /// deep, and on a bound-graph walk it is most of the work. Mutation goes
+    /// through [`lower_mut`](Self::lower_mut), which copies only if a reader is
+    /// still holding the old list; the passes that write bounds hold none.
+    pub lower: Rc<Vec<Bound>>,
     /// Upper bounds — `α <: U`. Intersected at negative (input) positions.
-    pub upper: Vec<Bound>,
+    /// Shared like [`lower`](Self::lower).
+    pub upper: Rc<Vec<Bound>>,
+}
+
+thread_local! {
+    /// One shared empty bound list, so a fresh variable costs no allocation.
+    ///
+    /// `Rc<Vec<_>>::default()` would allocate a control block per list, and a run
+    /// mints hundreds of thousands of variables — most of which never take a bound
+    /// at all. Handing every empty list the same `Rc` keeps that at zero; the first
+    /// write copies out of it, which is a `Vec` clone of nothing.
+    static NO_BOUNDS: Rc<Vec<Bound>> = Rc::new(Vec::new());
+}
+
+impl Default for InferBounds {
+    fn default() -> Self {
+        NO_BOUNDS.with(|empty| InferBounds {
+            lower: Rc::clone(empty),
+            upper: Rc::clone(empty),
+        })
+    }
+}
+
+impl InferBounds {
+    /// The lower bounds, for mutation — copy-on-write against any reader still
+    /// holding the list.
+    pub fn lower_mut(&mut self) -> &mut Vec<Bound> {
+        Rc::make_mut(&mut self.lower)
+    }
+
+    /// The upper bounds, for mutation — see [`lower_mut`](Self::lower_mut).
+    pub fn upper_mut(&mut self) -> &mut Vec<Bound> {
+        Rc::make_mut(&mut self.upper)
+    }
 }
 
 /// A type inference variable: an unknown type the solver pins down by

--- a/src/ccl/infer_var.rs
+++ b/src/ccl/infer_var.rs
@@ -185,25 +185,33 @@ impl Bound {
 
 /// The mutable bound lists of an [`InferVar`].
 ///
-/// `lower` are types that flow *into* the variable (`L <: α`); `upper` are
-/// types it must flow into (`α <: U`). The solver appends to
+/// The lower bounds are types that flow *into* the variable (`L <: α`); the
+/// upper bounds are types it must flow into (`α <: U`). The solver appends to
 /// these in place via the variable's [`RefCell`]; coalescing reads them to
 /// materialize a concrete [`Type`]. Each entry is a [`Bound`] carrying the
 /// substitution on its constraint edge.
+///
+/// Each list sits behind an [`Rc`] so a *reader* can take it away from the
+/// `RefCell` without copying it. Materialization does exactly that, once per
+/// variable visit, and a `Bound` owns a whole [`Type`] and a `Subst` — so the
+/// copy is deep, and on a bound-graph walk it is most of the work.
+///
+/// The lists are private because that read/write asymmetry is the whole point:
+/// every write goes through [`lower_mut`](Self::lower_mut) /
+/// [`set_lower`](Self::set_lower) / [`clear`](Self::clear), so "mutation is
+/// copy-on-write" is checked by the compiler rather than by convention.
+///
+/// Writing while a reader holds the list is not hypothetical: the transitive
+/// closure in `constrain_go` walks a snapshot of one bound list while the
+/// recursion under it records edges on the same variable, and a push that lands
+/// on the held list forks it. What makes that cheap is the ratio, not the
+/// absence — a fork costs one copy per *push*, so forks are bounded by the
+/// number of edges recorded, while the copies they replace were one per
+/// *visit*, and visits outnumber edges by orders of magnitude.
 #[derive(Debug, Clone)]
 pub struct InferBounds {
-    /// Lower bounds — `L <: α`. Unioned at positive (output) positions.
-    ///
-    /// Behind an [`Rc`] so a *reader* can take the list away from the `RefCell`
-    /// without copying it. Materialization does exactly that, once per variable
-    /// visit, and a `Bound` owns a whole [`Type`] and a `Subst` — so the copy is
-    /// deep, and on a bound-graph walk it is most of the work. Mutation goes
-    /// through [`lower_mut`](Self::lower_mut), which copies only if a reader is
-    /// still holding the old list; the passes that write bounds hold none.
-    pub lower: Rc<Vec<Bound>>,
-    /// Upper bounds — `α <: U`. Intersected at negative (input) positions.
-    /// Shared like [`lower`](Self::lower).
-    pub upper: Rc<Vec<Bound>>,
+    lower: Rc<Vec<Bound>>,
+    upper: Rc<Vec<Bound>>,
 }
 
 thread_local! {
@@ -226,6 +234,20 @@ impl Default for InferBounds {
 }
 
 impl InferBounds {
+    /// The lower bounds — `L <: α`, unioned at positive (output) positions.
+    ///
+    /// Handed out as the `Rc` itself: a walk clones it to read the list outside
+    /// the `RefCell` borrow, which is a refcount bump.
+    pub fn lower(&self) -> &Rc<Vec<Bound>> {
+        &self.lower
+    }
+
+    /// The upper bounds — `α <: U`, intersected at negative (input) positions.
+    /// Shared like [`lower`](Self::lower).
+    pub fn upper(&self) -> &Rc<Vec<Bound>> {
+        &self.upper
+    }
+
     /// The lower bounds, for mutation — copy-on-write against any reader still
     /// holding the list.
     pub fn lower_mut(&mut self) -> &mut Vec<Bound> {
@@ -235,6 +257,34 @@ impl InferBounds {
     /// The upper bounds, for mutation — see [`lower_mut`](Self::lower_mut).
     pub fn upper_mut(&mut self) -> &mut Vec<Bound> {
         Rc::make_mut(&mut self.upper)
+    }
+
+    /// Install a freshly built lower-bound list, discarding the old one.
+    ///
+    /// Distinct from [`lower_mut`](Self::lower_mut): the caller already owns the
+    /// whole list, so there is nothing to copy out of a shared `Rc` and nothing
+    /// of the old list to preserve.
+    pub fn set_lower(&mut self, bounds: Vec<Bound>) {
+        self.lower = Rc::new(bounds);
+    }
+
+    /// Install a freshly built upper-bound list — see
+    /// [`set_lower`](Self::set_lower).
+    pub fn set_upper(&mut self, bounds: Vec<Bound>) {
+        self.upper = Rc::new(bounds);
+    }
+
+    /// Sever both bound lists, releasing the [`Bound`]s they hold.
+    ///
+    /// Assignment, not `lower_mut().clear()`. On a variable that never took a
+    /// bound the list *is* the shared empty one, so `Rc::make_mut` would
+    /// allocate a copy in order to clear it — twice per variable, over the
+    /// population that dominates. And on a genuinely shared list it would clear
+    /// the copy and sever nothing, which is the opposite of what teardown wants:
+    /// dropping the `Rc` is what releases the bounds, and with them the
+    /// reference cycle, once no reader is left.
+    pub fn clear(&mut self) {
+        *self = Self::default();
     }
 }
 
@@ -336,5 +386,62 @@ impl std::hash::Hash for InferVar {
 impl fmt::Debug for InferVar {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "?{}", self.uid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccl::BaseType;
+
+    fn a_bound() -> Bound {
+        Bound::conc(Type::Base(BaseType::Int))
+    }
+
+    /// Teardown clears every variable in the arena, and most of them never took
+    /// a bound — so clearing must hand the list back to the shared empty `Rc`
+    /// rather than allocate a copy to clear. Pointer identity is the check: a
+    /// `Rc::make_mut` + `clear` on the shared empty list installs a *fresh* `Rc`
+    /// and fails here.
+    #[test]
+    fn clearing_bounds_restores_the_shared_empty_list() {
+        let mut bounds = InferBounds::default();
+        bounds.lower_mut().push(a_bound());
+        bounds.clear();
+        NO_BOUNDS.with(|empty| {
+            assert!(Rc::ptr_eq(bounds.lower(), empty));
+            assert!(Rc::ptr_eq(bounds.upper(), empty));
+        });
+    }
+
+    /// Clearing severs the holder's reference instead of emptying a copy — which
+    /// is what releases the `Bound`s (and the reference cycle through them) once
+    /// the last reader is gone.
+    #[test]
+    fn clearing_severs_a_shared_list_rather_than_emptying_a_copy() {
+        let mut bounds = InferBounds::default();
+        bounds.lower_mut().push(a_bound());
+        let reader = Rc::clone(bounds.lower());
+
+        bounds.clear();
+
+        assert!(bounds.lower().is_empty(), "the holder released its list");
+        assert_eq!(reader.len(), 1, "the reader's snapshot is untouched");
+        assert_eq!(
+            Rc::strong_count(&reader),
+            1,
+            "the holder no longer references the bounds it dropped"
+        );
+    }
+
+    /// A fresh variable's lists are the shared empty one, so minting costs no
+    /// allocation; the first write copies out of it.
+    #[test]
+    fn a_fresh_variable_shares_the_empty_bound_list() {
+        let bounds = InferBounds::default();
+        NO_BOUNDS.with(|empty| {
+            assert!(Rc::ptr_eq(bounds.lower(), empty));
+            assert!(Rc::ptr_eq(bounds.upper(), empty));
+        });
     }
 }


### PR DESCRIPTION
Materializing a type walks a variable's bounds, and to do that it took a copy of
them: `compact_go`'s variable arm cloned both bound lists and the `parents` set at
every visit. A `Bound` owns a whole `Type` and a `Subst`, so the list copy is deep,
and an inference-heavy program makes millions of visits. A profile of one puts
`memmove` at 8%, `malloc`/`free` at ~4.5%, and `BTreeSet`/`BTreeMap` clone, drop and
search after that, with a long tail of the same — no hotspot, just the walk paying
for a copy of what it is reading.

Neither copy is needed.

**The bound lists are shared, not copied.** `InferBounds` holds `Rc<Vec<Bound>>` in
private fields, so a reader takes the list away from the `RefCell` with a refcount
bump and every write has to go through `lower_mut` / `upper_mut` / `set_lower` /
`clear` — the copy-on-write discipline is compiler-checked, not conventional. A
writer that is itself holding a snapshot does fork the list, and one does:
`constrain_go`'s transitive closure walks a snapshot while the recursion under it
records edges on the same variable. That stays cheap on the ratio, not on never
happening — a fork costs one copy per *push*, so forks are bounded by edges
recorded, where the read side was copying per *visit*, and visits outnumber edges
by orders of magnitude. A fresh variable still costs no allocation: every empty
list is the same shared `Rc`, since a run mints hundreds of thousands of variables
and most never take a bound at all — and teardown hands them back to it rather than
allocating a copy in order to clear one.

**`parents` is a path, so it is a chain of stack frames.** It holds one entry per
variable on the current bound chain, is reset at every structural boundary, and is
only ever asked whether a uid is on it — a `BTreeSet` was answering that by
allocating a copy of itself per visit, for a path a handful of entries deep.
Borrowing the caller's frame costs nothing, and the type now says what the thing is.

## Measured

Best of three, on chains of generic wrappers applied at a concrete type:

| program | before | after |
|---|---|---|
| 2 wrappers | 286 ms | 178 ms |
| 3 wrappers | 2.31 s | 1.31 s |
| 4 wrappers | 12.1 s | 7.84 s |

Roughly 1.6×. Small programs are unchanged, as expected — a three-millisecond
comprehension never reaches the walk. The win is proportional to how much
bound-graph traversal a program does, which is the same axis every other inference
cost sits on.

A profile after the change confirms the mechanism rather than a coincidence: the
`BTreeSet<InferVarId>` and `BTreeMap<Name, Mapping>` clone/drop/search entries are
gone from it entirely. What surfaces behind them is free-variable counting
(`count_free_with_visited` and the type/predicate walks under it, together ~13%),
which is the next thing to look at and is unrelated to this.

Correctness is covered where it already was: the spurious-cycle pruning that
`parents` exists for is what makes `?a <: ?a` coalesce to a variable instead of
being reported as a recursive type, and the coalesce tests pin that.

