### PR TITLE
Declare a curried function's non-`Mut` parameter annotations instead of dropping them

### DIFF
--- a/src/ccl/lower/functions.rs
+++ b/src/ccl/lower/functions.rs
@@ -63,6 +63,57 @@ fn mut_param_history_type(
     }
 }
 
+/// If `param` is annotated `Feed(T)` (a pass-by-reference deferred output),
+/// return its history type `Feed(T)`.
+///
+/// The `Append` sibling of [`mut_param_history_type`]: both annotations name a
+/// [`Type::History`] carrier rather than an ordinary type, which is why neither
+/// reaches [`lower_type_annotation`] — a `Feed` there is still an unknown type
+/// application, so this recognizes it only in parameter position.
+///
+/// The domain is left inferred for the reason a `Mut` parameter's is: the call
+/// site's argument pins it, and leaving it open lets one writer serve feeds at
+/// different extents.
+fn feed_param_history_type(
+    param: &Param,
+    ctx: &mut LoweringContext,
+) -> Option<Result<Type, LoweringError>> {
+    let annotation = param.annotation.as_ref()?;
+    let ChlExpr::Call { func, args } = &annotation.ty.node else {
+        return None;
+    };
+    let ChlExpr::Name(head) = &func.node else {
+        return None;
+    };
+    if head.as_str() != "Feed" {
+        return None;
+    }
+    // Exact for the reason `Mut` is: `Type::History` is invariant in both
+    // payloads, so `<:` admits exactly what `:` does and claims nothing more.
+    if annotation.mode == AnnotationMode::Bounded {
+        return Some(Err(LoweringError::unsupported(
+            param.name_span,
+            format!(
+                "`{} <: Feed(…)` bounds a feed parameter by its own type: `Feed` is \
+                 invariant in its value type, so `<:` claims nothing `:` does not. \
+                 Write `{}: Feed(…)`",
+                param.name, param.name
+            ),
+        )));
+    }
+    let [value] = args.as_slice() else {
+        return Some(Err(LoweringError::unsupported(
+            annotation.ty.span,
+            "`Feed` takes one type argument: `Feed(T)`",
+        )));
+    };
+    Some(lower_type_expr(value, ctx).map(|t| Type::History {
+        value: Box::new(t),
+        domain: Box::new(Type::Hole),
+        kind: crate::ccl::HistoryKind::Append,
+    }))
+}
+
 /// Validate that the function or lambda has at least one parameter.
 ///
 /// The CHL parser already rejects `*args`, `**kwargs`, keyword-only and
