### PR TITLE
A variant type is spelled as its arms, so `Option` stops being the only one

### DIFF
--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -978,22 +978,38 @@ A leading dot is a constructor; a dot with an expression to its left
 stays attribute access (§3.9). A constructor is an ordinary atom, so it
 takes a postfix chain: `.some(r).x` is the attribute `x` of `.some(r)`.
 
-`Option(T)` abbreviates `{some: T, none: None}` and is a built-in type
-constructor in the same category as `List(T)` and `Map(K, V)` (§6.1) —
-not a distinguished kind of type. Nothing in the language privileges the
-spellings `some` and `none`; they are ordinary tags.
+A **variant type** is written as its arms, separated by `|`:
 
-> **Direction [Tentative].** Tags are undeclared today, so a *misspelled*
-> tag is caught only where it fails to meet its counterpart, and a
-> constructor's payload arity is not checked at the constructor. The
-> planned refinement is the structural type alias of §6.1 —
-> `Option(T) = some(T) | none`, `Result(T) = ok(T) | err(String)` — which
-> gives a tag a resolution site, checks the payload there, and would let
-> the disambiguating dot be dropped for a *declared* tag while keeping it
-> for an ad-hoc one. It would also replace the built-in `Option(T)` above
-> with a prelude definition. An alias is still structural: it names a
-> shape, so two aliases with the same tags are the same type. Nominality
-> is the separate `type` declaration direction (§6.1).
+```python
+x: some(Int) | none = .some(1)
+y: ok(Int) | err(String) = .err("nope")
+```
+
+Each arm is a tag with its payload type, `tag(T)`, or a bare `tag` for a tag
+carrying no payload. The arms are a *set*: they canonicalize by tag name, so
+`none | some(Int)` and `some(Int) | none` are the same type.
+
+`|` is also the logical-or operator (§3.4), and the two never collide, because
+an arm's head is lowercase where a type is capitalized (§6.1): in type position
+`some(Int)` can only be the tag `some` carrying `Int`, and a capitalized arm is
+rejected as a type where a tag belongs. In *term* position `|` is unaffected.
+
+`Option(T)` abbreviates `some(T) | none` and is a built-in type constructor in
+the same category as `List(T)` and `Map(K, V)` (§6.1) — not a distinguished kind
+of type, and interchangeable with writing those arms out. Nothing in the
+language privileges the spellings `some` and `none`; they are ordinary tags.
+
+> **Direction [Tentative].** A variant type can be *written* but not yet
+> *named*: tags have no declaration site, so a misspelled tag is caught only
+> where it fails to meet its counterpart, and a constructor's payload arity is
+> not checked at the constructor. The planned refinement is the structural type
+> alias of §6.1 — `Option(T) = some(T) | none`,
+> `Result(T) = ok(T) | err(String)` — which gives a tag a resolution site,
+> checks the payload there, and would let the disambiguating dot be dropped for
+> a *declared* tag while keeping it for an ad-hoc one. It would also replace the
+> built-in `Option(T)` above with a prelude definition. An alias is still
+> structural: it names a shape, so two aliases with the same tags are the same
+> type. Nominality is the separate `type` declaration direction (§6.1).
 
 ---
 

--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -5,9 +5,10 @@ use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
 
 use super::*;
 use crate::{
-    ccl::{BaseType, Branch, Expr, Lit, Pattern, Type, TypedBinding, TypedExprNode},
+    ccl::{BaseType, Branch, Expr, FieldKey, Lit, Pattern, Type, TypedBinding, TypedExprNode},
     chl_parser::ast::{
-        AssignTarget, IfBranch, Lit as ChlLit, MatchArm, Span, Spanned, Stmt as ChlStmt,
+        AssignTarget, BinOp as ChlBinOp, IfBranch, Lit as ChlLit, MatchArm, Span, Spanned,
+        Stmt as ChlStmt,
     },
     interpreter::{DataSink, HttpServerDataSource, http_server::SharedHttpServer},
 };
