### PR TITLE
Producers reject release guards they cannot honor

### DIFF
--- a/src/interpreter/design-operators.md
+++ b/src/interpreter/design-operators.md
@@ -153,6 +153,8 @@ Every operator must obey it in both directions, because a violation yields **wro
 
 `TileProducer::get` checks the producer's half in debug builds: the returned tile must carry no live data inside the accumulated `obsolete_guard`. What an operator can forward depends on how it reads its input, so it is specified per operator below.
 
+An operator must therefore **reject a guard it cannot honor rather than ignore it**. The guard accumulates in `obsolete_guard` whether or not `release_impl` acts on it, so dropping one silently leaves the operator free to re-emit that region — from its own state, or by re-reading an input it never passed the release to. Every `release_impl` is exhaustive; an operator with no sub-region to reclaim piecewise checks the guard with `TileGuard::expect_universal_or_empty`. Rejecting fires where the guard arrives, which does not depend on anything pulling afterwards — the `get` post-condition only fires if something does.
+
 ## Tile Operators
 
 Each `TileOperator` is a static (compile-time) node in the dataflow graph. It knows its output

--- a/src/interpreter/tile_operators/aggregate.rs
+++ b/src/interpreter/tile_operators/aggregate.rs
@@ -152,7 +152,7 @@ impl TileProducer for AggregateProducer {
         // each delivery as it folds it in, so whatever the input never delivered
         // — this aggregate being done before its source ran dry — would stay
         // stranded upstream.
-        if obsolete_guard.is_universal() {
+        if obsolete_guard.expect_universal_or_empty(&self.name()) {
             self.released = true;
             self.input.release(self.input.tiling().universal_guard());
         }
@@ -253,7 +253,7 @@ impl TileProducer for ExtractAggregateProducer {
     }
 
     fn release_impl(&mut self, obsolete_guard: TileGuard) {
-        if obsolete_guard.is_universal() {
+        if obsolete_guard.expect_universal_or_empty(&self.name()) {
             self.input.release(self.input.tiling().universal_guard());
         }
     }
@@ -383,7 +383,7 @@ impl TileProducer for MapExtractAggregateProducer {
             TileGuard::Function(FunctionGuard::Domain(p)) => {
                 TileGuard::Function(FunctionGuard::Domain(p))
             }
-            _ => todo!(),
+            g => todo!("MapExtractAggregate cannot honor the release guard {g:?}"),
         });
     }
 }

--- a/src/interpreter/tile_operators/combinators.rs
+++ b/src/interpreter/tile_operators/combinators.rs
@@ -225,7 +225,7 @@ impl TileProducer for ConverseProducer {
                         .release(TileGuard::Function(FunctionGuard::Domain(p.clone())))
                 }
             }
-            _ => {}
+            g => panic!("Converse cannot honor the release guard {g:?}"),
         }
     }
 }
@@ -326,7 +326,7 @@ impl TileProducer for MapDomainProducer {
             TileGuard::Function(FunctionGuard::Domain(p)) => {
                 TileGuard::Function(FunctionGuard::Domain(p))
             }
-            _ => todo!(),
+            g => todo!("Restrict cannot honor the release guard {g:?}"),
         });
     }
 }
@@ -492,7 +492,7 @@ impl TileProducer for UncurryProducer {
                 }
                 domain_guard
             }
-            g => panic!("Unsupported obsolete guard: {g:?}"),
+            g => panic!("Filter cannot honor the release guard {g:?}"),
         };
         trace!("{} releasing up with: {input_guard:?}", self.name());
         self.input.release(input_guard);

--- a/src/interpreter/tile_operators/extract_final.rs
+++ b/src/interpreter/tile_operators/extract_final.rs
@@ -243,7 +243,7 @@ impl TileProducer for ExtractFinalProducer {
     }
 
     fn release_impl(&mut self, obsolete_guard: TileGuard) {
-        if obsolete_guard.is_universal() {
+        if obsolete_guard.expect_universal_or_empty(&self.name()) {
             self.released = true;
             self.source.release(self.source.tiling().universal_guard());
             self.default

--- a/src/interpreter/tile_operators/fan.rs
+++ b/src/interpreter/tile_operators/fan.rs
@@ -440,7 +440,7 @@ impl TileProducer for FanInProducer {
                 TileGuard::Function(FunctionGuard::Codomain(g)) => {
                     TileGuard::Function(FunctionGuard::Codomain(g.clone()))
                 }
-                g => unimplemented!("Unexpected guard {g:?}"),
+                g => unimplemented!("FanIn cannot honor the release guard {g:?}"),
             })
         });
     }
