### PR TITLE
Reserve http test ports with a held lock, not a released bind hint

### DIFF
--- a/src/interpreter/http_server.rs
+++ b/src/interpreter/http_server.rs
@@ -118,67 +118,6 @@ impl SharedHttpServer {
         Ok(Self { routes })
     }
 
-    /// Reserve a port for a test program's `http_serve`, held against every other
-    /// concurrent test process for the rest of this process's life.
-    ///
-    /// **Test-only.** Shared through the default-off `test-helpers` feature so the
-    /// integration-test crates hold one implementation rather than a copy each.
-    ///
-    /// The obvious allocator — bind `:0`, read the port the kernel assigned,
-    /// close — is unsound here, and flakily so.  Closing makes the port a *hint*
-    /// that nothing owns: the listener that will really own it is [`Self::new`]'s,
-    /// opened at the far end of `compile_program`, and until then `bind(:0)` in a
-    /// *concurrently running test binary* is free to hand the very same port out
-    /// again.  Both compiles then race to bind it and the loser fails with
-    /// `EADDRINUSE`, surfacing as a lowering error from `http_serve`.  Under
-    /// `cargo test`, where the http test binaries run alongside each other, that
-    /// is the whole of the observed flakiness (measured: 13 failures in 7200
-    /// allocations at 24-way concurrency, every one of them a port two processes
-    /// had been handed at once).
-    ///
-    /// So the reservation has to be held by something that outlives the hint.  An
-    /// advisory lock on a per-port file does it: exclusive across processes,
-    /// released by the OS on exit, so a crashed run cannot permanently blacklist
-    /// a port the way a leftover lock *file* would.  Sequential allocation from
-    /// `BASE` is then collision-free by construction rather than by luck — the
-    /// lock, not chance, decides who gets a port.  The bind probe covers the one
-    /// thing the lock cannot: a *foreign* process already listening there.
-    #[cfg(any(test, feature = "test-helpers"))]
-    pub fn reserve_test_port() -> u16 {
-        use std::{fs::File, net::TcpListener, sync::Mutex};
-
-        /// Below the lowest `ip_local_port_range` floor in practice (32768 on
-        /// Linux, higher on macOS and Windows) so the kernel's own allocator
-        /// never draws from this band for outbound connections, and clear of the
-        /// privileged range.
-        const BASE: u16 = 20_000;
-        const SPAN: u16 = 10_000;
-
-        /// Every lock this process holds.  The reservation must outlive the call —
-        /// the server binds later, inside `compile_program` — and a test has no
-        /// scope to keep a guard in, so the locks live until the process exits.
-        static RESERVED: Mutex<Vec<File>> = Mutex::new(Vec::new());
-
-        let dir = std::env::temp_dir();
-        for candidate in BASE..BASE + SPAN {
-            let Ok(lock) = File::create(dir.join(format!("cambra-test-port-{candidate}.lock")))
-            else {
-                continue;
-            };
-            if lock.try_lock().is_err() {
-                continue;
-            }
-            // Probe the same wildcard address `Server::http` will bind, so a
-            // listener on any interface — not just loopback — rules the port out.
-            if TcpListener::bind(("0.0.0.0", candidate)).is_err() {
-                continue;
-            }
-            RESERVED.lock().unwrap().push(lock);
-            return candidate;
-        }
-        panic!("no test port available in {BASE}..{}", BASE + SPAN)
-    }
-
     /// Register a new `(method, path)` route and return the `Receiver` for incoming requests.
     ///
     /// Requests matching this route will be sent on the returned channel.  A value of `None`