@@ -974,6 +975,18 @@ pub(super) fn lower_type_annotation(annotation: &Spanned<ChlExpr>) -> Result<Typ
             let head = type_ctor_head(func)?;
             lower_type_application(annotation.span, head, args)
         }
+        // Variant type `tag(T) | tag2 | …` — a `|`-chain of tag forms.
+        //
+        // `|` lexes as the logical-or operator, so the chain arrives as nested
+        // `BinOp` nodes. The two readings never collide: in *type* position there
+        // is no boolean to disjoin, and an arm's head is lowercase, which
+        // `docs/chl-spec.md` reserves for terms — so `some(Int)` here can only be
+        // the tag `some` carrying `Int`, never a type application. `List(T)` and
+        // `Option(T)` keep working because they are capitalized.
+        ChlExpr::BinOp {
+            op: ChlBinOp::LogicalOr,
+            ..
+        } => lower_variant_type(annotation),
         // Record type `{name: T, …}`.
         ChlExpr::BraceRecord(fields) => {
             let mut out = Vec::with_capacity(fields.len());
@@ -1003,6 +1016,94 @@ pub(super) fn lower_type_annotation(annotation: &Spanned<ChlExpr>) -> Result<Typ
             format!("unsupported type annotation form: {:?}", annotation.node),
         )),
     }
+}
+
+/// Lower a `|`-chain of tag forms into a [`Type::Variant`].
+///
+/// Arms are canonicalized into **name order**, matching [`Type::option_of`] and the
+/// order the solver materializes a coalesced variant in. Without that, a
+/// hand-written `some(T) | none` would be a distinct type from `Option(T)` that
+/// merely happens to carry the same arms, and an annotation written in the other
+/// order would not compare equal to what inference produced.
+fn lower_variant_type(ann: &Spanned<ChlExpr>) -> Result<Type, LoweringError> {
+    let mut arms: Vec<(FieldKey, Type)> = Vec::new();
+    collect_variant_arms(ann, &mut arms)?;
+    arms.sort_by(|(a, _), (b, _)| a.cmp(b));
+    if let Some(dup) = arms.windows(2).find(|w| w[0].0 == w[1].0) {
+        return Err(LoweringError::unsupported(
+            ann.span,
+            format!(
+                "variant type names the tag `{}` twice; each tag carries one payload type",
+                dup[0].0
+            ),
+        ));
+    }
+    Ok(Type::Variant(arms))
+}
+
+/// Flatten one arm (or a nested `|`) of a variant type into `arms`.
+fn collect_variant_arms(
+    ann: &Spanned<ChlExpr>,
+    arms: &mut Vec<(FieldKey, Type)>,
+) -> Result<(), LoweringError> {
+    match &ann.node {
+        ChlExpr::BinOp {
+            left,
+            op: ChlBinOp::LogicalOr,
+            right,
+        } => {
+            collect_variant_arms(left, arms)?;
+            collect_variant_arms(right, arms)
+        }
+        // A bare tag carries no payload, so its payload type is `Unit` — the same
+        // type the nullary constructor `.tag` injects.
+        ChlExpr::Name(id) => {
+            arms.push((
+                variant_arm_tag(id.as_str(), ann.span)?,
+                Type::Base(BaseType::Unit),
+            ));
+            Ok(())
+        }
+        ChlExpr::Call { func, args } => {
+            let head = type_ctor_head(func)?;
+            let [payload] = args.as_slice() else {
+                return Err(LoweringError::unsupported(
+                    ann.span,
+                    format!(
+                        "a variant arm carries exactly one payload type: `{head}(T)` \
+                         (or `{head}` for no payload)"
+                    ),
+                ));
+            };
+            arms.push((
+                variant_arm_tag(head, func.span)?,
+                lower_type_annotation(payload)?,
+            ));
+            Ok(())
+        }
+        _ => Err(LoweringError::unsupported(
+            ann.span,
+            "a variant type's arms are tags: `some(Int) | none`",
+        )),
+    }
+}
+
+/// A variant arm's tag, rejecting a capitalized head.
+///
+/// `docs/chl-spec.md` reserves `Caps` for types without exception, so a
+/// capitalized arm is a type where a tag belongs — most likely a union of types
+/// was intended, which is not a form CHL has.
+fn variant_arm_tag(head: &str, span: Span) -> Result<FieldKey, LoweringError> {
+    if head.starts_with(char::is_uppercase) {
+        return Err(LoweringError::unsupported(
+            span,
+            format!(
+                "`{head}` is a type, but a variant arm names a tag, which is lowercase \
+                 (`some(Int) | none`)"
+            ),
+        ));
+    }
+    Ok(FieldKey::Name(head.into()))
 }
 
 /// Resolve a capitalized primitive type name (`Caps` means type —

