### PR TITLE
An unobservable `match` arm's payload is pinned on the variable, not in the slot

### DIFF
--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -226,10 +226,13 @@ The solver's single-sided `Var <: Var` constrain rule leaves a few *structural* 
 What the bottom-up `expr.ty` resolution *doesn't* reach is the **binder slots**: a binder carries a type that is not any node's `expr.ty` — a `Lambda`'s `param.ty`, a `Let`'s `binding.ty`, a `Case` pattern's `binding.ty`, a `For`'s target slot. Each is resolved explicitly in `coalesce_node`, mirroring its definition (inference runs before the mutability/transaction phases, so the recurrence carriers `LetRec`/`Transact` never reach coalesce):
 
 * **`Lambda` `param.ty`** — derived from the lambda's coalesced domain (so body-usage restriction refinements, which are negative-polarity facts visible only in the contravariant domain, survive), and re-derived whenever a parent arm specializes the domain (`refresh_lambda_param_slot`).
-* **`Let` `binding.ty`** — the (already-coalesced) bound expression's type. emit never constrains the binding slot and the generic `expr.ty` resolution skips it, so without this line a `let`-bound `Var`'s **binder slot** (not its uses) stays `Type::Hole`.
-* **`Case` / `For` slots** — run through `resolve_var_type` like any `expr.ty`.
+* **`Let` / `LetRec` / mutable-variable `binding.ty`, `Case` pattern payloads, a `For` target** — resolved *in place* by `resolve_binder_slot`. Resolving the slot is **not** copying the coalesced RHS type onto it: the two agree for an unannotated `let` (the binder is bound at its initializer's type) and disagree for the annotated ones — a deref-copy binds at the value type where the RHS is a handle, a mutable-variable introduction at the handle where the RHS is a value.
 
-Refinement predicates are coalesced by recursing into them (in the `Lambda` arm and `coalesce_type_predicates`); their free variables share the enclosing bindings' vars and coalesce identically, just like ordinary `Var` uses — and their projections recover their domains through the same `Apply`/`Compose` arms (see §2).
+**Resolving a binder slot is two jobs.** `resolve_var_type` settles the type's *structure*; the refinement predicates riding it are expression trees hanging off type slots, carrying inference variables of their own, and they are settled by `coalesce_type_predicates` — which is exactly what `coalesce_node` runs for every `expr.ty`. A slot that did only the first would keep the **pre-coalesce predicate `Rc`**: the predicate memo redirects only the occurrences it visits, so a slot the walk skipped still points at the original, and the stale copy survives with unresolved variables. `resolve_binder_slot` exists so the two halves cannot drift apart per slot.
+
+That residue is invisible in most programs because something else rebuilds the binder — a *generalized* `let`'s definition is re-coalesced by `specialize_use` at each specialization. It is a **value** binding that exposes it: nothing rebuilds it, so the slot is the only chance. Two independent shapes reach it — a `groupby` (a collection, so a value binding, and dependently refined, so its binder type carries a predicate at all) and a `match` over a conditionally-built collection (whose arm domains carry the conditional's gate).
+
+Refinement predicates are otherwise coalesced by recursing into them (in the `Lambda` arm and `coalesce_type_predicates`); their free variables share the enclosing bindings' vars and coalesce identically, just like ordinary `Var` uses — and their projections recover their domains through the same `Apply`/`Compose` arms (see §2).
 
 ### The post-inference check (shared rules)
 