@@ -191,6 +130,99 @@ impl SharedHttpServer {
         let (tx, rx) = mpsc::channel();
         self.routes.lock().unwrap().insert((method, path), tx);
         rx
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test port reservation
+// ---------------------------------------------------------------------------
+
+/// Reserve a port for a test program's `http_serve`, held against every other
+/// concurrent test — thread or process — for the rest of this process's life.
+///
+/// **Test-only.** Shared through the default-off `test-helpers` feature so the
+/// integration-test crates hold one implementation rather than a copy each.
+///
+/// The obvious allocator — bind `:0`, read the port the kernel assigned,
+/// close — is unsound here, and flakily so.  Closing makes the port a *hint*
+/// that nothing owns: the listener that will really own it is
+/// [`SharedHttpServer::new`]'s, opened at the far end of `compile_program`, and
+/// until then `bind(:0)` in a *concurrently running test binary* is free to hand
+/// the very same port out again.  Both compiles then race to bind it and the
+/// loser fails with `EADDRINUSE`, surfacing as a lowering error from
+/// `http_serve`.  Under `cargo test`, where the http test binaries run alongside
+/// each other, that is the whole of the observed flakiness (measured: 13
+/// failures in 7200 allocations at 24-way concurrency, every one of them a port
+/// two processes had been handed at once).
+///
+/// So the reservation has to be held by something that outlives the hint.  An
+/// advisory lock on a per-port file does it: exclusive across processes,
+/// released by the OS on exit, so a crashed run cannot permanently blacklist
+/// a port the way a leftover lock *file* would.  Sequential allocation from
+/// `BASE` is then collision-free by construction rather than by luck — the
+/// lock, not chance, decides who gets a port.  The bind probe covers the one
+/// thing the lock cannot: a *foreign* process already listening there.
+///
+/// The exclusion has to hold *within* a process too, since `cargo test` runs a
+/// binary's tests as threads of one process.  It does because [`File::try_lock`]
+/// locks the open file description (`flock`, not a per-process `fcntl` lock), so
+/// the second `File::create` of the same path contends with the first exactly as
+/// another process would.  That property is what
+/// `tests/reserve_port.rs` pins: were it to lapse, this allocator would go back
+/// to handing one port to two callers, and the flakiness would return unchanged.
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn reserve_test_port() -> u16 {
+    use std::{fs::File, net::TcpListener, sync::Mutex};
+
+    /// Below the lowest `ip_local_port_range` floor in practice (32768 on
+    /// Linux, higher on macOS and Windows) so the kernel's own allocator
+    /// never draws from this band for outbound connections, and clear of the
+    /// privileged range.
+    const BASE: u16 = 20_000;
+    const SPAN: u16 = 10_000;
+
+    /// Every lock this process holds.  The reservation must outlive the call —
+    /// the server binds later, inside `compile_program` — and a test has no
+    /// scope to keep a guard in, so the locks live until the process exits.
+    static RESERVED: Mutex<Vec<File>> = Mutex::new(Vec::new());
+
+    let dir = std::env::temp_dir();
+    let mut last_create_err = None;
+    for candidate in BASE..BASE + SPAN {
+        let lock = match File::create(dir.join(format!("cambra-test-port-{candidate}.lock"))) {
+            Ok(lock) => lock,
+            // Failing to *create* the lock file is not a port being in use, and
+            // the causes are per-directory rather than per-port: a read-only or
+            // full `TMPDIR`, a descriptor limit, or a shared `/tmp` whose lock
+            // files belong to another user.  Each of those rejects all 10 000
+            // candidates, so without the error the loop reports port exhaustion
+            // and points the reader at concurrency limits instead.
+            Err(e) => {
+                last_create_err = Some(e);
+                continue;
+            }
+        };
+        if lock.try_lock().is_err() {
+            continue;
+        }
+        // Probe the same wildcard address `Server::http` will bind, so a
+        // listener on any interface — not just loopback — rules the port out.
+        if TcpListener::bind(("0.0.0.0", candidate)).is_err() {
+            continue;
+        }
+        RESERVED.lock().unwrap().push(lock);
+        return candidate;
+    }
+    match last_create_err {
+        Some(e) => panic!(
+            "no test port available in {BASE}..{}: could not create a lock file in {}: {e}",
+            BASE + SPAN,
+            dir.display(),
+        ),
+        None => panic!(
+            "no test port available in {BASE}..{}: every port is reserved or already bound",
+            BASE + SPAN,
+        ),
     }
 }
 

--- a/src/interpreter/http_server.rs
+++ b/src/interpreter/http_server.rs
@@ -118,6 +118,67 @@ impl SharedHttpServer {
         Ok(Self { routes })
     }
 
+    /// Reserve a port for a test program's `http_serve`, held against every other
+    /// concurrent test process for the rest of this process's life.
+    ///
+    /// **Test-only.** Shared through the default-off `test-helpers` feature so the
+    /// integration-test crates hold one implementation rather than a copy each.
+    ///
+    /// The obvious allocator — bind `:0`, read the port the kernel assigned,
+    /// close — is unsound here, and flakily so.  Closing makes the port a *hint*
+    /// that nothing owns: the listener that will really own it is [`Self::new`]'s,
+    /// opened at the far end of `compile_program`, and until then `bind(:0)` in a
+    /// *concurrently running test binary* is free to hand the very same port out
+    /// again.  Both compiles then race to bind it and the loser fails with
+    /// `EADDRINUSE`, surfacing as a lowering error from `http_serve`.  Under
+    /// `cargo test`, where the http test binaries run alongside each other, that
+    /// is the whole of the observed flakiness (measured: 13 failures in 7200
+    /// allocations at 24-way concurrency, every one of them a port two processes
+    /// had been handed at once).
+    ///
+    /// So the reservation has to be held by something that outlives the hint.  An
+    /// advisory lock on a per-port file does it: exclusive across processes,
+    /// released by the OS on exit, so a crashed run cannot permanently blacklist
+    /// a port the way a leftover lock *file* would.  Sequential allocation from
+    /// `BASE` is then collision-free by construction rather than by luck — the
+    /// lock, not chance, decides who gets a port.  The bind probe covers the one
+    /// thing the lock cannot: a *foreign* process already listening there.
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn reserve_test_port() -> u16 {
+        use std::{fs::File, net::TcpListener, sync::Mutex};
+
+        /// Below the lowest `ip_local_port_range` floor in practice (32768 on
+        /// Linux, higher on macOS and Windows) so the kernel's own allocator
+        /// never draws from this band for outbound connections, and clear of the
+        /// privileged range.
+        const BASE: u16 = 20_000;
+        const SPAN: u16 = 10_000;
+
+        /// Every lock this process holds.  The reservation must outlive the call —
+        /// the server binds later, inside `compile_program` — and a test has no
+        /// scope to keep a guard in, so the locks live until the process exits.
+        static RESERVED: Mutex<Vec<File>> = Mutex::new(Vec::new());
+
+        let dir = std::env::temp_dir();
+        for candidate in BASE..BASE + SPAN {
+            let Ok(lock) = File::create(dir.join(format!("cambra-test-port-{candidate}.lock")))
+            else {
+                continue;
+            };
+            if lock.try_lock().is_err() {
+                continue;
+            }
+            // Probe the same wildcard address `Server::http` will bind, so a
+            // listener on any interface — not just loopback — rules the port out.
+            if TcpListener::bind(("0.0.0.0", candidate)).is_err() {
+                continue;
+            }
+            RESERVED.lock().unwrap().push(lock);
+            return candidate;
+        }
+        panic!("no test port available in {BASE}..{}", BASE + SPAN)
+    }
+
     /// Register a new `(method, path)` route and return the `Receiver` for incoming requests.
     ///
     /// Requests matching this route will be sent on the returned channel.  A value of `None`

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -7,7 +7,7 @@
 
 use std::{
     io::{Read, Write},
-    net::{TcpListener, TcpStream},
+    net::TcpStream,
     sync::mpsc,
     thread,
     time::{Duration, Instant},
@@ -19,7 +19,7 @@ use cambra::{
         lower::{LoweringContext, LoweringError, lower_stmts},
     },
     chl_parser,
-    interpreter::Consumer,
+    interpreter::{Consumer, http_server::SharedHttpServer},
 };
 use rstest_log::rstest;
 use test_log::test;
@@ -27,16 +27,6 @@ use test_log::test;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Allocate a free TCP port by briefly binding to port 0 and reading the
-/// OS-assigned address.
-fn free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
-}
 
 /// Send a raw HTTP/1.1 POST to `127.0.0.1:port` at `path` with the given
 /// `body`.  Returns the HTTP response body string.