--- a/tests/compilation_pipeline/variants.rs
+++ b/tests/compilation_pipeline/variants.rs
@@ -23,6 +23,8 @@ use cambra::interpreter::Value;
 use rstest_log::rstest;
 
 use cambra::ccl::FieldKey;
+use cambra::ccl::context::{GlobalContext, compile_program};
+use cambra::interpreter::Consumer;
 
 use crate::helpers::*;
 
@@ -284,5 +286,92 @@ fn test_match_default_arm(#[case] code: &str, #[case] expected: Value) {
     Value::String("hello".into())
 )]
 fn test_match_on_parameter(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Variant *types*
+//
+// `tag(T) | tag2` is the structural variant type. `|` lexes as the logical-or
+// operator, so a variant type arrives as a `|`-chain of tag forms and is
+// distinguished by position, not by a token of its own: in type position there is
+// no boolean to disjoin, and an arm's head is lowercase, which the spec reserves
+// for terms. `Option(T)` is capitalized and so stays a type application.
+//
+// Arms canonicalize into name order, which is what makes a hand-written
+// `some(T) | none` *the same type* as `Option(T)` rather than a look-alike.
+// ---------------------------------------------------------------------------
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// A payload arm and a nullary arm, against the value each admits.
+#[case(
+    "n: Int = 1\nx: some(Int) | none = .some(n)\nx",
+    union("some", Value::Int(1))
+)]
+#[case("x: some(Int) | none = .none\nx", union("none", Value::Unit))]
+// Arm order is not part of the type: the tags canonicalize by name.
+#[case(
+    "n: Int = 1\nx: none | some(Int) = .some(n)\nx",
+    union("some", Value::Int(1))
+)]
+// More than two arms, with distinct payload types.
+#[case(
+    "x: a(Int) | b(String) | c = .b(\"s\")\nx",
+    union("b", Value::String("s".into()))
+)]
+// A payload that is itself a variant type.
+#[case(
+    "n: Int = 1\nx: outer(some(Int) | none) | done = .outer(.some(n))\nx",
+    union("outer", union("some", Value::Int(1)))
+)]
+fn test_variant_type_annotation(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+/// A variant type is interchangeable with the `Option(T)` abbreviation for the
+/// same tags — it is not a distinct type that happens to have the same arms — so
+/// `match` dispatches over it exactly as it does over an annotated `Option`.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case(
+    "n: Int = 1\nx: some(Int) | none = .some(n)\nmatch x:\n    case some(v):\n        v\n    case none:\n        0",
+    Value::Int(1)
+)]
+#[case(
+    "x: some(Int) | none = .none\nmatch x:\n    case some(v):\n        v\n    case none:\n        0",
+    Value::Int(0)
+)]
+fn test_variant_type_dispatches_like_option(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+/// The annotation is a real constraint: a value carrying a tag the type does not
+/// name, or the wrong payload for a tag it does, is an annotation mismatch.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case("x: some(Int) | none = .some(\"s\")\nx")]
+#[case("x: some(Int) | none = .other(1)\nx")]
+// A capitalized arm is a type where a tag belongs (the spec reserves `Caps` for
+// types), and each tag carries exactly one payload type.
+#[case("x: Some(Int) | none = .some(1)\nx")]
+#[case("x: some(Int) | some(String) = .some(1)\nx")]
+#[case("x: some(Int, String) | none = .some(1)\nx")]
+fn test_variant_type_rejections(#[case] code: &str) {
+    let mut ctx = GlobalContext::default();
+    let consumer: Box<dyn Consumer> = Box::new(|| {});
+    assert!(
+        compile_program(&mut ctx, code, consumer).is_err(),
+        "expected a diagnostic for `{code}`"
+    );
+}
+
+/// `|` in *term* position is still logical or — the type reading is positional,
+/// so giving variant types a spelling took nothing away from expressions.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case("a: Bool = True\nb: Bool = False\n(a | b)", Value::Bool(true))]
+#[case("a: Bool = False\nb: Bool = False\n(a | b)", Value::Bool(false))]
+fn test_pipe_is_still_logical_or(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }


### PR DESCRIPTION
`Option(T)` was the only variant type that could be written down. Anything else had to be inferred, which made the annotation path — and every rejection that depends on it — testable at exactly one shape.

A variant type is now written as its arms:

```python
x: some(Int) | none = .some(1)
y: ok(Int) | err(String) = .err("nope")
```

An arm is `tag(T)`, or a bare `tag` for one carrying no payload — the same `Unit` payload the nullary constructor `.tag` injects.

**This needed no parser work.** Annotations are parsed as ordinary expressions and *interpreted* as types by `lower_type_annotation`, and `|` already lexes and folds as logical-or, so `some(Int) | none` has always parsed — it just had no type reading. This adds that reading: a `|`-chain in type position flattens into a `Type::Variant`.

The two readings of `|` cannot collide, and it is the spec's existing capitalization rule that separates them rather than anything new: `Caps` is reserved for types, so a *lowercase* head in type position can only be a tag. `some(Int)` is the tag `some` carrying `Int`; `List(Int)` and `Option(Int)` keep working because they are capitalized; a capitalized arm is rejected as a type where a tag belongs. `|` in term position is untouched, which a test pins.

**Arms canonicalize into name order**, matching `Type::option_of` and the order the solver materializes a coalesced variant in. That is what makes `some(T) | none` *the same type* as `Option(T)` rather than a look-alike that happens to carry the same arms — so `match` dispatches over it identically, and an annotation written `none | some(Int)` compares equal to what inference produced. Without it, the tag-order mismatch that keeps `variant_param_accepts_subtype` ignored would have become reachable from source.

Rejections carry their own diagnostics: a capitalized arm, a tag named twice, and an arm with more than one payload type are each reported at lowering with the shape that was expected.

`chl-spec.md` gains the syntax and loses an inaccuracy in the same passage: it described `Option(T)` as abbreviating `{some: T, none: None}`, but braces are *record* type syntax — the shape it names is `some(T) | none`. The §3.15 Direction narrows to what is still open, which is *naming* a variant type (a declaration site for tags, and payload arity checked at the constructor), not writing one.

Tests cover a payload arm and a nullary arm, arm-order insensitivity, three arms with distinct payloads, a variant payload nested inside a variant type, `match` over an annotated variant type behaving as it does over `Option`, all five rejections, and `|` still meaning logical-or in term position.

Thanks for putting this together — but a heads-up before you go further: Cambra isn't accepting external pull requests right now. See [CONTRIBUTING.md](../CONTRIBUTING.md) for why, and for what to do instead.

If this is a bug fix, the fastest path is to open an issue describing (or attaching) the patch — small, clearly-correct fixes may get applied as a team commit with credit to you.

This PR will likely be closed unreviewed. That's about where the project is right now, not a judgment on the change.