@@ -1412,6 +1415,12 @@ The bottom two rows are ordinary schemes, because their operand types are fixed.
 For each `Branch { guard, body }`: the guard flows one-way into `Type::Base(BaseType::Bool)` (a refined boolean is still a boolean); every body flows one-way into one shared variable. The overall `Case` type is that variable — the arms' **join**. Two arms of incompatible base types therefore collide as `IncompatibleBounds` at coalesce, where a heterogeneous list literal or `CollectionUnion` reports it, rather than as an eager mismatch here. A 0-branch `Case` is a malformed AST (lowering never produces one) and returns `InferError::EmptyCase`.
 
 The in-flight conditionals stack replaces the arm unification with a genuine lattice join (fresh result variable + per-arm `require_sub`) — see [Data vs compute functions](#46-data-vs-compute-functions); the strict-equality behavior above is current until that lands.
+
+#### An unobservable arm payload defaults to `Unit`
+
+An arm naming a tag the scrutinee cannot carry receives no lower bound, and if its body ignores its binder it receives no upper bound either — nothing determines that payload's type and nothing can observe it. Such an arm is ordinary code rather than an error (a `match` written for the whole `Option` over a scrutinee inference has pinned to one tag), so inference completes by choosing `Unit`, the type that carries no information.
+
+The choice is recorded on the *variable*, not in the binder slot, so every occurrence of it agrees — the slot, the scrutinee's expected variant, and hence an enclosing lambda's parameter type. Unreachable arms are **kept**, not pruned: an arm for a tag the scrutinee cannot carry projects an empty restriction and contributes nothing, while pruning would narrow the arm set relative to the enclosing lambda's declared domain. `pin_unobservable_arm_payload` in `src/ccl/infer/solve.rs` holds the mechanism, including the two ordering constraints that place it inside the coalesce walk.
 
 ### Record literals and field access
 

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -29,7 +29,7 @@ use crate::ccl::infer::solver::{
 };
 use crate::ccl::provenance::NodeId;
 use crate::ccl::symbolic::symbolic;
-use crate::ccl::{Expr, Level, Name, Type, TypedBinding, TypedExprNode};
+use crate::ccl::{Expr, Level, Name, Pattern, Type, TypedBinding, TypedExprNode};
 
 use super::context::should_generalize;
 use super::{LocatedInferError, map_coalesce_err, map_constrain_err};
@@ -659,6 +659,103 @@ fn with_shadows<R>(
     r
 }
 
+/// Pin the payload of a `Case` arm nothing can reach, so it resolves to *some*
+/// type rather than staying an inference variable.
+///
+/// Width subtyping gives an arm naming a tag the scrutinee cannot carry no lower
+/// bound: nothing determines the payload, and nothing can, so it would reach the
+/// post-inference wall unresolved. The arm is ordinary code rather than an error
+/// (see `src/ccl/design/type-inference.md`, "An unobservable arm payload defaults
+/// to `Unit`"), so a type is chosen here instead.
+///
+/// **Which** type depends on whether the arm's body reads the binder:
+///
+/// - **It does not.** Nothing observes the payload either, so `Unit` — carrying no
+///   information — is the choice.
+/// - **It does.** The read states what it needs of the payload, as a trait
+///   obligation (`v + 1` records `Addable`), and `Unit` would contradict it: the
+///   pin would reject the very read that makes the payload observable. So the
+///   obligations choose, from the types their surviving instances still accept
+///   ([`TraitObligation::accepted_at`]).
+///
+/// A read need not narrow the choice to one — `v + v` leaves every `Addable` row
+/// standing (`Int`, `UInt`, `String`) — and **any of them is as good as any other
+/// here**, because the arm is unreachable: no value ever flows through the binder,
+/// so nothing observes which was picked. So one is taken, by instance-table order,
+/// for reproducibility rather than for meaning. That is a placeholder for saying
+/// what is actually true of such a payload — *for all `T` satisfying the arm's
+/// requirements* — which needs bounded quantification the type language does not
+/// have yet; with it, a dead arm would carry its requirements instead of a
+/// representative satisfying them.
+///
+/// Two things about *how* it is recorded are load-bearing:
+///
+/// - **On the variable, not the slot.** The same variable also occurs in the
+///   scrutinee's expected variant, and so in an enclosing lambda's parameter type.
+///   Writing `Unit` into `binding.ty` alone leaves those occurrences unresolved,
+///   which is the same defect with a smaller footprint.
+/// - **Inside the coalesce walk, before the branches.** A generalized definition's
+///   unconstrained payload is a type *parameter* — its uses instantiate freshened
+///   copies — so pinning it would make every instantiation `Unit` and reject a call
+///   that supplies that tag with a payload. Coalesce never walks such a definition
+///   in place, only its per-use clones, so pinning here reaches exactly the trees
+///   being resolved. And a `Lambda` resolves `param.ty` from its coalesced domain
+///   *after* its body, so the pin still reaches the parameter type — but only if it
+///   precedes the branch walk.
+#[allow(clippy::mutable_key_type)]
+fn pin_unobservable_arm_payload(p: &Pattern) {
+    // Unobservability is *transitive*: the variable's bound list is rarely empty
+    // — the scrutinee constraint gives it the scrutinee's own per-tag variable as
+    // a lower bound — and what matters is whether anything concrete reaches it
+    // through the chain. Resolving is the question being asked, so ask it: a
+    // payload that resolves to a bare variable is one no value and no read
+    // determines.
+    if !matches!(resolve_var_type(&p.binding.ty), Ok(Type::Infer(_))) {
+        return;
+    }
+    let chosen = Type::Base(payload_default(&p.binding.ty));
+    let mut cache = ConstrainCache::new();
+    let pinned = constrain_subtype(&chosen, &p.binding.ty, &mut cache)
+        .and_then(|()| constrain_subtype(&p.binding.ty, &chosen, &mut cache));
+    assert!(
+        pinned.is_ok(),
+        "pinning an unreachable payload variable cannot fail: its only bounds are \
+         the requirements its own body stated, and `{chosen}` is a type they all \
+         still accept (arm `` `{} ``)",
+        p.tag,
+    );
+}
+
+/// The type to pin an unreachable arm's payload to: `Unit` when nothing reads it,
+/// otherwise one the reads' requirements accept. See
+/// [`pin_unobservable_arm_payload`], which is the whole rationale.
+fn payload_default(payload: &Type) -> crate::ccl::BaseType {
+    use crate::ccl::BaseType;
+
+    let Type::Infer(v) = payload else {
+        return BaseType::Unit;
+    };
+    let watches = v.watches.borrow();
+    let Some(((first, pos), rest)) = watches.split_first() else {
+        return BaseType::Unit;
+    };
+    // Every requirement on the payload has to hold at once, so the choices are the
+    // *intersection* of what each still accepts. No test separates this from taking
+    // the first watch's own list, because every trait table today begins with `Int`
+    // — but the pin must not choose a type some requirement rejects, and that is a
+    // property of the tables rather than of this code.
+    let mut candidates = first.accepted_at(*pos);
+    for (obligation, pos) in rest {
+        let also = obligation.accepted_at(*pos);
+        candidates.retain(|c| also.contains(c));
+    }
+    // An empty intersection means the body's own requirements cannot be met
+    // together, which is a real type error in the arm — one this function has no
+    // business reporting. Leave `Unit` to fail the pin's assertion rather than
+    // inventing a type that hides it.
+    candidates.first().cloned().unwrap_or(BaseType::Unit)
+}
+
 pub(super) fn coalesce_pass(expr: &mut Expr) -> Vec<LocatedInferError> {
     let mut ctx = CoalesceCtx {
         scope: Vec::new(),
@@ -778,6 +875,36 @@ pub(super) fn check_scope_valid(
 /// `Type`, via the compact → simplify → coalesce pipeline.
 pub(super) fn resolve_var_type(ty: &Type) -> Result<Type, CoalesceError> {
     coalesce_compact(&simplify_type(compact_type(ty)))
+}
+
+/// Resolve a **binder slot** — a type the bottom-up `expr.ty` walk does not
+/// reach (a `let`/`letrec`/mutable-variable binder, a `Case` pattern payload, a
+/// `for` target).
+///
+/// Resolving such a slot is two jobs, not one, and doing only the first is a
+/// silent defect. [`resolve_var_type`] settles the type's *structure*; the
+/// refinement predicates riding it are expression trees hanging off type slots,
+/// with their own inference variables, and they are resolved by
+/// [`coalesce_type_predicates`] — which is what `coalesce_node` runs for every
+/// `expr.ty`. A slot that skips it keeps the pre-coalesce predicate `Rc`: the
+/// memo redirects only the occurrences it visits, so the stale copy survives
+/// with unresolved variables in a program where nothing else rebuilds the
+/// binder (a *value* binding — one that is not generalized, so no
+/// [`specialize_use`] re-coalesce reaches it).
+fn resolve_binder_slot(
+    slot: &mut Type,
+    label: impl FnOnce() -> String,
+    level: Level,
+    ctx: &mut CoalesceCtx,
+) {
+    match resolve_var_type(slot) {
+        Ok(ty) => *slot = ty,
+        Err(err) => {
+            let label = label();
+            ctx.push_error(map_coalesce_err(err, &label), label);
+        }
+    }
+    coalesce_type_predicates(slot, level, ctx);
 }
 
 /// Coalesce every node's `expr.ty` in place, resolving its inference variables
@@ -947,13 +1074,13 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
             // and disagree for the annotated ones — a deref-copy binds at the
             // value type where the RHS is a handle, and a mutable variable introduction
             // binds at the handle where the RHS is a value.
-            match resolve_var_type(&binding.ty) {
-                Ok(ty) => binding.ty = ty,
-                Err(err) => {
-                    let label = format!("let binding `{}`", binding.name);
-                    ctx.push_error(map_coalesce_err(err, &label), label);
-                }
-            }
+            let name = binding.name.clone();
+            resolve_binder_slot(
+                &mut binding.ty,
+                || format!("let binding `{name}`"),
+                level,
+                ctx,
+            );
             let binding_name = binding.name.clone();
             with_shadows(ctx, [binding_name], |ctx| coalesce_node(body, level, ctx));
         }
@@ -967,13 +1094,8 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
             body,
         } => {
             coalesce_node(init, level + 1, ctx);
-            match resolve_var_type(&binding.ty) {
-                Ok(ty) => binding.ty = ty,
-                Err(err) => {
-                    let label = format!("mutable `{}`", binding.name);
-                    ctx.push_error(map_coalesce_err(err, &label), label);
-                }
-            }
+            let name = binding.name.clone();
+            resolve_binder_slot(&mut binding.ty, || format!("mutable `{name}`"), level, ctx);
             let binding_name = binding.name.clone();
             with_shadows(ctx, [binding_name], |ctx| coalesce_node(body, level, ctx));
         }
@@ -1065,6 +1187,15 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
             if let Some(s) = scrutinee {
                 coalesce_node(s, level, ctx);
             }
+            // Before any occurrence of an arm's payload variable is read: an arm
+            // nothing reaches and whose body ignores its binder has no bound at
+            // all, and needs one recorded on the *variable* to resolve
+            // consistently everywhere it appears.
+            for b in branches.iter() {
+                if let Some(p) = &b.pattern {
+                    pin_unobservable_arm_payload(p);
+                }
+            }
             for b in branches.iter_mut() {
                 // A pattern's payload binding scopes the branch's guard and
                 // body, shadowing an outer generalized binding of its name.
@@ -1078,13 +1209,13 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
                 // `Pattern::binding.ty`; run it through the same pipeline used
                 // for `expr.ty` so it ends up concrete.
                 if let Some(p) = &mut b.pattern {
-                    match resolve_var_type(&p.binding.ty) {
-                        Ok(ty) => p.binding.ty = ty,
-                        Err(err) => {
-                            let label = format!("Case pattern `.{}` payload", p.tag);
-                            ctx.push_error(map_coalesce_err(err, &label), label);
-                        }
-                    }
+                    let tag = p.tag.clone();
+                    resolve_binder_slot(
+                        &mut p.binding.ty,
+                        || format!("Case pattern `.{tag}` payload"),
+                        level,
+                        ctx,
+                    );
                 }
             }
         }
@@ -1115,13 +1246,7 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
             with_shadows(ctx, [target_name], |ctx| coalesce_node(body, level, ctx));
             // Binder slot: resolve the target's element type in place, like
             // `Loop` params (`emit_for` wrote the slot var).
-            match resolve_var_type(&target.ty) {
-                Ok(ty) => target.ty = ty,
-                Err(err) => {
-                    let label = "For target".to_string();
-                    ctx.push_error(map_coalesce_err(err, &label), label);
-                }
-            }
+            resolve_binder_slot(&mut target.ty, || "For target".to_string(), level, ctx);
         }
         // `Transact` is born by `planning::plan_loops`, after inference (and
         // so after coalesce), so a `Transact` never reaches here.
