### PR TITLE
Accept an `if`/`match` block as an assignment's value, and add the one-line `match`

### DIFF
--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -1313,11 +1313,11 @@ that block's value — its last statement's, by the rule in §4.5:
 
 ```python
 label = if score > 90:
-    "high"
-elif score > 50:
-    "mid"
-else:
-    "low"
+      "high"
+  elif score > 50:
+      "mid"
+  else:
+      "low"
 
 n = match msg:
     case `ping(seq):

--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -258,6 +258,7 @@ Python's `ast.Module`; the name is historical.)
 
 ```ebnf
 statement       ::= simple_stmt NEWLINE
+                 |  block_assign_stmt
                  |  compound_stmt
 
 simple_stmt     ::= return_stmt
@@ -279,17 +280,32 @@ aug_assign_stmt ::= assign_target aug_op expression
 define_stmt     ::= assign_target "<<=" expression
 expr_stmt       ::= expression
 
+-- The same six assignment forms with a block statement on the right (§4.3).
+-- The block's DEDENT ends the statement, so no NEWLINE follows it.
+block_assign_stmt ::= assign_target "=" block_value
+                   |  assign_target ":" expression "=" block_value
+                   |  assign_target [ ":" expression ] ":=" block_value
+                   |  assign_target aug_op block_value
+                   |  assign_target "<<=" block_value
+
+block_value     ::= if_stmt | match_stmt
+
 aug_op          ::= "+=" | "-=" | "*=" | "//="
 
 assign_target   ::= ident
                  |  "(" assign_target ( "," assign_target )* [ "," ] ")"
                  |  assign_target ( "," assign_target )+ [ "," ]
 
-compound_stmt   ::= if_stmt | for_stmt | with_stmt | def_stmt
+compound_stmt   ::= if_stmt | match_stmt | for_stmt | with_stmt | def_stmt
 
 if_stmt         ::= "if" expression ":" block
                     ( "elif" expression ":" block )*
                     [ "else" ":" block ]
+
+match_stmt      ::= "match" expression ":" NEWLINE INDENT case_arm+ DEDENT
+case_arm        ::= "case" case_pattern ":" block
+case_pattern    ::= "`" ident [ "(" ( ident | "_" ) ")" ]
+                 |  "_"
 
 for_stmt        ::= "for" assign_target "in" expression ":" block
 
@@ -360,6 +376,15 @@ expression ::= lambda_expr | yield_expr | feed_expr
              | ternary | bool_or | bool_and | bool_not
              | comparison | log_or | log_xor | log_and | collection_union
              | sum_expr | product | unary | postfix | atom
+
+-- Every position a bracket encloses: a list or tuple element, a call argument,
+-- a subscript index, a record field, a brace item, a refinement predicate, a
+-- comprehension clause. The one-line `match` (§4.10) is legal only here, so the
+-- enclosing `)`, `]` or `}` always closes its arm list. The bracketed atom forms
+-- in §2.4 recurse through this production rather than through `expression`.
+bracketed_expression ::= oneline_match | expression
+
+oneline_match ::= "match" expression ":" ( "case" case_pattern ":" expression )+
 ```
 
 ### 2.4 Atoms
@@ -1282,6 +1307,30 @@ is supported at any nesting depth.
 (the mutation `:=` is a statement, §1.8). **No multi-target chained
 assignment** (`a = b = c` is not in the grammar).
 
+**A block statement may sit on the right.** Every form in the table above
+accepts an `if` chain or a `match` where it accepts an expression, and binds
+that block's value — its last statement's, by the rule in §4.5:
+
+```python
+label = if score > 90:
+    "high"
+elif score > 50:
+    "mid"
+else:
+    "low"
+
+n = match msg:
+    case `ping(seq):
+        seq
+    case `close:
+        0
+```
+
+The block's DEDENT ends the statement, so nothing follows it on the line. Every
+branch must produce a value, and an `if` with no `else` is rejected (§4.5); a
+one-line spelling of the same thing is the ternary (§3.6) or, for `match`, the
+bracketed form in §4.10.
+
 Annotated assignment **requires** a value (`x: T` alone is a parse error,
 unlike Python's bare type-only declarations).
 
@@ -1417,8 +1466,9 @@ else:
     block_else
 ```
 
-`if`/`elif`/`else` is a *statement*; for an expression form use the
-ternary (§3.6).
+`if`/`elif`/`else` is a statement. It is value-yielding by position: as the
+last statement of a block, and on the right of an assignment (§4.3). The
+one-line spelling of the same choice is the ternary (§3.6).
 
 The branches are tried in source-text priority: the value of the
 statement is the value of the block under the first guard that holds,
@@ -1432,9 +1482,9 @@ non-winning blocks contribute no effects.
 
 Each branch's block is itself a statement block. When the `if` chain
 occurs in a position that requires a value (function body, program
-value), every branch — including `else` — must end in a value-yielding
-statement, and the missing-`else` case is rejected as "if used as an
-expression, all branches must produce a value."
+value, an assignment's right-hand side), every branch — including `else` —
+must end in a value-yielding statement, and the missing-`else` case is
+rejected as "if used as an expression, all branches must produce a value."
 
 ### 4.6 `for` — iteration
 
@@ -1663,16 +1713,42 @@ and bare calls. Dispatching per element is written as a `def` that matches
 on its parameter and is called from the loop or a comprehension, which is
 the same first-match rule reached through a call.
 
-> **Direction [Tentative].** What is missing is a **one-line** spelling, not
-> expression-ness: a `match` in a value position yields a value as an `if`
-> chain does (§4.5). The candidate spelling is the block with its line breaks
-> removed — `` match scrut: case `foo(x): x case `bar(y): to_x(y) `` — where
-> `case` delimits the arms, so no separator is needed. It waits on a one-line
-> block rule, which no block statement has today (`if c: x` does not parse
-> either), so the rule to settle is layout's rather than `match`'s. Tuple
-> destructuring on assignment targets (§4.3) is unaffected and remains the
-> only other pattern-like form.
->
+#### The one-line form
+
+```
+match scrut: case `foo(x): x case `bar(y): to_x(y)
+```
+
+The block with its line breaks removed, and an expression in place of each
+arm's block. `case` delimits the arms, so no separator is needed, and the arm
+list runs to the first token that cannot begin an arm.
+
+**A one-line `match` is legal only inside a bracket** — `(…)`, `[…]`, `{…}` —
+so a `)`, `]` or `}` is always in place to close the arm list. That covers a
+call argument, a list or tuple element, a subscript index, a record field, a
+comprehension clause, and a refinement predicate (§6.4). In a value position
+that has no bracket of its own, the parentheses are written:
+
+```python
+n = (match msg: case `ping(seq): seq case `close: 0)
+```
+
+The bracket is what makes nesting readable. An arm body is an ordinary
+expression, which cannot itself derive a one-line `match`, so a nested one
+carries its own bracket and two arm lists never compete for the same `case`.
+Without the requirement, `` match a: case `p: match b: case `q: 1 case `r: 2 ``
+has two readings, and under the greedy one the outer `match` has no way to
+spell an arm after `` `p ``.
+
+Restricting the arm body instead of requiring the bracket does not hold: a
+lambda body, a ternary else-branch, an `<<` right operand and a `=>` codomain
+each take a whole expression, so an inner `match` reappears through any of
+them.
+
+The indented and one-line forms differ in the arm body and in nothing else:
+same arms, same partition rule, same value.
+
+> **Direction [Tentative].**
 > `_` is accepted as an unused binder in a **pattern payload** only.
 > Extending it to every binder position — a lambda parameter, a `for` target,
 > a tuple destructuring slot — is **[Tentative]**. It needs a written rule for