@@ -573,7 +573,7 @@ impl TileProducer for ScalarFanInProducer {
     }
 
     fn release_impl(&mut self, obsolete_guard: TileGuard) {
-        if obsolete_guard.is_universal() {
+        if obsolete_guard.expect_universal_or_empty(&self.name()) {
             self.inputs
                 .iter_mut()
                 .for_each(|i| i.release(i.tiling().universal_guard()));
@@ -639,6 +639,41 @@ mod tests {
             log.borrow().is_empty(),
             "an empty release names nothing to free, so nothing is forwarded"
         );
+    }
+
+    /// A guard between the two extremes is **rejected, not ignored**. A
+    /// `ScalarFanIn` re-reads every operand on every pull, so it cannot stop
+    /// requesting one released field; silently dropping the guard would leave it
+    /// re-emitting that field, which the producer has already promised not to do.
+    #[test]
+    #[should_panic(expected = "cannot honor the partial release guard")]
+    fn scalar_fan_in_rejects_a_partial_record_release() {
+        let tiling = Tiling::Scalar(Extent::Base(BaseType::Int));
+        let mut inputs: Vec<Box<dyn TileProducer>> = Vec::new();
+        for _ in 0..2 {
+            let (spy, _log) =
+                ReleaseSpy::new(Tile::Scalar(ColumnValue::Ints(vec![1])), tiling.clone());
+            inputs.push(Box::new(spy));
+        }
+        let names: Vec<String> = (0..2).map(tuple_field).collect();
+        let out_tiling =
+            Tiling::Record(names.iter().map(|n| (n.clone(), tiling.clone())).collect());
+        let mut producer = ScalarFanInProducer {
+            base: ProducerBase::new(ScalarFanInProducer::alloc_id(), &out_tiling),
+            names: names.clone(),
+            inputs,
+        };
+
+        // Field `_0` released, `_1` still live — neither empty nor universal.
+        let partial = TileGuard::Record(
+            [
+                (names[0].clone(), TileGuard::Scalar(true)),
+                (names[1].clone(), TileGuard::Scalar(false)),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        producer.release(partial);
     }
 
     // ── FanInProducer: asymmetric per-branch presence ────────────────────────

--- a/src/interpreter/tile_operators/reshape.rs
+++ b/src/interpreter/tile_operators/reshape.rs
@@ -158,9 +158,7 @@ impl TileProducer for PermuteRecordDomainProducer {
                     &self.permutation,
                 ))))
             }
-            _ => {
-                unreachable!();
-            }
+            g => unreachable!("PermuteRecordDomain cannot honor the release guard {g:?}"),
         };
         self.input.release(upstream_guard);
     }

--- a/src/interpreter/tile_operators/scalar.rs
+++ b/src/interpreter/tile_operators/scalar.rs
@@ -90,7 +90,7 @@ impl TileProducer for ConstantProducer {
     }
 
     fn release_impl(&mut self, obsolete_guard: TileGuard) {
-        if obsolete_guard.is_universal() {
+        if obsolete_guard.expect_universal_or_empty(&self.name()) {
             self.released = true;
         }
     }
@@ -558,9 +558,9 @@ impl TileProducer for VariantProjectProducer {
     }
 
     fn release_impl(&mut self, obsolete_guard: TileGuard) {
-        // The scrutinee is always read in full (universal guard); only a
-        // universal release propagates meaningfully.
-        if obsolete_guard.is_universal() {
+        // The scrutinee is always read in full, so there is no sub-region of it
+        // this producer could stop requesting.
+        if obsolete_guard.expect_universal_or_empty(&self.name()) {
             self.input.release(self.input.tiling().universal_guard());
         }
     }
@@ -592,9 +592,9 @@ impl TileProducer for ToScalarProducer {
     }
 
     fn release_impl(&mut self, obsolete_guard: TileGuard) {
-        // The input is always read in full (universal guard), so only a universal
-        // release can be propagated meaningfully.
-        if obsolete_guard.is_universal() {
+        // The input is always read in full, so there is no sub-region of it this
+        // producer could stop requesting.
+        if obsolete_guard.expect_universal_or_empty(&self.name()) {
             self.input.release(self.input.tiling().universal_guard());
         }
     }
@@ -876,6 +876,22 @@ mod tests {
             fields["_1"],
             Tile::Scalar(ColumnValue::Ints(vec![100, 120]))
         );
+    }
+
+    /// A partial domain release is **rejected, not ignored**. `VariantProject`
+    /// reads its scrutinee in full on every pull, so it cannot stop requesting
+    /// the released rows; dropping the guard silently would leave it re-emitting
+    /// them, against the promise the producer has already recorded.
+    #[test]
+    #[should_panic(expected = "cannot honor the partial release guard")]
+    fn variant_project_rejects_a_partial_domain_release() {
+        let scrut = Box::new(commit_abort_scrutinee());
+        let mut op = VariantProject::new(scrut, FieldKey::Index(0));
+        let mut sched = Scheduler::new();
+        let mut producer = op.subscribe(op.tiling().universal_guard(), Box::new(|| {}), &mut sched);
+        producer.release(TileGuard::Function(FunctionGuard::Domain(
+            Predicate::LessThanEq(Value::UInt(0)),
+        )));
     }
 
     /// `VariantWrap` is domain-preserving, so output position `d` is payload

--- a/src/interpreter/tiling/guard.rs
+++ b/src/interpreter/tiling/guard.rs
@@ -140,6 +140,21 @@ impl TileGuard {
         }
     }
 
+    /// Returns whether this guard is universal, panicking unless it is universal
+    /// or empty — for producers that can only reclaim all or nothing. Quietly
+    /// dropping a partial guard would leave them free to re-emit the released
+    /// region, since a producer records the guard either way. `context` names the
+    /// producer in the panic message.
+    pub fn expect_universal_or_empty(&self, context: &str) -> bool {
+        if self.is_empty() {
+            false
+        } else if self.is_universal() {
+            true
+        } else {
+            panic!("{context} cannot honor the partial release guard {self:?}")
+        }
+    }
+
     /// Check whether this guard is structurally compatible with `tiling`.
     ///
     /// A guard is compatible when its variant matches the shape of the tiling


### PR DESCRIPTION
An operator that ignores a release guard goes on emitting the released region — from its own state, or by re-reading an input it never forwarded the release to. Eight producers silently dropped anything non-universal. Each now calls `TileGuard::expect_universal_or_empty`, which panics on anything between the two; five siblings that already rejected gained the operator's name in their message.

No current wiring produces such a guard and the suite passes unchanged, so this is a tripwire rather than a fix. Two unit tests cover it in the failing direction by building the guard by hand: `ScalarFanIn` with one record field released, `VariantProject` with a domain prefix.