### PR TITLE
Return a borrow from `Subst::shadow` rather than a copy that changes nothing

### DIFF
--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -6,6 +6,7 @@
 //! [`CompactType`] / [`CompactGraph`] are the shared currency consumed by the
 //! sibling [`mod@super::simplify_type`] and [`super::coalesce`] modules.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
@@ -638,7 +639,7 @@ fn compact_go(
             // codomain (it binds the name locally), so restrict it there.
             let cod_acc = match name {
                 Some(b) => subst_acc.shadow(b),
-                None => subst_acc.clone(),
+                None => Cow::Borrowed(subst_acc),
             };
             let cod = compact_go(c, pol, &cod_acc, None, st);
             CompactType {

--- a/src/ccl/infer/solver/spec_key.rs
+++ b/src/ccl/infer/solver/spec_key.rs
@@ -87,6 +87,7 @@
 //! under either use's pin is the same code*, because every edge the clone's own
 //! resolution can follow is followed, from the same side, by one of the two reads.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, btree_map::Entry};
 use std::fmt;
 use std::rc::Rc;
@@ -394,7 +395,7 @@ fn key_go(ty: &Type, pol: bool, subst_acc: &Subst, ctx: &mut KeyCtx) -> KeyView 
             // of the key — see `SpecKey::fun`.
             let cod_acc = match name {
                 Some(b) => subst_acc.shadow(b),
-                None => subst_acc.clone(),
+                None => Cow::Borrowed(subst_acc),
             };
             let cod = key_go(codomain, pol, &cod_acc, ctx);
             // Resolved through `KindMerge::of`, not off the `FunKind` itself: an

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -855,12 +855,12 @@ impl Subst {
     /// itself). The α-rename fallback is therefore asserted unreachable,
     /// which is also what deletes the same-discharge-twice determinism
     /// hazard: no fresh names are minted on any equality-mediated path.
-    fn under_binder(&self, binder: &Name, body: &TypedExpr) -> (Binder, Subst) {
+    fn under_binder(&self, binder: &Name, body: &TypedExpr) -> (Binder, Cow<'_, Subst>) {
         let restricted = self.shadow(binder);
         // If no substituted binder occurs free in the body, the substitution
         // is inert there — return the identity so the body is left untouched.
         if !restricted.0.keys().any(|k| is_free(k, body)) {
-            return (binder.clone(), Subst::id());
+            return (binder.clone(), Cow::Owned(Subst::id()));
         }
         restricted.assert_no_capture(binder);
         (binder.clone(), restricted)
@@ -928,13 +928,12 @@ impl Subst {
 
     /// This substitution with `binder` removed from its source domain (the
     /// binder shadows the outer mapping inside its scope).
-    pub fn shadow(&self, binder: &Name) -> Subst {
-        if !self.0.contains_key(binder) {
-            return self.clone();
+    pub fn shadow(&self, binder: &Name) -> Cow<'_, Subst> {
+        let mut out = Cow::Borrowed(self);
+        if out.0.contains_key(binder) {
+            out.to_mut().0.remove(binder);
         }
-        let mut m = self.0.clone();
-        m.remove(binder);
-        Subst(m)
+        out
     }
 
     /// This substitution restricted so it acts on **none** of `binders` — the
@@ -944,9 +943,11 @@ impl Subst {
     ///
     /// Returns a borrow when the restriction is vacuous, which is the common
     /// case: a substitution's domain is usually a single binder and the scope
-    /// being crossed usually does not name it. Folding [`Self::shadow`] over the
-    /// group instead would clone the map once per binder even on a miss, since
-    /// `shadow` returns an owned `Subst`.
+    /// being crossed usually does not name it. [`Self::shadow`] preserves the
+    /// borrow the same way, but cannot be *folded* over a group: each call
+    /// borrows from its receiver, so the intermediate `Cow` a fold would thread
+    /// has nothing outliving it to borrow from. This restricts against one
+    /// receiver for the whole group instead.
     ///
     /// The `contains_key` guard is what makes that true and is therefore
     /// load-bearing, not a micro-optimization: `to_mut()` on a `Cow::Borrowed`


### PR DESCRIPTION
`Subst::shadow` returned an owned `Subst`, so restricting against a binder the substitution never mentions still allocated a fresh `BTreeMap` and deep-copied every `Discharge` term it carried — 50,858 of 50,863 calls across the test suite, most of them carrying at least one term. It now returns `Cow<'_, Subst>`, the shape `shadow_all` already uses one function down. Every caller held the result by shared reference, so only `under_binder`'s return type had to follow, and the solver's unnamed-`Fun` arms drop their unconditional `subst_acc.clone()` at the same site.

`shadow_all`'s doc justified itself by `shadow` returning an owned value; its remaining reason is that `shadow` cannot be folded over a binder group, since each call borrows from its receiver.
