### PR TITLE
Fuzz the solver for arrival-order independence, and join a kind variable's pins at the read

### DIFF
--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -33,7 +33,39 @@ When a new constraint involves a variable, the solver records the bound and then
 
 This recursive propagation replaces the traditional "union-find" algorithm used in HM type inference.
 
-Note that propagation only sweeps the *existing* bounds on the side of the new bound — it does not eagerly transfer the other side's bounds onto the variable. For a variable-against-variable constraint `constrain(Var v, Var w)`, the LHS-variable arm fires (recording `w` as an upper bound of `v` and sweeping `v`'s lower bounds); the missing edges are recovered later by walking the bounds graph during simplification. Whether this one-sided handling is purely a redundancy-avoidance optimization or is semantically load-bearing is noted as an open question in the review thread.
+Note that propagation only sweeps the *existing* bounds on the side of the new bound — it does not
+eagerly transfer the other side's bounds onto the variable. For a variable-against-variable
+constraint `constrain(Var v, Var w)`, the LHS-variable arm fires (recording `w` as an upper bound of
+`v` and sweeping `v`'s lower bounds); the missing edges are recovered later by walking the bounds
+graph during simplification.
+
+**Bound arrival order does not change the answer.** Record-then-sweep makes that a property of the
+algorithm rather than of any one constraint, and one-sided var-var propagation is where it is least
+obvious: the edge records less than a symmetric rule would, and the difference is only recovered at
+simplification. `tests/constraint_order_fuzz.rs` states the property — the same constraint set applied in
+permuted orders coalesces every variable to the same type, or is rejected in every order — and
+checks it over 2000 generated sets, eight permutations each. Which constraint trips the rejection of
+an unsatisfiable set is order-relative and deliberately not part of the outcome: the last edge to
+arrive is the one that meets the already-recorded bounds, and emission order is fixed by the AST
+walk.
+
+**A kind pin is joined at the read, not at the edge.** `constrain_kind`'s
+variable-against-variable arm records that the two kinds are the same unknown, and `FunKindVar::pin`
+folds the join over everything that relation reaches. So a variable's kind is a function of the
+whole constraint set: a pin arriving after the edge crosses it, and so does one two edges away.
+Resolving
+at the edge instead — copying each side's pin onto the other — answers from the pins that happen to
+have arrived and drops the rest, and the two variables then coalesce to different arrows depending
+on which constraint came first. `a_shared_kind_var_resolves_the_same_way_in_every_order` checks
+all 24 orders of the shape that exhibits it. The join is the flat semilattice
+`Unpinned < {Compute, Data} < Conflict`, whose commutativity, associativity and idempotence are what
+make the fold order-blind: every reader folds the same set, and no fold step reads a value a later
+step can change.
+
+The arm is unreachable from lowered CHL — nothing in the integration corpus or the unit suite hits
+it, since a kind variable is minted only by an elimination's demand and two demands meet at
+compaction rather than at a constraint. It is reached by generated type pairs, which is what
+`tests/constraint_order_fuzz.rs` supplies.
 
 ### Positions and Polarity
 

--- a/src/ccl/infer/solver/constrain.rs
+++ b/src/ccl/infer/solver/constrain.rs
@@ -20,7 +20,7 @@ use std::rc::Rc;
 use smol_str::SmolStr;
 
 use crate::ccl::subst::Subst;
-use crate::ccl::ty::FunKind;
+use crate::ccl::ty::{FunKind, FunKindVar};
 use crate::ccl::{
     BaseType, Bound, HistoryKind, InferVar, InferVarId, Level, Name, Refinement, RefinementSet,
     Type,
@@ -185,7 +185,7 @@ impl Derivation {
     /// Whether a closed `Fun`/`Fun` codomain opens unconditionally rather than
     /// only toward a side carrying inference variables. A re-derivation is
     /// reconciling two passes' spellings of one type; the live solve is not, and
-    /// opening a ground pair at display names lets a free reference sharing a
+    /// opening a concrete pair at display names lets a free reference sharing a
     /// binder's spelling capture the reopened index.
     fn opens_unconditionally(self) -> bool {
         self != Derivation::LiveSolve
@@ -278,22 +278,25 @@ fn constrain_kind(k0: &FunKind, k1: &FunKind) -> Result<bool, ()> {
             v.pin_data();
             Ok(true)
         }
-        // Two variables meeting record nothing. What the pair resolves to is not
-        // known at this edge, and deciding it from pins that arrive later
-        // would make typing depend on constraint order; each is pinned by the
-        // concrete kind that reaches it, if one does. See [`FunKindVar`].
+        // The edge **relates** the two kinds; it does not resolve them. What the
+        // pair resolves to is not known here, so recording the edge and joining
+        // over it at the read ([`FunKindVar::pin`]) is what makes the answer a
+        // function of the whole constraint set rather than of its order. Copying
+        // each side's pin onto the other instead would answer from the pins that
+        // happen to have arrived, and drop every one that arrives later: `a—b`
+        // recorded while both are unpinned, then `a` pinned, would leave `b`
+        // unpinned, while the other order pinned both — the two coalescing to
+        // different arrows. Deferring the join to the read is the same rule the
+        // domain combination follows, and for the same reason: a value the fold is
+        // still accumulating cannot be read pairwise
+        // ([`super::compact::KindMerge`]).
         //
-        // Carrying nothing is only sound while the two sides agree, since a pin
-        // on one side would otherwise be dropped. No program in the suite reaches
-        // this arm at all, so the guard is what would notice one starting to: it
-        // catches a disagreement already present, not one a later pin creates.
+        // Still not a *data* edge (`Ok(false)`): whether the domains must join
+        // losslessly is a question about what the edge demands, and this edge
+        // demands nothing of either kind. Two `Data`-pinned variables therefore
+        // reach the lossless-domain rule through their pins, not through here.
         (Var(a), Var(b)) => {
-            debug_assert_eq!(
-                a.pin(),
-                b.pin(),
-                "a var-var kind edge relates two differently-pinned kinds, so this \
-                 arm would drop one side's pin"
-            );
+            FunKindVar::relate(a, b);
             Ok(false)
         }
     }
@@ -577,13 +580,13 @@ fn constrain_go_impl(
             //
             // On the live solve, opening is gated on the **opposite** side
             // carrying inference variables: only a live side records
-            // bounds, so only there would a dangling index land. A ground
+            // bounds, so only there would a dangling index land. A concrete
             // closed-closed pair compares index-to-index instead — opening it
             // at display names would let an unrelated *free* reference that
             // happens to share the binder's spelling capture the reopened
             // index (found by the differential oracle; with uniquified
             // binders the collision needs the same uid, which *is* the same
-            // binder, but the ground relation must not depend on that
+            // binder, but the concrete relation must not depend on that
             // convention). A post-pass re-derivation opens unconditionally: it
             // reconciles types that different passes spelled in different
             // forms (a closed function's codomain against a rebuilt,
@@ -1358,7 +1361,7 @@ mod tests {
         )
     }
 
-    /// The `Fun`/`Fun` opening does not fire between two ground sides, so a free
+    /// The `Fun`/`Fun` opening does not fire between two concrete sides, so a free
     /// reference sharing a binder's display spelling cannot capture the reopened
     /// index.
     ///
@@ -1367,9 +1370,9 @@ mod tests {
     /// whatever binds `x` outside the type. Opening the closed side at its
     /// display name spells both `__elem == x` and reads them as one. Uniquified
     /// binders make the collision need the same uid, which is the same binder,
-    /// and the ground relation must not depend on that convention.
+    /// and the concrete relation must not depend on that convention.
     #[test]
-    fn a_ground_pair_does_not_open_at_a_shared_spelling() {
+    fn a_concrete_pair_does_not_open_at_a_shared_spelling() {
         let x = Name::raw("x");
         let refinement = |referenced: &Name| {
             Type::Refinement(
@@ -1639,7 +1642,7 @@ mod tests {
         // base variable ?a can acquire the deficit {p}, so the constraint
         // succeeds by flowing `?a <: {Int | p}`. This is what lets a value
         // that is *already* refined be cast to add a further refinement (nested
-        // list-comprehension filters: `{D|p} ⇒ V <: {?a|q} ⇒ V`); a ground
+        // list-comprehension filters: `{D|p} ⇒ V <: {?a|q} ⇒ V`); a concrete
         // `{p} ⊆ {q}` check would reject it.
         let (p, q) = (1, 2);
         let a = fresh_var(0);
@@ -2511,6 +2514,170 @@ mod tests {
             ),
             Err(ConstrainError::KindMismatch { .. })
         ));
+    }
+
+    /// A function over a fixed domain and codomain, so a test varies only the
+    /// kind — which is the only thing `constrain_kind` reads.
+    fn kind_fun(kind: FunKind) -> Type {
+        Type::Fun {
+            name: None,
+            kind,
+            domain: Box::new(Type::UIntRange(3)),
+            codomain: Box::new(prim(BaseType::Int)),
+        }
+    }
+
+    #[test]
+    fn a_var_var_kind_edge_makes_each_side_read_the_other_s_pin() {
+        // The edge relates the two kinds, so a pin either side carries is a pin
+        // both read — whichever side it was recorded on.
+        let (a, b) = (FunKindVar::fresh(), FunKindVar::fresh());
+        let mut cache = ConstrainCache::new();
+        // Pin `a` to compute, leaving `b` unpinned.
+        constrain_subtype(
+            &kind_fun(FunKind::Var(Rc::clone(&a))),
+            &kind_fun(FunKind::Compute),
+            &mut cache,
+        )
+        .expect("a var meeting Compute records the pin");
+        assert_eq!(a.pin(), KindPin::Compute);
+        assert_eq!(b.pin(), KindPin::Unpinned);
+
+        constrain_subtype(
+            &kind_fun(FunKind::Var(Rc::clone(&b))),
+            &kind_fun(FunKind::Var(Rc::clone(&a))),
+            &mut cache,
+        )
+        .expect("a var-var kind edge is never a rejection");
+        assert_eq!(
+            b.pin(),
+            KindPin::Compute,
+            "the unpinned side reads the other's pin"
+        );
+        assert_eq!(
+            a.pin(),
+            KindPin::Compute,
+            "and the pinned side is unchanged"
+        );
+    }
+
+    /// A pin arriving **after** the edge crosses it, which is what makes the arm
+    /// order-independent: the join is folded at the read, so it sees every pin the
+    /// component ever acquired rather than the ones present when the edge landed.
+    #[test]
+    fn a_pin_arriving_after_a_var_var_kind_edge_still_crosses_it() {
+        let (a, b) = (FunKindVar::fresh(), FunKindVar::fresh());
+        // The edge first, both sides unpinned — nothing to carry.
+        constrain_subtype(
+            &kind_fun(FunKind::Var(Rc::clone(&a))),
+            &kind_fun(FunKind::Var(Rc::clone(&b))),
+            &mut ConstrainCache::new(),
+        )
+        .expect("a var-var kind edge is never a rejection");
+        assert_eq!(a.pin(), KindPin::Unpinned);
+        assert_eq!(b.pin(), KindPin::Unpinned);
+
+        // Then a concrete kind reaches `a` only.
+        constrain_subtype(
+            &kind_fun(FunKind::Var(Rc::clone(&a))),
+            &kind_fun(FunKind::Data),
+            &mut ConstrainCache::new(),
+        )
+        .expect("a var meeting Data records the pin");
+        assert_eq!(a.pin(), KindPin::Data);
+        assert_eq!(
+            b.pin(),
+            KindPin::Data,
+            "the far side of the edge reads a pin that arrived after it"
+        );
+    }
+
+    /// The relation is transitive at the read, because the join folds the whole
+    /// component and not just one edge's far end.
+    #[test]
+    fn a_pin_crosses_a_chain_of_var_var_kind_edges() {
+        let (a, b, c) = (
+            FunKindVar::fresh(),
+            FunKindVar::fresh(),
+            FunKindVar::fresh(),
+        );
+        for (x, y) in [(&a, &b), (&b, &c)] {
+            constrain_subtype(
+                &kind_fun(FunKind::Var(Rc::clone(x))),
+                &kind_fun(FunKind::Var(Rc::clone(y))),
+                &mut ConstrainCache::new(),
+            )
+            .expect("a var-var kind edge is never a rejection");
+        }
+        constrain_subtype(
+            &kind_fun(FunKind::Var(Rc::clone(&a))),
+            &kind_fun(FunKind::Data),
+            &mut ConstrainCache::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            c.pin(),
+            KindPin::Data,
+            "two edges away, and still one answer"
+        );
+        assert_eq!(b.pin(), KindPin::Data);
+        assert_eq!(a.pin(), KindPin::Data);
+    }
+
+    /// Pinning either end of a related pair to a different point is the conflict,
+    /// read from every member — the pins are joined, never arbitrated.
+    #[test]
+    fn a_var_var_kind_edge_between_disagreeing_pins_conflicts_from_either_end() {
+        let (a, b) = (FunKindVar::fresh(), FunKindVar::fresh());
+        constrain_subtype(
+            &kind_fun(FunKind::Var(Rc::clone(&a))),
+            &kind_fun(FunKind::Var(Rc::clone(&b))),
+            &mut ConstrainCache::new(),
+        )
+        .unwrap();
+        constrain_subtype(
+            &kind_fun(FunKind::Var(Rc::clone(&a))),
+            &kind_fun(FunKind::Compute),
+            &mut ConstrainCache::new(),
+        )
+        .unwrap();
+        constrain_subtype(
+            &kind_fun(FunKind::Var(Rc::clone(&b))),
+            &kind_fun(FunKind::Data),
+            &mut ConstrainCache::new(),
+        )
+        .unwrap();
+        assert_eq!(a.pin(), KindPin::Conflict);
+        assert_eq!(b.pin(), KindPin::Conflict);
+    }
+
+    #[test]
+    fn a_var_var_kind_edge_between_disagreeing_pins_is_a_conflict() {
+        // Absorption, not arbitration: holding both points is `Conflict`, exactly
+        // as on a concrete edge, and coalesce reports it.
+        let fun_over = kind_fun;
+        let (a, b) = (FunKindVar::fresh(), FunKindVar::fresh());
+        let mut cache = ConstrainCache::new();
+        constrain_subtype(
+            &fun_over(FunKind::Var(Rc::clone(&a))),
+            &fun_over(FunKind::Compute),
+            &mut cache,
+        )
+        .unwrap();
+        constrain_subtype(
+            &fun_over(FunKind::Var(Rc::clone(&b))),
+            &fun_over(FunKind::Data),
+            &mut cache,
+        )
+        .unwrap();
+        constrain_subtype(
+            &fun_over(FunKind::Var(Rc::clone(&a))),
+            &fun_over(FunKind::Var(Rc::clone(&b))),
+            &mut cache,
+        )
+        .expect("the edge records the join; the rejection is coalesce's");
+        assert_eq!(a.pin(), KindPin::Conflict);
+        assert_eq!(b.pin(), KindPin::Conflict);
     }
 
     #[test]

--- a/src/ccl/infer/solver/scheme.rs
+++ b/src/ccl/infer/solver/scheme.rs
@@ -739,8 +739,8 @@ mod tests {
     /// still be freshened.
     ///
     /// The shape is the one a comprehension produces: a `Fun` whose every
-    /// structural position is ground (`[0,2] ⇒ Int`), carrying a refinement whose
-    /// base is also ground — so `type_level` reports 0 for the whole thing — while
+    /// structural position is concrete (`[0,2] ⇒ Int`), carrying a refinement whose
+    /// base is also concrete — so `type_level` reports 0 for the whole thing — while
     /// the predicate holds a level-5 variable. Short-circuiting on `type_level`
     /// returns the type verbatim and the clone keeps pointing at the definition's
     /// live variable, which shows up downstream as a *duplicate* specialization:
@@ -758,7 +758,7 @@ mod tests {
                 .with_ty(Type::Infer(Rc::clone(&quantified))),
         );
         let refined_domain = Type::refined_one(
-            Type::UIntRange(3), // ground base: hides the predicate's level
+            Type::UIntRange(3), // concrete base: hides the predicate's level
             Refinement::sharing(&predicate),
         );
         let ty = Type::Fun {

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -1246,9 +1246,9 @@ pub fn type_free_vars(ty: &Type) -> BTreeSet<Binder> {
 }
 
 /// Whether `ty`'s structural skeleton contains an unresolved [`Type::Infer`]
-/// leaf. This is the per-type dual of `check_fully_typed`'s whole-program scan:
-/// a cheap "is this type ground" predicate for invariant assertions at pass
-/// boundaries. It walks the type skeleton only — a `Refinement`'s predicate is
+/// leaf — the negation of **concrete** for the one variant that survives
+/// solving ([`Type`]). This is the per-type dual of `check_fully_typed`'s
+/// whole-program scan, for invariant assertions at pass boundaries. It walks the type skeleton only — a `Refinement`'s predicate is
 /// a term, not a type, and is not descended into (an `Infer` embedded in a
 /// predicate cast is out of scope and would need a term walk).
 pub fn type_contains_infer(ty: &Type) -> bool {

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -427,6 +427,25 @@ pub enum KindPin {
     Conflict,
 }
 
+impl KindPin {
+    /// The join in the flat semilattice `Unpinned < {Compute, Data} < Conflict`.
+    ///
+    /// Commutative, associative, and idempotent, which is what makes a
+    /// variable's pin independent of the order the pins arrive in: every reader
+    /// folds the same set and no fold step reads a value a later step can
+    /// change.
+    pub fn join(self, other: KindPin) -> KindPin {
+        use KindPin::{Compute, Conflict, Data, Unpinned};
+        match (self, other) {
+            (Unpinned, p) | (p, Unpinned) => p,
+            (Compute, Compute) => Compute,
+            (Data, Data) => Data,
+            // Two points at once, or either point meeting the conflict.
+            _ => Conflict,
+        }
+    }
+}
+
 /// A kind-inference variable — an unknown [`FunKind`] an elimination mints
 /// and the value flowing in pins.
 ///
@@ -435,10 +454,17 @@ pub enum KindPin {
 /// alike ([`Type::pi_eliminated`], [`Type::fun_eliminated`]). Each mints one of
 /// these, and the kind edge pins it to whatever concrete kind the value carries
 /// (`constrain_kind`). Nothing else mints one — no scheme is kind-polymorphic and
-/// lowering stamps every function type it builds — so a variable is **written by the one
-/// value that reaches it**, never solved against other variables: two variables
-/// meeting record nothing, because what they resolve to is not known at that edge
-/// and no program needs it to be.
+/// lowering stamps every function type it builds — so a variable is **written by
+/// the one value that reaches it**.
+///
+/// Two variables meeting is a **relation**, not a resolution. What the pair
+/// resolves to is not known at that edge, so `constrain_kind` records the edge
+/// and [`FunKindVar::pin`] joins over it at the read. Resolving at the edge
+/// instead — copying each side's pin onto the other — loses a pin that arrives
+/// afterwards, and then which arrow the two coalesce to depends on which
+/// constraint came first. The rule is the one the domain combination follows for
+/// the same reason: a value the fold is still accumulating cannot be read
+/// pairwise (see [`crate::ccl::infer::solver::compact::KindMerge`]).
 ///
 /// Identity (`uid`) is immutable and lives outside the `RefCell`, so
 /// equality/hashing is borrow-free and never inspects the pin (mirroring
@@ -447,10 +473,19 @@ pub enum KindPin {
 pub struct FunKindVar {
     /// Stable, globally-unique identity.
     pub uid: FunKindVarId,
-    /// Which point this var has been pinned to. Private so that every write goes
-    /// through a pin, which is what makes reaching [`KindPin::Conflict`] the only
-    /// way to hold two points at once.
+    /// The point *this* variable was pinned to directly, by a concrete kind
+    /// reaching it. Private so that every write goes through a pin, and so that
+    /// no reader mistakes it for the answer: [`FunKindVar::pin`] is the answer,
+    /// and it also folds in everything [`FunKindVar::related`] reaches.
     pin: RefCell<KindPin>,
+    /// The variables this one meets at a variable-against-variable kind edge.
+    ///
+    /// Symmetric — `relate` records both directions — so the set reachable from
+    /// either end is the same component, and every member reads one join.
+    /// Empty for all but a handful of variables: nothing in lowered CHL puts two
+    /// kind variables on one edge, since a variable is minted by an
+    /// elimination's demand and two demands meet at compaction.
+    related: RefCell<Vec<Rc<FunKindVar>>>,
 }
 
 impl FunKindVar {
@@ -459,37 +494,89 @@ impl FunKindVar {
         Rc::new(FunKindVar {
             uid: FunKindVarId(FUN_KIND_VAR_COUNTER.fetch_add(1, Ordering::Relaxed)),
             pin: RefCell::new(KindPin::Unpinned),
+            related: RefCell::new(Vec::new()),
         })
     }
 
-    /// What this variable has been pinned to.
+    /// What this variable is pinned to: the [`KindPin::join`] of its own pin and
+    /// every pin reachable through [`FunKindVar::related`].
+    ///
+    /// The join is folded here rather than at the edges, so the answer is a
+    /// function of the whole recorded relation and not of the order its pins and
+    /// edges arrived in. An unrelated variable — every variable a CHL program
+    /// produces — answers from its own slot and walks nothing.
     pub fn pin(&self) -> KindPin {
-        *self.pin.borrow()
+        let own = *self.pin.borrow();
+        if self.related.borrow().is_empty() {
+            return own;
+        }
+        // Breadth-first over the component, reading each member's *own* slot so
+        // the walk is not re-entered per member. `seen` is a `Vec` because a
+        // component holding more than a couple of variables has never been
+        // observed; it also terminates the walk on the symmetric edges.
+        let mut acc = own;
+        let mut seen = vec![self.uid];
+        let mut stack: Vec<Rc<FunKindVar>> = self.related.borrow().clone();
+        while let Some(v) = stack.pop() {
+            if seen.contains(&v.uid) {
+                continue;
+            }
+            seen.push(v.uid);
+            acc = acc.join(*v.pin.borrow());
+            stack.extend(v.related.borrow().iter().cloned());
+        }
+        acc
+    }
+
+    /// Relate two kinds, so each reads the other's pins from now on — including
+    /// the ones that arrive after this edge.
+    ///
+    /// Recorded in both directions: the edge says the two kinds are the same
+    /// unknown, which is symmetric, and a reader starting from either end has to
+    /// see the same component. Relating a variable to itself, or recording an
+    /// edge twice, changes nothing — the join is idempotent.
+    pub fn relate(a: &Rc<FunKindVar>, b: &Rc<FunKindVar>) {
+        if a.uid == b.uid {
+            return;
+        }
+        let mut a_rel = a.related.borrow_mut();
+        if !a_rel.iter().any(|v| v.uid == b.uid) {
+            a_rel.push(Rc::clone(b));
+        }
+        drop(a_rel);
+        let mut b_rel = b.related.borrow_mut();
+        if !b_rel.iter().any(|v| v.uid == a.uid) {
+            b_rel.push(Rc::clone(a));
+        }
     }
 
     /// Pin this kind to `Compute`. Pinning to the point already recorded is
-    /// idempotent; pinning to the other one is the conflict, which absorbs.
+    /// idempotent; pinning to the other one is the conflict, which absorbs
+    /// ([`KindPin::join`]).
     pub fn pin_compute(&self) {
         let pin = &mut *self.pin.borrow_mut();
-        *pin = match *pin {
-            KindPin::Unpinned | KindPin::Compute => KindPin::Compute,
-            KindPin::Data | KindPin::Conflict => KindPin::Conflict,
-        };
+        *pin = pin.join(KindPin::Compute);
     }
 
     /// Pin this kind to `Data`. The dual of [`FunKindVar::pin_compute`].
     pub fn pin_data(&self) {
         let pin = &mut *self.pin.borrow_mut();
-        *pin = match *pin {
-            KindPin::Unpinned | KindPin::Data => KindPin::Data,
-            KindPin::Compute | KindPin::Conflict => KindPin::Conflict,
-        };
+        *pin = pin.join(KindPin::Data);
     }
 
     /// Copy `other`'s pin onto this variable, for a scheme instantiation carrying
     /// the definition site's answer onto the freshened copy.
+    ///
+    /// The copy takes the definition's *answer* — `other.pin()`, the component's
+    /// join — into its own slot, and starts related to nothing. That is what
+    /// decouples the instantiation: a pin the definition site acquires later does
+    /// not reach the copy, which is the same decoupling a fresh `uid` gives.
     pub fn adopt_pin(&self, other: &FunKindVar) {
         *self.pin.borrow_mut() = other.pin();
+        debug_assert!(
+            self.related.borrow().is_empty(),
+            "a freshened kind var adopts a pin before any edge relates it",
+        );
     }
 }
 
@@ -532,6 +619,15 @@ pub fn reset_kind_var_counter() {
 /// | `History` (`kind: Overwrite`) | Type checker only | "Mutable variable: a `value` cell tracked over a `domain` (loop index or transaction time)" | the unified phase (`transact_phase` / `mut_elim`, which runs *before* `channelize`; a survivor downstream is a compiler bug) |
 /// | `History` (`kind: Feed`) | Type checker only | "Feed channel `domain ⇒ value`: the defer binding's post-channelize stream type" | `channelize` (which runs after inference; a survivor downstream is a compiler bug) |
 /// | `ChanDom(d, _)` | Type checker only | "Rigid nominal domain of feed channel `d` — its domain resolves at channel assembly" | `channelize` (substituted to the concrete channel domain; a survivor downstream is a compiler bug) |
+///
+/// A type is **concrete** when none of those variants occurs anywhere in it, nor
+/// a [`FunKind::Var`]: it is what a checked program exhibits, and what every pass
+/// after inference reads. The word is not "ground", which in logic means
+/// variable-free — a concrete type may still carry a *free name*, since a
+/// refinement predicate references an enclosing binder by name until landing
+/// closes it to an index. [`crate::ccl::subst::type_contains_infer`] is the cheap
+/// per-type check for the `Infer` case, and `check_fully_typed` the
+/// whole-program one.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Type {
     /// A primitive base type.

--- a/tests/constraint_order_fuzz.rs
+++ b/tests/constraint_order_fuzz.rs
@@ -1,0 +1,319 @@
+//! Fuzz the solver for constraint arrival-order independence.
+//!
+//! The solver's design leans on constraint arrival order not mattering, and
+//! record-then-sweep makes that a property of the algorithm rather than of any
+//! one constraint (`src/ccl/design/type-inference.md`, "1. Algorithm Overview").
+//! No unit test states the property, because a single case cannot: it is over
+//! *every* permutation of a constraint set, and the sets where it fails are the
+//! ones nobody thought to write down.
+//!
+//! This applies the same constraint **set** in permuted orders, coalesces every
+//! variable, and asserts the outcomes agree. A violation is typing that depends
+//! on constraint arrival order — the same defect class as a non-transitive
+//! subtype relation, one level up.
+//!
+//! Seeded and dependency-free, so a failure replays: `CAMBRA_FUZZ_SEED` picks
+//! the seed and `CAMBRA_FUZZ_N` the number of constraint sets.
+
+mod type_gen;
+
+use std::rc::Rc;
+
+use cambra::ccl::infer::solver::{
+    ConstrainCache, coalesce_compact, compact_type, constrain_subtype, simplify_type,
+};
+use cambra::ccl::{BaseType, FunKind, FunKindVar, InferVar, Name, Telescope, Type};
+use type_gen::{KindVarPool, Rng, env_or, gen_ty, maybe_kind_var_from};
+
+/// One constraint in a generated set, phrased over variable *indices* so the
+/// same set can be replayed against freshly-minted variables per run.
+#[derive(Clone, Debug)]
+enum Spec {
+    /// `𝑇 <: vᵢ` — a lower bound arrives.
+    Low(usize, Type),
+    /// `vᵢ <: 𝑇` — an upper bound arrives.
+    Up(usize, Type),
+    /// `vᵢ <: vⱼ` — a var-var edge, where propagation is one-sided.
+    VarVar(usize, usize),
+}
+
+/// Replay `specs` in `order` against fresh variables, and render the outcome.
+///
+/// The outcome is **acceptance** — no constraint rejected, every variable
+/// coalesces — plus, when accepted, the per-variable coalesced types. *Which*
+/// constraint trips the rejection of an unsatisfiable set is intrinsically
+/// order-relative under record-then-sweep (the last edge to arrive meets the
+/// already-recorded bounds), and emission order is fixed by the AST walk in the
+/// real pipeline, so error identity is deliberately not part of the outcome. A
+/// set flipping between accepted and rejected across orders is a violation.
+///
+/// Every constraint gets a fresh cache, as real emission does.
+fn run(nvars: usize, specs: &[Spec], order: &[usize]) -> String {
+    // The generator's predicates reference its two Pi binder names, and it emits
+    // a dependent refinement independently of whether an enclosing function
+    // binds one. The variables therefore stand in a context holding both, which
+    // is what their telescope records; minting them scope-free would make the
+    // record-time closure check reject the generator's own output.
+    let scope = Telescope::empty()
+        .extended(Name::raw("x"))
+        .extended(Name::raw("y"));
+    let vars: Vec<Type> = (0..nvars)
+        .map(|_| Type::Infer(InferVar::fresh_in(0, &scope)))
+        .collect();
+    let mut rejected = false;
+    for &i in order {
+        let result = match &specs[i] {
+            Spec::Low(v, t) => constrain_subtype(t, &vars[*v], &mut ConstrainCache::new()),
+            Spec::Up(v, t) => constrain_subtype(&vars[*v], t, &mut ConstrainCache::new()),
+            Spec::VarVar(a, b) => {
+                constrain_subtype(&vars[*a], &vars[*b], &mut ConstrainCache::new())
+            }
+        };
+        rejected |= result.is_err();
+    }
+    let mut coalesced = Vec::with_capacity(nvars);
+    for v in &vars {
+        match coalesce_compact(&simplify_type(compact_type(v))) {
+            Ok(t) => coalesced.push(format!("{t}")),
+            Err(_) => rejected = true,
+        }
+    }
+    if rejected {
+        "rejected".to_string()
+    } else {
+        canonicalize(&format!("{coalesced:?}"))
+    }
+}
+
+/// Rename `?N` (inference variables) and `κN` (kind variables) in
+/// first-occurrence order, so globally-fresh uids across runs compare equal.
+fn canonicalize(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut seen: Vec<String> = Vec::new();
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '?' && c != 'κ' {
+            out.push(c);
+            continue;
+        }
+        let mut num = String::new();
+        while let Some(d) = chars.peek() {
+            if !d.is_ascii_digit() {
+                break;
+            }
+            num.push(*d);
+            chars.next();
+        }
+        if num.is_empty() {
+            out.push(c);
+            continue;
+        }
+        let key = format!("{c}{num}");
+        let idx = seen.iter().position(|k| *k == key).unwrap_or_else(|| {
+            seen.push(key);
+            seen.len() - 1
+        });
+        out.push(c);
+        out.push_str(&format!("#{idx}"));
+    }
+    out
+}
+
+fn gen_specs(rng: &mut Rng, nvars: usize) -> Vec<Spec> {
+    let count = 2 + rng.below(5) as usize;
+    let mut specs = Vec::with_capacity(count);
+    // One pool per set, so two constraints can carry the same kind variable and a
+    // pin recorded by one is read through the other.
+    let mut kinds = KindVarPool::new();
+    for _ in 0..count {
+        let v = rng.below(nvars as u64) as usize;
+        let concrete = |rng: &mut Rng, kinds: &mut KindVarPool| {
+            let t = gen_ty(rng, 2);
+            maybe_kind_var_from(rng, kinds, t)
+        };
+        match rng.below(4) {
+            0 => specs.push(Spec::Low(v, concrete(rng, &mut kinds))),
+            1 => specs.push(Spec::Up(v, concrete(rng, &mut kinds))),
+            2 if nvars > 1 => {
+                let mut w = rng.below(nvars as u64) as usize;
+                if w == v {
+                    w = (v + 1) % nvars;
+                }
+                specs.push(Spec::VarVar(v, w));
+            }
+            _ => {
+                // Correlated bounds — the same type arriving on both sides
+                // is where joins actually meet.
+                let t = concrete(rng, &mut kinds);
+                specs.push(if rng.chance(1, 2) {
+                    Spec::Low(v, t)
+                } else {
+                    Spec::Up(v, t)
+                });
+            }
+        }
+    }
+    specs
+}
+
+fn shuffle(rng: &mut Rng, n: usize) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..n).collect();
+    for i in (1..n).rev() {
+        let j = rng.below((i + 1) as u64) as usize;
+        order.swap(i, j);
+    }
+    order
+}
+
+/// The one shape the generated sets reach only by luck, stated directly: a kind
+/// variable shared between two inference variables, where the pin arrives after
+/// the edge that relates it.
+///
+/// Every permutation of these four constraints has to coalesce both variables the
+/// same way. `constrain_kind` relates two kind variables and `FunKindVar::pin`
+/// joins over the relation at the read, so the answer is a function of the set;
+/// resolving at the edge instead answers from the pins that had arrived, and `v1`
+/// renders `⇒` in the orders where the edge precedes the pin and `⤇` in the rest.
+///
+/// A generated set reaches this only when it draws two *distinct* kind variables
+/// onto opposite bounds of one variable, a third bound pinning one of them, and a
+/// second variable giving the other a rendered position — so it is written out
+/// rather than left to the sampler.
+#[test]
+fn a_shared_kind_var_resolves_the_same_way_in_every_order() {
+    let fun_over = |kind: FunKind| Type::Fun {
+        name: None,
+        kind,
+        domain: Box::new(Type::UIntRange(3)),
+        codomain: Box::new(Type::Base(BaseType::Int)),
+    };
+    // `k1` and `k2` meet on opposite bounds of `v0`, which is the var-var kind
+    // edge; `Data` reaches `k1` only; `k2` also sits in a positive position of
+    // `v1`, which is what makes its resolution show up in a coalesced type.
+    let build = |order: &[usize]| -> String {
+        let scope = Telescope::empty();
+        let v0 = Type::Infer(InferVar::fresh_in(0, &scope));
+        let v1 = Type::Infer(InferVar::fresh_in(0, &scope));
+        let (k1, k2) = (FunKindVar::fresh(), FunKindVar::fresh());
+        let mut rejected = false;
+        for &i in order {
+            let r = match i {
+                0 => constrain_subtype(
+                    &fun_over(FunKind::Var(Rc::clone(&k1))),
+                    &v0,
+                    &mut ConstrainCache::new(),
+                ),
+                1 => constrain_subtype(
+                    &v0,
+                    &fun_over(FunKind::Var(Rc::clone(&k2))),
+                    &mut ConstrainCache::new(),
+                ),
+                2 => constrain_subtype(
+                    &fun_over(FunKind::Var(Rc::clone(&k2))),
+                    &v1,
+                    &mut ConstrainCache::new(),
+                ),
+                _ => constrain_subtype(&v0, &fun_over(FunKind::Data), &mut ConstrainCache::new()),
+            };
+            rejected |= r.is_err();
+        }
+        let mut out = Vec::new();
+        for v in [&v0, &v1] {
+            match coalesce_compact(&simplify_type(compact_type(v))) {
+                Ok(t) => out.push(format!("{t}")),
+                Err(_) => {
+                    rejected = true;
+                    out.push("rejected".to_string())
+                }
+            }
+        }
+        format!(
+            "{}{}",
+            if rejected { "rejected " } else { "" },
+            out.join(", ")
+        )
+    };
+
+    let baseline = build(&[0, 1, 2, 3]);
+    let mut divergent = Vec::new();
+    for order in permutations(4) {
+        let got = build(&order);
+        if got != baseline {
+            divergent.push(format!("  order {order:?} -> {got}"));
+        }
+    }
+    assert!(
+        divergent.is_empty(),
+        "a shared kind variable resolves differently by arrival order\n  \
+         baseline [0, 1, 2, 3] -> {baseline}\n{}",
+        divergent.join("\n")
+    );
+}
+
+/// Every permutation of `0..n`, in lexicographic order.
+fn permutations(n: usize) -> Vec<Vec<usize>> {
+    let mut out = Vec::new();
+    let mut cur: Vec<usize> = (0..n).collect();
+    loop {
+        out.push(cur.clone());
+        // Next lexicographic permutation.
+        let Some(i) = (0..n.saturating_sub(1))
+            .rev()
+            .find(|&i| cur[i] < cur[i + 1])
+        else {
+            return out;
+        };
+        let j = (i + 1..n)
+            .rev()
+            .find(|&j| cur[j] > cur[i])
+            .expect("a larger successor exists");
+        cur.swap(i, j);
+        cur[i + 1..].reverse();
+    }
+}
+
+#[test]
+fn solving_is_independent_of_constraint_arrival_order() {
+    let seed: u64 = env_or("CAMBRA_FUZZ_SEED", 0xD1CE);
+    let n: usize = env_or("CAMBRA_FUZZ_N", 2000);
+
+    let mut rng = Rng::new(seed);
+    let mut mismatches = Vec::new();
+    for case in 0..n {
+        // Specs are regenerated from the same sub-seed per permutation run: a
+        // kind variable carries its pin in an `Rc<RefCell<_>>`, so a cloned spec
+        // would leak one run's pins into the next.
+        let case_seed = rng.next();
+        let build = || {
+            let mut r = Rng::new(case_seed);
+            let nvars = 1 + r.below(3) as usize;
+            let specs = gen_specs(&mut r, nvars);
+            (nvars, specs)
+        };
+        let (nvars, specs) = build();
+        let baseline = run(nvars, &specs, &(0..specs.len()).collect::<Vec<_>>());
+        for _ in 0..8 {
+            let (nvars, specs) = build();
+            let order = shuffle(&mut rng, specs.len());
+            let outcome = run(nvars, &specs, &order);
+            if outcome != baseline {
+                mismatches.push(format!(
+                    "case {case}: order {order:?} diverges\n  specs = {specs:?}\n  \
+                     baseline = {baseline}\n  permuted = {outcome}"
+                ));
+                break;
+            }
+        }
+    }
+    eprintln!(
+        "constraint order fuzz: {n} constraint sets (seed {seed}), 8 permutations each, \
+         {} order-dependent",
+        mismatches.len()
+    );
+    assert!(
+        mismatches.is_empty(),
+        "{} order-dependent outcomes (first 3):\n{}",
+        mismatches.len(),
+        mismatches[..mismatches.len().min(3)].join("\n\n")
+    );
+}

--- a/tests/type_gen/mod.rs
+++ b/tests/type_gen/mod.rs
@@ -1,0 +1,209 @@
+//! Seeded generation of variable-free `Type`s, shared by the integration tests that
+//! fuzz the solver. Deterministic and dependency-free, so a failing case
+//! replays from its seed.
+//!
+//! A test binary uses only part of this, so each item is `allow(dead_code)`:
+//! `mod type_gen;` compiles the whole module into every including binary, and
+//! `tests/constraint_order_fuzz.rs` does not generate the leaves and predicates
+//! directly the way an edit-driven harness does.
+#![allow(dead_code)]
+
+use std::rc::Rc;
+
+use smol_str::SmolStr;
+
+use cambra::ccl::{
+    BaseType, BinOpKind, CompareKind, FieldKey, FunKind, FunKindVar, Lit, Name, Openness,
+    Refinement, Type, TypedExpr,
+};
+
+/// A seed or case count from the environment, or `default`. Every harness here
+/// is replayable from its seed, which means every harness reads the same two
+/// knobs; one reader keeps them spelled once.
+pub fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+/// xorshift64* — deterministic, dependency-free.
+pub struct Rng(pub u64);
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Rng(seed | 1)
+    }
+    pub fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    pub fn below(&mut self, n: u64) -> u64 {
+        self.next() % n
+    }
+    pub fn chance(&mut self, num: u64, den: u64) -> bool {
+        self.below(den) < num
+    }
+}
+
+/// A predicate from the model's `Pred` vocabulary: `__elem`, literals, a
+/// binder reference, or `__elem == <binder>` (the dependent-refinement
+/// shape). Structural equality is all subtyping observes, so a small closed
+/// set that can collide and differ is enough.
+pub fn gen_pred(rng: &mut Rng) -> Rc<TypedExpr> {
+    match rng.below(6) {
+        0 => Rc::new(TypedExpr::var(Name::elem())),
+        1 => Rc::new(TypedExpr::lit(Lit::Bool(true))),
+        2 => Rc::new(TypedExpr::lit(Lit::Int(rng.below(3) as i64))),
+        _ => {
+            let x = if rng.chance(1, 2) { "x" } else { "y" };
+            Rc::new(TypedExpr::binop(
+                TypedExpr::var(Name::elem()),
+                BinOpKind::Compare(CompareKind::Equals),
+                TypedExpr::var(Name::raw(x)),
+            ))
+        }
+    }
+}
+
+pub fn gen_leaf(rng: &mut Rng) -> Type {
+    match rng.below(6) {
+        0 => Type::Base(BaseType::Int),
+        1 => Type::Base(BaseType::Bool),
+        2 => Type::Base(BaseType::String),
+        3 => Type::UIntRange(2 + rng.below(3) as usize),
+        4 => Type::DataSource(if rng.chance(1, 2) { "s" } else { "t" }.into()),
+        _ => Type::Txn,
+    }
+}
+
+/// The kind variables one generated constraint set draws from.
+///
+/// Sharing is the point. A variable minted per generated type is written by at
+/// most one constraint, which leaves the relation `constrain_kind` records
+/// between two kind variables unobservable: nothing checks whether a pin reaches
+/// the far side, or whether it still does when it arrives after the edge. Drawing
+/// from a pool gives a set a few variables spread across many constraints, so a
+/// pin recorded by one is read through another.
+pub struct KindVarPool(Vec<Rc<FunKindVar>>);
+
+impl Default for KindVarPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KindVarPool {
+    pub fn new() -> Self {
+        KindVarPool(Vec::new())
+    }
+
+    /// One of the variables already handed out, or a fresh one. Biased toward
+    /// reuse, since a set of all-distinct variables is the case that already had
+    /// coverage.
+    fn pick(&mut self, rng: &mut Rng) -> Rc<FunKindVar> {
+        if !self.0.is_empty() && rng.chance(2, 3) {
+            let i = rng.below(self.0.len() as u64) as usize;
+            return Rc::clone(&self.0[i]);
+        }
+        let v = FunKindVar::fresh();
+        self.0.push(Rc::clone(&v));
+        v
+    }
+}
+
+/// Replace a function's concrete kind with a kind *variable* from `pool`
+/// (sometimes, top-level only). Nothing else produces one: [`gen_ty`] stamps a
+/// concrete `FunKind`, so the states only a variable kind reaches —
+/// `KindMerge::Unknown`, and `constrain_kind`'s variable-against-variable arm —
+/// are unreachable without this. A kind variable holds mutable state behind an
+/// `Rc` (its pin, and the variables it is related to), which is why a generator
+/// that replays re-runs rather than cloning.
+pub fn maybe_kind_var_from(rng: &mut Rng, pool: &mut KindVarPool, t: Type) -> Type {
+    match t {
+        Type::Fun {
+            name,
+            kind: _,
+            domain,
+            codomain,
+        } if rng.chance(1, 2) => Type::Fun {
+            name,
+            kind: FunKind::Var(pool.pick(rng)),
+            domain,
+            codomain,
+        },
+        other => other,
+    }
+}
+
+/// [`maybe_kind_var_from`] with a pool of its own, so the variable is fresh — for
+/// a harness whose cases are independent and share nothing.
+pub fn maybe_kind_var(rng: &mut Rng, t: Type) -> Type {
+    maybe_kind_var_from(rng, &mut KindVarPool::new(), t)
+}
+
+pub fn gen_ty(rng: &mut Rng, depth: u32) -> Type {
+    if depth == 0 || rng.chance(1, 3) {
+        return gen_leaf(rng);
+    }
+    match rng.below(5) {
+        0 => {
+            let kind = if rng.chance(1, 2) {
+                FunKind::Data
+            } else {
+                FunKind::Compute
+            };
+            let domain = gen_ty(rng, depth - 1);
+            let name = match rng.below(3) {
+                0 => None,
+                1 => Some(Name::raw("x")),
+                _ => Some(Name::raw("y")),
+            };
+            // With a Pi binder present, bias the codomain toward a dependent
+            // refinement so the binder correspondence actually fires.
+            let codomain = if name.is_some() && rng.chance(1, 2) {
+                Type::refined_one(gen_ty(rng, depth - 1), Refinement::born(gen_pred(rng)))
+            } else {
+                gen_ty(rng, depth - 1)
+            };
+            Type::Fun {
+                name,
+                kind,
+                domain: Box::new(domain),
+                codomain: Box::new(codomain),
+            }
+        }
+        1 => Type::Tuple((0..rng.below(3)).map(|_| gen_ty(rng, depth - 1)).collect()),
+        2 => {
+            let mut fields = Vec::new();
+            for key in ["a", "b", "c"] {
+                if rng.chance(1, 2) {
+                    fields.push((key.to_string(), gen_ty(rng, depth - 1)));
+                }
+            }
+            Type::Record(fields)
+        }
+        3 => {
+            let mut tags = Vec::new();
+            if rng.chance(1, 2) {
+                for key in ["t0", "t1"] {
+                    if rng.chance(2, 3) {
+                        tags.push((FieldKey::Name(SmolStr::from(key)), gen_ty(rng, depth - 1)));
+                    }
+                }
+            } else {
+                for i in 0..rng.below(3) {
+                    tags.push((FieldKey::Index(i as usize), gen_ty(rng, depth - 1)));
+                }
+            }
+            // Closed: an open arm set is only ever *demanded*, never produced, so
+            // a generated type — which stands in for a value's type — is closed.
+            Type::Variant(tags, Openness::Closed)
+        }
+        _ => Type::refined_one(gen_ty(rng, depth - 1), Refinement::born(gen_pred(rng))),
+    }
+}


### PR DESCRIPTION
The solver records a bound and sweeps it against the ones already there, so nothing in it says what happens when the same constraints arrive in a different order. Arrival order not changing the answer is therefore a property of the algorithm rather than of any one constraint, and no test stated it — a unit test cannot, because the property is over *every* permutation of a constraint set, and the sets where it fails are the ones nobody thought to write down.

`tests/constraint_order_fuzz.rs` states it: the same constraint set, applied in permuted orders against fresh variables, has to coalesce every variable to the same type — or be rejected in every order. 2000 generated sets, eight permutations each, seeded and dependency-free so a failure replays (`CAMBRA_FUZZ_SEED`, `CAMBRA_FUZZ_N`). The sets mix concrete bounds, variable-against-variable edges, and functions carrying a kind variable, the last because nothing else reaches `constrain_kind`'s variable-against-variable arm or produces an undetermined kind at coalesce.

*Which* constraint trips the rejection of an unsatisfiable set is deliberately not part of the outcome. Under record-then-sweep the last edge to arrive is the one that meets the already-recorded bounds, so error identity is order-relative by construction, and emission order is fixed by the AST walk anyway. A set flipping between accepted and rejected across orders is the violation.

### What it caught

A kind variable's answer depended on which constraint arrived first.

`constrain_kind`'s variable-against-variable arm recorded nothing at all, on the grounds that no program reaches it, with a `debug_assert` claiming the two sides always agree. The fuzz reaches it with one side pinned and the other not, and the pin was simply dropped.

**The edge relates the two kinds; it does not resolve them.** The arm now records the edge, and `FunKindVar::pin` folds the join over everything the relation reaches, at the point the pin is read. So a variable's kind is a function of the whole constraint set: a pin arriving after the edge crosses it, and so does one two edges away. Copying each side's pin onto the other *at* the edge — the smaller fix — answers from whichever pins happen to have arrived and drops the rest, and the two variables then coalesce to different arrows depending on which constraint came first. Deferring the join to the read is the rule the domain combination already follows, for the same reason: a value the fold is still accumulating cannot be read pairwise.

The join is the flat semilattice `Unpinned < {Compute, Data} < Conflict`, now named once as `KindPin::join` and reused by `pin_compute` and `pin_data`, which had the absorption law written out twice. Its commutativity, associativity and idempotence are what make the fold order-blind: every reader folds the same set, and no step reads a value a later step can change.

The arm still answers `false` for "is this a data edge", so two `Data`-pinned variables reach the lossless-domain rule through their pins rather than through the edge. That is a question about what the edge *demands*, and this edge demands nothing of either kind.

### Tests, and what the fuzz cannot see

`a_shared_kind_var_resolves_the_same_way_in_every_order` checks all 24 orders of the shape that exhibits the defect, end to end through coalesce: one kind variable shared between two inference variables, with the pin arriving after the edge. Twelve of the 24 diverge without the change — `v1` coalescing to `⇒` in the orders where the edge precedes the pin and `⤇` in the rest.

That case is written out rather than left to the sampler, because the fuzz does not reach it by luck: the shape needs two *distinct* kind variables on opposite bounds of one variable, a third bound pinning one of them, and a second variable giving the other a rendered position. The generator now draws kind variables from a per-set pool (`KindVarPool`) so two constraints can share one at all — minting one per generated type left the relation unobservable — and that alone still does not find it.

Three unit tests pin the mechanism directly: a pin crossing an edge in either direction, a pin crossing a two-edge chain, and disagreeing pins reading as `Conflict` from either end.

### Reachability

No CHL program reaches the arm. Instrumented, the integration corpus and the 1249-test unit suite hit it zero times; a kind variable is minted only by an elimination's demand, and two demands meet at compaction rather than at a constraint. Every hit comes from generated type pairs, which is what the fuzz supplies. The property is worth holding anyway — it is the one place where a variable's resolution was a function of history rather than of the constraints.

### Naming

The solver had no word for "a type with no unknowns in it", and was borrowing **ground** for it — undefined, sitting beside eighteen pre-existing uses of **concrete** meaning the same thing (`infer_var.rs`: *"a concrete type, or a `Type::Infer`"*). All of them are now `concrete`: six in `constrain.rs`'s prose plus a seventh in a test's name, three in `scheme.rs`, and one in `subst.rs`. `Type`'s doc defines the term where its table already enumerates the complement: a type is concrete when none of the transient variants, nor a `FunKind::Var`, occurs anywhere in it.

A word-boundary search sees none of the identifiers, which is how `a_ground_pair_does_not_open_at_a_shared_spelling` outlived a sweep that had already converted its own doc comment to say "two concrete sides". What is left of the word is the sense it is right for — a *term* is ground, in `infer/mod.rs` and `infer/context.rs` — and `Type`'s doc rejecting it for types.

Not "ground", which in logic means variable-free: a concrete type may still carry a *free name*, since a refinement predicate references an enclosing binder by name until landing closes it to an index. `concrete` claims only what is true. `type_contains_infer`, which reached for `"is this type ground"` in scare quotes, now names the property it checks half of.

### Review guide

`tests/type_gen/mod.rs` is the seeded generator and `tests/constraint_order_fuzz.rs` the harness; both live in `tests/` because they are tests, and the generator is a module there so a second harness can share it. The source changes are `KindPin::join` and the relation on `FunKindVar` (`src/ccl/ty.rs`), and `constrain_kind`'s `(Var, Var)` arm (`src/ccl/infer/solver/constrain.rs`).

`type-inference.md`'s algorithm overview recorded the one-sided variable-against-variable handling as an open question in a review thread — an uncheckable reference to a transient place. It now states both properties and names the tests that check them.