@@ -166,21 +217,37 @@ pub(super) fn uncurry_params(
         .iter()
         .any(|p| mut_param_history_type(p, ctx).is_some())
     {
-        return Ok(params.iter().rev().fold(body_expr, |acc, param| {
-            let param_ty = match mut_param_history_type(param, ctx) {
-                Some(Ok((mut_ty, _is_txn))) => mut_ty,
-                _ => Type::Hole,
+        return params.iter().rev().try_fold(body_expr, |acc, param| {
+            // A `Mut(…)`/`Feed(…)` annotation names a history carrier rather than
+            // an ordinary type, so it lowers here and not through
+            // `lower_type_annotation`. A malformed `Mut(…)` already returned from
+            // `lower_function_body`; a malformed `Feed(…)` surfaces here.
+            let history_ty = match mut_param_history_type(param, ctx) {
+                Some(Ok((mut_ty, _is_txn))) => Some(mut_ty),
+                _ => match feed_param_history_type(param, ctx) {
+                    Some(Ok(feed_ty)) => Some(feed_ty),
+                    Some(Err(e)) => return Err(e),
+                    None => None,
+                },
             };
+            let param_ty = history_ty.clone().unwrap_or(Type::Hole);
             let mut lam = Expr::lambda(param.name.as_str(), param_ty.clone(), acc);
-            if matches!(param_ty, Type::History { .. })
-                && let TypedExprNode::Lambda { param: p, .. } = &mut lam.node
-            {
-                p.declare(param_ty);
+            if let TypedExprNode::Lambda { param: p, .. } = &mut lam.node {
+                match (history_ty, &param.annotation) {
+                    // The carrier is both the binder type and its declaration.
+                    (Some(_), _) => p.declare(param_ty),
+                    // Every other annotation is a checking-mode declaration, as in
+                    // the single-parameter arm: attach it so `emit_lambda` binds the
+                    // parameter at its declared type and an ill-typed argument is
+                    // rejected at the call site.
+                    (None, Some(ann)) => p.declare(lower_type_annotation(ann, ctx)?),
+                    (None, None) => {}
+                }
             }
             // Each curried lambda images one written parameter; the outermost
             // is re-tagged identically by the `def`/lambda caller.
-            ctx.tag_image(lam, fn_span)
-        }));
+            Ok(ctx.tag_image(lam, fn_span))
+        });
     }
 
     // Mint the tuple name after `body_expr` is lowered so that inner

--- a/tests/compilation_pipeline/mutability.rs
+++ b/tests/compilation_pipeline/mutability.rs
@@ -1545,3 +1545,112 @@ fn a_mut_param_still_binds_a_mut_var() {
         cambra::interpreter::Value::Int(1),
     );
 }
+
+#[test]
+fn a_non_mut_parameter_annotation_is_enforced_in_a_curried_function() {
+    check_compile_error(
+        indoc! {r#"
+            def f(a: Int, m: Mut(Int)):
+                m := 1
+
+            total: Mut(Int) := 0
+            f("hello", total)
+            total
+        "#},
+        "Type mismatch for Apply: expected Int, found String",
+    );
+}
+
+#[test]
+fn a_declared_curried_parameter_still_accepts_its_own_type() {
+    check_scalar(
+        indoc! {r#"
+            def f(a: Int, m: Mut(Int)):
+                m := a
+
+            total: Mut(Int) := 0
+            f(3, total)
+            total
+        "#},
+        Value::Int(3),
+    );
+}
+
+/// The curried chain is genuinely nested, so the annotation's scope holds the
+/// parameters to its left — why `reject_annotation_references` skips this path.
+/// The reference resolves: the diagnostic names the refinement it could not
+/// discharge rather than an unbound variable. A forward reference names a binder
+/// no enclosing scope holds, so it is an ordinary unbound variable and nothing
+/// needs to reject it.
+#[test]
+fn a_curried_parameter_annotation_may_name_a_parameter_to_its_left() {
+    check_compile_error(
+        indoc! {r#"
+            def f(a: Int, c: {Int where _ >= a}, m: Mut(Int)):
+                m := c
+
+            total: Mut(Int) := 0
+            f(1, 5, total)
+            total
+        "#},
+        "expected {Int | __elem >= a}",
+    );
+    check_compile_error(
+        indoc! {r#"
+            def f(c: {Int where _ >= b}, b: Int, m: Mut(Int)):
+                m := c
+
+            total: Mut(Int) := 0
+            f(5, 1, total)
+            total
+        "#},
+        "Unbound variable: 'b'",
+    );
+}
+
+#[test]
+fn a_feed_parameter_annotation_constrains_what_is_fed() {
+    check_compile_error(
+        indoc! {r#"
+            def fw(c: Mut(Int), o: Feed(String)):
+              o << c
+              c += 1
+            x := 0
+            out = defer()
+            for i in [1, 2, 3]:
+              fw(x, out)
+            out
+        "#},
+        "expected String, found Int",
+    );
+}
+
+#[test]
+fn a_feed_parameter_annotation_is_exact_and_takes_one_argument() {
+    check_compile_error(
+        indoc! {r#"
+            def fw(c: Mut(Int), o <: Feed(Int)):
+              o << c
+              c += 1
+            x := 0
+            out = defer()
+            for i in [1, 2, 3]:
+              fw(x, out)
+            out
+        "#},
+        "bounds a feed parameter by its own type",
+    );
+    check_compile_error(
+        indoc! {r#"
+            def fw(c: Mut(Int), o: Feed(Int, Int)):
+              o << c
+              c += 1
+            x := 0
+            out = defer()
+            for i in [1, 2, 3]:
+              fw(x, out)
+            out
+        "#},
+        "`Feed` takes one type argument: `Feed(T)`",
+    );
+}


### PR DESCRIPTION
A `def` with a `Mut(…)` parameter lowers to a curried chain of named lambdas, and that path bound every *other* parameter at `Hole` and discarded its annotation. `def f(a: Int, m: Mut(Int))` therefore accepted `f("hello", total)`, inferring `a` from the body alone — the defect the single-parameter arm's comment records having fixed there. Each non-history annotation is now a checking-mode declaration, as in the other two arms.

`Feed(T)` had to come with it: `lower_type_annotation` rejects `Feed(…)` as an unknown type application, so declaring one needs the interception `Mut(…)` already gets. `feed_param_history_type` recognizes it as the `Append` `Type::History` carrier — exact, one argument, for the reasons `Mut` is. Two existing feed cases relied on the drop.

Read the fold in `lower_function_body` first. The tests pin the enforcement, that a refinement naming a parameter to its left still resolves, and both malformed `Feed` spellings.