@@ -101,20 +91,27 @@ fn http_get(port: u16, path: &str) -> String {
 /// HTTP response dispatch is handled automatically by [`SinkConsumer`] when
 /// the scheduler notifies it; this function only needs to keep the scheduler
 /// ticking.
+///
+/// `check_for_notifications` has no blocking form, so the scheduler has to be
+/// pumped on a timer; `recv_timeout` supplies that cadence while still returning
+/// the instant the response lands, rather than up to a tick later.
 fn drive_until<T>(ctx: &mut GlobalContext, rx: &mpsc::Receiver<T>, timeout: Duration) -> T {
+    const PUMP_INTERVAL: Duration = Duration::from_millis(10);
+
     let deadline = Instant::now() + timeout;
     loop {
         ctx.scheduler().check_for_notifications();
 
-        if let Ok(value) = rx.try_recv() {
-            return value;
+        match rx.recv_timeout(PUMP_INTERVAL) {
+            Ok(value) => return value,
+            Err(mpsc::RecvTimeoutError::Timeout) => assert!(
+                Instant::now() < deadline,
+                "timed out after {timeout:?} waiting for HTTP response"
+            ),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("request thread dropped the channel without sending a response")
+            }
         }
-
-        assert!(
-            Instant::now() < deadline,
-            "timed out after {timeout:?} waiting for HTTP response"
-        );
-        thread::sleep(Duration::from_millis(10));
     }
 }
 
@@ -125,7 +122,7 @@ fn drive_until<T>(ctx: &mut GlobalContext, rx: &mpsc::Receiver<T>, timeout: Dura
 /// A CHL program echoes each POST body back with a "Received: " prefix.
 #[rstest]
 fn test_http_serve_echo() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let code = format!(
         "requests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
          for req in requests:\n\
@@ -136,9 +133,6 @@ fn test_http_serve_echo() {
 
     let mut ctx = GlobalContext::default();
     let _ = compile_program(&mut ctx, &code, consumer).unwrap_or_render("<test>", &code);
-
-    // Give tiny_http a moment to bind the port before the client connects.
-    thread::sleep(Duration::from_millis(50));
 
     // Send one POST request from a background thread and collect the response.
     let (tx, rx) = mpsc::channel::<String>();
@@ -154,7 +148,7 @@ fn test_http_serve_echo() {
 
 #[rstest]
 fn test_http_serve_const() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let code = format!(
         "requests, responses = http_serve(\"{port}\", \"GET\", \"/static\")\n\
          for req in requests:\n\
@@ -165,9 +159,6 @@ fn test_http_serve_const() {
 
     let mut ctx = GlobalContext::default();
     let _ = compile_program(&mut ctx, &code, consumer).unwrap_or_render("<test>", &code);
-
-    // Give tiny_http a moment to bind the port before the client connects.
-    thread::sleep(Duration::from_millis(50));
 
     // Send one GET request from a background thread and collect the response.
     let (tx, rx) = mpsc::channel::<String>();
@@ -185,7 +176,7 @@ fn test_http_serve_const() {
 /// its own prefixed response.
 #[rstest]
 fn test_http_serve_two_sequential_requests() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let code = format!(
         "requests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
          for req in requests:\n\
@@ -196,8 +187,6 @@ fn test_http_serve_two_sequential_requests() {
 
     let mut ctx = GlobalContext::default();
     let _ = compile_program(&mut ctx, &code, consumer).unwrap_or_render("<test>", &code);
-
-    thread::sleep(Duration::from_millis(50));
 
     // Send two requests sequentially; each blocks until the server responds.
     let (tx, rx) = mpsc::channel::<Vec<String>>();
@@ -219,7 +208,7 @@ fn test_http_serve_two_sequential_requests() {
 /// must fire and produce the expected responses.
 #[rstest]
 fn test_http_serve_two_paths() {
-    let port1 = free_port();
+    let port1 = SharedHttpServer::reserve_test_port();
     let code = format!(
         "reqs1, resps1 = http_serve(\"{port1}\", \"GET\", \"/greet\")\n\
          for req in reqs1:\n\
@@ -233,8 +222,6 @@ fn test_http_serve_two_paths() {
 
     let mut ctx = GlobalContext::default();
     let _ = compile_program(&mut ctx, &code, consumer).unwrap_or_render("<test>", &code);
-
-    thread::sleep(Duration::from_millis(50));
 
     // Send requests sequentially: each http_post/http_get blocks until the
     // server responds, so the second request is only sent after the first
@@ -256,7 +243,7 @@ fn test_http_serve_two_paths() {
 /// inside both for-loop bodies after the trailing-Record lowering.
 #[rstest]
 fn test_http_serve_two_paths_shared_outer_let() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let code = format!(
         "prefix = \"greeting: \"\n\
          reqs1, resps1 = http_serve(\"{port}\", \"POST\", \"/a\")\n\
@@ -271,8 +258,6 @@ fn test_http_serve_two_paths_shared_outer_let() {
 
     let mut ctx = GlobalContext::default();
     let _ = compile_program(&mut ctx, &code, consumer).unwrap_or_render("<test>", &code);
-
-    thread::sleep(Duration::from_millis(50));
 
     let (tx, rx) = mpsc::channel::<Vec<String>>();
     thread::spawn(move || {
@@ -290,7 +275,7 @@ fn test_http_serve_two_paths_shared_outer_let() {
 /// chained outer lets must remain visible to the for-loop body.
 #[rstest]
 fn test_http_serve_echo_with_outer_let() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let code = format!(
         "prefix = \"Echo: \"\n\
          requests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
@@ -302,8 +287,6 @@ fn test_http_serve_echo_with_outer_let() {
 
     let mut ctx = GlobalContext::default();
     let _ = compile_program(&mut ctx, &code, consumer).unwrap_or_render("<test>", &code);
-
-    thread::sleep(Duration::from_millis(50));
 
     let (tx, rx) = mpsc::channel::<String>();
     thread::spawn(move || {
@@ -318,7 +301,7 @@ fn test_http_serve_echo_with_outer_let() {
 /// `http_serve` inside an if/else branch is rejected at lowering time.
 #[test]
 fn test_http_serve_in_if_branch_is_error() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let code = format!(
         "if True:\n\
          \trequests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
@@ -344,7 +327,7 @@ fn test_http_serve_in_if_branch_is_error() {
 /// `http_serve` inside a function body is rejected at lowering time.
 #[test]
 fn test_http_serve_in_function_body_is_error() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let code = format!(
         "def handler():\n\
          \trequests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
@@ -371,7 +354,7 @@ fn test_http_serve_in_function_body_is_error() {
 /// Non-matching paths receive a 404 and do not produce a domain element.
 #[rstest]
 fn test_http_serve_wrong_path_gets_404() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let code = format!(
         "requests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
          for req in requests:\n\
@@ -382,8 +365,6 @@ fn test_http_serve_wrong_path_gets_404() {
 
     let mut ctx = GlobalContext::default();
     let _ = compile_program(&mut ctx, &code, consumer).unwrap_or_render("<test>", &code);
-
-    thread::sleep(Duration::from_millis(50));
 
     // Send to a path that doesn't match — expect a 404 status line.
     let request = format!(

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -19,7 +19,7 @@ use cambra::{
         lower::{LoweringContext, LoweringError, lower_stmts},
     },
     chl_parser,
-    interpreter::{Consumer, http_server::SharedHttpServer},
+    interpreter::{Consumer, http_server::reserve_test_port},
 };
 use rstest_log::rstest;
 use test_log::test;
@@ -122,7 +122,7 @@ fn drive_until<T>(ctx: &mut GlobalContext, rx: &mpsc::Receiver<T>, timeout: Dura
 /// A CHL program echoes each POST body back with a "Received: " prefix.
 #[rstest]
 fn test_http_serve_echo() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let code = format!(
         "requests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
          for req in requests:\n\
@@ -148,7 +148,7 @@ fn test_http_serve_echo() {
 
 #[rstest]
 fn test_http_serve_const() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let code = format!(
         "requests, responses = http_serve(\"{port}\", \"GET\", \"/static\")\n\
          for req in requests:\n\
@@ -176,7 +176,7 @@ fn test_http_serve_const() {
 /// its own prefixed response.
 #[rstest]
 fn test_http_serve_two_sequential_requests() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let code = format!(
         "requests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
          for req in requests:\n\
@@ -208,7 +208,7 @@ fn test_http_serve_two_sequential_requests() {
 /// must fire and produce the expected responses.
 #[rstest]
 fn test_http_serve_two_paths() {
-    let port1 = SharedHttpServer::reserve_test_port();
+    let port1 = reserve_test_port();
     let code = format!(
         "reqs1, resps1 = http_serve(\"{port1}\", \"GET\", \"/greet\")\n\
          for req in reqs1:\n\
@@ -243,7 +243,7 @@ fn test_http_serve_two_paths() {
 /// inside both for-loop bodies after the trailing-Record lowering.
 #[rstest]
 fn test_http_serve_two_paths_shared_outer_let() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let code = format!(
         "prefix = \"greeting: \"\n\
          reqs1, resps1 = http_serve(\"{port}\", \"POST\", \"/a\")\n\
@@ -275,7 +275,7 @@ fn test_http_serve_two_paths_shared_outer_let() {
 /// chained outer lets must remain visible to the for-loop body.
 #[rstest]
 fn test_http_serve_echo_with_outer_let() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let code = format!(
         "prefix = \"Echo: \"\n\
          requests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
@@ -301,7 +301,7 @@ fn test_http_serve_echo_with_outer_let() {
 /// `http_serve` inside an if/else branch is rejected at lowering time.
 #[test]
 fn test_http_serve_in_if_branch_is_error() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let code = format!(
         "if True:\n\
          \trequests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
@@ -327,7 +327,7 @@ fn test_http_serve_in_if_branch_is_error() {
 /// `http_serve` inside a function body is rejected at lowering time.
 #[test]
 fn test_http_serve_in_function_body_is_error() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let code = format!(
         "def handler():\n\
          \trequests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
@@ -354,7 +354,7 @@ fn test_http_serve_in_function_body_is_error() {
 /// Non-matching paths receive a 404 and do not produce a domain element.
 #[rstest]
 fn test_http_serve_wrong_path_gets_404() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let code = format!(
         "requests, responses = http_serve(\"{port}\", \"POST\", \"/echo\")\n\
          for req in requests:\n\

--- a/tests/programs/common/mod.rs
+++ b/tests/programs/common/mod.rs
@@ -50,14 +50,13 @@
 //! Sink program (HTTP / long-lived):
 //!
 //! ```ignore
-//! use super::common::{compile_sink, drive_until, free_port, http_get, http_post, wait_for_bind};
+//! use super::common::{SharedHttpServer, compile_sink, drive_until, http_get, http_post};
 //!
 //! #[test]
 //! fn http_greeter() {
-//!     let port = free_port();
+//!     let port = SharedHttpServer::reserve_test_port();
 //!     let source = include_str!("program.cambra").replace("{PORT}", &port.to_string());
 //!     let mut ctx = compile_sink(&source);
-//!     wait_for_bind();
 //!     // …send requests on a background thread, drive_until the responses arrive…
 //! }
 //! ```
@@ -66,12 +65,11 @@ use std::{
     any::Any,
     cell::RefCell,
     io::{Read, Write},
-    net::{TcpListener, TcpStream},
+    net::TcpStream,
     panic::{self, AssertUnwindSafe},
     process::{Command, Stdio},
     rc::Rc,
     sync::mpsc,
-    thread,
     time::{Duration, Instant},
 };
 
@@ -247,23 +245,11 @@ pub fn compile_sink(source: &str) -> GlobalContext {
     ctx
 }
 
-/// Allocate a free TCP port by briefly binding to port 0 and reading the
-/// OS-assigned address.  Used to populate the `{PORT}` placeholder in sink
-/// programs so tests don't fight over a hard-coded port.
-pub fn free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("failed to bind ephemeral port")
-        .local_addr()
-        .expect("failed to read local addr")
-        .port()
-}
-
-/// Sleep just long enough for `tiny_http` to have bound its listener after
-/// `compile_program` returns.  Without this, the first request can race the
-/// bind and ECONNREFUSED.
-pub fn wait_for_bind() {
-    thread::sleep(Duration::from_millis(50));
-}
+/// Port allocation for the `{PORT}` placeholder in sink programs.  Lives in the
+/// library, behind `test-helpers`, so this crate and `tests/http_server.rs`
+/// share one implementation — see [`SharedHttpServer::reserve_test_port`] for
+/// why the naive "bind `:0` and close" allocator is not safe here.
+pub use cambra::interpreter::http_server::SharedHttpServer;
 
 /// Send a raw HTTP/1.1 GET request and return the response body.  Uses a
 /// plain `TcpStream` so we don't need an HTTP-client crate as a dev
@@ -310,18 +296,26 @@ fn raw_http(port: u16, request: &str) -> String {
 /// HTTP sink dispatch is handled automatically by `SinkConsumer` when the
 /// scheduler notifies it; this function only needs to keep the scheduler
 /// ticking while the request-sending thread runs.
+///
+/// `check_for_notifications` has no blocking form, so the scheduler has to be
+/// pumped on a timer; `recv_timeout` supplies that cadence while still returning
+/// the instant the response lands, rather than up to a tick later.
 pub fn drive_until<T>(ctx: &mut GlobalContext, rx: &mpsc::Receiver<T>, timeout: Duration) -> T {
+    const PUMP_INTERVAL: Duration = Duration::from_millis(10);
+
     let deadline = Instant::now() + timeout;
     loop {
         ctx.scheduler().check_for_notifications();
-        if let Ok(value) = rx.try_recv() {
-            return value;
+        match rx.recv_timeout(PUMP_INTERVAL) {
+            Ok(value) => return value,
+            Err(mpsc::RecvTimeoutError::Timeout) => assert!(
+                Instant::now() < deadline,
+                "timed out after {timeout:?} waiting for sink response",
+            ),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("request thread dropped the channel without sending a response")
+            }
         }
-        assert!(
-            Instant::now() < deadline,
-            "timed out after {timeout:?} waiting for sink response",
-        );
-        thread::sleep(Duration::from_millis(10));
     }
 }
 

--- a/tests/programs/common/mod.rs
+++ b/tests/programs/common/mod.rs
@@ -50,11 +50,11 @@
 //! Sink program (HTTP / long-lived):
 //!
 //! ```ignore
-//! use super::common::{SharedHttpServer, compile_sink, drive_until, http_get, http_post};
+//! use super::common::{compile_sink, drive_until, http_get, http_post, reserve_test_port};
 //!
 //! #[test]
 //! fn http_greeter() {
-//!     let port = SharedHttpServer::reserve_test_port();
+//!     let port = reserve_test_port();
 //!     let source = include_str!("program.cambra").replace("{PORT}", &port.to_string());
 //!     let mut ctx = compile_sink(&source);
 //!     // …send requests on a background thread, drive_until the responses arrive…
@@ -247,9 +247,9 @@ pub fn compile_sink(source: &str) -> GlobalContext {
 
 /// Port allocation for the `{PORT}` placeholder in sink programs.  Lives in the
 /// library, behind `test-helpers`, so this crate and `tests/http_server.rs`
-/// share one implementation — see [`SharedHttpServer::reserve_test_port`] for
-/// why the naive "bind `:0` and close" allocator is not safe here.
-pub use cambra::interpreter::http_server::SharedHttpServer;
+/// share one implementation — see [`reserve_test_port`] for why the naive
+/// "bind `:0` and close" allocator is not safe here.
+pub use cambra::interpreter::http_server::reserve_test_port;
 
 /// Send a raw HTTP/1.1 GET request and return the response body.  Uses a
 /// plain `TcpStream` so we don't need an HTTP-client crate as a dev

--- a/tests/programs/http_accumulator/mod.rs
+++ b/tests/programs/http_accumulator/mod.rs
@@ -8,11 +8,11 @@
 
 use std::{sync::mpsc, thread, time::Duration};
 
-use super::common::{SharedHttpServer, compile_sink, drive_until, http_post};
+use super::common::{compile_sink, drive_until, http_post, reserve_test_port};
 
 #[test]
 fn http_accumulator() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let source = include_str!("program.cambra").replace("{PORT}", &port.to_string());
     let mut ctx = compile_sink(&source);
 

--- a/tests/programs/http_accumulator/mod.rs
+++ b/tests/programs/http_accumulator/mod.rs
@@ -8,14 +8,13 @@
 
 use std::{sync::mpsc, thread, time::Duration};
 
-use super::common::{compile_sink, drive_until, free_port, http_post, wait_for_bind};
+use super::common::{SharedHttpServer, compile_sink, drive_until, http_post};
 
 #[test]
 fn http_accumulator() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let source = include_str!("program.cambra").replace("{PORT}", &port.to_string());
     let mut ctx = compile_sink(&source);
-    wait_for_bind();
 
     let (tx, rx) = mpsc::channel::<Vec<String>>();
     thread::spawn(move || {

--- a/tests/programs/http_counter/mod.rs
+++ b/tests/programs/http_counter/mod.rs
@@ -13,14 +13,13 @@
 
 use std::{sync::mpsc, thread, time::Duration};
 
-use super::common::{compile_sink, drive_until, free_port, http_get, http_post, wait_for_bind};
+use super::common::{SharedHttpServer, compile_sink, drive_until, http_get, http_post};
 
 #[test]
 fn http_counter() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let source = include_str!("program.cambra").replace("{PORT}", &port.to_string());
     let mut ctx = compile_sink(&source);
-    wait_for_bind();
 
     let (tx, rx) = mpsc::channel::<String>();
     thread::spawn(move || {
@@ -46,7 +45,7 @@ fn http_counter() {
 /// `Strings` — with a non-identity map, the point being the map, not the value.)
 #[test]
 fn http_computed_live_read() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let source = format!(
         "set_reqs, set_resps = http_serve(\"{port}\", \"POST\", \"/set\")\n\
          get_reqs, get_resps = http_serve(\"{port}\", \"GET\", \"/get\")\n\
@@ -55,7 +54,6 @@ fn http_computed_live_read() {
          for req in get_reqs:\n    with begin():\n        get_resps << latest + \"!\"\n"
     );
     let mut ctx = compile_sink(&source);
-    wait_for_bind();
 
     let (tx, rx) = mpsc::channel::<String>();
     thread::spawn(move || {
@@ -77,7 +75,7 @@ fn http_computed_live_read() {
 /// /set` writes both registers, so `a + b` reflects the latest committed values.
 #[test]
 fn http_multi_register_live_read() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let source = format!(
         "set_reqs, set_resps = http_serve(\"{port}\", \"POST\", \"/set\")\n\
          get_reqs, get_resps = http_serve(\"{port}\", \"GET\", \"/get\")\n\
@@ -87,7 +85,6 @@ fn http_multi_register_live_read() {
          for req in get_reqs:\n    with begin():\n        get_resps << a + b\n"
     );
     let mut ctx = compile_sink(&source);
-    wait_for_bind();
 
     let (tx, rx) = mpsc::channel::<String>();
     thread::spawn(move || {

--- a/tests/programs/http_counter/mod.rs
+++ b/tests/programs/http_counter/mod.rs
@@ -13,11 +13,11 @@
 
 use std::{sync::mpsc, thread, time::Duration};
 
-use super::common::{SharedHttpServer, compile_sink, drive_until, http_get, http_post};
+use super::common::{compile_sink, drive_until, http_get, http_post, reserve_test_port};
 
 #[test]
 fn http_counter() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let source = include_str!("program.cambra").replace("{PORT}", &port.to_string());
     let mut ctx = compile_sink(&source);
 
@@ -45,7 +45,7 @@ fn http_counter() {
 /// `Strings` — with a non-identity map, the point being the map, not the value.)
 #[test]
 fn http_computed_live_read() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let source = format!(
         "set_reqs, set_resps = http_serve(\"{port}\", \"POST\", \"/set\")\n\
          get_reqs, get_resps = http_serve(\"{port}\", \"GET\", \"/get\")\n\
@@ -75,7 +75,7 @@ fn http_computed_live_read() {
 /// /set` writes both registers, so `a + b` reflects the latest committed values.
 #[test]
 fn http_multi_register_live_read() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let source = format!(
         "set_reqs, set_resps = http_serve(\"{port}\", \"POST\", \"/set\")\n\
          get_reqs, get_resps = http_serve(\"{port}\", \"GET\", \"/get\")\n\

--- a/tests/programs/http_greeter/mod.rs
+++ b/tests/programs/http_greeter/mod.rs
@@ -7,11 +7,11 @@
 
 use std::{sync::mpsc, thread, time::Duration};
 
-use super::common::{SharedHttpServer, compile_sink, drive_until, http_get, http_post};
+use super::common::{compile_sink, drive_until, http_get, http_post, reserve_test_port};
 
 #[test]
 fn http_greeter() {
-    let port = SharedHttpServer::reserve_test_port();
+    let port = reserve_test_port();
     let source = include_str!("program.cambra").replace("{PORT}", &port.to_string());
     let mut ctx = compile_sink(&source);
 

--- a/tests/programs/http_greeter/mod.rs
+++ b/tests/programs/http_greeter/mod.rs
@@ -7,14 +7,13 @@
 
 use std::{sync::mpsc, thread, time::Duration};
 
-use super::common::{compile_sink, drive_until, free_port, http_get, http_post, wait_for_bind};
+use super::common::{SharedHttpServer, compile_sink, drive_until, http_get, http_post};
 
 #[test]
 fn http_greeter() {
-    let port = free_port();
+    let port = SharedHttpServer::reserve_test_port();
     let source = include_str!("program.cambra").replace("{PORT}", &port.to_string());
     let mut ctx = compile_sink(&source);
-    wait_for_bind();
 
     let (tx, rx) = mpsc::channel::<Vec<String>>();
     thread::spawn(move || {

--- a/tests/reserve_port.rs
+++ b/tests/reserve_port.rs
@@ -1,0 +1,47 @@
+//! Coverage for [`reserve_test_port`], the allocator the http tests' anti-flake
+//! guarantee rests on.
+//!
+//! Nothing else exercises the allocator directly: the http tests consume a port
+//! and would only report a regression as the same intermittent `EADDRINUSE` the
+//! allocator exists to remove — a failure that is expensive to diagnose and easy
+//! to write off as environmental.  These two tests turn that into a deterministic
+//! red.
+
+use std::{collections::HashSet, net::TcpListener, thread};
+
+use cambra::interpreter::http_server::reserve_test_port;
+
+/// The reservation must be exclusive *within* the process too: `cargo test` runs
+/// a binary's tests as threads, so two concurrent calls handed the same port
+/// would reproduce exactly the `EADDRINUSE` this allocator prevents.  It holds
+/// because the lock is on the open file description (`flock`) rather than the
+/// process (`fcntl(F_SETLK)`, under which the second lock in a process
+/// *succeeds*) — a platform or std change there would silently restore the
+/// flakiness, and this is what catches it.
+#[test]
+fn reserve_test_port_is_exclusive_across_threads() {
+    let ports: Vec<u16> = thread::scope(|s| {
+        let handles: Vec<_> = (0..16).map(|_| s.spawn(reserve_test_port)).collect();
+        handles.into_iter().map(|h| h.join().unwrap()).collect()
+    });
+
+    let unique: HashSet<u16> = ports.iter().copied().collect();
+    assert_eq!(
+        unique.len(),
+        ports.len(),
+        "duplicate ports handed out: {ports:?}"
+    );
+    assert!(
+        ports.iter().all(|p| (20_000..30_000).contains(p)),
+        "ports outside the reserved band: {ports:?}"
+    );
+}
+
+/// A reserved port must still be bindable by the caller — the bind probe's
+/// listener has to be closed, not leaked into the static that holds the locks —
+/// and bindable on the same wildcard address `SharedHttpServer::new` uses.
+#[test]
+fn reserved_port_is_bindable_by_the_caller() {
+    let port = reserve_test_port();
+    TcpListener::bind(("0.0.0.0", port)).expect("reserved port must be bindable by its reserver");
+}


### PR DESCRIPTION
The `http_server` and `programs` test binaries fail intermittently with `http_serve: failed to bind port 35545: Address already in use`: `free_port()` bound `:0`, read the port the kernel assigned, and *closed* it, leaving a hint nothing owns until `SharedHttpServer::new` binds it a compile-window later — long enough for a concurrently running test process to be handed the same port. `reserve_test_port` replaces it with a reservation held for the life of the process, making a collision impossible by construction rather than by luck. Measured at 24-way concurrency: 1 failing run in 240 before this change, 0 in 432 after.

The reservation is a per-port advisory file lock held until exit, allocation from a band below every `ip_local_port_range` floor, and a bind probe for a foreign listener; its doc comment carries the why, including the `flock`-vs-`fcntl` dependency that same-process exclusion rests on. Living in the library behind the default-off `test-helpers` feature also collapses the two copies of `free_port`.

### Sleeps

`wait_for_bind()` and the twelve fixed 50 ms waits before a first request are gone — `SharedHttpServer::new` binds before spawning its dispatcher, so the race they claimed to cover cannot happen. Both `drive_until` loops now wait on `recv_timeout` rather than `try_recv` plus `sleep`.

### Tests

`tests/reserve_port.rs` pins the two properties the guarantee rests on: exclusion between threads of one process, and a reserved port still bindable by its reserver.