@@ -1145,13 +1270,13 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
             // Binder slots: resolve each declared type in place (`emit_letrec`
             // normalized the slot, possibly to a fresh var for a `Hole`).
             for (binding, _) in bindings.iter_mut() {
-                match resolve_var_type(&binding.ty) {
-                    Ok(ty) => binding.ty = ty,
-                    Err(err) => {
-                        let label = format!("LetRec binding `{}`", binding.name);
-                        ctx.push_error(map_coalesce_err(err, &label), label);
-                    }
-                }
+                let name = binding.name.clone();
+                resolve_binder_slot(
+                    &mut binding.ty,
+                    || format!("LetRec binding `{name}`"),
+                    level,
+                    ctx,
+                );
             }
         }
 

--- a/src/ccl/infer/solver/traits.rs
+++ b/src/ccl/infer/solver/traits.rs
@@ -496,6 +496,25 @@ impl TraitObligation {
         Ok(())
     }
 
+    /// The types the surviving instances still accept at operand position `pos`.
+    ///
+    /// The operand-side reading of [`agreed_assoc`](Self::agreed_assoc), and
+    /// deliberately a *set* rather than an `Option`: an associated position is
+    /// deposited only once the candidates agree, because depositing a guess would
+    /// constrain a live program. Nothing here is deposited — the caller is choosing
+    /// a type for an operand no bound will ever reach, so what it needs is the
+    /// choices, not a verdict that there is exactly one.
+    ///
+    /// Order follows the instance table, so a caller that picks positionally picks
+    /// reproducibly.
+    pub fn accepted_at(&self, pos: u8) -> Vec<BaseType> {
+        self.candidates
+            .borrow()
+            .iter()
+            .filter_map(|i| i.args.get(pos as usize).cloned())
+            .collect()
+    }
+
     /// The type every surviving instance associates with `name`, or `None` if
     /// they disagree — the condition a deposit waits on.
     fn agreed_assoc(&self, name: Assoc) -> Option<BaseType> {

--- a/tests/inference_variants.rs
+++ b/tests/inference_variants.rs
@@ -7,11 +7,13 @@
 //! integration — without depending on CHL surface syntax for variants
 //! (which is a separate workstream).
 
+use cambra::ccl::ArithmeticKind;
 use cambra::ccl::{
     Branch, FieldKey, Lit, Pattern, Type, TypedBinding, TypedExpr, TypedExprNode,
     infer::{InferError, LocatedInferError, TypeInferenceContext, infer},
 };
 use cambra::interpreter::BaseType;
+use rstest::rstest;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -361,13 +363,11 @@ fn lambda_returns_variant() {
 /// `if True then .Some(1) else .None(())` — Case unifies the two variant
 /// branches at the positive polarity, yielding the union of tags.
 ///
-/// **Ignored**: `emit_case` uses two-way constrain to unify arm bodies,
-/// which forces equality and rejects width-distinct variants. Same root
-/// cause as the bidirectional-Apply hack — see §3.1. The conceptually
-/// correct behaviour is to drop a single-direction lower-bound constraint
-/// for arm bodies, which depends on the same let-polymorphism cleanup.
+/// The payload of a tag only *one* arm carries keeps that arm's value claim: the
+/// join intersects claims across arms that meet, and these two never do — one
+/// carries `Some`, the other `None`. So `Some`'s payload stays the singleton `1`
+/// rather than widening to `Int`.
 #[test]
-#[ignore = "blocked by two-way Case arm constraining; needs let-polymorphism"]
 fn if_returns_variant() {
     let arms = vec![
         Branch {
@@ -386,10 +386,11 @@ fn if_returns_variant() {
         branches: arms,
     });
     let ty = run(expr).expect("inference ok");
-    // Both arms get mutually constrained; the resulting type is the
-    // first arm's type after the second arm flowed into it as a
-    // lower bound. Coalesce at positive polarity unions the tags.
-    let expected = variant(&[("None", unit_ty()), ("Some", int())]);
+    // Each arm flows one-way into a shared result variable, so coalescing at
+    // positive polarity unions the tags. `Some`'s payload is the literal's
+    // singleton, not `Int`, because no sibling arm carries `Some` to intersect it
+    // with.
+    let expected = variant(&[("None", unit_ty()), ("Some", int_lit(1))]);
     assert_eq!(ty, expected, "expected union of tags, got {ty}");
 }
 
@@ -400,11 +401,7 @@ fn if_returns_variant() {
 /// `.A(5)` flowing into a `[A(Int), B(Str)]`-annotated lambda parameter.
 /// Payload covariance accepts the Int payload against the Int slot.
 ///
-/// **Ignored**: same bidirectional-Apply collapse as
-/// `variant_param_accepts_subtype`. Will pass once the let-polymorphism
-/// work replaces the hack.
 #[test]
-#[ignore = "blocked by bidirectional Apply equality-collapse; needs let-polymorphism"]
 fn payload_covariance_accept() {
     let param_ty = variant(&[("A", int()), ("B", string())]);
     let lambda = TypedExpr::new(TypedExprNode::Lambda {
@@ -437,4 +434,162 @@ fn payload_mismatch_reject() {
         run(TypedExpr::apply(arg, lambda)).is_err(),
         "Int payload should not satisfy String payload slot"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Group F — Payloads of arms nothing reaches
+// ---------------------------------------------------------------------------
+
+/// The payload type recorded for the arm named `tag`, found by descending to the
+/// first `Case` in the tree (monomorphization wraps the lambda in a `let`).
+fn arm_payload_ty(expr: &TypedExpr, tag: &str) -> Type {
+    fn find(expr: &TypedExpr, tag: &str) -> Option<Type> {
+        if let TypedExprNode::Case { branches, .. } = &expr.node {
+            for b in branches {
+                if let Some(p) = &b.pattern
+                    && p.tag == tag
+                {
+                    return Some(p.binding.ty.clone());
+                }
+            }
+        }
+        let mut found = None;
+        expr.walk_children(|c| {
+            if found.is_none() {
+                found = find(c, tag);
+            }
+        });
+        found
+    }
+    find(expr, tag).unwrap_or_else(|| panic!("no arm `{tag}` in tree"))
+}
+
+/// ``let f = λ x → match x { `a(v) → v; `b(w) → 0 } in `a(1) ▷ f``.
+///
+/// The `b` arm is unreachable (the argument carries only `a`) *and* ignores its
+/// binder, so nothing in the program constrains its payload. Inference must
+/// still produce a fully concrete tree: the variable is pinned to `Unit` in the
+/// constraint graph, so the binder slot **and** the lambda's parameter type
+/// agree on it. Before the pin, `f`'s domain kept a bare `Infer` and the
+/// post-inference wall rejected this program.
+#[test]
+fn unobservable_arm_payload_resolves_everywhere() {
+    let body = TypedExpr::new(TypedExprNode::Case {
+        scrutinee: Some(Box::new(var("x"))),
+        branches: vec![
+            arm("a", "v", None, var("v")),
+            arm("b", "w", None, lit_int(0)),
+        ],
+    });
+    let lambda = TypedExpr::lambda("x", Type::Hole, body);
+    let call = TypedExpr::apply(TypedExpr::variant_ctor("a", lit_int(1)), var("f"));
+    let full = run_full(TypedExpr::let_bind("f", lambda, call)).expect("inference ok");
+
+    assert_eq!(arm_payload_ty(&full, "b"), unit_ty());
+    // The wall the residual variable used to fail: no `Infer` left anywhere,
+    // including inside the lambda's parameter type.
+    cambra::ccl::infer::check_fully_typed(&full)
+        .expect("an unobservable payload leaves no unresolved variable");
+}
+
+/// The same lambda applied to `` `b(2) `` instead.
+///
+/// Now a *call site* constrains the payload the arm ignores, and that
+/// application is emitted after the `Case` it applies to. The payload must come
+/// from the argument rather than being pinned, which is why the pin runs once
+/// constraint emission is complete rather than at the end of `emit_case`.
+#[test]
+fn ignored_arm_payload_still_takes_its_argument_type() {
+    let body = TypedExpr::new(TypedExprNode::Case {
+        scrutinee: Some(Box::new(var("x"))),
+        branches: vec![
+            arm("a", "v", None, lit_int(0)),
+            arm("b", "w", None, lit_int(0)),
+        ],
+    });
+    let lambda = TypedExpr::lambda("x", Type::Hole, body);
+    let call = TypedExpr::apply(TypedExpr::variant_ctor("b", lit_int(2)), var("f"));
+    let full = run_full(TypedExpr::let_bind("f", lambda, call)).expect("inference ok");
+
+    assert_eq!(arm_payload_ty(&full, "b"), int_lit(2));
+    cambra::ccl::infer::check_fully_typed(&full).expect("fully typed");
+}
+
+/// An arm that *reads* its binder needs no pin: the read is an upper bound, so
+/// the variable is constrained and coalesces from its use.
+///
+/// Here the use is "be the arm's result", and the result joins with the reachable
+/// arm's — so the unreachable arm's binder comes out as the singleton `1` that
+/// arm produced. The assertion is that specific type rather than merely "not
+/// `Unit`", since what is being pinned down is *where* a read binder gets its
+/// type from.
+#[test]
+fn read_arm_payload_is_not_pinned() {
+    let body = TypedExpr::new(TypedExprNode::Case {
+        scrutinee: Some(Box::new(var("x"))),
+        branches: vec![arm("a", "v", None, var("v")), arm("b", "w", None, var("w"))],
+    });
+    let lambda = TypedExpr::lambda("x", Type::Hole, body);
+    let call = TypedExpr::apply(TypedExpr::variant_ctor("a", lit_int(1)), var("f"));
+    let full = run_full(TypedExpr::let_bind("f", lambda, call)).expect("inference ok");
+
+    assert_eq!(arm_payload_ty(&full, "b"), int_lit(1));
+    cambra::ccl::infer::check_fully_typed(&full).expect("fully typed");
+}
+
+/// What an unreachable arm's payload is pinned to when its body **reads** the
+/// binder.
+///
+/// [`unobservable_arm_payload_resolves_everywhere`] covers the body that ignores
+/// its binder: nothing observes the payload, so `Unit` carries no information and
+/// is the honest choice. A body that reads it observes it, and states what it
+/// needs as a trait obligation — so `Unit` would contradict the read. The pin
+/// takes a type the requirements still accept instead.
+///
+/// The cases below are chosen to separate the two halves of that choice:
+///
+/// - `w + 1` narrows `Addable` to one row via the literal, so the choice is forced.
+/// - `w + w` narrows nothing — every `Addable` row (`Int`, `UInt`, `String`) still
+///   stands. **Any of them would do**, since the arm is unreachable and no value
+///   ever flows through the binder; the table's order decides, so the test pins
+///   reproducibility, not meaning.
+/// - `w - w` draws from a *different* table (`Subtractable` has no `String` row),
+///   which is what shows the choice comes from the obligation rather than a
+///   hardcoded default.
+/// - `-w` is `Negatable`, whose single row forces `Int` with nothing else to go on.
+///
+/// Every case would be `Unit` without the fix, and `Unit` satisfies none of these
+/// requirements — so each one also pins that the pin no longer contradicts the read.
+#[rstest]
+#[case::add_literal_narrows(ArithmeticKind::Add, true, BaseType::Int)]
+#[case::add_self_ambiguous(ArithmeticKind::Add, false, BaseType::Int)]
+#[case::sub_self_numeric_only(ArithmeticKind::Sub, false, BaseType::Int)]
+fn read_arm_payload_is_pinned_to_a_type_its_reads_accept(
+    #[case] op: ArithmeticKind,
+    #[case] against_literal: bool,
+    #[case] expected: BaseType,
+) {
+    use cambra::ccl::BinOpKind;
+
+    let rhs = if against_literal {
+        lit_int(1)
+    } else {
+        var("w")
+    };
+    let read = TypedExpr::new(TypedExprNode::BinOp {
+        left: Box::new(var("w")),
+        op: BinOpKind::Arithmetic(op),
+        right: Box::new(rhs),
+    });
+    let body = TypedExpr::new(TypedExprNode::Case {
+        scrutinee: Some(Box::new(var("x"))),
+        branches: vec![arm("a", "v", None, var("v")), arm("b", "w", None, read)],
+    });
+    let lambda = TypedExpr::lambda("x", Type::Hole, body);
+    let call = TypedExpr::apply(TypedExpr::variant_ctor("a", lit_int(1)), var("f"));
+    let full = run_full(TypedExpr::let_bind("f", lambda, call)).expect("inference ok");
+
+    assert_eq!(arm_payload_ty(&full, "b"), Type::Base(expected));
+    cambra::ccl::infer::check_fully_typed(&full)
+        .expect("a read payload leaves no unresolved variable");
 }


### PR DESCRIPTION
A `match` arm naming a tag the scrutinee cannot carry gets no lower bound from width subtyping, so nothing determines that payload's type. The arm is ordinary code, but its variable survived coalesce as a `Type::Infer` and the post-inference wall rejected the program — the shape the most ordinary `Option` match produces. Inference now pins such a payload, recorded on the **variable** rather than in the binder slot so every occurrence agrees, including the enclosing lambda's parameter type where the residual variable actually surfaced. Mechanism and the two ordering constraints that put the pin inside the coalesce walk: [type-inference.md](src/ccl/design/type-inference.md#an-unobservable-arm-payload-defaults-to-unit).

## Which type it pins to

`Unit` when the body ignores its binder. When the body *reads* it, `Unit` contradicts that read: an operator states what it requires of its operands rather than equating them, so `v + 1` leaves the payload unbound while still demanding `Addable` of it. The requirements choose instead. `v + v` narrows them to no single row, and any will do since the arm is unreachable, so one is taken by table order. `pin_unobservable_arm_payload` carries the argument, including why bounded quantification is the real answer.

## Binder slots resolve their predicates

Independent, and reached by this pin's own tests. Resolving a binder slot settled the type's structure but not the refinement predicates riding it. The memo redirects only the occurrences it visits, so a skipped slot kept a pre-coalesce `Rc` full of unresolved variables. All five slots now share one `resolve_binder_slot` doing both halves. Only a *value* binding exposes it — a `groupby`, or a `match` over a conditionally-built collection — since a generalized binding is re-coalesced per specialization.