### PR TITLE
A sum's body may be another sum

### DIFF
--- a/src/ccl/infer/api.rs
+++ b/src/ccl/infer/api.rs
@@ -515,9 +515,19 @@ fn identical_rendering_hint(type_a: &Type, type_b: &Type) -> Option<String> {
         .find(|((_, x), y)| x != y)
         .map(|((i, _), _)| i)
     else {
-        // One structure is a *prefix* of the other, so no character disagrees and a window
-        // would quote the same text twice. The difference is depth: something wraps one
-        // side and not the other.
+        // No character disagrees. Either one structure is a *prefix* of the other — the
+        // difference is depth, something wrapping one side and not the other — or the two
+        // are structurally identical, in which case the types are not what disagree at all
+        // and the rule that rejected them is where to look.
+        if a.len() == b.len() {
+            return Some(
+                "note: these are structurally identical, not merely identical as printed — \
+                 so the disagreement is not in the types. Look at the rule that rejected \
+                 them: it failed on something the types do not carry (a witness range read \
+                 from the index, a kind obligation, a scope) rather than on their shape."
+                    .to_string(),
+            );
+        }
         let (shorter, longer, which) = if a.len() < b.len() {
             (a.len(), b.len(), "found")
         } else {

--- a/src/ccl/infer/check.rs
+++ b/src/ccl/infer/check.rs
@@ -236,6 +236,24 @@ impl Typing for CheckCtx {
             // destructured here and reaches the error below by name: consuming one is
             // per-candidate, which this position cannot express.
             Type::Sigma(s) if s.body_residue().is_some() => {
+                // **Peel every binder, publishing each range.** One deep, the body is
+                // `𝑤 ⤇ 𝑉` and the consumer's domain is that witness. Nested, the innermost
+                // body's domain names one witness per position, and that is what the
+                // consumer destructures to — so the loop, not a second rule.
+                let mut innermost: &crate::ccl::ty::SigmaType = s;
+                let mut nested = false;
+                crate::ccl::ty::witness_ctx::note_range(innermost.binder(), innermost.kind());
+                while let Type::Sigma(inner) = &*innermost.body {
+                    innermost = inner;
+                    nested = true;
+                    crate::ccl::ty::witness_ctx::note_range(innermost.binder(), innermost.kind());
+                }
+                if nested
+                    && let Some((_, cod)) = innermost.body_residue()
+                    && let Some(dom) = innermost.body.domain()
+                {
+                    return Ok((dom, cod.clone()));
+                }
                 let (_, cod) = s.body_residue().expect("guarded by the arm");
                 // **Opened, exactly as Emit opens it.** The consumer's domain is a name for
                 // whichever domain the witness picked, carrying the kind it ranges over —

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -489,8 +489,37 @@ fn unify_sum_witnesses(lv: &Rc<InferVar>, lows: Vec<Bound>) -> Vec<Bound> {
 /// this point, so the reference stays free in the graph until materialization binds it
 /// (in `src/ccl/infer/solver/compact.rs`). None may survive coalesce still free — that is
 /// the escape check.
+/// Bring the sum's witnesses under the **names the context already gave them**, position by
+/// position. Answers whether every witness in `body_domain` was named, in which case there is
+/// no edge left to draw.
+///
+/// A consumer whose domain is a witness reference was written against a consumption that
+/// already happened, and the sum's own binder is bound, so adopting the context's name is
+/// α-conversion and changes nothing. Nesting makes that positional rather than whole:
+/// two generators index a `Tuple`, one witness per component, and each names its own.
+///
+/// The range travels with the name — a `Type::WitnessRef` names a binder and nothing else,
+/// so a reader holding the context's name has to find the range under *that* binder. At one
+/// witness the range is the sum's own kind; deeper, each peeled binder published its range
+/// on the way in, so the index is where the inner ones are read from.
+fn adopt_the_contexts_names(consumer: &Type, body_domain: &Type, range: &TypeKind) -> bool {
+    match (consumer, body_domain) {
+        (Type::WitnessRef(named), Type::WitnessRef(w)) => {
+            let range = crate::ccl::ty::witness_ctx::range(*w).unwrap_or_else(|| range.clone());
+            crate::ccl::ty::witness_ctx::note_range(*named, &range);
+            true
+        }
+        (Type::Tuple(cs), Type::Tuple(bs)) if cs.len() == bs.len() => cs
+            .iter()
+            .zip(bs)
+            .all(|(c, b)| adopt_the_contexts_names(c, b, range)),
+        _ => false,
+    }
+}
+
 fn demand_domain_range(
     domain: &Type,
+    body_domain: &Type,
     binder: crate::ccl::infer_var::WitnessBinderId,
     range: &TypeKind,
     sl: &Subst,
@@ -509,14 +538,18 @@ fn demand_domain_range(
     // carried by the *term* could deliver; taking the name the context offers is the same
     // move the `Fun` rule makes for a Pi binder, which is derived from the correspondence
     // rather than reproduced.
-    if let Type::WitnessRef(named) = domain {
-        crate::ccl::ty::witness_ctx::note_range(*named, &range);
+    if adopt_the_contexts_names(domain, body_domain, &range) {
         return Ok(());
     }
     // Publish before handing out a reference: a `Type::WitnessRef` names a binder and
     // nothing else, so the range has to be findable from the binder alone.
     crate::ccl::ty::witness_ctx::note_range(binder, &range);
-    constrain_go(domain, &Type::WitnessRef(binder), sr, sl, cache)
+    // **The body's domain, not the bare witness.** At one binder deep the two are the same
+    // type — a sum's body is `𝑤 ⤇ 𝑉` — but once sums nest, the innermost body's domain is
+    // a `Tuple` naming a witness per position. Relating structurally puts each consumer
+    // position against the witness that indexes it, and needs no rule about tuples: the
+    // ordinary walk reaches the `Type::WitnessRef` leaves.
+    constrain_go(domain, body_domain, sr, sl, cache)
 }
 
 fn free_witness_of(domain: &Type) -> Option<crate::ccl::infer_var::WitnessBinderId> {
@@ -1157,6 +1190,15 @@ fn constrain_go_impl(
                 ..
             },
         ) => {
+            // **A sum whose body is a sum** publishes its own range and hands the body to
+            // this same rule. Binders peel one at a time and the demand lands on the
+            // innermost body, whose domain names every witness peeled on the way — so
+            // nothing here has to know how deep the nesting goes.
+            if matches!(&*s.body, Type::Sigma(_)) {
+                let range = s.kind().map_children(|d| sl.apply_type(d));
+                crate::ccl::ty::witness_ctx::note_range(s.binder(), &range);
+                return constrain_go(&s.body, rhs, sl, sr, cache);
+            }
             match s.body_residue() {
                 // A **factored** sum, `Σ 𝐷 ∈ 𝐾. 𝐷 ⤇ 𝑉`. Naming the witness needs no
                 // candidates at all — that is exactly what naming buys over presenting —
@@ -1168,7 +1210,11 @@ fn constrain_go_impl(
                 // `Fun`/`Fun` arm would derive has to be derived here too — the body is
                 // destructured rather than recursed into.
                 Some((binder, cod)) => {
-                    demand_domain_range(d1, s.binder(), s.kind(), sl, sr, cache)?;
+                    let body_dom = s
+                        .body
+                        .domain()
+                        .expect("a residue means the body is an arrow");
+                    demand_domain_range(d1, &body_dom, s.binder(), s.kind(), sl, sr, cache)?;
                     let cod_sl = match (binder.as_ref(), n1) {
                         (Some(k), Some(x)) => sl.extended_rename(k, x),
                         _ => sl.clone(),
@@ -1185,7 +1231,16 @@ fn constrain_go_impl(
                 None => match collection_candidates(lhs) {
                     Some(domains) => {
                         let range = TypeKind::Enumerated(domains);
-                        demand_domain_range(d1, s.binder(), &range, sl, sr, cache)?;
+                        // The body *is* the witness here, so it is its own domain.
+                        demand_domain_range(
+                            d1,
+                            &Type::WitnessRef(s.binder()),
+                            s.binder(),
+                            &range,
+                            sl,
+                            sr,
+                            cache,
+                        )?;
                         for cod in collection_codomains(lhs) {
                             constrain_go(&cod, c1, sl, sr, cache)?;
                         }
@@ -1664,11 +1719,32 @@ fn constrain_go_impl(
         //
         // A described kind lists nothing to distribute over and stays a mismatch: the
         // consumer would have to be valid at domains not yet named.
-        (Type::Sigma(s), _) if s.kind().listed().is_some() => {
+        //
+        // **Witness-bodied only**, which is the shape named above and not a further
+        // condition: distributing *instantiates* the witness, so a body that still mentions
+        // it after instantiation has had it pinned to one candidate — the silent narrowing
+        // the `Type::WitnessRef` arms refuse by name. Where the body is the witness there is
+        // nothing left to pin. The arm below is the same rule for a body that is not.
+        (Type::Sigma(s), _) if s.body_is_witness() && s.kind().listed().is_some() => {
             for c in s.kind().listed().expect("guarded above") {
                 constrain_go(&s.instantiate_body(c), rhs, sl, sr, cache)?;
             }
             Ok(())
+        }
+
+        // **A demand that still names the witness is domain-*preserving*,** so it takes the
+        // naming rule rather than distribution — the same split the `(Σ, Fun)` arm makes,
+        // stated for the shapes that arm does not cover. A nested sum's body is a `Tuple`
+        // (two generators index a pair, one component per witness), and a tuple demand
+        // relates componentwise, so each witness meets its own position and none is pinned.
+        //
+        // Publish before recursing: the body's witness references are about to reach edges,
+        // and a reference names a binder and nothing else, so the range has to be findable
+        // from the binder alone.
+        (Type::Sigma(s), _) => {
+            let range = s.kind().map_children(|d| sl.apply_type(d));
+            crate::ccl::ty::witness_ctx::note_range(s.binder(), &range);
+            constrain_go(&s.body, rhs, sl, sr, cache)
         }
 
         _ => Err(ConstrainError::Mismatch {

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -1739,9 +1739,14 @@ impl Type {
                 domain: Box::new(domain),
                 codomain: Box::new(codomain),
             },
-            Type::Sigma(s) if matches!(&*s.body, Type::Fun { .. }) => Type::Sigma(Box::new(
-                SigmaType::bound(s.witness.clone(), Type::fun_like(&s.body, domain, codomain)),
-            )),
+            // Through **every** wrapper: a sum's body may be another sum, and rebuilding
+            // only the innermost would drop the binders above it.
+            Type::Sigma(s) if matches!(&*s.body, Type::Fun { .. } | Type::Sigma(_)) => {
+                Type::Sigma(Box::new(SigmaType::bound(
+                    s.witness.clone(),
+                    Type::fun_like(&s.body, domain, codomain),
+                )))
+            }
             _ => Type::fun(domain, codomain),
         }
     }

--- a/tests/compilation_pipeline/conditionals.rs
+++ b/tests/compilation_pipeline/conditionals.rs
@@ -1054,36 +1054,39 @@ fn test_boxed_conditional_collection(#[case] code: &str, #[case] expected: Value
 /// witnesses apart (`two_conditional_sources_keep_their_witnesses_apart`, in
 /// `tests/type_check.rs`); what it does not yet do is compile.
 ///
-/// Two generators nest two sums — `Σ σ₄ ∈ 𝐾₄. Σ σ₇ ∈ 𝐾₇. ((σ₄, σ₇) ⤇ Int)` — and what
-/// each blocker has in common is that **a nested sum has no settled rule**, not that a case
-/// is missing. Measured in order, each one reached by getting past the last:
+/// Two generators nest two sums — `Σ σ₄ ∈ 𝐾₄. Σ σ₇ ∈ 𝐾₇. ((σ₄, σ₇) ⤇ Int)`. The **typing**
+/// half now works: formation is pinned by `two_conditional_sources_keep_their_witnesses_apart`
+/// and consumption by `a_nested_sum_is_consumed_by_an_aggregate` (both in `tests/type_check.rs`),
+/// the latter reaching the post-inference wall where every depth-one assumption lived.
 ///
-/// 1. `SigmaType::body_residue` hits its `unreachable!`: the body is a `Sigma`, and the
-///    witness-independent residue of a sum inside a sum is not defined. Returning the inner
-///    sum's residue gets past it and is probably right, but it is a *guess* until width says
-///    what a nested sum's search covers.
-/// 2. Consumption (`Σ <: Fun`) then places a range demand from **one** witness on the
-///    consumer's whole domain, which here is the tuple `(σ₄, σ₇)`. Two witnesses index two
-///    tuple components; one demand cannot say that.
-/// 3. `Proj` on that tuple fails with `expected [0, 1], found σ` — projecting a component
-///    resolves against a concrete candidate where a witness stands.
+/// What remains is downstream of inference, and is **not** about nesting. At the
+/// post-lambda-elimination wall an application's argument edge compares the collection
+/// **opened** against the parameter's **closed** sum:
 ///
-/// The question under all three is whether nesting means one sum over the **product** kind
-/// (candidates `𝐾₄ × 𝐾₇`, one witness, everything downstream unchanged, n×m candidates) or
-/// two binders peeled in turn (no explosion, but width, consumption and projection each
-/// need a rule for *which* witness a position names). That is a type-system decision, so it
-/// is not made here.
+/// ```text
+/// found    (σ@4, σ@7)                                              — the body, witnesses free
+/// expected Σ σ@4 ∈ {[0,1],[0,2]}. Σ σ@7 ∈ {[0,1],[0,2]}. (σ@4, σ@7) — the sum that binds them
+/// ```
+///
+/// The two render identically because `coalesce_for_error` closes a free witness back into
+/// its sum for display — which is why the reported message says the types agree. Structurally
+/// it is a **bound-versus-free** disagreement: "one leaf, and scope decides what it means",
+/// at a position where the two decisions differ.
+///
+/// The fix is *not* a `𝑈 <: Σ` subtyping arm — "only a term builds a sum" is load-bearing,
+/// and an arm admitting an opened body would be that rule with an extra condition. Whatever
+/// produced the opened type at an argument position is what has to bind it back, the way
+/// `lambda_elim`'s Σ rebuild does for a lambda (which does not fire here: it needs an arrow,
+/// and this body is a tuple).
 ///
 /// It is **not** the copair/disjoint-join split, which this test was previously ignored
 /// for: that diagnosis predates the witness-identity work and does not survive it. The
-/// failure has moved four times under measurement (a sum in a domain position reaching
-/// `extent_of`, then a free witness on the index, then an unresolved variable, then
-/// `[0, 1] <: σ` at `constrain_go`'s witness arm), so the reasons above are what a run says
-/// today and nothing more — re-measure before trusting them.
+/// failure has moved five times under measurement, so the reason above is what a run says
+/// today and nothing more — re-measure before trusting it.
 #[rstest]
 #[timeout(Duration::from_secs(30))]
-#[ignore = "two generators nest two sums, and a nested sum has no width, consumption or \
-            projection rule; measured 2026-08-11"]
+#[ignore = "post-lambda-elim: an argument edge meets the collection opened against the \
+            parameter's closed sum — bound versus free; measured 2026-08-11"]
 fn two_conditional_sources_compile() {
     check_scalar(
         r"

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -2618,3 +2618,30 @@ y = a if d else box([1, 2, 3, 4, 5])
         "the two joins keep their witnesses apart: {ty}"
     );
 }
+
+/// **A nested sum is consumed like any other collection.** Aggregating a comprehension over
+/// *two* conditional sources has to reach through both binders: the consumer's demand lands
+/// on the innermost body, whose domain is the index `Tuple` naming one witness per position.
+///
+/// This is the consumption half of `two_conditional_sources_keep_their_witnesses_apart`,
+/// which pins the formation. Every rule between them assumed a sum was one binder deep — a
+/// body `𝑤 ⤇ 𝑉` — and answered the demand against the bare witness, which a tuple is not.
+#[test]
+fn a_nested_sum_is_consumed_by_an_aggregate() {
+    // Through `infer_and_check`: the rules that assumed one binder live at the
+    // post-inference wall, where Check re-derives what Emit inferred, so inference alone
+    // does not exercise them.
+    let ty = infer_and_check(
+        r"
+c = 3 > 2
+d = 4 > 3
+a = box([1, 2]) if c else box([1, 2, 3])
+b = box([10, 20]) if d else box([10, 20, 30])
+sum([x + y for x in a for y in b])",
+    );
+    assert_eq!(
+        ty,
+        Type::Base(cambra::ccl::BaseType::Int),
+        "aggregating over two conditional sources is an `Int`, the witnesses consumed: {ty}"
+    );
+}


### PR DESCRIPTION
A sum's body may be another sum

Two generators nest two sums — `Σ σ₄ ∈ 𝐾₄. Σ σ₇ ∈ 𝐾₇. ((σ₄, σ₇) ⤇ Int)` — and
every rule between formation and the post-inference wall assumed a sum was **one
binder deep**, with a body `𝑤 ⤇ 𝑉`. Formation already builds the nested type
(`two_conditional_sources_keep_their_witnesses_apart` pins it); consuming one hit
`SigmaType::body_residue`'s `unreachable!` on the first rule that looked.

None of this needed a new rule. Each site states the rule it already had in terms
of the body it actually has:

- **Consumption** (`demand_domain_range`) related the consumer's domain to the
  *bare witness*. It now relates it to the **body's** domain, which at one binder
  deep *is* that witness and nested is the index `Tuple`. Tuples need no rule of
  their own — the ordinary structural walk reaches the `Type::WitnessRef` leaves.
- **Peeling** is one arm: a sum whose body is a sum publishes its range and hands
  the body to the same rule, so nothing has to know how deep the nesting goes.
- **`Check`'s function destructuring** and **`Type::fun_like`** each unwrapped or
  rebuilt exactly one wrapper; both now go through as many as there are.
- **Adopting the context's name** was whole-domain ("a consumer whose domain *is* a
  witness reference was written against a consumption that already happened"). It
  is now positional, so each component of an index tuple adopts its own.

The distributing arm is **restricted to witness-bodied sums**, which is the shape
its own comment already describes (`Σ 𝐷 ∈ 𝐾. 𝐷`) rather than a new condition.
Distribution *instantiates* the witness, so a body still mentioning it afterwards
has been pinned to one candidate — the silent narrowing the `Type::WitnessRef`
arms refuse by name, and what put a concrete `[0, 1]` where a witness belonged. A
demand that still names the witness is domain-*preserving* and takes the naming
rule, the same split the `(Σ, Fun)` arm makes, stated for the shapes it does not
cover.

`identical_rendering_hint` reported "0 more characters of structure" when two
types were *equal* as debug strings — the `find` returning `None` means either a
prefix or equality, and it assumed prefix. Equality is the more useful answer,
because it says the disagreement is not in the types at all and points at the rule
that rejected them.

End to end, `two_conditional_sources_compile` is still ignored, and its blocker is
now a different one: past `lambda_elim`, an application's argument edge meets the
collection **opened** — `(σ@4, σ@7)`, witnesses free — against the parameter's
**closed** sum. The two render identically only because `coalesce_for_error` closes
a free witness back into its sum for display. That is bound-versus-free, not depth,
and its fix is not a `𝑈 <: Σ` arm — whatever produced the opened type is what has to
bind it back.