### PR TITLE
Typecheck a never-called function before dropping it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,23 @@ Comment when the *why* is non-obvious — a hidden constraint, a load-bearing in
 
 Avoid comments that describe the history of the codebase.  Comments should explain how and why the code works.  If there is an alternative approach that seems reasonable but doesn't work, it's ok to describe that, but the comments should always fully make sense just by looking at the current version of the code.
 
+### Embedded source in tests: use `indoc!`, never `\n`
+
+A test's CHL (or any embedded source) program must read as the program it is. Write
+multi-line programs with `indoc! {r#"…"#}` (already used in
+`tests/compilation_pipeline/transactions.rs` and `tests/chl_parser_roundtrip.rs`),
+**never** as a single string with embedded `\n`: escaped newlines hide the
+indentation an off-side-rule language depends on, and a one-line diff on such a case
+touches the whole program.
+
+Two corollaries:
+
+- **A genuinely one-line program stays a plain string.** `indoc!` is for programs
+  with line structure, not a uniform wrapper.
+- **Don't let boilerplate force `indoc!` on a one-liner.** If cases share a fixed
+  trailing line (a program value, a call that makes something live), append it in
+  the test body and let each case carry only its own content.
+
 ### Referencing docs and sections
 
 Cross-references into the docs are checked by `./ci.sh doc_refs` (Markdown

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -118,7 +118,7 @@ def identity(x):
 * **Inference:** The parameter `x` is a fresh variable `α`; since the body just returns `x`, the type is `α → α`.
 * **Bounds:** `x` is never passed to another function (no upper bounds) and never assigned a concrete value (no lower bounds): `α.lower = []`, `α.upper = []`.
 * **Coalesce:** `α` has no concrete atoms. In pure algebraic subtyping this is fine — it is the principal, universally quantified type `∀α. α → α`.
-* **The Cambra position:** Cambra's public `ccl::Type` has no `Type::ForAll`. It uses level-based type variables for *implicit* polymorphism because that is efficient and meshes with the solver, and it lowers that polymorphism to concrete code by monomorphizing at use sites — the natural fit for an engine that wants concrete types on every node for codegen. An `identity` that is *let-bound and used at several types* is generalized, then specialized per distinct use type during the coalesce walk (see the roadmap above); one that is *never applied* is dropped (its definition is dead code). At every applied call site the function's domain is fixed to the value flowing in, pinning the type to that site — the monomorphic coalescing rule (see §2, Pass 1). This is a pragmatic choice, not a commitment never to *represent* polymorphism: explicit `∀`/Π types could coexist (the `cast`/`iterate` signatures already point that way — see §1, *Roadmap*).
+* **The Cambra position:** Cambra's public `ccl::Type` has no `Type::ForAll`. It uses level-based type variables for *implicit* polymorphism because that is efficient and meshes with the solver, and it lowers that polymorphism to concrete code by monomorphizing at use sites — the natural fit for an engine that wants concrete types on every node for codegen. An `identity` that is *let-bound and used at several types* is generalized, then specialized per distinct use type during the coalesce walk (see the roadmap above); one that is *never applied* is typechecked and then dropped (its definition is dead code — see [Typechecking a never-called definition](#typechecking-a-never-called-definition)). At every applied call site the function's domain is fixed to the value flowing in, pinning the type to that site — the monomorphic coalescing rule (see §2, Pass 1). This is a pragmatic choice, not a commitment never to *represent* polymorphism: explicit `∀`/Π types could coexist (the `cast`/`iterate` signatures already point that way — see §1, *Roadmap*).
 
 ### Roadmap and Current Prototype Status
 
@@ -249,9 +249,76 @@ Because the algorithm drops HM's union-find equality engine, it behaves in ways 
 
 Vanilla algebraic subtyping makes a `let`-bound function polymorphic by **freshening**: every time a generalized binding is used, the solver copies its type graph, minting fresh variables for that use site. This is ordinary let-generalization/instantiation — the same idea as HM's `∀`-quantification — applied to the bound graph rather than to a syntactic type scheme.
 
-**How Cambra applies this — and then lowers it.** A `let` binding a *function definition* (`should_generalize`) is typed one level deeper (`in_let_rhs`) and generalized into a `PolyScheme` at the binding level (`scoped_let`); each `Var` use then `instantiate`s a fresh copy, exactly the freshening above. Because every pass after inference is monomorphic, the generalized binding is lowered to concrete code **inside the coalesce walk** (integrated monomorphization): the walk carries a scope of *specialization frames* — one per in-scope generalized `let`, plus shadow markers for every other binder — and a use of a generalized binding specializes at first visit (`specialize_use`). By coalesce time the constraint graph is *complete* (emission saw the whole program), so a use's instantiation is fully determined when the bottom-up walk reaches it: the walk resolves it off the live graph, and on a memo miss clones the definition (`freshen_expr_type_slots` freshens an independent copy — uniformly over terms and types, so a refinement predicate's slots and the suspended-substitution payloads riding the copied bound edges are renamed in the same traversal as every other slot), **pins the clone two-way to the use's live instantiation type**, coalesces the clone re-entrantly *in the definition site's scope* (entries pushed between definition and use are suspended, so a same-named binder introduced in between cannot capture the clone's references), renames the use to a synthetic `Mono` name (`Name::mono`) carrying the source binding plus a globally-fresh uid, and stamps the specialization's resolved type on it. When the `let`'s body walk completes, the node rebuilds itself as the chain of demanded specializations (`coalesce_generalized_let`), running the §6.2 `let`-closing discharge per spliced layer; a binding never demanded is dropped as dead code. Uses that instantiate the definition identically share one clone — the memo is keyed on a `SpecKey`, taken from the use's live type before its pin, and an entry stores the key of the use that minted it (see [Keying a specialization](#keying-a-specialization)). The definition's own subtree is never coalesced in place: its quantified variables have no use-site bounds, so coalescing it would both produce an under-determined type and overwrite the bound-bearing `InferVar`s the clones freshen from.
+**How Cambra applies this — and then lowers it.** A `let` binding a *function definition* (`should_generalize`) is typed one level deeper (`in_let_rhs`) and generalized into a `PolyScheme` at the binding level (`scoped_let`); each `Var` use then `instantiate`s a fresh copy, exactly the freshening above. Because every pass after inference is monomorphic, the generalized binding is lowered to concrete code **inside the coalesce walk** (integrated monomorphization): the walk carries a scope of *specialization frames* — one per in-scope generalized `let`, plus shadow markers for every other binder — and a use of a generalized binding specializes at first visit (`specialize_use`). By coalesce time the constraint graph is *complete* (emission saw the whole program), so a use's instantiation is fully determined when the bottom-up walk reaches it: the walk resolves it off the live graph, and on a memo miss clones the definition (`freshen_expr_type_slots` freshens an independent copy — uniformly over terms and types, so a refinement predicate's slots and the suspended-substitution payloads riding the copied bound edges are renamed in the same traversal as every other slot), **pins the clone two-way to the use's live instantiation type**, coalesces the clone re-entrantly *in the definition site's scope* (entries pushed between definition and use are suspended, so a same-named binder introduced in between cannot capture the clone's references), renames the use to a synthetic `Mono` name (`Name::mono`) carrying the source binding plus a globally-fresh uid, and stamps the specialization's resolved type on it. When the `let`'s body walk completes, the node rebuilds itself as the chain of demanded specializations (`coalesce_generalized_let`), running the §6.2 `let`-closing discharge per spliced layer; a binding never demanded is resolved for its diagnostics and then dropped as dead code (see [Typechecking a never-called definition](#typechecking-a-never-called-definition)). Uses that instantiate the definition identically share one clone — the memo is keyed on a `SpecKey`, taken from the use's live type before its pin, and an entry stores the key of the use that minted it (see [Keying a specialization](#keying-a-specialization)). The definition's own subtree is never coalesced in place *while it has clones*: its quantified variables have no use-site bounds, so coalescing it would both produce an under-determined type and overwrite the bound-bearing `InferVar`s the clones freshen from. A definition with no clones is the never-called case above, where neither objection applies.
 
 Specializing *during* the walk — rather than splicing after it — is load-bearing twice over. First, every parent derives its type from concrete children on the first pass: in particular a parent `Apply`'s dependent-codomain discharge forces against the specialization's resolved predicate terms, so parent types are never re-derived from a second, graph-unreachable copy of the discharge logic. Second, chained polymorphism (a generalized UDF used only inside *another* generalized definition, poly-calls-poly) needs no special ordering: the inner use is reached only inside an outer clone's re-entrant walk, after that clone's pin has driven the use's instantiation concrete, and the inner binding's frame is still in scope below the outer's. The ordering invariant that makes in-walk specialization sound: **specialization may only add bounds to variables the walk has not yet read** — a use's pin touches its own instantiation variables (read right after, at its own stamp), the clone's fresh variables (read only inside the clone's walk), and otherwise deposits only α-copies of demands the instantiation already made at emit; `coalesce_node`'s `Apply` arm coalesces function before argument to keep even those copies behind the read front. The invariant is **checked explicitly, not just argued**: the walk logs every graph read as a `(var-laden type, resolution)` pair (the snapshot shares the live `InferVar`s), and `assert_reads_stable` re-resolves each against the *final* graph at end of pass, requiring the structural skeleton — bases, ranges, shapes, refinement-layer count, with under-determined positions wildcarded and predicate *content* deferred to `check_scope_valid` / the post-inference reconcile — to be unchanged. A pin that retroactively altered an already-read variable's resolution trips it by name (debug builds; free in release). Refinement layers count because a refinement is lattice content like a record field, so a bound determines it as much as it determines the base; the **one** read that excludes them is a use's own instantiation resolution, where the pin that immediately follows the read is itself what moves the refinements (`ReadPurpose::Instantiation`). That is sound because the read's consumers are refinement-insensitive — it seeds the clone's channel-domain pairings and blames a resolution failure — and, in particular, *sharing does not ride on it*: that is the `SpecKey`'s job, and a key consults both bound directions precisely so it does not depend on which polarity a rendering would have picked. The read's *skeleton* is still held fixed — a stale one would pair channel domains wrong. The contravariant-domain coalescing of §2 — the opposite-polarity fallback plus `coalesce_node`'s per-morphism domain specialization (projections and lambdas) — is the monomorphic coalescing rule for those vars; it is sound because every variable reaching coalesce is monomorphically determined (§1).
+
+#### Typechecking a never-called definition
+
+Dropping a never-demanded binding as dead code is a decision about what to *lower*,
+not about what to *check*. A definition body is emitted whether or not it is called,
+so any demand that conflicts with a concrete type is already reported (`f = \a -> a
+and 3` is rejected with no call site). What emission records without judging is a
+demand on a **quantified** variable: one bound among several, a conflict only when
+the bounds are read together. Reading them together is what resolution does — so a
+definition like `f = \a -> (a.0, a.foo)`, which asks `𝑎` to be both a tuple and a
+record, was accepted for exactly as long as nobody called it. `coalesce_generalized_let`
+therefore resolves an undemanded definition (`typecheck_discarded_definition`) before
+dropping it, and keeps only the diagnostics.
+
+The general prohibition on coalescing a definition in place is about definitions with
+clones, and neither half of it survives their absence: nothing was freshened from this
+definition, and its binding leaves scope at the `let`, so nothing can freshen from it
+later. What remains is the under-determination — its quantified variables never
+received use-site bounds — which inference tolerates (`Type::Infer`'s invariant) and
+no strict check ever sees, because the resolved definition is discarded either way.
+
+The walk descends through uses, so it also typechecks what dead code *calls*: a use
+inside it of a generalized binding declared further out specializes normally, which is
+what makes the call's argument meet the callee's demands. That specialization must not
+be *registered*, though — its enclosing `let` survives the dead definition and would
+splice a binding nothing references. The walk records the scope depth it began at
+(`CoalesceCtx::discard_boundary`) and drops any specialization it mints on a frame
+below that line, so dead code is checked without re-entering the program. The boundary
+is a line rather than a switch: a frame pushed *inside* the discarded subtree registers
+as usual, because it is dropped along with it.
+
+**Deadness is the absence of a demand, not of a specialization.** The two come apart
+in both directions — a use whose instantiation fails to resolve reports and returns
+before minting anything, and a use inside a discarded subtree deliberately does not
+register — so `specs.is_empty()` cannot decide this. `SpecializeFrame::demanded`,
+set on entry to `specialize_use`, is what does. Reading the memo instead re-walks the
+definition of a binding whose uses merely *failed*, which reports that body's conflict
+a second time from its own nodes: one defect, four diagnostics.
+
+*Known gap, not fixed:* a use that fails to resolve is never renamed, so it still
+names a binding whose `let` the rebuild then drops — leaving that reference dangling
+in the tree a failed pass leaves behind. It is unobservable while an inference error
+discards the tree, and the fix is a node meaning "could not be built, errors pending"
+(today's `TypedExprNode::Error` is contracted to lowering recovery), which would also
+let the rebuild stay unconditional.
+
+**What this does not reach.** Resolution reads the bounds a body *recorded*, so a
+requirement that only takes effect when a concrete type is **delivered** is not
+evaluated here and cannot fail here. Trait obligations are the case: an obligation
+narrows its candidate set as bases arrive, and one whose operand never receives a base
+narrows nothing and so rejects nothing, however few implementations could ever satisfy
+it. Closing that is a property of the obligation machinery — an unsatisfiable
+*intersection* of the requirements on one variable is visible without any delivery — not
+of this walk, which only decides whether the definition's copies are resolved at all.
+
+**A shape that looks like an escape and is not.** `if 𝑝: [x for x in xs if 𝑞] else: xs`
+is accepted with no call site, and rejected at one. That is not laxity: both arms'
+domains are the *same* variable (`xs`'s), so the filter is recorded as a refinement on
+it rather than as a second domain alternative, and the definition types as
+`(…, {𝐷 | 𝑞} ⤇ 𝑉) ⇒ …` — *give me a collection whose domain already satisfies the
+filter*, which is exactly the condition under which the two arms share a domain and the
+join loses nothing. The requirement is in the type, not dropped. Supplying a concrete
+domain at a call site re-materializes the arms as two distinct domains and meets the
+interim Σ diagnosis ([The domain join is a Σ](#the-domain-join-is-a-σ)) — which is also
+why the same body over a *literal* or *source* collection is diagnosed either way: those
+domains are concrete in the body already, so there is no shared variable for the
+refinement to land on.
 
 #### Keying a specialization
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -276,12 +276,14 @@ no strict check ever sees, because the resolved definition is discarded either w
 The walk descends through uses, so it also typechecks what dead code *calls*: a use
 inside it of a generalized binding declared further out specializes normally, which is
 what makes the call's argument meet the callee's demands. That specialization must not
-be *registered*, though — its enclosing `let` survives the dead definition and would
-splice a binding nothing references. The walk records the scope depth it began at
-(`CoalesceCtx::discard_boundary`) and drops any specialization it mints on a frame
-below that line, so dead code is checked without re-entering the program. The boundary
-is a line rather than a switch: a frame pushed *inside* the discarded subtree registers
-as usual, because it is dropped along with it.
+be *spliced*, though — its enclosing `let` survives the dead definition and would
+gain a binding nothing references. It is still registered, which is what shares the
+clone with the next dead use, and marked unreferenced instead
+(`Specialization::referenced`), so dead code is checked without re-entering the
+program. Which frames that applies to is asked of each frame when it is pushed
+(`SpecializeFrame::inside_discarded`) rather than computed from a scope depth: a frame
+created *inside* the discarded subtree dies with it, so what it splices is moot, and
+the re-entrant clone walk truncates the scope stack, which a depth cannot survive.
 
 **Deadness is the absence of a demand, not of a specialization.** The two come apart
 in both directions — a use whose instantiation fails to resolve reports and returns
@@ -297,6 +299,21 @@ in the tree a failed pass leaves behind. It is unobservable while an inference e
 discards the tree, and the fix is a node meaning "could not be built, errors pending"
 (today's `TypedExprNode::Error` is contracted to lowering recovery), which would also
 let the rebuild stay unconditional.
+
+**What it costs.** The walk runs unconditionally, in release, on every definition
+nothing calls — so the specialization blowup documented under
+`SpecializeFrame::specs`, "The remaining gap" (one clone per distinct argument
+tuple, compounding through a call chain) is now reachable from code no one calls,
+where before dead code cost nothing. Two things keep that bounded rather than
+multiplied. A use inside the discarded subtree still *registers* its
+specialization, so the memo shares clones exactly as a live use does — declining to
+register instead made every dead use re-clone its callee, which measured ~5× the
+shared cost at a call-chain depth of six; splice-liveness is decided separately, at
+the rebuild (`Specialization::referenced`). And a dead definition nested inside a
+*live* generalized one is walked once per clone of its enclosing binding — which is
+correct, since its body can depend on the instantiation — but a diagnostic it
+repeats is dropped, so one defect stays one diagnostic however many specializations
+enclose it.
 
 **What this does not reach.** Resolution reads the bounds a body *recorded*, so a
 requirement that only takes effect when a concrete type is **delivered** is not

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -148,21 +148,22 @@ pub(super) struct CoalesceCtx {
     /// [`coalesce_node`] on both exit paths. The same discipline `emit_node` and
     /// `check_node` use; seeded with the tree's root at construction.
     current_node: NodeId,
-    /// While a **discarded** subtree is being walked — a dead generalized
+    /// Whether a **discarded** subtree is being walked — a dead generalized
     /// definition, resolved for its diagnostics and then dropped
-    /// ([`typecheck_discarded_definition`]) — the `scope` depth at which that
-    /// walk began; `None` outside one. Frames at or above the boundary were
-    /// pushed *inside* the discarded subtree and go away with it, so a
-    /// specialization minted on one is registered as usual. A frame *below* it
-    /// belongs to a binding that survives, and registering there would splice a
-    /// specialization into the surviving program whose only use is about to be
-    /// discarded — so [`specialize_use`] typechecks such a use and drops it
-    /// (see [`SpecializeFrame::specs`], "The remaining gap", for the same
-    /// liveness question on the sharing path).
+    /// ([`typecheck_discarded_definition`]).
     ///
-    /// The *outermost* discarded walk owns the boundary: everything a nested one
-    /// could register is already inside a subtree being dropped.
-    discard_boundary: Option<usize>,
+    /// A specialization minted while this holds serves a use that is about to be
+    /// dropped, so it is registered — the memo is what stops the walk re-cloning —
+    /// but marked unreferenced ([`Specialization::referenced`]) unless its own
+    /// frame is being dropped too ([`SpecializeFrame::inside_discarded`]).
+    ///
+    /// Deliberately *not* a `scope` depth. A depth answers "is this frame outside
+    /// the discarded subtree" only while the stack grows monotonically, and
+    /// [`specialize_use`] truncates it (`split_off(frame_idx)`) for the re-entrant
+    /// clone walk: frames the clone's own body pushes then land at indices below
+    /// the mark and read as surviving, though they die with the clone. Asking each
+    /// frame what it is, at the moment it is created, is immune to that.
+    discarding: bool,
     /// Every read the walk performed, for the end-of-pass ordering-invariant
     /// check ([`assert_reads_stable`]). Debug builds only.
     #[cfg(debug_assertions)]
@@ -460,14 +461,28 @@ struct SpecializeFrame {
     /// The binding's polymorphism level — the freshen cutoff: variables
     /// deeper than this are the quantified ones.
     cutoff: Level,
+    /// Whether this binding is itself inside a subtree being discarded — recorded
+    /// from [`CoalesceCtx::discarding`] when the frame is pushed, the one moment
+    /// the answer is unambiguous.
+    ///
+    /// A specialization minted on such a frame is spliced as usual: the `let` it
+    /// splices into is going away with the subtree, so liveness there is moot. It
+    /// is the frames that **outlive** a discarded walk whose splices need filtering.
+    inside_discarded: bool,
     /// Whether the body demanded this binding at all — set by [`specialize_use`]
-    /// on entry, before anything can go wrong.
+    /// on entry, before anything can go wrong, and so **including uses that sit in
+    /// dead code**.
+    ///
+    /// That is deliberate: such a binding is not discard-walked, and does not need
+    /// to be. It was already checked through the clone the dead use pinned, which
+    /// is a *stricter* reading than the generic one a discard walk would take — a
+    /// specialization only adds bounds. Walking it again would report whatever that
+    /// clone already reported (`through_a_call_in_dead_code` covers the case).
     ///
     /// This is *not* `!specs.is_empty()`, and the difference is exactly the case
     /// where a use exists but produced no specialization: a use whose
-    /// instantiation fails to resolve reports and returns before minting one, and
-    /// a use inside a discarded subtree deliberately does not register (see
-    /// [`CoalesceCtx::discard_boundary`]). Only *this* flag answers "is the
+    /// instantiation fails to resolve reports and returns before minting one. Only
+    /// *this* flag answers "is the
     /// definition dead code", which is what decides whether it is typechecked on
     /// the way out ([`typecheck_discarded_definition`]) — asking `specs` instead
     /// re-walks a definition whose uses merely failed, and reports its body's
@@ -565,8 +580,22 @@ struct Specialization {
     name: Name,
     /// The specialized, fully-coalesced definition. Spliced as a `let`
     /// binding around the generalized `let`'s body once that body's walk
-    /// completes.
+    /// completes — if [`referenced`](Self::referenced).
     def: Expr,
+    /// Whether a use that **survives** refers to this specialization.
+    ///
+    /// A use inside a discarded subtree still needs a clone — pinning and
+    /// coalescing it is what typechecks the call — but the `let` it would splice
+    /// outlives the subtree its only use is in, so splicing would leave the
+    /// program a definition nothing references. Splitting that from the memo is
+    /// what lets the clone be *shared*: declining to register instead made every
+    /// dead use re-clone and re-coalesce its callee, which compounds through a
+    /// call chain (see [`SpecializeFrame::specs`], "The remaining gap", where the
+    /// same split is what reference-liveness filtering asks for).
+    ///
+    /// False at mint for a discarded use; a later surviving use that *hits* this
+    /// entry sets it, because sharing the clone is exactly what makes it live.
+    referenced: bool,
 }
 
 /// Find the scope entry a free use of `name` refers to: scanning innermost-
@@ -604,7 +633,7 @@ pub(super) fn coalesce_pass(expr: &mut Expr) -> Vec<LocatedInferError> {
         current_node: expr.node_id(),
         errors: Vec::new(),
         pred_memo: PredMemo::new(),
-        discard_boundary: None,
+        discarding: false,
         #[cfg(debug_assertions)]
         reads: Vec::new(),
     };
@@ -1367,6 +1396,19 @@ pub(super) fn specialize_use(use_expr: &mut Expr, frame_idx: usize, ctx: &mut Co
     };
     if let Some(spec) = frame.specs.iter().find(|s| s.key == key) {
         let (name, ty) = (spec.name.clone(), spec.def.ty.clone());
+        // Sharing is what makes an entry live: an entry minted for a discarded use
+        // is spliced after all once a surviving use adopts it.
+        if surviving_use(ctx, frame_idx) {
+            let ScopeEntry::Generalized(frame) = &mut ctx.scope[frame_idx] else {
+                unreachable!("lookup_generalized returns indices of Generalized entries only");
+            };
+            let spec = frame
+                .specs
+                .iter_mut()
+                .find(|s| s.key == key)
+                .expect("the entry just found is still there");
+            spec.referenced = true;
+        }
         // A hit is *not* re-pinned, and the reason is worth recording because
         // pinning here looks like the obvious way to make the key's faithfulness
         // checked rather than argued. It is not available: a miss pins a
@@ -1455,14 +1497,7 @@ pub(super) fn specialize_use(use_expr: &mut Expr, frame_idx: usize, ctx: &mut Co
 
     use_expr.node = TypedExprNode::Var(spec_name.clone());
     use_expr.ty = clone.ty.clone();
-    // This use lives in a subtree that is about to be dropped, while the binding
-    // it specializes outlives that subtree: the clone was built for its
-    // diagnostics, which the walk above has already collected, and registering it
-    // would leave the surviving program a definition nothing references. Drop it
-    // instead — see [`CoalesceCtx::discard_boundary`].
-    if ctx.discard_boundary.is_some_and(|depth| frame_idx < depth) {
-        return;
-    }
+    let referenced = surviving_use(ctx, frame_idx);
     let ScopeEntry::Generalized(frame) = &mut ctx.scope[frame_idx] else {
         unreachable!("suspended entries were restored above the frame");
     };
@@ -1481,7 +1516,22 @@ pub(super) fn specialize_use(use_expr: &mut Expr, frame_idx: usize, ctx: &mut Co
         key,
         name: spec_name,
         def: clone,
+        referenced,
     });
+}
+
+/// Whether a use being specialized on `frame_idx` will still be in the program
+/// when the walk finishes — the predicate deciding whether its specialization is
+/// spliced ([`Specialization::referenced`]).
+///
+/// It is not, exactly when the use sits in a discarded subtree that its binding
+/// outlives. A binding *inside* that subtree is dropped along with the use, so
+/// what it splices is moot and this reads `true`.
+fn surviving_use(ctx: &CoalesceCtx, frame_idx: usize) -> bool {
+    let ScopeEntry::Generalized(frame) = &ctx.scope[frame_idx] else {
+        unreachable!("lookup_generalized returns indices of Generalized entries only");
+    };
+    !ctx.discarding || frame.inside_discarded
 }
 
 /// Coalesce a generalized `let`: walk the body under a specialization frame
@@ -1515,6 +1565,7 @@ pub(super) fn coalesce_generalized_let(expr: &mut Expr, level: Level, ctx: &mut 
             name: binding.name,
             def: *bound_expr,
             cutoff: level,
+            inside_discarded: ctx.discarding,
             demanded: false,
             specs: Vec::new(),
         })));
@@ -1546,7 +1597,7 @@ pub(super) fn coalesce_generalized_let(expr: &mut Expr, level: Level, ctx: &mut 
     // "Typechecking a never-called definition", for why that dangling reference is
     // unobservable today and what fixes it.
     let mut result = body;
-    for spec in frame.specs.into_iter().rev() {
+    for spec in frame.specs.into_iter().rev().filter(|s| s.referenced) {
         // The discharge only does work when the specialization binder is free
         // in the body type's refinement predicates; skip cloning `spec.def`
         // otherwise (it is still moved into the rebuilt `let` below).
@@ -1599,13 +1650,33 @@ pub(super) fn coalesce_generalized_let(expr: &mut Expr, level: Level, ctx: &mut 
 /// written. `level` is the enclosing `let`'s level, and the definition — like
 /// every `let` RHS — was emitted one deeper (`in_let_rhs`).
 fn typecheck_discarded_definition(def: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
-    let outer_boundary = ctx.discard_boundary;
-    // The outermost discarded walk owns the boundary; a nested one changes
-    // nothing, since every frame it could reach is already inside a dropped
-    // subtree.
-    ctx.discard_boundary.get_or_insert(ctx.scope.len());
+    let before = ctx.errors.len();
+    let was_discarding = std::mem::replace(&mut ctx.discarding, true);
     coalesce_node(def, level + 1, ctx);
-    ctx.discard_boundary = outer_boundary;
+    ctx.discarding = was_discarding;
+
+    // A dead definition nested inside a *live* generalized one sits inside each of
+    // its clones, so it is walked once per specialization of the enclosing binding
+    // — and one defect would be reported once per clone (five uses of the enclosing
+    // function, fifteen diagnostics for one bug). Walking per clone is right, since
+    // the body can depend on the enclosing instantiation and so can fail in one and
+    // not another; reporting the *same* diagnostic again is not. Drop a new error
+    // that repeats one already reported.
+    //
+    // Compared only against what preceded this walk, never within it: a walk's own
+    // shape — one report per node whose type carries the defect — is what coalesce
+    // does everywhere, and dead code should read the same as live code.
+    let mut i = before;
+    while i < ctx.errors.len() {
+        if ctx.errors[..before]
+            .iter()
+            .any(|seen| seen.error == ctx.errors[i].error)
+        {
+            ctx.errors.remove(i);
+        } else {
+            i += 1;
+        }
+    }
 }
 
 /// Specialize a projection morphism to the value flowing into it — the
@@ -1970,18 +2041,20 @@ mod tests {
         );
     }
 
-    /// The boundary is a *line*, not a switch: a frame pushed **inside** the
-    /// discarded subtree registers as usual (it is dropped along with it), while one
-    /// below the line does not.
+    /// Splice-liveness is a property of the *frame*, not of a position in the scope
+    /// stack: a binding created inside the discarded subtree is dropped with it, so
+    /// its splices are moot, while one that outlives the subtree must not gain a
+    /// binding nothing references.
     ///
-    /// Dead `f` contains `h`, used inside `f`, which calls the live `g`. `h`'s frame
-    /// is inside the discarded walk, so its specialization is registered — which is
-    /// what carries the `g` call into a clone at all; `g`'s frame is below the line,
-    /// so the specialization minted there is dropped. `g` is separately live at one
-    /// type, so exactly one specialization survives. Suppressing at `h`'s level too
-    /// would leave `h` looking dead and get its definition walked a second time.
+    /// Dead `f` contains `h`, used inside `f`, which calls the live `g`. `h` is
+    /// created inside the discarded walk, so its specialization splices as usual —
+    /// which is what carries the `g` call into a clone at all; `g` outlives the walk,
+    /// so the specialization minted there is registered but not spliced. `g` is
+    /// separately live at one type, so exactly one specialization survives. Marking
+    /// `h`'s level unreferenced too would leave `h` looking dead and get its
+    /// definition walked a second time.
     #[test]
-    fn the_discard_boundary_only_suppresses_surviving_frames() {
+    fn splice_liveness_follows_the_frame_not_the_scope_depth() {
         // let g = λx. x + 1 in let f = λa. (let h = λb. g(b) in h(2)) in g(5)
         let g = TypedExpr::lambda(
             "x",

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -148,6 +148,21 @@ pub(super) struct CoalesceCtx {
     /// [`coalesce_node`] on both exit paths. The same discipline `emit_node` and
     /// `check_node` use; seeded with the tree's root at construction.
     current_node: NodeId,
+    /// While a **discarded** subtree is being walked — a dead generalized
+    /// definition, resolved for its diagnostics and then dropped
+    /// ([`typecheck_discarded_definition`]) — the `scope` depth at which that
+    /// walk began; `None` outside one. Frames at or above the boundary were
+    /// pushed *inside* the discarded subtree and go away with it, so a
+    /// specialization minted on one is registered as usual. A frame *below* it
+    /// belongs to a binding that survives, and registering there would splice a
+    /// specialization into the surviving program whose only use is about to be
+    /// discarded — so [`specialize_use`] typechecks such a use and drops it
+    /// (see [`SpecializeFrame::specs`], "The remaining gap", for the same
+    /// liveness question on the sharing path).
+    ///
+    /// The *outermost* discarded walk owns the boundary: everything a nested one
+    /// could register is already inside a subtree being dropped.
+    discard_boundary: Option<usize>,
     /// Every read the walk performed, for the end-of-pass ordering-invariant
     /// check ([`assert_reads_stable`]). Debug builds only.
     #[cfg(debug_assertions)]
@@ -445,6 +460,19 @@ struct SpecializeFrame {
     /// The binding's polymorphism level — the freshen cutoff: variables
     /// deeper than this are the quantified ones.
     cutoff: Level,
+    /// Whether the body demanded this binding at all — set by [`specialize_use`]
+    /// on entry, before anything can go wrong.
+    ///
+    /// This is *not* `!specs.is_empty()`, and the difference is exactly the case
+    /// where a use exists but produced no specialization: a use whose
+    /// instantiation fails to resolve reports and returns before minting one, and
+    /// a use inside a discarded subtree deliberately does not register (see
+    /// [`CoalesceCtx::discard_boundary`]). Only *this* flag answers "is the
+    /// definition dead code", which is what decides whether it is typechecked on
+    /// the way out ([`typecheck_discarded_definition`]) — asking `specs` instead
+    /// re-walks a definition whose uses merely failed, and reports its body's
+    /// conflicts a second time.
+    demanded: bool,
     /// Specializations minted so far, scanned linearly.
     /// A candidate use's [`SpecKey`] is compared against each entry's — both
     /// computed by the *same* procedure at the *same* point in the pin's lifecycle
@@ -576,6 +604,7 @@ pub(super) fn coalesce_pass(expr: &mut Expr) -> Vec<LocatedInferError> {
         current_node: expr.node_id(),
         errors: Vec::new(),
         pred_memo: PredMemo::new(),
+        discard_boundary: None,
         #[cfg(debug_assertions)]
         reads: Vec::new(),
     };
@@ -1222,7 +1251,8 @@ fn coalesce_type_predicates(ty: &mut Type, level: Level, ctx: &mut CoalesceCtx) 
 // [`crate::ccl::inline`]). The binding's
 // `let` node then rebuilds itself as the chain of demanded specializations
 // (`coalesce_generalized_let`). A binding used at K distinct types becomes K
-// nested `let`s; one never used at all is dropped as dead code.
+// nested `let`s; one never used at all is typechecked, then dropped as dead code
+// (`typecheck_discarded_definition`).
 //
 // Specializing *during* the walk (rather than in a post-coalesce pass) is
 // what lets every parent derive its type from concrete children on the first
@@ -1291,6 +1321,13 @@ fn freshen_clone_node_ids(expr: &mut Expr) {
 // (matching the solver's module-level allow).
 #[allow(clippy::mutable_key_type)]
 pub(super) fn specialize_use(use_expr: &mut Expr, frame_idx: usize, ctx: &mut CoalesceCtx) {
+    // Record the demand before anything below can fail or decline to register: a
+    // definition is dead code only if no use ever reached this function.
+    let ScopeEntry::Generalized(frame) = &mut ctx.scope[frame_idx] else {
+        unreachable!("lookup_generalized returns indices of Generalized entries only");
+    };
+    frame.demanded = true;
+
     // The use's instantiation type, resolved off the live graph. The graph is
     // complete (emission saw the whole program), so everything this use
     // depends on has already been constrained — including, for a use inside
@@ -1418,6 +1455,14 @@ pub(super) fn specialize_use(use_expr: &mut Expr, frame_idx: usize, ctx: &mut Co
 
     use_expr.node = TypedExprNode::Var(spec_name.clone());
     use_expr.ty = clone.ty.clone();
+    // This use lives in a subtree that is about to be dropped, while the binding
+    // it specializes outlives that subtree: the clone was built for its
+    // diagnostics, which the walk above has already collected, and registering it
+    // would leave the surviving program a definition nothing references. Drop it
+    // instead — see [`CoalesceCtx::discard_boundary`].
+    if ctx.discard_boundary.is_some_and(|depth| frame_idx < depth) {
+        return;
+    }
     let ScopeEntry::Generalized(frame) = &mut ctx.scope[frame_idx] else {
         unreachable!("suspended entries were restored above the frame");
     };
@@ -1450,7 +1495,8 @@ pub(super) fn specialize_use(use_expr: &mut Expr, frame_idx: usize, ctx: &mut Co
 /// over its binding (`[name_i ↦ def_i]`, the §6.2 move site), exactly as
 /// `coalesce_node`'s tail does for a monomorphic `let` — the specializations
 /// are concrete here, so the discharge splices resolved types. A binding the
-/// body never demanded (no uses at any type) is dropped entirely — its
+/// body never demanded (no uses at any type) is resolved for its diagnostics
+/// ([`typecheck_discarded_definition`]) and then dropped entirely — its
 /// definition is dead code.
 pub(super) fn coalesce_generalized_let(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
     let saved_annotation = expr.user_annotation.take();
@@ -1469,16 +1515,36 @@ pub(super) fn coalesce_generalized_let(expr: &mut Expr, level: Level, ctx: &mut 
             name: binding.name,
             def: *bound_expr,
             cutoff: level,
+            demanded: false,
             specs: Vec::new(),
         })));
     coalesce_node(&mut body, level, ctx);
-    let Some(ScopeEntry::Generalized(frame)) = ctx.scope.pop() else {
+    let Some(ScopeEntry::Generalized(mut frame)) = ctx.scope.pop() else {
         unreachable!("the binding's frame still tops the scope after a balanced body walk");
     };
+
+    // A definition no use demanded is dead code — but it is still the user's
+    // code, so it is typechecked before it is dropped.
+    if !frame.demanded {
+        debug_assert!(
+            frame.specs.is_empty(),
+            "specialization without a demand: `{}` registered {} specialization(s) \
+             though no use reached `specialize_use`",
+            frame.name,
+            frame.specs.len(),
+        );
+        typecheck_discarded_definition(&mut frame.def, level, ctx);
+    }
 
     // Wrap the body in one specialized `let` per distinct type. Built in
     // reverse so first-demanded types end up outermost; ordering is
     // immaterial since the specializations never reference one another.
+    //
+    // Dropping the binding rests on every use having been *renamed* to a
+    // specialization. A use that failed to resolve was not, so it is left naming a
+    // binding this rebuild deletes — see `src/ccl/design/type-inference.md`,
+    // "Typechecking a never-called definition", for why that dangling reference is
+    // unobservable today and what fixes it.
     let mut result = body;
     for spec in frame.specs.into_iter().rev() {
         // The discharge only does work when the specialization binder is free
@@ -1502,6 +1568,44 @@ pub(super) fn coalesce_generalized_let(expr: &mut Expr, level: Level, ctx: &mut 
     }
     *expr = result;
     expr.user_annotation = saved_annotation;
+}
+
+/// Resolve a generalized definition that no use demanded, for its diagnostics
+/// alone: the definition is dead code and is dropped as soon as this returns.
+///
+/// A definition that *is* used never comes here, and must not: its quantified
+/// variables carry no use-site bounds, and coalescing it in place would resolve
+/// it under-determined *and* overwrite the bound-bearing variables its per-use
+/// clones freshen from (see [`coalesce_node`]). Neither objection survives the
+/// absence of uses — nothing was cloned from this definition, and the binding
+/// goes out of scope here, so nothing can clone it later. What is left is the
+/// under-determination, which inference tolerates (`Type::Infer`'s invariant)
+/// and which no strict check ever sees, because the resolved types are dropped
+/// with the definition.
+///
+/// What the walk is *for* is the class of error only resolution sees. Emission
+/// visits a definition body whether or not it is used, so a demand that conflicts
+/// with a *concrete* type is already reported (`λ 𝑎 → 𝑎 and 3`); what emission
+/// records without judging is a demand on a **quantified** variable, one bound
+/// among several. `λ 𝑎 → (𝑎.0, 𝑎.foo)` asks `𝑎` to be both a tuple and a record,
+/// and that is a conflict only when the bounds are read together — which is what
+/// resolution does. Before this walk existed, such a definition was accepted
+/// precisely as long as nobody called it.
+///
+/// See `src/ccl/design/type-inference.md`, "Typechecking a never-called definition".
+///
+/// Runs in the definition site's scope: the binding's frame is popped before the
+/// call, so `ctx.scope` is already what was in scope where the definition was
+/// written. `level` is the enclosing `let`'s level, and the definition — like
+/// every `let` RHS — was emitted one deeper (`in_let_rhs`).
+fn typecheck_discarded_definition(def: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
+    let outer_boundary = ctx.discard_boundary;
+    // The outermost discarded walk owns the boundary; a nested one changes
+    // nothing, since every frame it could reach is already inside a dropped
+    // subtree.
+    ctx.discard_boundary.get_or_insert(ctx.scope.len());
+    coalesce_node(def, level + 1, ctx);
+    ctx.discard_boundary = outer_boundary;
 }
 
 /// Specialize a projection morphism to the value flowing into it — the
@@ -1645,7 +1749,8 @@ fn refresh_lambda_param_slot(expr: &mut Expr) {
 mod tests {
     use super::super::test_helpers::*;
     use crate::ccl::infer::{int_lit_ty, str_lit_ty};
-    use crate::ccl::{BaseType, Type, TypedExpr, TypedExprNode};
+    use crate::ccl::symbolic::symbolic;
+    use crate::ccl::{ArithmeticKind, BaseType, BinOpKind, Lit, Type, TypedExpr, TypedExprNode};
 
     // ----- ordering-invariant comparison (`types_agree_modulo_unread`) -----
 
@@ -1661,7 +1766,7 @@ mod tests {
     fn refinement_drift_fails_a_stamp_read_and_passes_an_instantiation_read() {
         use super::types_agree_modulo_unread;
         let plain = Type::Base(BaseType::Int);
-        let refined = refined_int(TypedExpr::lit(crate::ccl::Lit::Int(8)));
+        let refined = refined_int(TypedExpr::lit(Lit::Int(8)));
         for (read, now) in [(&plain, &refined), (&refined, &plain)] {
             assert!(
                 !types_agree_modulo_unread(read, now, true),
@@ -1821,6 +1926,94 @@ mod tests {
             "the two identical `Int` uses share one specialization"
         );
         assert_eq!(used_names.len(), 2);
+    }
+
+    /// Typechecking a dead definition must not resurrect it, and must not
+    /// resurrect what it *calls* either.
+    ///
+    /// `f` is dead, so it is resolved for its diagnostics and dropped
+    /// ([`typecheck_discarded_definition`]) — and that walk reaches `f`'s use of
+    /// `g`, whose frame is still in scope beneath it. Specializing there is what
+    /// typechecks the call, but registering the specialization would splice a
+    /// definition into the surviving program whose only use is the one being
+    /// dropped. Both bindings must vanish: the program is `1`.
+    #[test]
+    fn a_dead_definitions_calls_splice_no_specialization() {
+        // let g = λx. x + 1 in let f = λa. g(1) in 1
+        let g = TypedExpr::lambda(
+            "x",
+            Type::Hole,
+            TypedExpr::binop(
+                TypedExpr::var("x"),
+                BinOpKind::Arithmetic(ArithmeticKind::Add),
+                lit_int(1),
+            ),
+        );
+        let f = TypedExpr::lambda(
+            "a",
+            Type::Hole,
+            TypedExpr::apply(lit_int(1), TypedExpr::var("g")),
+        );
+        let mut e = TypedExpr::let_bind("g", g, TypedExpr::let_bind("f", f, lit_int(1)));
+        let ty = run_inference(&mut e).expect("a dead definition's call type-checks");
+        assert_eq!(ty, int_lit_ty(1));
+        let (specializations, used_names) = specialization_stats(&e);
+        assert_eq!(
+            specializations, 0,
+            "a specialization minted while walking a dead definition is dropped with it"
+        );
+        assert!(used_names.is_empty());
+        assert!(
+            matches!(e.node, TypedExprNode::Lit(Lit::Int(1))),
+            "both dead bindings are gone, leaving the body: {}",
+            symbolic(&e)
+        );
+    }
+
+    /// The boundary is a *line*, not a switch: a frame pushed **inside** the
+    /// discarded subtree registers as usual (it is dropped along with it), while one
+    /// below the line does not.
+    ///
+    /// Dead `f` contains `h`, used inside `f`, which calls the live `g`. `h`'s frame
+    /// is inside the discarded walk, so its specialization is registered — which is
+    /// what carries the `g` call into a clone at all; `g`'s frame is below the line,
+    /// so the specialization minted there is dropped. `g` is separately live at one
+    /// type, so exactly one specialization survives. Suppressing at `h`'s level too
+    /// would leave `h` looking dead and get its definition walked a second time.
+    #[test]
+    fn the_discard_boundary_only_suppresses_surviving_frames() {
+        // let g = λx. x + 1 in let f = λa. (let h = λb. g(b) in h(2)) in g(5)
+        let g = TypedExpr::lambda(
+            "x",
+            Type::Hole,
+            TypedExpr::binop(
+                TypedExpr::var("x"),
+                BinOpKind::Arithmetic(ArithmeticKind::Add),
+                lit_int(1),
+            ),
+        );
+        let h = TypedExpr::lambda(
+            "b",
+            Type::Hole,
+            TypedExpr::apply(TypedExpr::var("b"), TypedExpr::var("g")),
+        );
+        let f = TypedExpr::lambda(
+            "a",
+            Type::Hole,
+            TypedExpr::let_bind("h", h, TypedExpr::apply(lit_int(2), TypedExpr::var("h"))),
+        );
+        let mut e = TypedExpr::let_bind(
+            "g",
+            g,
+            TypedExpr::let_bind("f", f, TypedExpr::apply(lit_int(5), TypedExpr::var("g"))),
+        );
+        run_inference(&mut e).expect("the nested dead call type-checks");
+        let (specializations, used_names) = specialization_stats(&e);
+        assert_eq!(
+            specializations, 1,
+            "only `g`'s live specialization survives; the dead walk's are dropped"
+        );
+        assert_eq!(used_names.len(), 1, "and the surviving one is referenced");
     }
 
     #[test]

--- a/tests/alloc_probe/mod.rs
+++ b/tests/alloc_probe/mod.rs
@@ -1,0 +1,172 @@
+//! A per-thread allocation counter for integration tests, plus its own tests.
+//!
+//! Include it with `mod alloc_probe;` and measure with
+//! [`allocations`](alloc_probe::allocations). Including the module installs a
+//! `#[global_allocator]` for that test binary — which is why this is a module rather
+//! than a library: an allocator is per-binary, so each test binary needs its own
+//! instance of it, but they can share the code.
+//!
+//! # The window is per-thread, and has to be
+//!
+//! "Allocations during a window of wall-clock time" is not a property worth
+//! asserting; "allocations *this thread* made while running `body`" is. A
+//! process-global counter conflates them, and the difference is not hypothetical:
+//! libtest runs each test on a spawned thread and its main thread keeps working right
+//! afterwards, doing exactly four one-time allocations before it blocks —
+//! `running_tests.insert` (first insert into an empty `HashMap`),
+//! `timeout_queue.push_back` (first push into an empty `VecDeque`), and two inside the
+//! first blocking `rx.recv_timeout`. If the spawned test thread wins the race to the
+//! measured code, a global counter charges all four to it. That is a real observed
+//! failure ("the scoped walk allocated 4 times") — rare, because the main thread
+//! normally finishes those four before a freshly spawned thread is scheduled at all,
+//! but reachable whenever the main thread is preempted right after the spawn, which is
+//! what a loaded CI runner does.
+//!
+//! Counting per-thread costs nothing in strength for code that spawns nothing: every
+//! allocation such code could make is made by the thread that armed the window, so the
+//! counter still sees all of them and now sees only them.
+//!
+//! # The probe tests itself
+//!
+//! [`the_probe_counts_allocations_made_by_the_measuring_thread`] and
+//! [`another_threads_allocations_are_not_charged_to_this_window`] live here rather
+//! than beside any one measurement, so a binary that adopts the probe adopts the
+//! evidence that it works. A zero-allocation claim measured by a counter that counts
+//! nothing would pass for the wrong reason, and no assertion in the *using* file would
+//! notice.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+
+thread_local! {
+    /// Allocations this thread has made since it armed its window.
+    static ALLOCS: Cell<usize> = const { Cell::new(0) };
+    /// Is this thread's measurement window open?
+    static COUNTING: Cell<bool> = const { Cell::new(false) };
+}
+
+struct Counting;
+
+impl Counting {
+    /// Charge one allocation to the current thread, if its window is open.
+    ///
+    /// Both thread-locals are `const`-initialized and hold a type with no
+    /// destructor, so the access is a direct TLS read: no lazy initializer, no
+    /// destructor registration, and so no allocation. That matters here and not
+    /// just for accuracy — an allocating counter inside `GlobalAlloc` would
+    /// recurse.
+    fn charge() {
+        if COUNTING.get() {
+            ALLOCS.set(ALLOCS.get() + 1);
+        }
+    }
+}
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        Self::charge();
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        Self::charge();
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static A: Counting = Counting;
+
+/// An open measurement window on the current thread, closed when dropped.
+///
+/// The guard exists so that no path can leave a window open. A `body` that
+/// panics — a failing assertion inside one of these tests is exactly that —
+/// would otherwise leave `COUNTING` set, and every later window on the same
+/// thread would then be measuring from an armed counter it did not arm.
+struct Window;
+
+impl Window {
+    /// Zero this thread's counter and arm it.
+    fn open() -> Self {
+        ALLOCS.set(0);
+        COUNTING.set(true);
+        Window
+    }
+}
+
+impl Drop for Window {
+    fn drop(&mut self) {
+        COUNTING.set(false);
+    }
+}
+
+/// Allocations the calling thread performs while running `body`. Other threads'
+/// allocations are not counted — see the module docs for why that is the
+/// measurement the assertions want.
+pub fn allocations(body: impl FnOnce()) -> usize {
+    let _window = Window::open();
+    body();
+    ALLOCS.get()
+}
+
+/// The probe has to be able to *see* an allocation, or a zero-allocation claim
+/// measured with it passes for the wrong reason — so pay one allocation on the
+/// measuring thread and check it lands.
+#[test]
+fn the_probe_counts_allocations_made_by_the_measuring_thread() {
+    let allocs = allocations(|| {
+        let v: Vec<u8> = Vec::with_capacity(64);
+        std::hint::black_box(&v);
+    });
+    assert_eq!(
+        allocs, 1,
+        "one `Vec::with_capacity` is one allocation; the probe saw {allocs}"
+    );
+}
+
+/// The other half of that: a window must see *only* its own thread. This is the
+/// property the whole probe rests on, and the one a global counter silently
+/// loses — swap the counters back for process-global ones and this reports 1002
+/// rather than 0, the worker's thousand plus two the test harness happened to
+/// make, while every other assertion stays green.
+///
+/// The window has to bracket the worker's allocating loop and nothing else.
+/// Spawning heap-allocates the closure and the result slot *on the spawning
+/// thread*, and joining does bookkeeping of its own, so a window drawn around
+/// `thread::scope` counts those — correctly, as its own — and drowns the signal.
+/// Hence the handshake: two `AtomicBool`s, which spin without allocating.
+#[test]
+fn another_threads_allocations_are_not_charged_to_this_window() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    const N: usize = 1000;
+
+    let go = AtomicBool::new(false);
+    let done = AtomicBool::new(false);
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            while !go.load(Ordering::Acquire) {
+                std::hint::spin_loop();
+            }
+            for _ in 0..N {
+                std::hint::black_box(Vec::<u8>::with_capacity(64));
+            }
+            done.store(true, Ordering::Release);
+        });
+
+        let allocs = allocations(|| {
+            go.store(true, Ordering::Release);
+            while !done.load(Ordering::Acquire) {
+                std::hint::spin_loop();
+            }
+        });
+
+        assert_eq!(
+            allocs, 0,
+            "another thread's allocations were charged to this window: {allocs}"
+        );
+    });
+}

--- a/tests/dead_code_specialization_cost.rs
+++ b/tests/dead_code_specialization_cost.rs
@@ -1,0 +1,72 @@
+//! Typechecking a never-called definition must not cost *more* than compiling the
+//! same code live.
+//!
+//! A use inside a discarded subtree specializes like any other, and the memo is what
+//! stops it re-cloning the callee. That memo is separate from the decision of what to
+//! splice (`Specialization::referenced`), and conflating the two — declining to
+//! register a specialization whose use is about to be dropped — silently reintroduces
+//! a clone per dead call site, compounding through a call chain.
+//!
+//! Allocation count is the probe rather than wall-clock: it is deterministic, so the
+//! guard can be a hard bound instead of a flaky timing threshold. The counter is
+//! `tests/alloc_probe/mod.rs`. The chain `aᵢ = λx. aᵢ₋₁(x) + aᵢ₋₁(x)` is the shape
+//! that makes re-cloning visible — every level doubles the call sites sharing must
+//! collapse.
+
+mod alloc_probe;
+
+use alloc_probe::allocations;
+use cambra::ccl::{
+    infer::{TypeInferenceContext, infer},
+    lower::{LoweringContext, lower_stmts},
+};
+use cambra::chl_parser;
+
+/// `a1 … a{depth}`, each calling its predecessor twice, then `f` calling the last.
+/// With `live`, `f` is applied; without, `f` is dead code.
+fn chain(depth: usize, live: bool) -> String {
+    let mut s = String::from("a1 = \\x -> x + 1\n");
+    for i in 2..=depth {
+        s.push_str(&format!("a{i} = \\x -> a{p}(x) + a{p}(x)\n", p = i - 1));
+    }
+    s.push_str(&format!("f = \\q -> a{depth}(q)\n"));
+    if live {
+        s.push_str("live = f(1)\n");
+    }
+    s.push_str("1\n");
+    s
+}
+
+/// Allocations `infer` performs on this thread. Parsing and lowering are done first,
+/// outside the window, so only inference is measured.
+fn inference_allocations(code: &str) -> usize {
+    let mut lctx = LoweringContext::default();
+    let stmts = chl_parser::parse_module(code)
+        .into_result()
+        .expect("parse")
+        .body;
+    let mut expr = lower_stmts(&stmts, &mut lctx).into_result().expect("lower");
+    let mut ictx = TypeInferenceContext::new();
+    let mut typed = false;
+    let allocs = allocations(|| typed = infer(&mut expr, &mut ictx).is_ok());
+    assert!(typed, "the chain type-checks");
+    allocs
+}
+
+#[test]
+fn a_dead_call_chain_does_not_cost_more_than_a_live_one() {
+    const DEPTH: usize = 4;
+    let live = inference_allocations(&chain(DEPTH, true));
+    let dead = inference_allocations(&chain(DEPTH, false));
+    // Dead does the same specialization work as live and then splices none of it, so
+    // it should come in *well* under. The factor is a calibrated guard rather than a
+    // law — measured at this depth, sharing gives `dead ≈ 0.28 × live`, and a lost
+    // memo gives `≈ 0.94 ×` (and exceeds `live` outright one level deeper). Halfway
+    // between leaves room for ordinary drift while still catching the regression.
+    assert!(
+        dead * 2 <= live,
+        "typechecking a never-called chain allocated {dead}, against {live} for the \
+         same code live: the specialization memo is not being shared across uses \
+         inside the discarded subtree"
+    );
+}

--- a/tests/scope_walk_allocations.rs
+++ b/tests/scope_walk_allocations.rs
@@ -9,106 +9,15 @@
 //! `is_free_in_value` is the right probe — unlike `is_free` it threads no
 //! `visited` set, so nothing but the walk itself can allocate.
 //!
-//! # The window is per-thread, and has to be
-//!
-//! "Allocations during a window of wall-clock time" is not the property under
-//! test; "allocations *this thread* made during the walk" is. A process-global
-//! counter conflates them, and the difference is not hypothetical: libtest runs
-//! each test on a spawned thread and its main thread keeps working right
-//! afterwards, doing exactly four one-time allocations before it blocks —
-//! `running_tests.insert` (first insert into an empty `HashMap`),
-//! `timeout_queue.push_back` (first push into an empty `VecDeque`), and two
-//! inside the first blocking `rx.recv_timeout`. If the spawned test thread wins
-//! the race to the walk, a global counter charges all four to the walk. That is
-//! a real observed failure ("the scoped walk allocated 4 times") — rare, because
-//! the main thread normally finishes those four before a freshly spawned thread
-//! is scheduled at all, but reachable whenever the main thread is preempted
-//! right after the spawn, which is what a loaded CI runner does.
-//!
-//! Counting per-thread costs nothing in strength. The walk is a plain recursive
-//! fold that spawns nothing, so every allocation it could make is made by the
-//! thread that armed the window; the counter still sees all of them and now
-//! sees only them.
+//! The counter is `tests/alloc_probe/mod.rs`, which measures per thread and
+//! documents why that is the measurement this assertion wants.
 
-use std::alloc::{GlobalAlloc, Layout, System};
-use std::cell::Cell;
+mod alloc_probe;
 
+use alloc_probe::allocations;
 use cambra::ccl::TypedBinding;
 use cambra::ccl::ccl_utils::is_free_in_value;
 use cambra::ccl::{Name, TypedExpr};
-
-thread_local! {
-    /// Allocations this thread has made since it armed its window.
-    static ALLOCS: Cell<usize> = const { Cell::new(0) };
-    /// Is this thread's measurement window open?
-    static COUNTING: Cell<bool> = const { Cell::new(false) };
-}
-
-struct Counting;
-
-impl Counting {
-    /// Charge one allocation to the current thread, if its window is open.
-    ///
-    /// Both thread-locals are `const`-initialized and hold a type with no
-    /// destructor, so the access is a direct TLS read: no lazy initializer, no
-    /// destructor registration, and so no allocation. That matters here and not
-    /// just for accuracy — an allocating counter inside `GlobalAlloc` would
-    /// recurse.
-    fn charge() {
-        if COUNTING.get() {
-            ALLOCS.set(ALLOCS.get() + 1);
-        }
-    }
-}
-
-unsafe impl GlobalAlloc for Counting {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        Self::charge();
-        unsafe { System.alloc(layout) }
-    }
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        unsafe { System.dealloc(ptr, layout) }
-    }
-    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        Self::charge();
-        unsafe { System.realloc(ptr, layout, new_size) }
-    }
-}
-
-#[global_allocator]
-static A: Counting = Counting;
-
-/// An open measurement window on the current thread, closed when dropped.
-///
-/// The guard exists so that no path can leave a window open. A `body` that
-/// panics — a failing assertion inside one of these tests is exactly that —
-/// would otherwise leave `COUNTING` set, and every later window on the same
-/// thread would then be measuring from an armed counter it did not arm.
-struct Window;
-
-impl Window {
-    /// Zero this thread's counter and arm it.
-    fn open() -> Self {
-        ALLOCS.set(0);
-        COUNTING.set(true);
-        Window
-    }
-}
-
-impl Drop for Window {
-    fn drop(&mut self) {
-        COUNTING.set(false);
-    }
-}
-
-/// Allocations the calling thread performs while running `body`. Other threads'
-/// allocations are not counted — see the module docs for why that is the
-/// measurement the assertions want.
-fn allocations(body: impl FnOnce()) -> usize {
-    let _window = Window::open();
-    body();
-    ALLOCS.get()
-}
 
 #[test]
 fn a_freeness_query_over_a_letrec_spine_does_not_allocate() {
@@ -142,65 +51,4 @@ fn a_freeness_query_over_a_letrec_spine_does_not_allocate() {
          substitution, so the walk must borrow its binder group rather than \
          collecting it into a Vec"
     );
-}
-
-/// The probe has to be able to *see* an allocation, or the assertion above
-/// passes for the wrong reason. A zero-allocation claim measured by a counter
-/// that counts nothing is vacuous, and nothing else in this file would notice —
-/// so pay one allocation on the measuring thread and check it lands.
-#[test]
-fn the_probe_counts_allocations_made_by_the_measuring_thread() {
-    let allocs = allocations(|| {
-        let v: Vec<u8> = Vec::with_capacity(64);
-        std::hint::black_box(&v);
-    });
-    assert_eq!(
-        allocs, 1,
-        "one `Vec::with_capacity` is one allocation; the probe saw {allocs}"
-    );
-}
-
-/// The other half of that: a window must see *only* its own thread. This is the
-/// property the whole probe rests on, and the one a global counter silently
-/// loses — swap the counters back for process-global ones and this reports 1002
-/// rather than 0, the worker's thousand plus two the test harness happened to
-/// make, while both assertions above stay green.
-///
-/// The window has to bracket the worker's allocating loop and nothing else.
-/// Spawning heap-allocates the closure and the result slot *on the spawning
-/// thread*, and joining does bookkeeping of its own, so a window drawn around
-/// `thread::scope` counts those — correctly, as its own — and drowns the signal.
-/// Hence the handshake: two `AtomicBool`s, which spin without allocating.
-#[test]
-fn another_threads_allocations_are_not_charged_to_this_window() {
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    const N: usize = 1000;
-
-    let go = AtomicBool::new(false);
-    let done = AtomicBool::new(false);
-
-    std::thread::scope(|s| {
-        s.spawn(|| {
-            while !go.load(Ordering::Acquire) {
-                std::hint::spin_loop();
-            }
-            for _ in 0..N {
-                std::hint::black_box(Vec::<u8>::with_capacity(64));
-            }
-            done.store(true, Ordering::Release);
-        });
-
-        let allocs = allocations(|| {
-            go.store(true, Ordering::Release);
-            while !done.load(Ordering::Acquire) {
-                std::hint::spin_loop();
-            }
-        });
-
-        assert_eq!(
-            allocs, 0,
-            "another thread's allocations were charged to this window: {allocs}"
-        );
-    });
 }

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -187,6 +187,238 @@ fn test_let(#[case] code: &str, #[case] expected: Type) {
 }
 
 // ---------------------------------------------------------------------------
+// Never-called definitions
+// ---------------------------------------------------------------------------
+
+/// Close a program over definitions nothing calls: `defs` followed by the program
+/// value they are dead with respect to.
+///
+/// Cases below carry the definitions alone, so a one-line definition stays a plain
+/// string and only a genuinely multi-line one reaches for `indoc!`. A case that
+/// needs a *live* use of one of its definitions binds it (`live = f(1)`) rather
+/// than ending the program with it — a monomorphic binding's RHS is walked whether
+/// or not the binding is read, so the use specializes exactly as a trailing call
+/// would.
+fn dead_code(defs: &str) -> String {
+    format!("{}\n1", defs.trim_end())
+}
+
+/// A function nobody calls is still typechecked. Monomorphization drops such a
+/// definition as dead code, but it resolves it first, which is what makes the
+/// errors only *resolution* sees reachable in it.
+///
+/// Every case here is a body whose demands are jointly unsatisfiable while no
+/// single demand is a conflict on its own, so emission — which visits the body
+/// whether or not it is called — records them all without judging. `a` is asked to
+/// be a tuple *and* a record; a parameter to be `Int` *and* `String`. Only reading
+/// the bounds together rejects it, and that is resolution's job.
+///
+/// The cases fan out over *how the demand reaches the definition*, because the walk
+/// has to descend the same way a live specialization's walk does: through a call
+/// chain of dead definitions, into a lambda handed to a callee, and into a
+/// definition nested inside another (dead *or* live) one.
+#[rstest]
+#[case::conflicting_projections("f = \\a -> (a.0, a.foo)")]
+#[case::conflicting_projections_nested("f = \\r -> (r.x.0, r.x.foo)")]
+#[case::conflicting_projections_curried("f = \\a -> \\b -> a.0 + a.foo")]
+#[case::monomorphic_param_at_two_types("f = \\g -> g(1) + g(\"s\")")]
+#[case::conflicting_operand_types("f = \\a -> (a + 1, a + \"s\")")]
+#[case::through_a_call_in_dead_code(indoc! {r#"
+    g = \x -> x + 1
+    f = \a -> g("s")
+"#})]
+#[case::through_a_two_level_dead_chain(indoc! {r#"
+    g = \x -> x + 1
+    h = \y -> g(y)
+    f = \a -> h("s")
+"#})]
+#[case::through_a_three_level_dead_chain(indoc! {r#"
+    a1 = \x -> x + 1
+    a2 = \y -> a1(y)
+    a3 = \z -> a2(z)
+    f = \q -> a3("s")
+"#})]
+#[case::lambda_argument_to_a_dead_callee(indoc! {r#"
+    apply = \k -> k(1)
+    f = \a -> apply(\x -> x + "s")
+"#})]
+#[case::lambda_argument_to_a_live_callee(indoc! {r#"
+    apply = \k -> k(1)
+    f = \a -> apply(\x -> x + "s")
+    live = apply(\x -> x + 1)
+"#})]
+#[case::nested_in_a_dead_definition(indoc! {r#"
+    def f(a):
+        h = \y -> (y.0, y.foo)
+        1
+"#})]
+#[case::nested_in_a_live_definition(indoc! {r#"
+    def g(x):
+        h = \y -> (y.0, y.foo)
+        x
+    live = g(1)
+"#})]
+#[case::nested_call_out_of_a_dead_definition(indoc! {r#"
+    g = \x -> x + 1
+    def f(a):
+        h = \b -> g("s")
+        h(2)
+    live = g(5)
+"#})]
+#[case::shadowed_by_a_later_binding(indoc! {r#"
+    f = \a -> a.0 + a.foo
+    f = 3
+"#})]
+#[case::annotated_param(indoc! {r#"
+    def f(x: Int):
+        x + "s"
+"#})]
+fn a_never_called_function_is_still_typechecked(#[case] defs: &str) {
+    assert!(
+        !infer_program_err(&dead_code(defs)).is_empty(),
+        "an ill-typed definition must be rejected whether or not it is called"
+    );
+}
+
+/// The complement, and the guard against the walk over-rejecting: typechecking a
+/// never-called definition is not the same as demanding it be *monomorphic*. Its
+/// quantified variables have no use-site bounds, so it resolves under-determined —
+/// which inference tolerates, and which no later pass sees, because the definition
+/// is dropped either way.
+///
+/// The cases are the constructs whose types a live use-site pin would normally
+/// settle — a collection parameter's element type and domain, a comprehension's
+/// arrow kind, an induction accumulator, a generator's feed, a mutable register —
+/// each of which must resolve to *under-determined*, not to a conflict, when
+/// nothing calls the definition.
+#[rstest]
+#[case::generic_identity("f = \\a -> a")]
+#[case::higher_order("f = \\g -> g(1)")]
+#[case::curried("f = \\a -> \\b -> a + b")]
+#[case::multi_param("f = \\a, b -> a * b + 1")]
+#[case::record_param("f = \\r -> (r.name, r.age + 1)")]
+#[case::tuple_param("f = \\t -> t.0 + t.1")]
+#[case::collection_param("f = \\xs -> [x + 1 for x in xs]")]
+#[case::filter_over_param("f = \\xs -> [x for x in xs if x > 0]")]
+#[case::aggregate_over_param("f = \\xs -> sum([x for x in xs])")]
+#[case::groupby_over_param("f = \\xs -> groupby(xs, \\x -> x)")]
+#[case::calls_a_generic(indoc! {r#"
+    g = \x -> x
+    f = \a -> g(a)
+"#})]
+#[case::annotated_param(indoc! {r#"
+    def f(x: Int):
+        x + 1
+"#})]
+#[case::induction_loop(indoc! {r#"
+    def f(a):
+        s := 0
+        for i in [1, 2, 3]:
+            s := s + i
+        s
+"#})]
+#[case::generator(indoc! {r#"
+    def f(a):
+        for x in [1, 2]:
+            yield x
+"#})]
+#[case::mut_param(indoc! {r#"
+    def f(x: Mut(Int)):
+        x := 1
+        x
+"#})]
+#[case::equal_length_conditional_collections(indoc! {r#"
+    def f(a):
+        if a > 0:
+            [1, 2]
+        else:
+            [3, 4]
+"#})]
+fn a_never_called_generic_function_is_accepted(#[case] defs: &str) {
+    assert_eq!(infer_program(&dead_code(defs)), int_lit(1));
+}
+
+/// A never-called definition that reads a *source* is checked against the source's
+/// element type, and accepted when it uses it consistently. The rejection case is
+/// the discriminating one: its live counterpart — same body, with `f(1)` appended —
+/// fails identically, so the walk is reporting the definition's own conflict rather
+/// than anything a caller would have supplied.
+#[rstest]
+#[case::consistent_use("f = \\a -> [x + 1 for x in nums()]", false)]
+#[case::aggregate("f = \\a -> sum([x for x in nums()])", false)]
+#[case::element_type_conflict("f = \\a -> [x + \"s\" for x in nums()]", true)]
+#[case::via_a_derived_binding(indoc! {r#"
+    ys = [x for x in nums()]
+    f = \a -> [y + "s" for y in ys]
+"#}, true)]
+fn a_never_called_function_over_a_source_is_typechecked(
+    #[case] defs: &str,
+    #[case] rejected: bool,
+) {
+    let code = dead_code(defs);
+    let sources = &[("nums", int())][..];
+    if rejected {
+        assert!(!infer_program_with_sources_err(&code, sources).is_empty());
+    } else {
+        assert_eq!(infer_program_with_sources(&code, sources), int_lit(1));
+    }
+}
+
+/// Deadness is the absence of a *demand*, not of a specialization: a use can be
+/// reached and still register nothing. Registering nothing is what the memo records,
+/// so reading deadness off the memo walks the definition of a binding that is very
+/// much used — reporting its body's defect a second time, from its own nodes.
+///
+/// Here the demand comes from **dead code**: `g` is dropped, so the walk over it
+/// specializes `f` — which is what checks the call, and reports `f`'s defect once,
+/// through the clone — but registers nothing on `f`'s frame, deliberately
+/// (`CoalesceCtx::discard_boundary`). The defect is a record/tuple key conflict,
+/// which neither the Σ work nor the trait rework changes, so this stays a rejection.
+///
+/// The exact count is the assertion: three diagnostics for one defect, not six.
+#[test]
+fn a_suppressed_specialization_does_not_get_its_definition_re_walked() {
+    let errs = infer_program_err(&dead_code(indoc! {r#"
+        f = \a -> (a.0, a.foo)
+        g = \q -> f(q)
+    "#}));
+    assert_eq!(
+        errs.len(),
+        3,
+        "one defect, reported once per site that met it — a definition demanded \
+         without registering must not also be walked as dead code: {errs:?}"
+    );
+}
+
+/// The same distinction reached by the other route: a use that *fails to resolve* its
+/// instantiation reports and returns before minting, so it too leaves the memo empty
+/// without the definition being dead. Here the domain join inside `f` is unsupported.
+///
+/// **This program is legal under Σ.** When the dependent sum lands
+/// ([type-inference.md, "The domain join is a Σ"](../src/ccl/design/type-inference.md#the-domain-join-is-a-σ)),
+/// `f` type-checks and this test fails for a reason that has nothing to do with what
+/// it guards — re-anchor it on another program that reaches
+/// `specialize_use`'s early return, or drop it: the sibling test above covers the
+/// same distinction with a defect Σ does not touch.
+#[test]
+fn a_failed_use_does_not_get_its_definition_re_walked() {
+    let errs = infer_program_err(indoc! {r#"
+        def f(a):
+            if a > 0:
+                [1, 2]
+            else:
+                [3]
+        f(1)
+    "#});
+    assert_eq!(
+        errs.len(),
+        2,
+        "one defect, reported once per site that met it — a definition whose use \
+         failed must not also be walked as dead code: {errs:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Unary operator tests
 // ---------------------------------------------------------------------------
 

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -371,9 +371,10 @@ fn a_never_called_function_over_a_source_is_typechecked(
 ///
 /// Here the demand comes from **dead code**: `g` is dropped, so the walk over it
 /// specializes `f` — which is what checks the call, and reports `f`'s defect once,
-/// through the clone — but registers nothing on `f`'s frame, deliberately
-/// (`CoalesceCtx::discard_boundary`). The defect is a record/tuple key conflict,
-/// which neither the Σ work nor the trait rework changes, so this stays a rejection.
+/// through the clone — but that specialization is marked unreferenced rather than
+/// spliced, so nothing about it reaches the program. The defect is a record/tuple key
+/// conflict, which neither the Σ work nor the trait rework changes, so this stays a
+/// rejection.
 ///
 /// The exact count is the assertion: three diagnostics for one defect, not six.
 #[test]
@@ -387,6 +388,39 @@ fn a_suppressed_specialization_does_not_get_its_definition_re_walked() {
         3,
         "one defect, reported once per site that met it — a definition demanded \
          without registering must not also be walked as dead code: {errs:?}"
+    );
+}
+
+/// A dead definition nested inside a *live* generalized one sits inside each of that
+/// binding's clones, so it is discard-walked once per specialization. Walking it per
+/// clone is right — its body can reference the enclosing parameter, so it can be
+/// ill-typed at one instantiation and fine at another — but the *diagnostics* must not
+/// multiply: a dead helper inside a function used at five types is one bug, not
+/// fifteen.
+///
+/// The count is therefore held fixed while the number of enclosing specializations
+/// varies. `h` is dead inside `g`, and `g` is live at one, two, and three distinct
+/// types.
+#[rstest]
+#[case::one_enclosing_specialization("live1 = g(1)")]
+#[case::two_enclosing_specializations("live1 = g(1)\nlive2 = g(\"s\")")]
+#[case::three_enclosing_specializations("live1 = g(1)\nlive2 = g(\"s\")\nlive3 = g(True)")]
+fn one_defect_does_not_multiply_by_the_enclosing_specialization_count(#[case] uses: &str) {
+    let code = dead_code(&format!(
+        "{}\n{uses}",
+        indoc! {r#"
+            def g(x):
+                h = \y -> (y.0, y.foo)
+                x
+        "#}
+        .trim_end()
+    ));
+    let errs = infer_program_err(&code);
+    assert_eq!(
+        errs.len(),
+        3,
+        "one defect in a dead helper, however many clones of its enclosing \
+         definition contain it: {errs:?}"
     );
 }
 


### PR DESCRIPTION
Monomorphization drops a generalized definition that no use demanded — and dropped it *unresolved*, so a type error only resolution finds needed a call site to appear: `f = \a -> (a.0, a.foo)` asks `a` to be both a tuple and a record, and type-checked as long as nobody called `f`. `coalesce_generalized_let` now resolves an undemanded definition before dropping it, keeping only the diagnostics. Soundness and the residual gap: [type-inference.md, "Typechecking a never-called definition"](src/ccl/design/type-inference.md#typechecking-a-never-called-definition).

## Two distinctions to review

**`SpecializeFrame::demanded`, not `specs.is_empty()`, gates the walk** — a use can fail to resolve before minting one, or decline to register inside dead code. Gating on the memo re-walks a definition that is used, double-reporting its body's conflict. A related gap is *recorded, not fixed*: a failed use is left naming a binding the rebuild drops — which wants the "could not be built" node, not a rescue here.

**Registering a specialization and splicing it are separate decisions.** A use in dead code still specializes — that is what checks the call — and still registers, so the memo shares its clone; `Specialization::referenced` carries splice-liveness and the rebuild filters on it, so nothing dead re-enters the program. Which frames that applies to is recorded per frame when it is pushed (`SpecializeFrame::inside_discarded`), not derived from a scope depth, which the re-entrant clone walk truncates.

## Behaviour

A/B over a 67-case matrix: 19 previously-accepted programs are now rejected, and nothing else moved (error counts and specialization counts unchanged). Three rejections are `Unsupported` domain-join limits reached through dead code; each fails identically when called.

## Tests

15 rejection cases over how the demand reaches the definition, 16 over-rejection guards, 4 source cases, two unit tests for splice liveness. One defect stays one diagnostic however many specializations of an enclosing definition contain it, held fixed across a varying count. `dead_code_specialization_cost` bounds the cost by allocation count rather than wall-clock, so the guard is hard rather than flaky; its probe moved to `tests/alloc_probe/`, shared with `scope_walk_allocations` and carrying its own self-tests. Programs use `indoc!`, a convention recorded in `CLAUDE.md`.