@@ -2098,20 +2174,16 @@ A `match` over `_` is the idiomatic way to refine a variant:
 { { `some{Int} | `none } where
     match _:
         case `some(x): x > 0
-        case `none: true
+        case `none: True
 }
 ```
 
-> **[Open]** — the layout of that `match`. Newlines and indentation are
-> **ignored** inside brackets (§1.4), so a `match` written inside `{…}`
-> gets no `INDENT`/`DEDENT` to delimit its arms: the arms above are
-> readable to a human but invisible to the layout rules, and the parser
-> would have to delimit each arm by the next `case` or the closing brace
-> instead. That is parseable — neither token can continue an expression —
-> but it is a second, delimiter-derived block discipline for `match`
-> alongside the indentation-derived one it has today (§4.10). A
-> **single-line `match`** form would collapse the two; its spelling is
-> undecided, and so is any expression form of `match` at all (§4.10).
+That `match` is the one-line form (§4.10). Newlines and indentation are
+ignored inside brackets (§1.4), so a `match` written inside `{…}` gets no
+`INDENT`/`DEDENT` to delimit its arms; the refinement's own `}` closes the arm
+list instead, and the line breaks above are for the reader. The predicate needs
+no parentheses of its own, because the braces are already the bracket the
+one-line form requires.
 
 `_` is the value being refined, so a predicate that mentions *another* value
 relies on that value having a name where the refinement sits. In a function
@@ -2913,11 +2985,9 @@ with parser-level support that lowering rejects:
   would replace the built-in `Option(T)` with a prelude definition
   (**[Tentative]**, §3.15, §6.1).
 - **Pattern matching** beyond a `match` arm's single tag — `match` / `case`
-  tag dispatch over a variant is implemented (§4.10), but patterns are
-  shallow: no nesting, no literal patterns, and no per-arm guard. `match` is a
-  statement only; an expression form is **[Open]**, and the layout rules
-  (§1.4) force the question for a `match` inside a refinement predicate
-  (§6.4).
+  tag dispatch over a variant is implemented (§4.10), in both the indented and
+  the one-line form, but patterns are shallow: no nesting, no literal patterns,
+  and no per-arm guard.
 - **Destructuring patterns** beyond tuples — record, variant, and
   wildcard patterns in assignment targets and `for` binders (a `match`
   arm's tag pattern is §4.10), and per-component annotations with `:`

--- a/src/ccl/design/lowering.md
+++ b/src/ccl/design/lowering.md
@@ -140,6 +140,27 @@ The inference pass types `Defer`/`Feed`/`Define` directly — `Defer : Feed(Chan
 
 Mutation-loop inference (`emit_loop`) learns the loop body's full Record codomain from the body itself via a one-way subtyping constraint: `require_sub(body_codomain, product({step: σ}))` pins the `step` field while width-subtyping lets the body's Record literal supply whatever `to_<defer>` fields it carries. This is the general pattern for "a known core plus an open set of additional fields" — an open record demanded by `require_sub`, not a dedicated partial-record type.
 
+## `if` and `match` in value position
+
+A block statement in value position — `x = if c: … else: …`, `x = match v: …`,
+and the one-line `match` ([chl-spec.md](../../../docs/chl-spec.md#the-one-line-form),
+"The one-line form") — reaches lowering as `ChlExpr::Block` wrapping the
+`Stmt::If` or `Stmt::Match` it parsed to. Every spelling routes through
+`lower_final_stmt`, so a block right-hand side lowers to the `Case` its
+tail-position and ternary counterparts already produce and adds no IR node.
+
+`lower_assigned_value` is what carries the enclosing scope into a block
+right-hand side. The names bound above the assignment are what a `for` inside
+one of the block's branches consults to tell a loop-carried accumulator from a
+branch-local (`find_mutation_loop_vars`), and `lower_expr` has no scope to pass.
+
+Three positions reach the block through `lower_expr` and so drop that scope: a
+one-line `match`, and a block right-hand side inside a loop body or a `with
+begin():` block, each of which lowers an assignment's value itself. None admits
+a `for` in the branch — a one-line arm body is a single expression, and a
+nested `for` is rejected in both enclosing blocks — so the dropped scope is
+unobservable.
+
 ## Variants and match
 
 Surface variants ([chl-spec.md](../../../docs/chl-spec.md#315-variant-constructors) §3.15, [§4.10](../../../docs/chl-spec.md#410-match--tag-dispatch)) add **no IR node**. Both halves already existed for the conditionals stack: `match` is the surface for a concept the IR already had.

--- a/src/ccl/lower/exprs.rs
+++ b/src/ccl/lower/exprs.rs
@@ -359,7 +359,7 @@ fn chl_binop_to_ccl(op: ChlBinOp) -> BinOpKind {
 pub(super) fn lower_aug_binop(
     target_name: &str,
     op: AugOp,
-    value: &Spanned<ChlExpr>,
+    right_expr: Expr,
     stmt_span: Span,
     ctx: &mut LoweringContext,
 ) -> Result<Expr, LoweringError> {
@@ -368,7 +368,6 @@ pub(super) fn lower_aug_binop(
         stmt_span,
         "lower.aug_binop",
     );
-    let right_expr = lower_expr(value, ctx)?;
     let kind = match op {
         AugOp::Add => BinOpKind::Arithmetic(ArithmeticKind::Add),
         AugOp::Sub => BinOpKind::Arithmetic(ArithmeticKind::Sub),
@@ -404,11 +403,10 @@ pub(super) fn lower_feed(
 
 pub(super) fn lower_define(
     target: &Spanned<AssignTarget>,
-    value: &Spanned<ChlExpr>,
-    ctx: &mut LoweringContext,
+    value: Expr,
 ) -> Result<Expr, LoweringError> {
     let name = extract_name_target(target, "handle defining")?;
-    Ok(Expr::define(name, lower_expr(value, ctx)?))
+    Ok(Expr::define(name, value))
 }
 
 /// Lower a CHL unary expression to a CCL [`Expr::UnaryOp`].

--- a/src/ccl/lower/loops.rs
+++ b/src/ccl/lower/loops.rs
@@ -839,7 +839,7 @@ fn lower_loop_body_chain(
                     return Err(in_loop_aug_assign_error(stmt.span, &name));
                 }
                 check_mut_write_context(&name, stmt.span, ctx)?;
-                let val = lower_aug_binop(&name, *op, value, stmt.span, ctx)?;
+                let val = lower_aug_binop(&name, *op, lower_expr(value, ctx)?, stmt.span, ctx)?;
                 let write = ctx.tag_image(Expr::mut_write(name, val), stmt.span);
                 ctx.tag_image(Expr::expr_stmt(write, chain), stmt.span)
             }

--- a/src/ccl/lower/mod.rs
+++ b/src/ccl/lower/mod.rs
@@ -933,6 +933,23 @@ fn lower_expr_inner(
         }
         // `target << value` — feed into a deferred output.
         ChlExpr::Feed { target, value } => lower_feed(target, value, ctx),
+        // A block in value position, reached with no enclosing scope to pass:
+        // a one-line `match`, and a block right-hand side in a loop body or a
+        // `with begin():` block, whose own statement handlers lower an
+        // assignment's value with `lower_expr`. The scope is what tells a `for`
+        // inside a branch that a write targets a loop-carried accumulator
+        // rather than a branch-local, and none of these positions admits such a
+        // `for`: a one-line arm body is a single expression, and a `for` nested
+        // in either enclosing block is rejected already. The statement path
+        // through `lower_assigned_value` carries the scope where a `for` can
+        // appear.
+        ChlExpr::Block(stmt) => {
+            debug_assert!(
+                matches!(stmt.node, ChlStmt::If { .. } | ChlStmt::Match { .. }),
+                "Expr::Block wraps an `if` or a `match`; the parser builds no other block value"
+            );
+            lower_final_stmt(stmt, &[], &HashSet::new(), ctx)
+        }
         // `yield e` is only valid in a generator-for body; reject elsewhere.
         ChlExpr::Yield(_) => Err(LoweringError::unsupported(
             expr.span,

--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -365,7 +365,8 @@ pub(super) fn lower_final_stmt(
         ChlStmt::AugAssign { target, op, value } => {
             let name = extract_name_target(target, "augmented assignment")?;
             check_mut_write_context(&name, last.span, ctx)?;
-            let val = lower_aug_binop(&name, *op, value, last.span, ctx)?;
+            let rhs = lower_assigned_value(value, preceding, outer_bindings, ctx)?;
+            let val = lower_aug_binop(&name, *op, rhs, last.span, ctx)?;
             Ok(ctx.tag_image(Expr::mut_write(name, val), last.span))
         }
         // A bare `x := e` as the final statement is a mutable-variable *write* when `x` is
@@ -386,7 +387,7 @@ pub(super) fn lower_final_stmt(
         {
             let name = extract_name_target(target, "mutable assignment")?;
             check_mut_write_context(&name, last.span, ctx)?;
-            let val = lower_expr(value, ctx)?;
+            let val = lower_assigned_value(value, preceding, outer_bindings, ctx)?;
             Ok(ctx.tag_image(Expr::mut_write(name, val), last.span))
         }
         // A standalone `with begin():` as the program's final statement: one
@@ -404,6 +405,30 @@ pub(super) fn lower_final_stmt(
             "last statement must be a bare expression, if/else, or \
                  for/yield generator loop",
         )),
+    }
+}
+
+/// Lower the right-hand side of an assignment.
+///
+/// A [`ChlExpr::Block`] right-hand side — `x = if c: … else: …`, `x = match v:
+/// …` — is the block statement it wraps, lowered in the scope the assignment
+/// sits in. Those names are what a `for` inside one of the block's branches
+/// consults to tell a loop-carried accumulator from a branch-local
+/// ([`find_mutation_loop_vars`]); reaching the block through [`lower_expr`]
+/// would lose them, and the loop would be read as a generator.
+///
+/// A loop body and a `with begin():` block lower an assignment's value with
+/// [`lower_expr`] instead, and so drop the scope. Neither admits a nested
+/// `for`, so nothing there depends on it.
+fn lower_assigned_value(
+    value: &Spanned<ChlExpr>,
+    preceding: &[Spanned<ChlStmt>],
+    outer_bindings: &HashSet<String>,
+    ctx: &mut LoweringContext,
+) -> Result<Expr, LoweringError> {
+    match &value.node {
+        ChlExpr::Block(stmt) => lower_final_stmt(stmt, preceding, outer_bindings, ctx),
+        _ => lower_expr(value, ctx),
     }
 }
 
@@ -510,7 +535,7 @@ pub(super) fn lower_middle_stmt(
         // top-level `=` to a name that is *also* a live mutable variable just shadows it.
         ChlStmt::Assign { target, value } => {
             let name = extract_name_target(target, "assignment")?;
-            let val = lower_expr(value, ctx)?;
+            let val = lower_assigned_value(value, preceding, outer_bindings, ctx)?;
             Ok(ctx.tag_image(Expr::let_bind(name, val, body), stmt.span))
         }
         ChlStmt::AnnAssign {
@@ -538,7 +563,7 @@ pub(super) fn lower_middle_stmt(
                 ));
             }
             let annotation_ty = lower_type_annotation(annotation, ctx)?;
-            let val = lower_expr(value, ctx)?;
+            let val = lower_assigned_value(value, preceding, outer_bindings, ctx)?;
             Ok(ctx.tag_image(
                 Expr::let_bind_annotated(name, val, body, annotation_ty),
                 stmt.span,
@@ -569,7 +594,7 @@ pub(super) fn lower_middle_stmt(
             if annotation.is_none() {
                 check_mut_write_context(&name, stmt.span, ctx)?;
             }
-            let val = lower_expr(value, ctx)?;
+            let val = lower_assigned_value(value, preceding, outer_bindings, ctx)?;
             // A bare `x := e` where `x` is already in scope is a *write*, not a
             // declaration: emit a `MutWrite` marker (mutability checked
             // post-inference; the unified phase turns it into a recurrence in a
@@ -639,13 +664,15 @@ pub(super) fn lower_middle_stmt(
             // otherwise it is a bare mutable write whose target-is-a-mutable check
             // runs post-inference.
             check_mut_write_context(&name, stmt.span, ctx)?;
-            let val = lower_aug_binop(&name, *op, value, stmt.span, ctx)?;
+            let rhs = lower_assigned_value(value, preceding, outer_bindings, ctx)?;
+            let val = lower_aug_binop(&name, *op, rhs, stmt.span, ctx)?;
             let write = ctx.tag_image(Expr::mut_write(name, val), stmt.span);
             Ok(ctx.tag_image(Expr::expr_stmt(write, body), stmt.span))
         }
         // `x <<= e` — defer-define statement, distinct from AugAssign.
         ChlStmt::Define { target, value } => {
-            let lowered = lower_define(target, value, ctx)?;
+            let rhs = lower_assigned_value(value, preceding, outer_bindings, ctx)?;
+            let lowered = lower_define(target, rhs)?;
             let define = ctx.tag_image(lowered, stmt.span);
             Ok(ctx.tag_image(Expr::expr_stmt(define, body), stmt.span))
         }
@@ -1576,6 +1603,7 @@ mod tests {
     use super::super::test_helpers::*;
     use super::super::*;
     use crate::ccl::symbolic::symbolic;
+    use indoc::indoc;
     use rstest::rstest;
 
     // -----------------------------------------------------------------------
@@ -1853,6 +1881,160 @@ x";
         assert!(matches!(err, LoweringError::Unsupported { .. }));
     }
 
+    // -----------------------------------------------------------------------
+    // `if`/`match` in value position: a block right-hand side, and the one-line
+    // `match`. Both arrive as `ChlExpr::Block` and lower to the `Case` the
+    // ternary and the tail-position statement forms already produce.
+    // -----------------------------------------------------------------------
+
+    #[rstest]
+    // A block `if` on the right of an assignment is the `Case` the tail-position
+    // form lowers to, bound by the assignment's `let`.
+    #[case(
+        indoc! {"
+            x = if c:
+                1
+            else:
+                2
+            x"},
+        indoc! {"
+            let x = { c → 1; true → 2 }
+            in x"}
+    )]
+    // The elif chain is one `Case`, exactly as at statement level.
+    #[case(
+        indoc! {"
+            x = if a:
+                1
+            elif b:
+                2
+            else:
+                3
+            x"},
+        indoc! {"
+            let x = { a → 1; b → 2; true → 3 }
+            in x"}
+    )]
+    // A branch is a full block: its own bindings, and its last statement's value.
+    #[case(
+        indoc! {"
+            x = if c:
+                a = 1
+                a + 1
+            else:
+                2
+            x"},
+        indoc! {"
+            let x = { c → let a = 1
+            in a + 1; true → 2 }
+            in x"}
+    )]
+    // A block `match` right-hand side, and the one-line spelling of the same
+    // dispatch, lower alike.
+    #[case(
+        indoc! {"
+            x = match v:
+                case `a(n):
+                    n
+                case `b:
+                    0
+            x"},
+        indoc! {"
+            let x = match v { `a(n) → n; `b(__match_payload_0) → 0 }
+            in x"}
+    )]
+    #[case(
+        indoc! {"
+            x = (match v: case `a(n): n case `b: 0)
+            x"},
+        indoc! {"
+            let x = match v { `a(n) → n; `b(__match_payload_0) → 0 }
+            in x"}
+    )]
+    // A nested one-line `match` carries its own bracket, and nests in the IR.
+    #[case(
+        indoc! {"
+            x = (match v: case `a(w): (match w: case `p: 1) case `b: 0)
+            x"},
+        indoc! {"
+            let x = match v { `a(w) → match w { `p(__match_payload_0) → 1 }; \
+            `b(__match_payload_1) → 0 }
+            in x"}
+    )]
+    fn test_lower_block_value(#[case] code: &str, #[case] expected: &str) {
+        let stmts = parse_module(code);
+        let ccl = lower_stmts(&stmts, &mut LoweringContext::default())
+            .into_result()
+            .expect("lowering failed");
+        assert_eq!(symbolic(&ccl), expected);
+    }
+
+    /// A block right-hand side is the same `Case` the ternary builds, so the two
+    /// spellings of a two-way choice lower to one node.
+    #[test]
+    fn test_block_if_and_ternary_agree() {
+        let lower = |code: &str| {
+            let stmts = parse_module(code);
+            symbolic(
+                &lower_stmts(&stmts, &mut LoweringContext::default())
+                    .into_result()
+                    .expect("lowering failed"),
+            )
+        };
+        assert_eq!(
+            lower(indoc! {"
+                x = if c:
+                    1
+                else:
+                    2
+                x"}),
+            lower(indoc! {"
+                x = 1 if c else 2
+                x"})
+        );
+    }
+
+    /// A `for` inside a branch of a block right-hand side sees the names bound
+    /// above the assignment, so a write to one of them reads as the
+    /// loop-carried accumulator it is rather than as a branch-local.
+    /// `lower_assigned_value` is what carries that scope in.
+    #[test]
+    fn test_block_right_hand_side_sees_the_enclosing_scope() {
+        let stmts = parse_module(indoc! {"
+            acc := 0
+            x = if c:
+                for i in [1, 2]:
+                    acc += i
+                acc
+            else:
+                0
+            x"});
+        let ccl = lower_stmts(&stmts, &mut LoweringContext::default())
+            .into_result()
+            .expect("lowering failed");
+        let rendered = symbolic(&ccl);
+        assert!(
+            rendered.contains("acc :="),
+            "the loop writes the outer accumulator, got: {rendered}"
+        );
+    }
+
+    /// A bare `if` has no value on the false path, in an assignment as anywhere
+    /// else that requires one.
+    #[test]
+    fn test_block_right_hand_side_without_else_rejected() {
+        let stmts = parse_module(indoc! {"
+            x = if c:
+                1
+            x"});
+        let err = expect_one_lowering_error(&stmts);
+        let LoweringError::Unsupported { message, .. } = &err;
+        assert!(
+            message.contains("if without else"),
+            "expected the missing-else rejection, got: {message}"
+        );
+    }
+
     /// A colon-free brace group `{T, U}` is structural *type* syntax; it has no
     /// term-level value, so it is rejected in value position (it is accepted as
     /// a tuple type in annotation position — see `lower_type_annotation`).
@@ -1892,9 +2074,12 @@ x";
     /// rides `user_annotation` (still `Hole`-typed pre-inference), so the test
     /// reads the annotation back off the `Let` and renders *its* type — one
     /// string that surfaces the base, the predicate, and the resolved subject.
+    ///
+    /// Each case is the annotated binding alone; the trailing `x` that makes it
+    /// a program is appended below.
     #[rstest]
     // Flat refinement: the predicate's `_` becomes `__elem`.
-    #[case("x: {Int where _ != 0} = 5\nx", "{Int | __elem != 0}")]
+    #[case("x: {Int where _ != 0} = 5", "{Int | __elem != 0}")]
     // Nested refinement: both levels' `_` resolve to `__elem`, and the
     // save/restore of `in_refinement_predicate` around the inner annotation
     // keeps the flag from leaking — the outer `_` still lowers to `__elem`
@@ -1902,13 +2087,22 @@ x";
     // refinement set: both predicates restrict the same element, so the source's
     // nesting carries nothing the set does not.
     #[case(
-        "x: { {Int where _ != 1} where _ != 0} = 5\nx",
+        "x: { {Int where _ != 1} where _ != 0} = 5",
         "{Int | __elem != 0, __elem != 1}"
+    )]
+    // A one-line `match` as the predicate. The refinement's braces are the
+    // bracket that closes the arm list, so the predicate needs no parentheses of
+    // its own; `{…}` suppresses newlines, which is what puts the indented `match`
+    // out of reach here (`docs/chl-spec.md`, "6.4 Refinement syntax").
+    #[case(
+        "x: {{`a | `b} where match _: case `a: True case `b: False} = v",
+        "{{`a | `b} | match __elem { `a(__match_payload_0) → true; \
+         `b(__match_payload_1) → false }}"
     )]
     fn test_lower_refinement_annotation(#[case] code: &str, #[case] expected_ty: &str) {
         use crate::ccl::{Type, TypedExprNode};
 
-        let stmts = parse_module(code);
+        let stmts = parse_module(&format!("{code}\nx"));
         let ccl = lower_stmts(&stmts, &mut LoweringContext::default())
             .into_result()
             .expect("lowering failed");

--- a/src/ccl/lower/transactions.rs
+++ b/src/ccl/lower/transactions.rs
@@ -211,7 +211,7 @@ fn lower_tx_block_inner(
             // `balance += value` — the compound-write shorthand, likewise a write.
             ChlStmt::AugAssign { target, op, value } => {
                 let name = extract_name_target(target, "augmented assignment")?;
-                let val = lower_aug_binop(&name, *op, value, stmt.span, ctx)?;
+                let val = lower_aug_binop(&name, *op, lower_expr(value, ctx)?, stmt.span, ctx)?;
                 write_or_let(name, val, chain, stmt.span, ctx)?
             }
             // `x = value` — a plain immutable binding: a per-transaction local

--- a/src/chl_parser/ast.rs
+++ b/src/chl_parser/ast.rs
@@ -598,6 +598,19 @@ pub enum Expr {
         value: Box<Spanned<Expr>>,
     },
 
+    /// A block statement in value position: an `if`/`match` on the right of an
+    /// assignment, or a one-line `match` inside a bracket.
+    ///
+    /// The block's value is its last statement's, by the same rule that gives a
+    /// function body its value (`docs/chl-spec.md`, "4.5 `if` / `elif` /
+    /// `else`"). The indented and one-line arm layouts differ in how an arm
+    /// body is parsed, so both build the same statement here and lowering
+    /// routes both through `lower_final_stmt`.
+    ///
+    /// **Invariant:** the statement is a [`Stmt::If`] or a [`Stmt::Match`].
+    /// Lowering asserts it.
+    Block(Box<Spanned<Stmt>>),
+
     /// Recovery placeholder inserted when chumsky's bracket-level
     /// `recover_with` matched. The placeholder's [`Span`] covers the
     /// bracketed region whose contents failed to parse.

--- a/src/chl_parser/design-chl-parser.md
+++ b/src/chl_parser/design-chl-parser.md
@@ -96,7 +96,16 @@ highest precedence:
 13. `*`, `//`
 14. unary `-`
 15. postfix: call `f(…)`, subscript `x[…]`, attribute `x.name` / `x.0`
-16. atom: literal, name, parenthesised, list, dict/record, comprehension
+16. atom: literal, name, parenthesised, list, record, brace type, comprehension
+
+Every position a bracket encloses — a list or tuple element, a call argument, a
+subscript index, a record field, a brace item, a refinement predicate, a
+comprehension clause — goes through `bracketed_expr` rather than `expr`. That
+production is `oneline_match | expr`, which is what confines the one-line
+`match` to a position where a `)`, `]` or `}` closes its arm list. `match` is a
+keyword, so no `expr` can start with one and the choice needs no backtracking.
+See [docs/chl-spec.md](../../docs/chl-spec.md), "The one-line form" for the rule
+and why the bracket rather than the arm body carries it.
 
 Notably absent vs. Python: `/` (true division), `%` (modulo), `**`
 (power), `>>` (right shift), `~` (bitwise not), `is`, `in`, `not in`,
@@ -115,21 +124,28 @@ Key shape choices:
 - **`if`/`elif` chains flatten.** `Stmt::If` carries a `Vec<IfBranch>` (one
   per `if`/`elif`) plus an optional `else_body`, rather than nesting an
   `If` inside an `Else`. This matches the `Case` shape in CCL.
+- **A block statement in value position is `Expr::Block`.** `x = if c: … else:
+  …`, `x = match v: …`, and the one-line `match` all wrap the `Stmt::If` or
+  `Stmt::Match` they parsed to, so each construct keeps one AST shape and
+  lowering routes every spelling through `lower_final_stmt`. The two `match`
+  layouts share `match_arms`, a production over how an arm's body is spelled:
+  an indented `block` for the statement form, a single expression for the
+  one-line one. The six assignment operators likewise share `assign_tail`, a
+  production over the right-hand side, which is what gives every one of them a
+  block right-hand side rather than only `=`.
 - **Records are parens; braces are types.** A record *value* `(x=1)` parses
   as `Expr::Record`; brace literals are type syntax — `{x: T}` is
-  `Expr::BraceRecord`, `{T, U}` is `Expr::BraceGroup`, `{"name": v}` is
-  `Expr::Dict`. Lowering reads the brace forms as types and rejects them as
-  values. Because braces are always a *product* in type position and never
-  grouping, the brace parser captures the trailing comma rather than merely
-  allowing it: `{T,}` is the one-element product and a comma-free `{T}` is a
-  parse error, while the empty `{}` is the **unit type**, which lowering reads as
-  `Unit` (see [docs/chl-spec.md](../../docs/chl-spec.md),
-  "6.6 The empty product is unit"). A `where` clause after a single colon-free
-  base turns the brace into a refinement type `{T where p}` (`Expr::BraceRefinement`,
-  [docs/chl-spec.md](../../docs/chl-spec.md), "6.4 Refinement syntax"); the
-  clause gates off the one-element `{T}` diagnostic, and its predicate `p` — an
-  ordinary expression whose subject `_` lowering maps to the refinement binder —
-  is parsed with the same `expr` as everything else.
+  `Expr::BraceRecord` and `{T, U}` is `Expr::BraceGroup`. Lowering reads the brace forms as types
+  and rejects them as values. Because braces are always a *product* in type position and never
+  grouping, the brace parser captures the trailing comma rather than merely allowing it: `{T,}` is
+  the one-element product and a comma-free `{T}` is a parse error, while the empty `{}` is the
+  **unit type**, which lowering reads as `Unit` (see
+  [docs/chl-spec.md](../../docs/chl-spec.md), "6.6 The empty product is unit"). A `where` clause
+  after a single colon-free base turns the brace into a refinement type `{T where p}`
+  (`Expr::BraceRefinement`, [docs/chl-spec.md](../../docs/chl-spec.md), "6.4 Refinement syntax");
+  the clause gates off the one-element `{T}` diagnostic, and its predicate `p` — an ordinary
+  expression whose subject `_` lowering maps to the refinement binder — is parsed with the same
+  `bracketed_expr` as every other bracketed position.
 - **The function-type arrow `=>` is the loosest binary form.** `T => U` parses
   to `Expr::FunctionType`, a level below `feed` in the precedence chain. It is
   right-associative — `A => B => C` is `A => (B => C)` — because it takes the

--- a/src/chl_parser/parser.rs
+++ b/src/chl_parser/parser.rs
@@ -183,9 +183,51 @@ where
             .map_with(|s, e| (s, e.span()))
             .labelled("identifier");
 
+        // ---- One-line `match` (bracketed positions only) --------------
+        //
+        // `` match s: case `a: e case `b: e `` — the layout-free spelling of the
+        // `match` statement, whose arm bodies are single expressions. It is
+        // reachable only from `bracketed_expr` below, so a `)`, `]` or `}` is
+        // always in place to close the arm list.
+        //
+        // That bracket is what makes nesting unambiguous. An arm body is a
+        // plain `expr`, which cannot derive a one-line `match`, so a nested one
+        // needs a bracket of its own and two arm lists never compete for the
+        // same `case`. Without the requirement the arms after an inner `match`
+        // could belong to either it or the outer one, and the greedy reading
+        // leaves the outer `match` with no way to spell a later arm.
+        //
+        // Restricting the *arm body* instead would not hold: a lambda body, a
+        // ternary else-branch, an `<<` right operand and a `=>` codomain each
+        // recurse into the whole `expr`, so an inner `match` reappears through
+        // any of them.
+        let oneline_match = just(Token::Match)
+            .ignore_then(expr.clone())
+            .then_ignore(just(Token::Colon))
+            .then(match_arms(expr.clone().map_with(
+                |body: Spanned<Expr>, e| vec![Spanned::new(e.span(), Stmt::Expr(body))],
+            )))
+            .map_with(|(scrutinee, arms), e| {
+                let span = e.span();
+                Spanned::new(
+                    span,
+                    Expr::Block(Box::new(Spanned::new(
+                        span,
+                        Stmt::Match { scrutinee, arms },
+                    ))),
+                )
+            })
+            .boxed();
+
+        // Every position enclosed by a bracket — list and tuple elements, call
+        // arguments, a subscript index, a record field, a brace item, a
+        // refinement predicate, a comprehension clause. `match` is a keyword, so
+        // no `expr` can start with one and the choice needs no backtracking.
+        let bracketed_expr = choice((oneline_match, expr.clone())).boxed();
+
         // List literal / list comprehension. We parse the first element,
         // then peek for `for` (comprehension) vs `,` / `]` (list).
-        let list_elements = expr
+        let list_elements = bracketed_expr
             .clone()
             .separated_by(just(Token::Comma))
             .allow_trailing()
@@ -198,10 +240,10 @@ where
                         .map_err(|bad| Rich::custom(bad, "invalid comprehension target"))
                 }))
                 .then_ignore(just(Token::In))
-                .then(expr.clone())
+                .then(bracketed_expr.clone())
                 .map(|(target, iter)| CompClause::For { target, iter });
             let if_clause = just(Token::If)
-                .ignore_then(expr.clone())
+                .ignore_then(bracketed_expr.clone())
                 .map(CompClause::If);
             choice((for_clause, if_clause))
                 .repeated()
@@ -214,7 +256,7 @@ where
                 // Empty list `[]`.
                 just(Token::RBracket)
                     .map_with(|_, e| Spanned::new(e.span(), Expr::List(vec![])))
-                    .or(expr
+                    .or(bracketed_expr
                         .clone()
                         .then(choice((
                             // Comprehension: first element, then `for ...`
@@ -256,7 +298,7 @@ where
         // `(x, y)`, `(x == y)`) falls through to a group/tuple.
         let record_field = ident_only
             .then_ignore(just(Token::Eq))
-            .then(expr.clone())
+            .then(bracketed_expr.clone())
             .map(|((name, name_span), value)| RecordField {
                 name,
                 name_span,
@@ -277,7 +319,8 @@ where
                 just(Token::RParen).map_with(|_, e| Spanned::new(e.span(), Expr::Tuple(vec![]))),
                 // Record value `(name=value, …)`.
                 paren_record,
-                expr.clone()
+                bracketed_expr
+                    .clone()
                     .then(choice((
                         // Generator expression `(expr for ...)`.
                         comp_clauses.clone().map(GroupTail::Gen),
@@ -327,9 +370,11 @@ where
         // because it is the token that distinguishes the form. Whether a
         // *missing* one is an error depends on the position, so that judgment is
         // the caller's (see `brace_type`) and rides out as the `bool`.
-        let brace_item = expr
-            .clone()
-            .then(just(Token::Colon).ignore_then(expr.clone()).or_not());
+        let brace_item = bracketed_expr.clone().then(
+            just(Token::Colon)
+                .ignore_then(bracketed_expr.clone())
+                .or_not(),
+        );
         let brace_group = just(Token::LBrace)
             .ignore_then(
                 brace_item
@@ -339,9 +384,14 @@ where
                     // A `where p` clause turns the brace into a refinement type
                     // `{ T where p }` (§6.4). It binds looser than everything in
                     // `p`, which extends to the closing `}` (newlines are already
-                    // suppressed inside brackets, §1.4), so `expr` greedily
-                    // consumes the predicate up to `}`.
-                    .then(just(Token::Where).ignore_then(expr.clone()).or_not()),
+                    // suppressed inside brackets, §1.4), so `bracketed_expr`
+                    // greedily consumes the predicate up to `}`. A one-line
+                    // `match` predicate takes that `}` as its arm-list terminator.
+                    .then(
+                        just(Token::Where)
+                            .ignore_then(bracketed_expr.clone())
+                            .or_not(),
+                    ),
             )
             .then_ignore(just(Token::RBrace))
             .validate(|((items, trailing_comma), refinement), e, emitter| {
@@ -580,7 +630,7 @@ where
         .boxed();
 
         // ---- Postfix: call, subscript, attribute ---------------------
-        let call_args = expr
+        let call_args = bracketed_expr
             .clone()
             .separated_by(just(Token::Comma))
             .allow_trailing()
@@ -591,7 +641,7 @@ where
         // the index itself (`xs[0]`); several become a tuple (`Mut(Int, Txn)`
         // — the multi-argument type-annotation form), matching Python's
         // `a[i, j]` tuple-index convention.
-        let subscript = expr
+        let subscript = bracketed_expr
             .clone()
             .separated_by(just(Token::Comma))
             .allow_trailing()
@@ -1083,69 +1133,16 @@ where
         //
         // The arm list is itself an indented block, so a `match` is two levels
         // of layout: `Indent` for the arms, then each arm's own `block` for its
-        // body. A pattern spells its tag exactly as a constructor does — ``
-        // `tag(binder) `` — so an arm reads as the inverse of what it matches.
-        let match_ident = select! { Token::Ident(s) => s }.map_with(|s, e| (s, e.span()));
-        // `case _:` is the **default arm**, and takes no backtick: `_` is not a
-        // tag, it is the absence of one. Accepting it here rather than as a tag
-        // named `_` is what keeps it from silently matching nothing (no
-        // constructor can spell that name).
-        let case_pattern = choice((
-            just(Token::Backtick).ignore_then(match_ident),
-            select! { Token::Ident(s) if s.as_str() == "_" => s }.map_with(|s, e| (s, e.span())),
-        ));
-        // The payload position takes a name or `_`. `_` is the **unused-binder**
-        // spelling — the arm has a payload and declines to read it — so it is mapped
-        // to `Ignored` rather than to a variable called `_`: nothing may refer to it.
-        let case_binder = choice((
-            select! { Token::Ident(s) if s.as_str() == "_" => s }.map(|_| None),
-            match_ident.map(|(name, _)| Some(name)),
-        ));
-        let case_arm = just(Token::Case)
-            .ignore_then(case_pattern)
-            .then(
-                case_binder
-                    .delimited_by(just(Token::LParen), just(Token::RParen))
-                    .or_not(),
-            )
-            .then_ignore(just(Token::Colon))
-            .then(block.clone())
-            .then_ignore(just(Token::Newline).repeated())
-            .validate(|(((tag, tag_span), binder), body), e, emitter| {
-                if tag.as_str() == "_" {
-                    if binder.is_some() {
-                        emitter.emit(Rich::custom(
-                            e.span(),
-                            "the default arm `case _:` binds no payload: the tags it \
-                             covers have different payload types",
-                        ));
-                    }
-                    return MatchArm {
-                        pattern: None,
-                        body,
-                    };
-                }
-                let payload = match binder {
-                    Some(Some(name)) => PayloadPattern::Named(name),
-                    Some(None) => PayloadPattern::Ignored,
-                    None => PayloadPattern::Absent,
-                };
-                MatchArm {
-                    pattern: Some(MatchPattern {
-                        tag,
-                        tag_span,
-                        payload,
-                    }),
-                    body,
-                }
-            });
-
+        // body. The arms themselves come from `match_arms`, shared with the
+        // one-line form in `expression()`.
         let match_stmt = just(Token::Match)
             .ignore_then(expr.clone())
             .then_ignore(just(Token::Colon))
             .then_ignore(just(Token::Newline))
             .then_ignore(just(Token::Indent).labelled("indented `case` arms"))
-            .then(case_arm.repeated().at_least(1).collect::<Vec<_>>())
+            .then(match_arms(
+                block.clone().then_ignore(just(Token::Newline).repeated()),
+            ))
             .then_ignore(just(Token::Dedent))
             .map_with(|(scrutinee, arms), e| {
                 Spanned::new(e.span(), Stmt::Match { scrutinee, arms })
@@ -1189,17 +1186,11 @@ where
             });
 
         // ---- def name(params): body ---------------------------------
-        // `x: T` (exact) or `x <: T` (bounded) — the mode is the only difference.
-        let annotation_mode = choice((
-            just(Token::Colon).to(AnnotationMode::Exact),
-            just(Token::LtColon).to(AnnotationMode::Bounded),
-        ));
         let param = select! { Token::Ident(s) => s }
             .map_with(|s, e| (s, e.span()))
             .labelled("parameter name")
             .then(
-                annotation_mode
-                    .clone()
+                annotation_mode()
                     .then(expr.clone())
                     .map(|(mode, ty)| TypeAnnotation { mode, ty })
                     .or_not(),
@@ -1240,14 +1231,6 @@ where
 
         let pass_stmt = just(Token::Pass).map_with(|_, e| Spanned::new(e.span(), Stmt::Pass));
 
-        // Augmented assignment: `target OP= value`.
-        let aug_op = choice((
-            just(Token::PlusEq).to(AugOp::Add),
-            just(Token::MinusEq).to(AugOp::Sub),
-            just(Token::StarEq).to(AugOp::Mul),
-            just(Token::DoubleSlashEq).to(AugOp::FloorDiv),
-        ));
-
         // Statement-level rules that begin with an expression. We parse
         // a comma-separated *list* of expressions first (so bare-tuple
         // targets `a, b = …` and bare-tuple expression statements
@@ -1270,87 +1253,30 @@ where
                     Spanned::new(e.span(), Expr::Tuple(elts))
                 }
             });
+        // `try_map_with` so an LHS that doesn't reduce to a binding pattern
+        // (e.g. `1 + 2 = x`) becomes a parse error rather than a lowering-time
+        // rejection. Expression statements (`AssignTail::None`) keep the full
+        // `Expr` shape.
         let expr_or_assign = bare_tuple
-            .then(choice((
-                just(Token::Eq)
-                    .ignore_then(expr.clone())
-                    .map(AssignTail::Plain),
-                // An annotated binding: `: ty` (exact) or `<: ty` (bounded),
-                // then `=` (immutable) or `:=` (mutable). The annotation's mode
-                // and the assignment operator are independent choices.
-                annotation_mode
-                    .then(expr.clone())
-                    .map(|(mode, ty)| TypeAnnotation { mode, ty })
-                    .then(choice((
-                        just(Token::Eq)
-                            .ignore_then(expr.clone())
-                            .map(|v| (false, v)),
-                        just(Token::ColonEq)
-                            .ignore_then(expr.clone())
-                            .map(|v| (true, v)),
-                    )))
-                    .map(|(ann, (mutable, val))| {
-                        if mutable {
-                            AssignTail::MutAnnotated(ann, val)
-                        } else {
-                            AssignTail::Annotated(ann, val)
-                        }
-                    }),
-                // `:= value` — a bare mutable assignment (no annotation).
-                just(Token::ColonEq)
-                    .ignore_then(expr.clone())
-                    .map(AssignTail::MutPlain),
-                aug_op
-                    .then(expr.clone())
-                    .map(|(op, val)| AssignTail::Aug(op, val)),
-                just(Token::LShiftEq)
-                    .ignore_then(expr.clone())
-                    .map(AssignTail::Define),
-                empty().to(AssignTail::None),
-            )))
-            // `try_map_with` so an LHS that doesn't reduce to a binding
-            // pattern (e.g. `1 + 2 = x`) becomes a parse error rather than
-            // a lowering-time rejection. Expression statements
-            // (`AssignTail::None`) keep the full `Expr` shape.
-            .try_map_with(|(target, tail), e| {
-                let span = e.span();
-                let to_target = |t| {
-                    expr_to_assign_target(t)
-                        .map_err(|bad| Rich::custom(bad, "invalid assignment target"))
-                };
-                let stmt = match tail {
-                    AssignTail::Plain(value) => Stmt::Assign {
-                        target: to_target(target)?,
-                        value,
-                    },
-                    AssignTail::Annotated(ann, val) => Stmt::AnnAssign {
-                        target: to_target(target)?,
-                        annotation: ann,
-                        value: val,
-                    },
-                    AssignTail::MutPlain(value) => Stmt::MutAssign {
-                        target: to_target(target)?,
-                        annotation: None,
-                        value,
-                    },
-                    AssignTail::MutAnnotated(ann, val) => Stmt::MutAssign {
-                        target: to_target(target)?,
-                        annotation: Some(ann),
-                        value: val,
-                    },
-                    AssignTail::Aug(op, val) => Stmt::AugAssign {
-                        target: to_target(target)?,
-                        op,
-                        value: val,
-                    },
-                    AssignTail::Define(value) => Stmt::Define {
-                        target: to_target(target)?,
-                        value,
-                    },
-                    AssignTail::None => Stmt::Expr(target),
-                };
-                Ok(Spanned::new(span, stmt))
+            .clone()
+            .then(assign_tail(expr.clone(), expr.clone()).or(empty().to(AssignTail::None)))
+            .try_map_with(|(target, tail), e| assign_stmt(target, tail, e.span()));
+
+        // `x = if c: … else: …` and `x = match v: …` — a block statement on the
+        // right of an assignment, whose value is the block's own
+        // (`docs/chl-spec.md`, "4.5 `if` / `elif` / `else`"). The block's
+        // `Dedent` ends the statement, so this form takes no `stmt_terminator`
+        // and cannot ride `simple_stmt`. It is tried before `simple_stmt`, which
+        // reparses the target when the right-hand side turns out to be an
+        // ordinary expression.
+        let block_value =
+            choice((if_stmt.clone(), match_stmt.clone())).map(|stmt: Spanned<Stmt>| {
+                let span = stmt.span;
+                Spanned::new(span, Expr::Block(Box::new(stmt)))
             });
+        let block_assign = bare_tuple
+            .then(assign_tail(block_value, expr.clone()))
+            .try_map_with(|(target, tail), e| assign_stmt(target, tail, e.span()));
 
         // A simple statement ends in either `Newline` or `;` (Python-style
         // one-liners: `x = 1; y = 2`). A statement followed by `;` may also
@@ -1411,6 +1337,7 @@ where
             for_stmt,
             with_stmt,
             def_stmt,
+            block_assign,
             simple_stmt,
         ))
         .labelled("statement")
@@ -1438,6 +1365,196 @@ enum AssignTail {
 
 /// Convert an [`Expr`] parsed in target position into an [`AssignTarget`].
 ///
+/// What follows an assignment target, over parsers for the right-hand side and
+/// for an annotation's type.
+///
+/// Two right-hand sides reach this: an expression, and a block statement in
+/// value position ([`Expr::Block`]). They differ in nothing else, so the six
+/// assignment operators and the annotation grammar are written here once.
+///
+/// [`AssignTail::None`] — the bare expression statement — is not among the
+/// alternatives, because it would match the empty input and so make every
+/// caller succeed. A caller that wants it appends `empty().to(AssignTail::None)`.
+fn assign_tail<'src, I, R, T>(rhs: R, ty: T) -> impl Parser<'src, I, AssignTail, PErr<'src>> + Clone
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+    R: Parser<'src, I, Spanned<Expr>, PErr<'src>> + Clone,
+    T: Parser<'src, I, Spanned<Expr>, PErr<'src>> + Clone,
+{
+    let aug_op = choice((
+        just(Token::PlusEq).to(AugOp::Add),
+        just(Token::MinusEq).to(AugOp::Sub),
+        just(Token::StarEq).to(AugOp::Mul),
+        just(Token::DoubleSlashEq).to(AugOp::FloorDiv),
+    ));
+    choice((
+        just(Token::Eq)
+            .ignore_then(rhs.clone())
+            .map(AssignTail::Plain),
+        // An annotated binding: `: ty` (exact) or `<: ty` (bounded), then `=`
+        // (immutable) or `:=` (mutable). The annotation's mode and the
+        // assignment operator are independent choices.
+        annotation_mode()
+            .then(ty)
+            .map(|(mode, ty)| TypeAnnotation { mode, ty })
+            .then(choice((
+                just(Token::Eq).ignore_then(rhs.clone()).map(|v| (false, v)),
+                just(Token::ColonEq)
+                    .ignore_then(rhs.clone())
+                    .map(|v| (true, v)),
+            )))
+            .map(|(ann, (mutable, val))| {
+                if mutable {
+                    AssignTail::MutAnnotated(ann, val)
+                } else {
+                    AssignTail::Annotated(ann, val)
+                }
+            }),
+        // `:= value` — a bare mutable assignment (no annotation).
+        just(Token::ColonEq)
+            .ignore_then(rhs.clone())
+            .map(AssignTail::MutPlain),
+        aug_op
+            .then(rhs.clone())
+            .map(|(op, val)| AssignTail::Aug(op, val)),
+        just(Token::LShiftEq)
+            .ignore_then(rhs)
+            .map(AssignTail::Define),
+    ))
+}
+
+/// `x: T` (exact) or `x <: T` (bounded) — the mode is the only difference.
+fn annotation_mode<'src, I>() -> impl Parser<'src, I, AnnotationMode, PErr<'src>> + Clone
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+{
+    choice((
+        just(Token::Colon).to(AnnotationMode::Exact),
+        just(Token::LtColon).to(AnnotationMode::Bounded),
+    ))
+}
+
+/// Build the statement an assignment target and its [`AssignTail`] denote.
+///
+/// Errors when the target does not reduce to a binding pattern, carrying the
+/// offending sub-expression's span.
+fn assign_stmt<'src>(
+    target: Spanned<Expr>,
+    tail: AssignTail,
+    span: Span,
+) -> Result<Spanned<Stmt>, Rich<'src, Token, Span>> {
+    let to_target =
+        |t| expr_to_assign_target(t).map_err(|bad| Rich::custom(bad, "invalid assignment target"));
+    let stmt = match tail {
+        AssignTail::Plain(value) => Stmt::Assign {
+            target: to_target(target)?,
+            value,
+        },
+        AssignTail::Annotated(ann, val) => Stmt::AnnAssign {
+            target: to_target(target)?,
+            annotation: ann,
+            value: val,
+        },
+        AssignTail::MutPlain(value) => Stmt::MutAssign {
+            target: to_target(target)?,
+            annotation: None,
+            value,
+        },
+        AssignTail::MutAnnotated(ann, val) => Stmt::MutAssign {
+            target: to_target(target)?,
+            annotation: Some(ann),
+            value: val,
+        },
+        AssignTail::Aug(op, val) => Stmt::AugAssign {
+            target: to_target(target)?,
+            op,
+            value: val,
+        },
+        AssignTail::Define(value) => Stmt::Define {
+            target: to_target(target)?,
+            value,
+        },
+        AssignTail::None => Stmt::Expr(target),
+    };
+    Ok(Spanned::new(span, stmt))
+}
+
+/// The `case` arms of a `match`, over a parser for how an arm's body is spelled.
+///
+/// Two spellings reach this: an indented block (the statement form) and a
+/// single expression (the one-line form). They differ in the body and in
+/// nothing else, so the pattern grammar and the default-arm rule are written
+/// here once and both spellings build the same [`MatchArm`].
+///
+/// The arm list is greedy over `case` and stops at the first token that cannot
+/// begin an arm. `case` is a keyword, so no arm body can continue across one.
+///
+/// A pattern spells its tag exactly as a constructor does — `` `tag(binder) ``
+/// — so an arm reads as the inverse of what it matches. `case _:` is the
+/// **default arm**, and takes no backtick: `_` is not a tag, it is the absence
+/// of one. Accepting it here rather than as a tag named `_` is what keeps it
+/// from silently matching nothing, since no constructor can spell that name.
+///
+/// The payload position takes a name or `_`. `_` is the **unused-binder**
+/// spelling — the arm has a payload and declines to read it — so it maps to
+/// [`PayloadPattern::Ignored`] rather than to a variable called `_`: nothing
+/// may refer to it.
+fn match_arms<'src, I, B>(body: B) -> impl Parser<'src, I, Vec<MatchArm>, PErr<'src>> + Clone
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+    B: Parser<'src, I, Vec<Spanned<Stmt>>, PErr<'src>> + Clone,
+{
+    let match_ident = select! { Token::Ident(s) => s }.map_with(|s, e| (s, e.span()));
+    let case_pattern = choice((
+        just(Token::Backtick).ignore_then(match_ident),
+        select! { Token::Ident(s) if s.as_str() == "_" => s }.map_with(|s, e| (s, e.span())),
+    ));
+    let case_binder = choice((
+        select! { Token::Ident(s) if s.as_str() == "_" => s }.map(|_| None),
+        match_ident.map(|(name, _)| Some(name)),
+    ));
+    just(Token::Case)
+        .ignore_then(case_pattern)
+        .then(
+            case_binder
+                .delimited_by(just(Token::LParen), just(Token::RParen))
+                .or_not(),
+        )
+        .then_ignore(just(Token::Colon))
+        .then(body)
+        .validate(|(((tag, tag_span), binder), body), e, emitter| {
+            if tag.as_str() == "_" {
+                if binder.is_some() {
+                    emitter.emit(Rich::custom(
+                        e.span(),
+                        "the default arm `case _:` binds no payload: the tags it \
+                         covers have different payload types",
+                    ));
+                }
+                return MatchArm {
+                    pattern: None,
+                    body,
+                };
+            }
+            let payload = match binder {
+                Some(Some(name)) => PayloadPattern::Named(name),
+                Some(None) => PayloadPattern::Ignored,
+                None => PayloadPattern::Absent,
+            };
+            MatchArm {
+                pattern: Some(MatchPattern {
+                    tag,
+                    tag_span,
+                    payload,
+                }),
+                body,
+            }
+        })
+        .repeated()
+        .at_least(1)
+        .collect::<Vec<_>>()
+}
+
 /// CHL binding patterns are bare names and (possibly-nested) tuples of
 /// patterns. We parse the LHS as a full expression so the regular grammar
 /// (with its error recovery) handles it, then narrow to the binding-pattern
@@ -1462,6 +1579,7 @@ fn expr_to_assign_target(spanned: Spanned<Expr>) -> Result<Spanned<AssignTarget>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::{formatdoc, indoc};
 
     fn parse_e(src: &str) -> Spanned<Expr> {
         parse_expression(src)
@@ -2103,6 +2221,168 @@ mod tests {
             }
             other => panic!("expected Match, got {other:?}"),
         }
+    }
+
+    /// A one-line `match` in a bracket parses to an [`Expr::Block`] over the
+    /// same [`Stmt::Match`] the indented form builds.
+    #[test]
+    fn oneline_match_is_a_block_expression() {
+        let e = parse_e("(match v: case `some(n): n case `none: 0)");
+        let Expr::Block(stmt) = &e.node else {
+            panic!("expected a Block expression, got {:?}", e.node)
+        };
+        let Stmt::Match { scrutinee, arms } = &stmt.node else {
+            panic!("expected a Match statement, got {:?}", stmt.node)
+        };
+        assert!(matches!(scrutinee.node, Expr::Name(_)));
+        assert_eq!(arms.len(), 2);
+        assert_eq!(
+            arms[0].pattern.as_ref().expect("tagged arm").payload,
+            PayloadPattern::Named("n".into())
+        );
+        assert_eq!(
+            arms[1].pattern.as_ref().expect("tagged arm").payload,
+            PayloadPattern::Absent
+        );
+        // Each arm body is its single expression, held as a one-statement block.
+        for arm in arms {
+            assert_eq!(arm.body.len(), 1);
+            assert!(matches!(arm.body[0].node, Stmt::Expr(_)));
+        }
+    }
+
+    /// The one-line form is reachable only from a bracketed position, so an
+    /// unbracketed one is not a `match` with a missing body — the `match`
+    /// statement is what the parser is in, and it wants indented arms.
+    #[test]
+    fn oneline_match_outside_a_bracket_is_rejected() {
+        let result = parse_module("x = match v: case `a: 1 case `b: 2");
+        assert!(
+            !result.errors.is_empty(),
+            "an unbracketed one-line `match` has no reading"
+        );
+    }
+
+    /// A nested one-line `match` needs a bracket of its own. Without it the arms
+    /// after the inner `match` could belong to either arm list, and the greedy
+    /// reading would leave the outer `match` no way to spell a later arm.
+    #[test]
+    fn nested_oneline_match_needs_its_own_bracket() {
+        let bare = parse_module("x = (match v: case `a(w): match w: case `p: 1 case `b: 0)");
+        assert!(
+            !bare.errors.is_empty(),
+            "an unbracketed nested one-line `match` has no reading"
+        );
+
+        let bracketed = parse_m(indoc! {"
+            x = (match v: case `a(w): (match w: case `p: 1) case `b: 0)
+            x"});
+        let Stmt::Assign { value, .. } = &bracketed.body[0].node else {
+            panic!("expected an assignment, got {:?}", bracketed.body[0].node)
+        };
+        let Expr::Block(outer) = &value.node else {
+            panic!("expected a Block expression, got {:?}", value.node)
+        };
+        let Stmt::Match { arms, .. } = &outer.node else {
+            panic!("expected a Match statement, got {:?}", outer.node)
+        };
+        assert_eq!(arms.len(), 2, "the outer arm list keeps its second arm");
+        assert!(matches!(
+            arms[0].body[0].node,
+            Stmt::Expr(Spanned {
+                node: Expr::Block(_),
+                ..
+            })
+        ));
+    }
+
+    /// A one-line `match` reaches every bracketed position, including the one
+    /// the layout rules put out of reach of the indented form: a refinement
+    /// predicate, where `{…}` suppresses the newlines the arms would need.
+    #[test]
+    fn oneline_match_reaches_every_bracketed_position() {
+        for src in [
+            "x = (match v: case `a: 1)",
+            "x = f(match v: case `a: 1)",
+            "x = [match v: case `a: 1]",
+            "x = xs[match v: case `a: 1]",
+            "x = (f=match v: case `a: 1)",
+            "x: {Int where match _: case `a: True} = 1",
+            "x = [y for y in match v: case `a: [1]]",
+        ] {
+            let result = parse_module(src);
+            assert!(
+                result.errors.is_empty(),
+                "expected `{src}` to parse, got {:#?}",
+                result.errors
+            );
+        }
+    }
+
+    /// `x = if c: … else: …` and `x = match v: …` — a block statement on the
+    /// right of an assignment, wrapped in the same [`Expr::Block`] the one-line
+    /// form uses.
+    #[test]
+    fn block_statement_on_the_right_of_an_assignment() {
+        let m = parse_m(indoc! {"
+            x = if c:
+                1
+            else:
+                2
+            x
+        "});
+        let Stmt::Assign { value, .. } = &m.body[0].node else {
+            panic!("expected an assignment, got {:?}", m.body[0].node)
+        };
+        let Expr::Block(stmt) = &value.node else {
+            panic!("expected a Block expression, got {:?}", value.node)
+        };
+        let Stmt::If {
+            branches,
+            else_body,
+        } = &stmt.node
+        else {
+            panic!("expected an If statement, got {:?}", stmt.node)
+        };
+        assert_eq!(branches.len(), 1);
+        assert!(else_body.is_some());
+    }
+
+    /// Every assignment operator takes a block right-hand side: they share one
+    /// `assign_tail`, so the block form is not a property of `=`.
+    #[test]
+    fn every_assignment_operator_takes_a_block_right_hand_side() {
+        for op in ["=", ": Int =", ":=", ": Int :=", "+=", "<<="] {
+            let src = formatdoc! {"
+                x {op} if c:
+                    1
+                else:
+                    2
+                x"};
+            let result = parse_module(&src);
+            assert!(
+                result.errors.is_empty(),
+                "expected `x {op} <block>` to parse, got {:#?}",
+                result.errors
+            );
+        }
+    }
+
+    /// The block right-hand side ends at its `Dedent`, and the statement after
+    /// it starts a new line with no terminator in between.
+    #[test]
+    fn a_statement_follows_a_block_right_hand_side() {
+        let m = parse_m(indoc! {"
+            x = match v:
+                case `a(n):
+                    n
+                case `b:
+                    0
+            y = x + 1
+            y
+        "});
+        assert_eq!(m.body.len(), 3);
+        assert!(matches!(m.body[1].node, Stmt::Assign { .. }));
     }
 
     /// `case _:` is the default arm, not a tag named `_` — `_` lexes as an ordinary

--- a/tests/compilation_pipeline/conditionals.rs
+++ b/tests/compilation_pipeline/conditionals.rs
@@ -6,6 +6,7 @@
 use std::time::Duration;
 
 use cambra::interpreter::{ColumnValue, Tile, Value};
+use indoc::indoc;
 use rstest_log::rstest;
 
 use crate::helpers::*;
@@ -140,6 +141,64 @@ False if c else True",
     Value::Bool(false)
 )]
 fn test_value_ternary_scalar(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// A block `if` on the right of an assignment binds the block's value, and that
+// value is the same `Case` the ternary in the same position builds
+// (`docs/chl-spec.md`, "4.3 Assignment forms"). What is worth pinning end to
+// end is that a *branch* is a full block: its own bindings, then its value.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case(
+    indoc! {"
+        a: Int = 1
+        x = if a == 1:
+            100
+        else:
+            200
+        x"},
+    Value::Int(100)
+)]
+// The `elif` chain is one choice, and the last guard wins nothing the earlier
+// ones already took.
+#[case(
+    indoc! {"
+        a: Int = 5
+        x = if a > 10:
+            1
+        elif a > 3:
+            2
+        else:
+            3
+        x"},
+    Value::Int(2)
+)]
+// A branch binds before it yields.
+#[case(
+    indoc! {"
+        a: Int = 4
+        x = if a > 3:
+            d = a * 2
+            d + 1
+        else:
+            0
+        x"},
+    Value::Int(9)
+)]
+// The value feeds an ordinary expression after the block: the `Dedent` ends the
+// statement, and `x` is in scope from there.
+#[case(
+    indoc! {"
+        a: Int = 2
+        x = if a == 2:
+            10
+        else:
+            20
+        x + 5"},
+    Value::Int(15)
+)]
+fn test_block_if_as_an_assigned_value(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
 

--- a/tests/compilation_pipeline/variants.rs
+++ b/tests/compilation_pipeline/variants.rs
@@ -20,6 +20,7 @@
 use std::time::Duration;
 
 use cambra::interpreter::Value;
+use indoc::indoc;
 use rstest_log::rstest;
 
 use cambra::ccl::FieldKey;
@@ -276,6 +277,54 @@ match x:
     union("some", Value::Int(6))
 )]
 fn test_match_scalar(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// `match` in value position: a block right-hand side, and the one-line form
+// (`docs/chl-spec.md`, "The one-line form"). Both wrap the same `Stmt::Match`
+// the indented statement builds, so the two spellings and the statement form
+// yield one value.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// The indented block as an assignment's value.
+#[case(
+    indoc! {"
+        x = `some(7)
+        n = match x:
+            case `some(v):
+                v + 1
+            case `none:
+                0
+        n"},
+    Value::Int(8)
+)]
+// The one-line form, parenthesised because the value position has no bracket of
+// its own.
+#[case(
+    indoc! {"
+        x = `some(7)
+        n = (match x: case `some(v): v + 1 case `none: 0)
+        n"},
+    Value::Int(8)
+)]
+// A one-line `match` as a call argument — a bracket the source already carries.
+#[case(
+    indoc! {"
+        def double(k):
+            k * 2
+        x = `none
+        double(match x: case `some(v): v case `none: 21)"},
+    Value::Int(42)
+)]
+// A nested one-line `match` inside an arm body, under its own bracket.
+#[case(
+    indoc! {"
+        x = `some(`none)
+        n = (match x: case `some(w): (match w: case `some(v): v case `none: 3) case `none: 9)
+        n"},
+    Value::Int(3)
+)]
+fn test_match_as_an_assigned_value(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
 


### PR DESCRIPTION
CHL makes `if` and `match` value-yielding by position — a block's value is its last statement's — but gave that value no spelling where one was required. `x = if c: … else: …` did not parse, and a `match` inside a refinement predicate had no way to delimit its arms, because `{…}` suppresses the layout tokens the indented form depends on. Both are expressions now, through one AST node: `Expr::Block` wraps the `Stmt::If` or `Stmt::Match` already built. Nothing new reaches the IR — every spelling routes through `lower_final_stmt` to the same `Case` the ternary and the tail-position statement forms produce.

## The bracket closes the arm list

A one-line `match` is reachable only from `bracketed_expr`, so a `)`, `]` or `}` always terminates its arms. An arm body is a plain `expr`, which cannot derive a one-line `match`, so a nested one carries its own bracket and two arm lists never compete for the same `case`. Restricting the arm body instead does not hold — a lambda body, a ternary else-branch, an `<<` right operand and a `=>` codomain each take a whole expression. [The one-line form](docs/chl-spec.md#the-one-line-form) records the rule.

## Two productions in place of two would-be copies

`match_arms` is the arm grammar over a parser for how a body is spelled, and `assign_tail` is the six assignment operators over a parser for the right-hand side — which is why all six take a block rather than only `=`. Both are described in `src/chl_parser/design-chl-parser.md`.

## Scope on a block right-hand side

`lower_assigned_value` carries the enclosing scope in: a `for` inside one of the branches needs the names bound above the assignment to tell a loop-carried accumulator from a branch-local. Three positions take the scope-free `lower_expr` path instead — the one-line `match`, and a block right-hand side in a loop body or a `with begin():` block. None admits a `for` in a branch, so the dropped scope is unobservable.

`lower_aug_binop` and `lower_define` now take an already-lowered value, so each caller picks the path.

## Coverage

`tests/compilation_pipeline/` runs the block `if`, both `match` spellings, and a nested one-line `match` end to end; the parser and lowering tests pin the bracket rule and the six operators. A refinement predicate stops at lowering, because no refinement annotation discharges through the pipeline yet.

Spec: [§4.3](docs/chl-spec.md#43-assignment-forms) grammar and table, §4.5, §4.10, and the `[Open]` in [§6.4](docs/chl-spec.md#64-refinement-syntax), now closed.