### PR TITLE
Carry provenance panes down to `post-lambda-elim`, with the topology declared once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,8 @@ jobs:
         # feature) in automated runs so it keeps guarding against a pass that
         # produces an ill-typed tree — it is off by default locally because it is
         # superlinear on nested comprehensions (see `ci_test` / `debug_typecheck`).
-        # `CAMBRA_PROVENANCE_GATE=1` makes every compile fold both pane pairs and
-        # gate the leak classes, so the gate's corpus is the whole test suite
+        # `CAMBRA_PROVENANCE_GATE=1` makes every compile fold every gated pane pair
+        # and gate the leak classes, so the gate's corpus is the whole test suite
         # rather than the handful of programs `context.rs`'s `corpus()` lists. Two
         # recording gaps lived outside that sample; measured at ~+4% on the test
         # step, which is worth paying to keep the next one from doing the same.

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -933,6 +933,20 @@ pub(crate) fn collect_tree_ids(expr: &Expr) -> std::collections::HashSet<NodeId>
         if let TypedExprNode::Cast { target, .. } = &e.node {
             from_ty(target, acc);
         }
+        // A binder's declared type and its annotation are type slots too. This
+        // walk and `TypedExpr::walk_type_slots` enumerate the same domain, and
+        // must: the rewriting passes reach predicates through `walk_type_slots`,
+        // so anything it covers and this does not is a predicate a pass may
+        // rebuild while the fold has never enumerated the original — which reads
+        // as `DanglingParent` against an id the input pane demonstrably holds.
+        // `f: (Int => {Int where _ == 9}) = …` is the shape: the predicate rides
+        // the `let` binder's annotation and nothing else.
+        e.walk_binders(|b| {
+            from_ty(&b.ty, acc);
+            if let Some(ann) = &b.user_annotation {
+                from_ty(ann, acc);
+            }
+        });
         e.walk_children(|c| from_expr(c, acc));
     }
 

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -18,10 +18,12 @@ use crate::{
         },
         inline, lambda_elim,
         lower::{LoweringContext, LoweringError, lower_stmts},
-        mut_elim, planning,
+        mut_elim,
+        panes::gate_leaks,
+        planning,
         provenance::{
-            Leak, LoweringSession, NodeId, PhaseScope, ProvenanceMap, ProvenanceTable,
-            SourceProjection, TableSession, fold, fold_lowering,
+            Leak, LoweringSession, NodeId, PhaseScope, ProvenanceTable, SourceProjection,
+            TableSession, fold, fold_lowering,
         },
         symbolic::{symbolic, symbolic_typed},
         transact_phase, uniquify,
@@ -534,6 +536,22 @@ pub struct CompiledProgram {
     /// Every id preserved through inline/transact/letrec/channelize is shared with
     /// [`post_inference_ir`](Self::post_inference_ir).
     pub post_channelize_ir: Expr,
+    /// The post-as-of-read IR snapshot, taken after
+    /// [`transact_phase::rewrite_as_of_reads`](crate::ccl::transact_phase::rewrite_as_of_reads).
+    ///
+    /// Distinct from [`post_channelize_ir`](Self::post_channelize_ir) because
+    /// that rewrite runs between the two: on a program with a fed-out mutable
+    /// read the trees differ, and on every other program they agree node for
+    /// node. Isolating it is what lets the pair ending here gate that one
+    /// rewrite rather than fold it in with lambda elimination.
+    pub post_as_of_read_ir: Expr,
+    /// The post-lambda-elim IR snapshot, taken after
+    /// [`lambda_elim::run`](crate::ccl::lambda_elim::run).
+    ///
+    /// The pass re-mints nearly every pass-through node, so almost no id here is
+    /// shared with the pane before it and the pair's relation falls to the
+    /// parents walk rather than to shared ids. That is what the pair measures.
+    pub post_lambda_elim_ir: Expr,
     /// The compile's provenance record: `NodeId → { parents, blame, rule }`, one
     /// row per node a phase produced, written by the recorder as those phases run
     /// ([`crate::ccl::provenance`]).
@@ -544,8 +562,8 @@ pub struct CompiledProgram {
     /// [`Phase::Infer`] (everything monomorphization mints inside `infer`, which
     /// bridges the pre-inference ⇄ post-inference panes) and [`Phase::Inline`],
     /// [`Phase::Transact`], [`Phase::Letrec`], [`Phase::Channelize`] (the four phases
-    /// between the post-inference and post-channelize snapshots) — see
-    /// [`INFER_PHASES`] and [`CHANNELIZE_PHASES`].
+    /// between the post-inference and post-channelize snapshots) — see [`PANES`],
+    /// which declares which phases each pane pair folds.
     ///
     /// Rows exist only for nodes a recording produced, so an untouched node has
     /// none — it was never rewritten. Refinement-predicate interiors are rows
@@ -606,57 +624,6 @@ impl CompiledProgram {
     pub fn sinks(&self) -> impl Iterator<Item = &CompiledOutput> {
         self.outputs.iter().filter(|o| !o.is_main())
     }
-
-    /// Fold [`provenance_table`](Self::provenance_table) across the two pane pairs into
-    /// the per-pane [`SourceProjection`]s, the pane-pair [`ProvenanceMap`]s, and
-    /// each pair's [`Leak`]s. Cold path (snapshot-serve only), never called
-    /// by [`compile_program`]:
-    ///
-    /// * pre-inference pane = the lowering projection (`uniquify` preserves every
-    ///   id in place, so lowering's keys are still the pane's keys);
-    /// * post-inference pane = fold the [`INFER_PHASES`] rows against the
-    ///   pre-inference pane;
-    /// * post-channelize pane = fold the [`CHANNELIZE_PHASES`] rows against the
-    ///   post-inference pane.
-    ///
-    /// The leaks are **returned, not asserted**: a span reaches zero only once
-    /// every phase inside it records its rewrites, so [`gate_leaks`] is left to
-    /// the callers that fold an instrumented span. The deaths ride alongside them
-    /// as a product, since nothing declares a fate.
-    // Cold path: the inspector's snapshot serve, which is not in this workspace.
-    #[allow(dead_code)]
-    pub(crate) fn materialize_panes(&self) -> MaterializedPanes {
-        let pre_ids = collect_tree_ids(&self.pre_inference_ir);
-        let post_inf_ids = collect_tree_ids(&self.post_inference_ir);
-        let post_des_ids = collect_tree_ids(&self.post_channelize_ir);
-
-        let (infer_map, post_inference, infer_deaths, infer_leaks) = fold(
-            &self.provenance_table,
-            INFER_PHASES,
-            &pre_ids,
-            &post_inf_ids,
-            &self.lowering_projection,
-        );
-        let (channelize_map, post_channelize, channelize_deaths, channelize_leaks) = fold(
-            &self.provenance_table,
-            CHANNELIZE_PHASES,
-            &post_inf_ids,
-            &post_des_ids,
-            &post_inference,
-        );
-
-        MaterializedPanes {
-            pre_inference: self.lowering_projection.clone(),
-            post_inference,
-            post_channelize,
-            infer_map,
-            channelize_map,
-            infer_deaths,
-            channelize_deaths,
-            infer_leaks,
-            channelize_leaks,
-        }
-    }
 }
 
 /// The compiler phase that rewrote a node — a
@@ -716,102 +683,23 @@ pub enum Phase {
     /// synthesizes new nodes (channel unions, contribution records, floated
     /// lambdas, DI wrappers) that are tagged `{via: Channelize, nature: Machinery}`.
     Channelize,
+    /// The as-of-read rewrite
+    /// ([`crate::ccl::transact_phase::rewrite_as_of_reads`]): turning a
+    /// read-only reply that reads a mutable variable out of its block into an
+    /// outer-indexed as-of join.
+    ///
+    /// Its code lives in `transact_phase`, but a phase is declared where the
+    /// rewrite *runs*, not where its code sits — this one runs after
+    /// `Channelize` and before `LambdaElim`. Reusing [`Transact`](Self::Transact)
+    /// for it would put one phase on both sides of the post-channelize pane, and
+    /// a fold restricting by that phase would resolve straight past it.
+    AsOfRead,
     /// Lambda elimination: synthesizing point-free combinators (`Compose`,
-    /// `Zip`, `Id`) from explicit lambdas. **Never constructed**: `lambda_elim`
-    /// opens no recording, so no row carries this tag. The variant exists so the
-    /// axis covers every phase.
+    /// `Zip`, `Id`) from explicit lambdas.
     LambdaElim,
     /// Join/dataflow planning: hash-join and restrict scaffolding, clause
     /// fusion, refinement-predicate compilation.
     Planning,
-}
-
-/// The phases between each adjacent pair of panes — the set
-/// [`CompiledProgram::materialize_panes`] restricts the whole-compile table by.
-///
-/// A pane pair's fold is defined by the phases that ran between its two panes,
-/// not by a position in a list: a program that skips a phase must not shift the
-/// other pair's set, and a row produced outside a pair's phases has to read to it
-/// as an ordinary un-produced id.
-pub(crate) const INFER_PHASES: &[Phase] = &[Phase::Infer];
-
-/// The phases between the post-inference and post-channelize panes. See
-/// [`INFER_PHASES`].
-pub(crate) const CHANNELIZE_PHASES: &[Phase] = &[
-    Phase::Inline,
-    Phase::Transact,
-    Phase::Letrec,
-    Phase::Channelize,
-];
-
-/// The per-pane projections, pane-pair provenance maps, and per-pair leaks
-/// materialized from [`CompiledProgram::provenance_table`] — see
-/// [`CompiledProgram::materialize_panes`].
-// Consumed by the inspector model; unused within the compiler itself.
-#[allow(dead_code)]
-pub(crate) struct MaterializedPanes {
-    /// pre-inference pane projection (= the lowering projection).
-    pub(crate) pre_inference: SourceProjection,
-    /// post-inference pane projection.
-    pub(crate) post_inference: SourceProjection,
-    /// post-channelize pane projection.
-    pub(crate) post_channelize: SourceProjection,
-    /// pre-inference → post-inference provenance map: `Infer`'s rewrites, of
-    /// which monomorphization's fan-out is the bulk. Dense: an id that survived is
-    /// its own self-edge.
-    pub(crate) infer_map: ProvenanceMap<NodeId, NodeId>,
-    /// post-inference → post-channelize provenance map.
-    pub(crate) channelize_map: ProvenanceMap<NodeId, NodeId>,
-    /// The pre-inference ids absent from the post-inference pane — `input_ids ∖
-    /// output_ids`, which is the whole of what "died" means here.
-    pub(crate) infer_deaths: Vec<NodeId>,
-    /// The post-inference ids absent from the post-channelize pane.
-    pub(crate) channelize_deaths: Vec<NodeId>,
-    /// Leaks between the pre-inference and post-inference panes.
-    pub(crate) infer_leaks: Vec<Leak>,
-    /// Leaks between the post-inference and post-channelize panes.
-    pub(crate) channelize_leaks: Vec<Leak>,
-}
-
-impl MaterializedPanes {
-    /// `(pane-pair name, leaks)` for each pane pair, in pipeline order.
-    #[allow(dead_code)]
-    pub(crate) fn pane_pairs(&self) -> [(&'static str, &[Leak]); 2] {
-        [
-            ("pre-inference → post-inference", &self.infer_leaks),
-            ("post-inference → post-channelize", &self.channelize_leaks),
-        ]
-    }
-
-    /// The pane pairs a gate can hold at zero: the ones whose phases are
-    /// **instrumented**. Same discipline as an audit span's endpoint. A gate over
-    /// a pane pair whose phases do not record cannot reach zero however correct
-    /// the recording is, so it would report a constant rather than a regression.
-    ///
-    /// Today that is the second pair only. The first spans monomorphization and
-    /// inference, and **inference's predicate producers do not record**:
-    /// `specialize_use` clones a definition per instantiation, and the copies of
-    /// a predicate term inside it row against interior ids no phase ever
-    /// produced. It is the crossing "Known prerequisites" records.
-    ///
-    /// The residue's class signature is what makes it a constant. Inference's own
-    /// rewrites sit inside a recording scope, so every post-inference node
-    /// carries a row and [`Leak::Unrecorded`] is zero; what dangles is the
-    /// parents those rows name. Returning both pairs here and running
-    /// `CAMBRA_PROVENANCE_GATE=1` over `tests/compilation_pipeline` fails six
-    /// programs on 46 leaks, every one [`Leak::DanglingParent`] and none
-    /// [`Leak::Unrecorded`]: four UDF-with-filter or poly-wrapper shapes and two
-    /// refined-annotation shapes. A [`Leak::Unrecorded`] arriving there would be
-    /// a missed mint and a defect now, which is the reading the two classes carry
-    /// that a single class would not.
-    ///
-    /// No count is pinned here, because a count over an uninstrumented phase
-    /// measures how little it records and churns with every unrelated change.
-    /// **Add the first pair here in the commit that makes inference record**,
-    /// exactly as an audit span's endpoint moves with the phase that earns it.
-    pub(crate) fn gated_pane_pairs(&self) -> [(&'static str, &[Leak]); 1] {
-        [("post-inference → post-channelize", &self.channelize_leaks)]
-    }
 }
 
 /// Ids carried by two *distinct* predicate terms, or by a predicate term and the
@@ -955,26 +843,6 @@ pub(crate) fn collect_tree_ids(expr: &Expr) -> std::collections::HashSet<NodeId>
     acc
 }
 
-/// The leak gate: **a fold's [`Leak`] vector must be empty**.
-///
-/// Both classes are asserted the same way. Each means a node reached the output
-/// pane with nothing recording where it came from, and neither localizes the site
-/// to fix on its own, so the gate reads the vector's emptiness and not its
-/// composition (see [`Leak`]). A death is not a leak and reaches a caller as its
-/// own collection, so there is nothing here to filter.
-///
-/// Debug/test only, single code path (`cfg!`, not `#[cfg]`).
-fn gate_leaks(leaks: &[Leak], pair: &str) {
-    if !cfg!(any(debug_assertions, test)) {
-        return;
-    }
-    assert!(
-        leaks.is_empty(),
-        "provenance capture defect between the {pair} panes ({} leaks): {leaks:?}",
-        leaks.len(),
-    );
-}
-
 /// Every duplicated [`NodeId`] over the **main tree** — the `walk_children`
 /// node-set, refinement predicates excluded. Returns `(id, node kind)` for each
 /// occurrence *beyond the first*.
@@ -1091,7 +959,7 @@ const PROVENANCE_PREDICATES_ENV: &str = "CAMBRA_PROVENANCE_PREDICATES";
 /// `#[test]`, so the name is dead in a lib build; it lives here rather than
 /// beside its reader so that adding a fifth switch means editing one block.
 #[cfg(test)]
-const PERF_REPS_ENV: &str = "CAMBRA_PERF_REPS";
+pub(crate) const PERF_REPS_ENV: &str = "CAMBRA_PERF_REPS";
 
 /// The audit span named by [`PROVENANCE_AUDIT_ENV`], if any. **Sole reader** of
 /// that variable — see the section note above.
@@ -1642,15 +1510,21 @@ pub fn compile_program(
     // rather than a point-free `const` a planning-time recognizer would have to
     // reject. Uniform across the reading loop's domain. See
     // `transact_phase::rewrite_as_of_reads`.
-    transact_phase::rewrite_as_of_reads(&mut channelized)
-        .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
+    recorded(capture_provenance, Phase::AsOfRead, || {
+        transact_phase::rewrite_as_of_reads(&mut channelized)
+    })
+    .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
     assert_unique_node_ids(&channelized, "post-as-of-read");
     typecheck(&channelized).expect("as-of-read rewrite produced an ill-typed tree");
     // The last instrumented pane: see the span's own note at `ProvenanceAudit::start`.
     audit.finish(&channelized);
+    // A pane snapshot; see `pre_inference_ir`.
+    let post_as_of_read_ir = channelized.clone_preserving_ids();
 
     let lambda_elim = lambda_elim::run(channelized).errs()?;
     assert_unique_node_ids(&lambda_elim, "post-lambda-elim");
+    // A pane snapshot; see `pre_inference_ir`.
+    let post_lambda_elim_ir = lambda_elim.clone_preserving_ids();
     debug!("λ-eliminated CCL:\n{}", symbolic(&lambda_elim));
     debug!("λ-eliminated typed CCL:\n{}", symbolic_typed(&lambda_elim));
 
@@ -1787,6 +1661,8 @@ pub fn compile_program(
         pre_inference_ir,
         post_inference_ir,
         post_channelize_ir,
+        post_as_of_read_ir,
+        post_lambda_elim_ir,
         provenance_table,
         source_ast: module,
         source: code.to_string(),
@@ -1795,8 +1671,8 @@ pub fn compile_program(
     // Every compile its own gate — see `provenance_gate_every_compile` for why this
     // is opt-in and what it covers that the sampled gate does not.
     if provenance_gate_every_compile() {
-        for (pair, leaks) in program.materialize_panes().gated_pane_pairs() {
-            gate_leaks(leaks, pair);
+        for pair in program.materialize_panes().gated_pane_pairs() {
+            gate_leaks(&pair.leaks, &pair.name);
         }
     }
 
@@ -1807,641 +1683,6 @@ pub fn compile_program(
 mod tests {
     use super::*;
     use rstest::rstest;
-
-    /// The pane-measurement corpus: every demo-gallery program that compiles
-    /// today, plus four inline programs covering the phases the gallery does not
-    /// reach (a `with begin():` transaction, a group-by, a UDF chain, and a
-    /// nested comprehension).
-    ///
-    /// The gallery's remaining programs are excluded for reasons unrelated to
-    /// provenance: most are deliberate *failure* fixtures (`while`, record-term
-    /// syntax, `Feed(_)` types) that pin errors and so have no panes to fold,
-    /// and the three HTTP demos bind a real listening socket during lowering,
-    /// which collides with itself under a parallel test runner.
-    fn corpus() -> Vec<(&'static str, String)> {
-        vec![
-            (
-                "arithmetic",
-                include_str!("../../tests/programs/arithmetic/program.cambra").to_string(),
-            ),
-            (
-                "filter_and_aggregate",
-                include_str!("../../tests/programs/filter_and_aggregate/program.cambra").to_string(),
-            ),
-            (
-                "for_accumulator",
-                include_str!("../../tests/programs/for_accumulator/program.cambra").to_string(),
-            ),
-            (
-                "generator_pipeline",
-                include_str!("../../tests/programs/generator_pipeline/program.cambra").to_string(),
-            ),
-            (
-                "inner_join",
-                include_str!("../../tests/programs/inner_join/program.cambra").to_string(),
-            ),
-            (
-                "prefix_lines",
-                include_str!("../../tests/programs/prefix_lines/program.cambra").to_string(),
-            ),
-            (
-                "streaming_echo",
-                include_str!("../../tests/programs/streaming_echo/program.cambra").to_string(),
-            ),
-            (
-                "transaction",
-                "out = defer()\n\
-                 pool: Mut(Int, Txn) := 100\n\
-                 for r in [10, 20, 30]:\n\
-                 \x20   with begin():\n\
-                 \x20       pool := pool - r\n\
-                 with begin():\n\
-                 \x20   out << pool\n\
-                 out\n"
-                    .to_string(),
-            ),
-            (
-                "group_by",
-                "[sum(x) for x in groupby([y + 10 for y in [2,3,4,5,6] if y < 6], \\x -> x // 2)]\n"
-                    .to_string(),
-            ),
-            (
-                "udf_chain",
-                "def double(x):\n    x * 2\ndef bump(x):\n    double(x) + 1\n\
-                 xs = [1, 2, 3]\n[bump(x) for x in xs]\n"
-                    .to_string(),
-            ),
-            (
-                "feed_loop",
-                "out = defer()\nfor x in [1, 2, 3]:\n    out << x * 2\nout\n".to_string(),
-            ),
-        ]
-    }
-
-    /// Compile `code` through the full pipeline, panicking on error.
-    fn compile_ok(code: &str) -> CompiledProgram {
-        let mut ctx = GlobalContext::default();
-        let consumer: Box<dyn Consumer> = Box::new(|| {});
-        match compile_program(&mut ctx, code, consumer) {
-            Ok(p) => p,
-            Err(errs) => panic!("expected a successful compile, got {errs:?}"),
-        }
-    }
-
-    /// Per-leak-class counts, for reporting one fold.
-    #[derive(Default, Debug, PartialEq, Eq)]
-    struct LeakCounts {
-        unrecorded: usize,
-        dangling_parent: usize,
-    }
-
-    impl LeakCounts {
-        fn tally(leaks: &[Leak]) -> Self {
-            let mut c = LeakCounts::default();
-            for l in leaks {
-                match l {
-                    Leak::Unrecorded { .. } => c.unrecorded += 1,
-                    Leak::DanglingParent { .. } => c.dangling_parent += 1,
-                }
-            }
-            c
-        }
-
-        fn add(&mut self, o: &LeakCounts) {
-            self.unrecorded += o.unrecorded;
-            self.dangling_parent += o.dangling_parent;
-        }
-    }
-
-    /// **Capture totality**, as a corpus-wide property rather than a per-phase
-    /// assertion: both pane pairs materialize and fold over every corpus
-    /// program, every output-pane node has an origin (`Unrecorded == 0`), and
-    /// no node's ancestry dangles (`DanglingParent == 0`).
-    ///
-    /// The two invariants fail differently and are worth reading apart.
-    /// `dangling_parent == 0` says no node's ancestry stops at an id the fold
-    /// never heard of. `Unrecorded == 0` says no rewrite went
-    /// *unrecorded* — it is the gate the whole driver-capture design exists to
-    /// phase, and the number a newly-added rewrite site breaks first.
-    #[test]
-    fn pane_pair_folds_have_no_structural_leaks() {
-        let mut totals = [LeakCounts::default(), LeakCounts::default()];
-        for (name, code) in corpus() {
-            let program = compile_ok(&code);
-            let panes = program.materialize_panes();
-            for (i, (pair, leaks)) in panes.pane_pairs().into_iter().enumerate() {
-                let c = LeakCounts::tally(leaks);
-                assert_eq!(
-                    c.dangling_parent, 0,
-                    "{name}: structural leaks between the {pair} panes: {c:?}"
-                );
-                assert_eq!(
-                    c.unrecorded, 0,
-                    "{name}: unrecorded output nodes between the {pair} panes — a rewrite \
-                     that mints with nothing recording: {c:?}"
-                );
-                eprintln!("[pane {name} / {pair}] {c:?}");
-                totals[i].add(&c);
-            }
-            // The panes are the thing being materialized: each projection must
-            // hold entries for the tree it describes, and each map edges.
-            assert!(!panes.pre_inference.is_empty(), "{name}");
-            assert!(!panes.post_inference.is_empty(), "{name}");
-            assert!(!panes.post_channelize.is_empty(), "{name}");
-            assert!(!panes.infer_map.edges().is_empty(), "{name}");
-            assert!(!panes.channelize_map.edges().is_empty(), "{name}");
-        }
-        eprintln!("[pane totals] pre→post-inference {:?}", totals[0]);
-        eprintln!(
-            "[pane totals] post-inference→post-channelize {:?}",
-            totals[1]
-        );
-    }
-
-    /// Every phase that records rows in a normal compile belongs to exactly one
-    /// pane pair, so no rewrite is folded twice and none is silently dropped.
-    ///
-    /// [`INFER_PHASES`] and [`CHANNELIZE_PHASES`] are the only things that decide
-    /// which pane pair a row reaches, so a phase that opens a scope without
-    /// joining neither would record rows nothing ever folds.
-    #[test]
-    fn every_recorded_phase_belongs_to_exactly_one_pane_pair() {
-        for (name, code) in corpus() {
-            let program = compile_ok(&code);
-            for p in program.provenance_table.recorded_phases() {
-                assert!(
-                    INFER_PHASES.contains(&p) != CHANNELIZE_PHASES.contains(&p),
-                    "{name}: {p:?} is in neither pane pair, or in both",
-                );
-            }
-        }
-    }
-
-    /// The `program / pane pair` names at which the provenance map is **not**
-    /// vacuous — where some node's origin is another node, so the fold had to
-    /// read a row. See
-    /// [`the_pane_folds_derive_a_non_vacuous_provenance_map`].
-    ///
-    /// Pinned rather than counted: a recording that opens after the clone that
-    /// produced its nodes captures nothing, and the fold still succeeds — it
-    /// reads the pane pair as pure identity. The pin is what makes that
-    /// difference visible, so it lists names and not a total.
-    const EXERCISED_BOUNDARIES: &[&str] = &[
-        "arithmetic / pre-inference → post-inference",
-        "feed_loop / post-inference → post-channelize",
-        "feed_loop / pre-inference → post-inference",
-        "filter_and_aggregate / pre-inference → post-inference",
-        "for_accumulator / post-inference → post-channelize",
-        "for_accumulator / pre-inference → post-inference",
-        "generator_pipeline / post-inference → post-channelize",
-        "generator_pipeline / pre-inference → post-inference",
-        "group_by / pre-inference → post-inference",
-        "inner_join / pre-inference → post-inference",
-        "prefix_lines / pre-inference → post-inference",
-        "streaming_echo / pre-inference → post-inference",
-        "transaction / post-inference → post-channelize",
-        "transaction / pre-inference → post-inference",
-        "udf_chain / post-inference → post-channelize",
-        "udf_chain / pre-inference → post-inference",
-    ];
-
-    /// **The provenance map is well-formed and non-vacuous** on every corpus
-    /// program: every edge runs from an input-pane id to an output-pane id,
-    /// every id present in both panes is its own dense self-edge, and the
-    /// pane pairs where the fold had to read a *row* are exactly the ones
-    /// pinned above.
-    ///
-    /// The non-vacuity half is what this test is for. Six of the twenty-two
-    /// corpus pane pairs are pure identity: no phase inside them minted, so the
-    /// map is the input pane's self-edges and holds for reasons that have
-    /// nothing to do with the recording. A corpus edit that
-    /// silently dropped the rewriting programs would otherwise leave a green
-    /// tautology behind.
-    #[test]
-    fn the_pane_folds_derive_a_non_vacuous_provenance_map() {
-        let mut exercised: Vec<String> = Vec::new();
-        for (name, code) in corpus() {
-            let program = compile_ok(&code);
-            let panes = program.materialize_panes();
-            let pre = collect_tree_ids(&program.pre_inference_ir);
-            let post_inf = collect_tree_ids(&program.post_inference_ir);
-            let post_des = collect_tree_ids(&program.post_channelize_ir);
-
-            let pairs: [(&str, &ProvenanceMap<NodeId, NodeId>, _, _); 2] = [
-                (
-                    "pre-inference → post-inference",
-                    &panes.infer_map,
-                    &pre,
-                    &post_inf,
-                ),
-                (
-                    "post-inference → post-channelize",
-                    &panes.channelize_map,
-                    &post_inf,
-                    &post_des,
-                ),
-            ];
-
-            for (pair, map, input_ids, output_ids) in pairs {
-                let edges = map.edges();
-                assert!(
-                    !edges.is_empty(),
-                    "{name}: the {pair} fold derived no edges at all",
-                );
-                for (u, d) in &edges {
-                    assert!(
-                        input_ids.contains(u),
-                        "{name}: {u:?} is an edge origin at {pair} but not an input-pane id",
-                    );
-                    assert!(
-                        output_ids.contains(&d.id),
-                        "{name}: {:?} is an edge target at {pair} but not an output-pane id",
-                        d.id,
-                    );
-                }
-                // Dense: a node present in both panes is its own self-edge, and
-                // a node descends from itself — so a consumer only ever follows
-                // edges, never reconstructs one, and reads ancestry off the
-                // label it finds there.
-                for id in input_ids.intersection(output_ids) {
-                    let self_edge = map.upstream(id).iter().find(|l| l.id == *id);
-                    assert!(
-                        self_edge.is_some_and(|l| l.labels.has_ancestry()),
-                        "{name}: {id:?} survives {pair} without an ancestry self-edge",
-                    );
-                }
-                // A non-self edge is the only proof a row was consulted: a
-                // pane pair whose phases rewrote nothing derives its whole
-                // map from the two pane id sets.
-                if edges.iter().any(|(u, d)| *u != d.id) {
-                    exercised.push(format!("{name} / {pair}"));
-                }
-            }
-        }
-        exercised.sort();
-        assert_eq!(
-            exercised, EXERCISED_BOUNDARIES,
-            "the pane pairs at which the fold actually reads a row have changed",
-        );
-    }
-
-    /// The `program / pane pair` names at which a **blame** edge reaches the
-    /// provenance map — where a rewrite named blame and the fold labelled the
-    /// edge it contributed. See
-    /// [`blame_reaches_the_provenance_map_labelled`].
-    const RELATING_BOUNDARIES: &[&str] = &[
-        "for_accumulator / post-inference → post-channelize",
-        "transaction / post-inference → post-channelize",
-    ];
-
-    /// **Blame reaches the provenance map, labelled**: the `blame` column is
-    /// closed transitively alongside `parents`, so a consumer receives the
-    /// blame edges and can render or prune them.
-    ///
-    /// Pinned as the set of pane pairs where such an edge exists, for the same
-    /// reason [`EXERCISED_BOUNDARIES`] is pinned: blame is named at a handful of
-    /// sites, all in the mutability phases and so all inside the second pane
-    /// pair, and a corpus or recording edit that stopped exercising them
-    /// would otherwise leave the labelled half of the map untested.
-    ///
-    /// A blame edge is *only* blame here: no corpus rewrite both
-    /// consumes a node and blames it, so nothing in the corpus pins the
-    /// both-labels case — the fold tests in `provenance.rs` do.
-    #[test]
-    fn blame_reaches_the_provenance_map_labelled() {
-        let mut relating: Vec<String> = Vec::new();
-        for (name, code) in corpus() {
-            let program = compile_ok(&code);
-            let panes = program.materialize_panes();
-            let pairs = [
-                ("pre-inference → post-inference", &panes.infer_map),
-                ("post-inference → post-channelize", &panes.channelize_map),
-            ];
-            for (pair, map) in pairs {
-                if map.edges().iter().any(|(_, d)| d.labels.has_blame()) {
-                    relating.push(format!("{name} / {pair}"));
-                }
-            }
-        }
-        relating.sort();
-        assert_eq!(
-            relating, RELATING_BOUNDARIES,
-            "the pane pairs at which blame contributes an edge have changed",
-        );
-    }
-
-    /// The corpus programs whose definitions inference **generalizes and then
-    /// specializes** — the ones monomorphization actually clones a subtree for.
-    /// Everything else in the corpus is first-order, and mono mints nothing.
-    const SPECIALIZING: &[&str] = &["generator_pipeline", "udf_chain"];
-
-    /// Monomorphization — the one thing that mints between the first two panes —
-    /// explains every node it produces, on first-order and specializing
-    /// programs alike.
-    ///
-    /// Two recordings get it there, and both are needed: `specialize_use` sinks
-    /// the clone's `on_copy` pairs, and `coalesce_generalized_let` sinks the
-    /// chain of `let`s the binding rebuilds itself as. Without the second, a
-    /// specializing program leaves one unrecorded `let` per demanded
-    /// specialization — a per-program count that tracks how many types the body
-    /// asked for, which is why it read as a small constant on this corpus.
-    ///
-    /// Asserted both ways so the zero cannot be vacuous: a specializing program
-    /// must also *kill* nodes here, since its generalized definition is
-    /// replaced by clones. A regression that stopped running mono at all would
-    /// otherwise pass.
-    #[test]
-    fn monomorphization_explains_every_node_it_produces() {
-        for (name, code) in corpus() {
-            let panes = compile_ok(&code).materialize_panes();
-            let c = LeakCounts::tally(&panes.infer_leaks);
-            assert_eq!(c.dangling_parent, 0, "{name}: {c:?}");
-            assert_eq!(
-                c.unrecorded, 0,
-                "{name}: pre-inference → post-inference is uncaptured: {c:?}"
-            );
-            if SPECIALIZING.contains(&name) {
-                assert!(
-                    !panes.infer_deaths.is_empty(),
-                    "{name}: specializes, so the generalized definition must die"
-                );
-            }
-        }
-    }
-
-    /// All four phases inside the second pane pair explain what they produce.
-    ///
-    /// The interesting programs are the ones that drive a *whole-program*
-    /// rewrite, where naming one node is least obviously applicable: a
-    /// transaction is disassembled into a commit carrier whose pieces have no
-    /// single source node, and a defer cluster becomes a `LetRec` assembled from
-    /// contributions scattered across the body. Both are covered by recording
-    /// against the node each product stands in for — the `with begin():`
-    /// statement, the register declaration, the `let d = Defer`.
-    ///
-    /// Asserted with a non-vacuity guard for the same reason the first pane pair is: a
-    /// program that reaches one of these phases must also kill nodes, so a
-    /// regression that stopped running the phase cannot pass as capture.
-    #[test]
-    fn the_second_pane_pair_explains_every_node_its_phases_produce() {
-        /// Reaches `transact_phase` or `channelize` — the whole-program
-        /// rewrites, and the last two phases to adopt the recorder.
-        const WHOLE_PROGRAM_REWRITES: &[&str] = &["transaction", "feed_loop", "generator_pipeline"];
-        for (name, code) in corpus() {
-            let panes = compile_ok(&code).materialize_panes();
-            let c = LeakCounts::tally(&panes.channelize_leaks);
-            assert_eq!(c.dangling_parent, 0, "{name}: {c:?}");
-            assert_eq!(
-                c.unrecorded, 0,
-                "{name}: post-inference → post-channelize is uncaptured: {c:?}"
-            );
-            if WHOLE_PROGRAM_REWRITES.contains(&name) {
-                assert!(
-                    !panes.channelize_deaths.is_empty(),
-                    "{name}: rewrites its whole shape, so nodes must die"
-                );
-            }
-        }
-    }
-
-    /// Deaths are the live-set difference and nothing else: what the fold reports
-    /// between two panes is exactly `input_ids ∖ output_ids` on a real program,
-    /// with no phase having declared any of them. `for_accumulator` folds a
-    /// mutation loop into a `LetRec`, so the difference is non-empty.
-    #[test]
-    fn deaths_between_two_panes_are_the_set_difference() {
-        let program = compile_ok(include_str!(
-            "../../tests/programs/for_accumulator/program.cambra"
-        ));
-        let panes = program.materialize_panes();
-        let input = collect_tree_ids(&program.post_inference_ir);
-        let output = collect_tree_ids(&program.post_channelize_ir);
-        let mut expected: Vec<NodeId> = input.difference(&output).copied().collect();
-        expected.sort_unstable();
-        assert!(!expected.is_empty(), "the fixture must actually kill nodes");
-        assert_eq!(panes.channelize_deaths, expected);
-    }
-
-    /// **Distinct predicate terms never share a `NodeId`** — with each other, or
-    /// with the main tree — on the three trees the panes retain.
-    ///
-    /// [`assert_unique_node_ids`] runs the same [`predicate_id_collisions`] walk
-    /// at every phase boundary, so what this adds is the panes: `pre_inference_ir`
-    /// is snapshotted after `uniquify`, between two boundaries, and no boundary
-    /// walk reaches it.
-    ///
-    /// What the walk catches is a rebuild that **preserves ids when it should
-    /// not**. A predicate cannot be mutated through its `Rc`, so every rewrite
-    /// builds a new `Rc` and repoints the refinement it was handed. That is a
-    /// *replacement* only if the walk reaches every occurrence; otherwise the
-    /// original survives on some type the walk missed, and preserving ids puts one
-    /// id-set on two live terms. `PredMemo::replacing` is the opt-in for walks
-    /// that do reach everything, and `uniquify` — the only one — asserts its own
-    /// 1:1 correspondence separately.
-    #[test]
-    fn distinct_predicate_terms_never_share_a_node_id() {
-        let mut found: Vec<(String, usize, &'static str)> = Vec::new();
-        for (name, code) in corpus() {
-            let program = compile_ok(&code);
-            for (pane, tree) in [
-                ("pre-inference", &program.pre_inference_ir),
-                ("post-inference", &program.post_inference_ir),
-                ("post-channelize", &program.post_channelize_ir),
-            ] {
-                for (_, kind) in predicate_id_collisions(tree) {
-                    found.push((format!("{name} / {pane}"), 1, kind));
-                }
-            }
-        }
-        assert!(
-            found.is_empty(),
-            "{} predicate id collisions: {found:?}",
-            found.len(),
-        );
-    }
-
-    /// A phase that rewrites the program records its rewrites under its own phase
-    /// tag — the tag being the one part of a row no recording site knows, and the
-    /// only thing that places a row in a pane pair's fold.
-    ///
-    /// A phase that rewrites *nothing* on a given program records nothing, which
-    /// is the preserve case and correct (most of the corpus preserves end to
-    /// end), so the fixture is one that drives three of the five: the
-    /// transaction, which `transact_phase` disassembles, `mut_elim` rebuilds as
-    /// a `LetRec`, and `channelize` rewrites.
-    #[test]
-    fn a_rewriting_phase_tags_its_rows_with_itself() {
-        let (_, code) = corpus()
-            .into_iter()
-            .find(|(name, _)| *name == "transaction")
-            .expect("the transaction fixture");
-        let program = compile_ok(&code);
-        let mut recorded = program.provenance_table.recorded_phases();
-        recorded.sort_by_key(|p| format!("{p:?}"));
-        assert_eq!(
-            recorded,
-            vec![
-                Phase::Channelize,
-                Phase::Infer,
-                Phase::Letrec,
-                Phase::Transact
-            ],
-            "the transaction fixture is rewritten by exactly these four phases",
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // Perf sanity for pane capture
-    // -----------------------------------------------------------------------
-
-    /// One generated program shape, parameterized by size.
-    ///
-    /// The shapes are chosen to hit the phases the panes span: `comprehension`
-    /// and `arith` are `inline`-light and mostly id-preserving, `udf` drives
-    /// inlining and monomorphization, `loop_acc` drives `mut_elim`, and `feed`
-    /// drives `channelize`.
-    ///
-    /// Sizes are deliberately small. Compile time here is **superlinear in
-    /// program size** for reasons that predate provenance capture (a UDF-heavy 63-line
-    /// program compiles in tens of seconds), so a corpus large enough to be a
-    /// benchmark would be too slow to run; this is a sanity check on the
-    /// *ratio* between capture on and capture off, not a benchmark.
-    fn generated(shape: &str, n: usize) -> String {
-        match shape {
-            "arith" => {
-                let terms: Vec<String> = (1..=n).map(|i| format!("{i} * {}", i + 1)).collect();
-                format!("x = {}\nx\n", terms.join(" + "))
-            }
-            "comprehension" => {
-                // Independent comprehensions summed, rather than a chain: a
-                // chained comprehension trips an unrelated substitution bug
-                // ("discharged binder still free after substitution into
-                // predicate") that has nothing to do with provenance.
-                let parts: Vec<String> = (0..n)
-                    .map(|i| format!("sum([y + {i} for y in xs if y > 0])"))
-                    .collect();
-                format!("xs = [1, 2, 3, 4, 5]\nt = {}\nt\n", parts.join(" + "))
-            }
-            "udf" => {
-                let mut src = String::new();
-                for i in 0..n {
-                    src.push_str(&format!("def f{i}(x):\n    x + {i}\n"));
-                }
-                src.push_str("xs = [1, 2, 3, 4, 5]\n");
-                let calls: Vec<String> = (0..n).map(|i| format!("f{i}(y)")).collect();
-                src.push_str(&format!("[{} for y in xs]\n", calls.join(" + ")));
-                src
-            }
-            "loop_acc" => {
-                let mut src = String::from("xs = [1, 2, 3, 4, 5]\n");
-                for i in 0..n {
-                    src.push_str(&format!("a{i}: Mut(Int) := 0\n"));
-                }
-                src.push_str("for v in xs:\n");
-                for i in 0..n {
-                    src.push_str(&format!("    a{i} += v + {i}\n"));
-                }
-                src.push_str(&format!("a{}\n", n - 1));
-                src
-            }
-            "feed" => {
-                let mut src = String::from("out = defer()\nxs = [1, 2, 3, 4, 5]\n");
-                for i in 0..n {
-                    src.push_str(&format!("for v in xs:\n    out << v + {i}\n"));
-                }
-                src.push_str("out\n");
-                src
-            }
-            other => panic!("unknown shape {other}"),
-        }
-    }
-
-    /// The perf corpus: `(shape, size)` pairs, sized to keep the whole run in
-    /// the low seconds per repetition.
-    const PERF_CORPUS: &[(&str, usize)] = &[
-        ("arith", 40),
-        ("arith", 80),
-        ("arith", 160),
-        ("comprehension", 6),
-        ("comprehension", 12),
-        ("comprehension", 20),
-        ("udf", 5),
-        ("udf", 8),
-        ("udf", 12),
-        ("loop_acc", 4),
-        ("loop_acc", 8),
-        ("loop_acc", 14),
-        ("feed", 3),
-        ("feed", 6),
-        ("feed", 12),
-    ];
-
-    /// Rough compile-time and retained-memory sanity for pane capture. Ignored
-    /// by default — it is a measurement, not an assertion.
-    ///
-    /// Run it as two interleaved processes so the two arms see the same machine
-    /// state, and take the min over repetitions:
-    ///
-    /// ```text
-    /// for i in 1 2 3; do
-    ///   CAMBRA_PROVENANCE=1 cargo test --release --lib provenance_pane_perf -- --ignored --nocapture
-    ///   CAMBRA_PROVENANCE=0 cargo test --release --lib provenance_pane_perf -- --ignored --nocapture
-    /// done
-    /// ```
-    ///
-    /// With capture on it also materializes and folds both panes, since that is
-    /// the cost the design actually incurs.
-    #[test]
-    #[ignore = "measurement, not an assertion; see the doc comment for the driver"]
-    fn provenance_pane_perf() {
-        let capture = provenance_capture_enabled();
-        let reps: usize = std::env::var(PERF_REPS_ENV)
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(3);
-        let mut total_compile = std::time::Duration::ZERO;
-        let mut total_fold = std::time::Duration::ZERO;
-        for (shape, n) in PERF_CORPUS {
-            let code = generated(shape, *n);
-            let mut best_compile = std::time::Duration::MAX;
-            let mut best_fold = std::time::Duration::MAX;
-            let mut rows = 0usize;
-            let mut tags = 0usize;
-            // The three retained pane snapshots are unconditional — they are not
-            // part of what the capture switch turns off — so their size is the
-            // pane design's real memory floor, against which the logs are noise.
-            let mut panes_nodes = 0usize;
-            for _ in 0..reps {
-                let t0 = std::time::Instant::now();
-                let program = compile_ok(&code);
-                best_compile = best_compile.min(t0.elapsed());
-                rows = program.provenance_table.len();
-                tags = program.provenance_table.tag_count();
-                panes_nodes = collect_tree_ids(&program.pre_inference_ir).len()
-                    + collect_tree_ids(&program.post_inference_ir).len()
-                    + collect_tree_ids(&program.post_channelize_ir).len();
-                if capture {
-                    let t1 = std::time::Instant::now();
-                    let panes = program.materialize_panes();
-                    std::hint::black_box(&panes.post_channelize);
-                    best_fold = best_fold.min(t1.elapsed());
-                }
-            }
-            if !capture {
-                best_fold = std::time::Duration::ZERO;
-            }
-            total_compile += best_compile;
-            total_fold += best_fold;
-            eprintln!(
-                "[perf capture={capture}] {shape}/{n}: compile {:?} fold {:?} rows {rows} \
-                 tags {tags} pane_nodes {panes_nodes} lines {}",
-                best_compile,
-                best_fold,
-                code.lines().count(),
-            );
-        }
-        eprintln!("[perf capture={capture}] TOTAL compile {total_compile:?} fold {total_fold:?}");
-    }
 
     /// Driver that runs `compile_program` for an error-only test, returning
     /// the collected error list. Discards the program — these tests only

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -571,7 +571,7 @@ pub struct CompiledProgram {
     /// explain them, and `PredMemo::rebuild` records a derived predicate against
     /// the one it was built from. What is not recorded is planning **raising** a
     /// predicate back into the main tree; see `design/provenance.md`, "Known
-    /// prerequisites for panes past `post-channelize`".
+    /// prerequisites for panes past `post-planning`".
     ///
     /// Empty when capture is switched off — no phase scope is opened then, so
     /// every flush is a no-op — see [`provenance_capture_enabled`]. This is the
@@ -1047,6 +1047,12 @@ fn recorded<R>(capture: bool, phase: Phase, f: impl FnOnce() -> R) -> R {
 /// genuinely-dead input id reaches the audit through the fold's death
 /// collection, which it counts apart from the [`Leak`]s that really are
 /// recording bugs.
+///
+/// TODO(provenance-audit-retire): scaffolding for the instrumentation campaign.
+/// This, [`PROVENANCE_PREDICATES_ENV`] and the audit clause in
+/// [`provenance_capture_enabled`] all go once every pane pair is gated, at which
+/// point no span has a question left to ask. See `design/provenance.md`, "What
+/// retires when the last phase records".
 struct ProvenanceAudit {
     span: &'static str,
     state: Option<(PhaseScope, std::collections::HashSet<NodeId>)>,
@@ -1372,24 +1378,25 @@ pub fn compile_program(
     let post_inference_ir = expr.clone_preserving_ids();
 
     // Driver-capture audit span: post-inference pane in, and out at the **last
-    // instrumented pane** — currently `post-as-of-read`, covering inline,
-    // transact, mut_elim, channelize and the as-of-read rewrite.
+    // instrumented pane** — currently `post-lambda-elim`, covering inline,
+    // transact, mut_elim, channelize, the as-of-read rewrite and lambda
+    // elimination.
     //
     // The endpoint is chosen rather than inherited. An audit measures what the
     // recordings explain, so a span running past the last instrumented phase
     // reports every node the uninstrumented tail mints as a defect — a number
     // that cannot reach zero however correct the recording is, which makes the
-    // audit read as a broken gate instead of a measurement. `lambda_elim` is the
-    // next phase here and records nothing (it re-mints nearly every pass-through
-    // node), so the span stops in front of it.
+    // audit read as a broken gate instead of a measurement. `planning` is the
+    // next phase here, and its group-by and hash-join recognizers mint with
+    // nothing recording, so the span stops in front of it.
     //
     // **Move this endpoint when a phase becomes instrumented, in the same commit
-    // that instruments it** — to `post-lambda-elim` when the elim phase records,
-    // and to `join-planned` when planning does. Leaving it behind understates
-    // coverage; moving it ahead reintroduces the unreachable-zero problem.
+    // that instruments it** — to `join-planned` when planning records. Leaving
+    // it behind understates coverage; moving it ahead reintroduces the
+    // unreachable-zero problem.
     let audit = ProvenanceAudit::start(
         "full",
-        "post-inference..post-as-of-read",
+        "post-inference..post-lambda-elim",
         &post_inference_ir,
     );
     // A narrower pane pair over just the mutability phases (inline, transact,
@@ -1516,13 +1523,16 @@ pub fn compile_program(
     .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
     assert_unique_node_ids(&channelized, "post-as-of-read");
     typecheck(&channelized).expect("as-of-read rewrite produced an ill-typed tree");
-    // The last instrumented pane: see the span's own note at `ProvenanceAudit::start`.
-    audit.finish(&channelized);
     // A pane snapshot; see `pre_inference_ir`.
     let post_as_of_read_ir = channelized.clone_preserving_ids();
 
-    let lambda_elim = lambda_elim::run(channelized).errs()?;
+    let lambda_elim = recorded(capture_provenance, Phase::LambdaElim, || {
+        lambda_elim::run(channelized)
+    })
+    .errs()?;
     assert_unique_node_ids(&lambda_elim, "post-lambda-elim");
+    // The last instrumented pane: see the span's own note at `ProvenanceAudit::start`.
+    audit.finish(&lambda_elim);
     // A pane snapshot; see `pre_inference_ir`.
     let post_lambda_elim_ir = lambda_elim.clone_preserving_ids();
     debug!("λ-eliminated CCL:\n{}", symbolic(&lambda_elim));

--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -411,6 +411,13 @@ sink, mirroring `infer_var::ACTIVE_ARENA`:
   recording open around a rewrite *captures* the births and copies in its dynamic
   extent, innermost first. An empty stack means recording is off, which costs one
   emptiness check on the construction hot path.
+
+  **Both hooks assert coverage**, under a phase scope that writes rows: a node
+  reaches a tree by being minted or by being copied, so a check on one channel
+  alone leaves the other silent. The silence was not hypothetical — when the
+  copy-side check was added, copies outnumbered mints among the uncaptured nodes,
+  and the one gap it found in an instrumented phase was inference freshening a
+  refinement predicate per scheme instantiation.
 - `TableSession` installs the table for a **whole compile**; `PhaseScope` names
   the phase rows are tagged with, for **one phase**. The two nest that way because a
   row's key is a process-unique `NodeId` and needs no phase set to disambiguate
@@ -444,16 +451,20 @@ a loud failure rather than a silent misattribution):
   all in the mutability phases, so `parents` alone is what recovers a source
   location for almost every node.
 
-`enter` is the only constructor a phase uses. `copy_frame` is the one recording
-that names **no** node: uncurry's template-interior freshens and the compare-chain
-operand freshens duplicate nodes with nothing being rewritten, and each captured
-copy carries its own origin from the hook. A recording that names no node has
-nowhere to attach a mint or a consume, which `OpenRecording::assert_copy_only`
-enforces.
+`enter` is the constructor a phase uses to record a rewrite. `copy_frame` is the
+one recording that names **no** node, for a duplication with nothing being
+rewritten and so no id to name: lowering's uncurry template-interior and
+compare-chain operand freshens, and inference freshening a refinement predicate
+per scheme instantiation. Each captured copy carries its own origin from the
+hook, so the named node is never read. A recording that names no node has nowhere
+to attach a mint or a consume, which `OpenRecording::assert_copy_only` enforces —
+which is also what keeps the two constructors apart, since a mint captured in a
+copy-only recording is a site that should have named a node.
 
 **Where recordings are open today.** Lowering's leaf appends and copy sinks, plus
 recordings inside the two pane pairs: `infer/solve` (`mono.specialize`,
-`mono.coalesce_let`), `infer/emit` (`infer.lit_singleton`), `inline`
+`mono.coalesce_let`), `infer/emit` (`infer.lit_singleton`),
+`infer/solver/scheme` (`infer.freshen_predicate`), `inline`
 (`inline.alias`, `inline.udf`, `inline.beta`), `mut_elim` (`letrec.loop`,
 `letrec.bare_write`, `letrec.hoist_writer_body`, `letrec.terminalize_write`),
 `transact_phase` (strip, unwrap block, writer, commit record, history binding,

--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -15,12 +15,10 @@ features: the inspector's consumption of the AST snapshots (panes), and adoption
 further phases. A reader can tell the two apart by the marker alone; unmarked prose
 describes code you can go read.
 
-Three sites record without reaching any table in a normal build, because
-`compile_program` opens no `PhaseScope` around them: `simplify`,
-`planning/iterate`, and `transact_phase`'s as-of-read rewrite. `lambda_elim`
-records nothing at all, and operator conversion has no identity to record
-against; see
-[Known prerequisites for panes past `post-channelize`](#known-prerequisites-for-panes-past-post-channelize).
+Two sites record without reaching any table in a normal build, because
+`compile_program` opens no `PhaseScope` around them: `simplify` and
+`planning/iterate`. Operator conversion has no identity to record against; see
+[Known prerequisites for panes past `post-planning`](#known-prerequisites-for-panes-past-post-planning).
 
 ## Mechanism at a glance
 
@@ -109,8 +107,10 @@ the ambient session that logs every mint and copy ([The recorder](#the-recorder)
 `assert_unique_node_ids` backstops that it never persists into a checked tree.
 
 **`Phase`** names the compiler stage that produced or rewrote a node (`Lower`, `Uniquify`, `Infer`,
-`Inline`, `Channelize`, `Transact`, `Letrec`, `LambdaElim`, `Planning`). It lives in the provenance
-data, as each row's `via`, and never in a type.
+`Inline`, `Transact`, `Letrec`, `Channelize`, `AsOfRead`, `LambdaElim`, `Planning`). It lives in the
+provenance data, as each row's `via`, and never in a type. Declaration order is pipeline order, so a
+phase is declared where its rewrite **runs** — `AsOfRead`'s code lives in `transact_phase`, and the
+module a rewrite's code sits in is not its phase.
 
 ### Walking the ids
 
@@ -179,7 +179,7 @@ original survives on a type the walk missed with the rebuild's ids on both.
 `uniquify` is its one caller.
 
 The corpus test `distinct_predicate_terms_never_share_a_node_id` runs the same
-check on the three retained panes, which the boundary walk does not reach: the
+check on every retained pane, which the boundary walk does not reach: the
 `pre-inference` pane is taken after uniquify, between two boundaries.
 
 ### Duplication
@@ -324,7 +324,7 @@ Ids inside refinement predicates are rows like any other. Lowering's projection
 covers every id `collect_tree_ids` enumerates, and `PredMemo::rebuild` records a
 derived predicate against the one it was built from. What is **not** recorded is
 planning raising a predicate back into the main tree; see
-[Known prerequisites for panes past `post-channelize`](#known-prerequisites-for-panes-past-post-channelize).
+[Known prerequisites for panes past `post-planning`](#known-prerequisites-for-panes-past-post-planning).
 
 The backing store is a `HashMap`; the paged, delta-encoded form is a later pure
 re-encoding behind the same accessors.
@@ -463,7 +463,9 @@ which is also what keeps the two constructors apart, since a mint captured in a
 copy-only recording is a site that should have named a node.
 
 **Where recordings are open today.** Lowering's leaf appends and copy sinks, plus
-recordings inside the two pane pairs: `infer/solve` (`mono.specialize`,
+every recording a pane pair's fold reads — each of the phases below runs inside a
+`PhaseScope` that `compile_program` opens, and sits between two retained AST
+snapshots: `infer/solve` (`mono.specialize`,
 `mono.coalesce_let`), `infer/emit` (`infer.lit_singleton`),
 `infer/solver/scheme` (`infer.freshen_predicate`), `inline`
 (`inline.alias`, `inline.udf`, `inline.beta`), `mut_elim` (`letrec.loop`,
@@ -471,22 +473,30 @@ recordings inside the two pane pairs: `infer/solve` (`mono.specialize`,
 `transact_phase` (strip, unwrap block, writer, commit record, history binding,
 key rebind, key-init stash, carrier, the cross-domain and await-final rules), and
 `channelize` (`channelize.cluster`, `channelize.defer_lift`,
-`channelize.defer_collapse`). Two shared helpers record under whichever phase
+`channelize.defer_collapse`), `transact_phase`'s as-of-read rewrite
+(`transact.as_of_read`), and `lambda_elim` (`lambda_elim.abstract`,
+`lambda_elim.point_free`, `lambda_elim.filter`, `lambda_elim.value_case`). Two
+shared helpers record under whichever phase
 scope is open around them: `subst` (`subst.vacuous`, `subst.transport`,
 `subst.force_refinement`) and `ccl_utils`' `PredMemo::rebuild`
 (`predicate.rebuild`).
 
-Three sites record **below** `post_channelize_ir`, so no pane pair's fold reads their
-rows:
-`simplify` (one combinator covering all thirteen `&mut` rule invocations, with no
-rule-body edits), `planning/iterate`, and `transact_phase`'s as-of-read rewrite.
-`compile_program` opens no `PhaseScope` around any of them, so their recordings
-are inert in a normal build and land only under an audit a caller opens.
-`CAMBRA_PROVENANCE_AUDIT=full` (`post-inference..post-as-of-read`) covers the
-as-of-read rewrite; reaching `simplify` and `planning/iterate` needs
-`CAMBRA_PROVENANCE_AUDIT=planning` (`recognized..join-planned`), which is what the
-coverage figures below were measured with. `lambda_elim` records nothing, which
-is what an audit's endpoint stops in front of.
+Two sites record where nothing reads their rows: `simplify` (one combinator
+covering all thirteen `&mut` rule invocations, with no rule-body edits) and
+`planning/iterate`. `compile_program` opens no `PhaseScope` around either, and a
+recording outside a phase scope writes nothing at all — the hooks capture into a
+stack that is never routed to a table — so in a normal build these two cost an
+emptiness check and produce no rows.
+
+They become visible only when a developer sets `CAMBRA_PROVENANCE_AUDIT=planning`
+in the environment before running the compiler or its tests. That opens one scope
+spanning `recognized..join-planned` and prints a coverage and leak line to stderr
+when the span closes: a measurement, run by hand while a phase is being
+instrumented, of how much of that phase's rewriting its recordings explain. It is
+what the coverage figures below were measured with. Naming a span turns pane
+capture off (`provenance_capture_enabled`), so an audit never runs in a build
+that also serves panes. Both sites stop needing one in the commit that runs
+`planning` under a `Phase::Planning` scope.
 
 ### Where to open a recording
 
@@ -587,6 +597,13 @@ The dense self-edge is **ancestry**: a surviving node descends from itself, whic
 is the identity of the weakest-link composition, so density needs no special
 case.
 
+A phase that re-mints its pass-through nodes therefore has almost no self-edges,
+and its pair's relation comes from the parents walk alone: every node is still
+explained, but the pair cannot say that an untouched node was untouched, so each
+pass-through node reads to a consumer as a rewrite of its predecessor.
+`lambda_elim` is that phase today, and its catch-all traversal arm carries why a
+preserve is not taken there.
+
 The leak audit reads the ancestry label alone. `DanglingParent` is a claim about
 `parents` — an ancestry hop stopping at an id that describes nothing — while a
 blamed id the fold never heard of contributes no edge and no class, the same
@@ -671,8 +688,8 @@ id, nothing recorded), so an id cannot be minted **unrecorded**. Minting one and
 then discarding it stays possible, and costs the stranded row named under
 "Freshen at placement, not at construction".
 
-The fold runs over the inspector's two pane pairs today; **planned** is the
-inspector's consumption of what it produces.
+The fold runs over each adjacent pane pair; **planned** is the inspector's
+consumption of what it produces.
 
 ### Gate and audit coverage
 
@@ -683,8 +700,9 @@ An audit's endpoint is **chosen**, because a span running past the last
 instrumented phase counts everything the uninstrumented tail mints as a defect — a
 number that cannot reach zero however correct the recording is, which makes the
 audit read as a broken gate rather than a measurement. The `full` span therefore
-ends at the last instrumented pane, `post-inference..post-as-of-read`, stopping in
-front of `lambda_elim`.
+ends at the last instrumented pane, `post-inference..post-lambda-elim`, stopping
+in front of `planning`, whose group-by and hash-join recognizers mint with
+nothing recording.
 
 **The same discipline governs the gate.** `CAMBRA_PROVENANCE_GATE=1` makes *every*
 compile fold both pane pairs and gate the leak classes, so the gate's corpus
@@ -695,19 +713,43 @@ sample is what let two recording gaps live: `transact_phase` calling
 value-position writer hoist. Both are shapes the eleven listed programs do not
 have. CI runs with it on; it costs about 4% of the test step.
 
-It gates `gated_pane_pairs()`, which is every pair whose phases record. The two
-at the bottom are not there yet: `lambda_elim` and `planning` each mint with
-nothing open, and a gate over such a pair cannot reach zero however correct the
-recording is — it would report a count of how little that phase records, a
-constant rather than a regression. No program count is pinned for them either,
-for the same reason: it churns with every unrelated change. **Flip
-`PaneSpec::gated` in the commit that instruments the last phase in the pair**,
-the same way an endpoint moves.
+It gates `gated_pane_pairs()`, which is every pair whose phases record. The
+bottom one is not there yet: `planning` mints with nothing open, and a gate over
+such a pair cannot reach zero however correct the recording is — it would report
+a count of how little that phase records, a constant rather than a regression. No
+program count is pinned for it either, for the same reason: it churns with every
+unrelated change. **Flip `PaneSpec::gated` in the commit that instruments the
+last phase in the pair**, the same way an endpoint moves.
 
 **Move the endpoint when a phase becomes instrumented, in the commit that
-instruments it:** to `post-lambda-elim` when the elim phase records, and to
-`join-planned` when planning does. Leaving it behind understates coverage; moving
+instruments it:** to `join-planned` when planning records. Leaving it behind
+understates coverage; moving
 it ahead reintroduces the unreachable zero.
+
+#### What retires when the last phase records
+
+The audit is scaffolding for the instrumentation campaign and nothing else: with
+every pane pair gated, a span measuring how much of a phase's rewriting its
+recordings explain has no question left to ask.
+`TODO(provenance-audit-retire)` marks the sites, and it takes with it
+
+- `ProvenanceAudit` and `CAMBRA_PROVENANCE_AUDIT`, along with the audit clause in
+  `provenance_capture_enabled` — capture becomes unconditional once nothing else
+  contends for the phase scopes;
+- `CAMBRA_PROVENANCE_PREDICATES`, whose only reader is the audit's live set;
+- `PaneSpec::gated` and `gated_pane_pairs`, one bit per pair existing only to
+  describe a half-instrumented pipeline — `gate_leaks` then covers every pair;
+- the paragraph in [The recorder](#the-recorder) about the two sites whose rows
+  nothing reads, and the by-hand coverage figures the spans were run to produce.
+
+**What stays is the pane product and the validations over it.** None of it is
+scaffolding for the campaign; all of it is what the campaign was for:
+
+- the recordings at each phase;
+- `PANES`, the fold, and `gate_leaks`;
+- `CAMBRA_PROVENANCE=0`, which measures what capture costs, and
+  `CAMBRA_PROVENANCE_GATE=1`, which trades a second fold per compile for a corpus
+  of every program the caller compiles rather than the handful `corpus()` lists.
 
 ## The seam
 
@@ -786,46 +828,57 @@ it ahead reintroduces the unreachable zero.
   structurally impossible — the projection is *produced by* the fold, never
   mutated incrementally.
 - **Materialization (cold, inspector-only).** `CompiledProgram::materialize_panes`
-  folds `provenance_table` across the two pane pairs, restricting it by phase:
-  `INFER_PHASES` bridges pre → post-inference; `CHANNELIZE_PHASES` (Inline, Transact,
-  Letrec, Channelize) bridges post-inference → post-channelize. It returns the three per-pane
-  `SourceProjection`s, the two pane-pair `ProvenanceMap`s, and each pair's deaths
-  and leak vector. There is no catch-all bridge: a node is explained by a recorded
-  row or it is not explained at all, and the gate is what says which.
-  Materialization returns the leaks rather than asserting on them: a pane pair is
-  clean only once every phase inside it records.
+  folds `provenance_table` across every adjacent pane pair, restricting it by
+  phase. `PANES` is the topology and declares it once: each entry names a pane,
+  the phases that produced it from the pane before it, and whether its pair is
+  gated. It returns a `SourceProjection` per pane and a `PanePair` per pair, each
+  carrying that pair's map, deaths and leak vector. There is no catch-all bridge:
+  a node is explained by a recorded row or it is not explained at all, and the
+  gate is what says which. Materialization returns the leaks rather than
+  asserting on them: a pair is clean only once every phase inside it records.
+
+  The first entry is the anchor — it has no predecessor, and its projection is
+  the lowering projection rather than a fold product. Read `PANES` for the
+  current set rather than a list here; today it runs `pre-inference` through
+  `post-planning`, six panes and five pairs. Projections chain: each pair folds
+  against the projection of the pane above it, so the first pair whose phases do
+  not record leaves every pane below it with nothing to carry forward.
 - **The pane leak gate.** `gate_leaks` asserts the whole `Leak` vector empty at
-  the lowering handoff and at both pane pairs: `Unrecorded` (an output node no
-  capture explains) and `DanglingParent` (an ancestry edge to an id the fold has
-  never heard of) are the only classes, deaths having their own channel.
+  the lowering handoff and at each gated pane pair. `Unrecorded` (an output node
+  no capture explains) and `DanglingParent` (a parent edge to an id the fold has
+  never heard of) are the only two classes. A death is not one of them: it is an
+  ordinary product of any rewrite that replaces a node, carried on its own
+  `PanePair::deaths` channel and never asserted on.
 
-  Where the gate stands: **zero on both classes, at both pane pairs, for every
-  program in `corpus()`** — that being what
-  `pane_pair_folds_have_no_structural_leaks` asserts, as a property rather
-  than a pinned residue count. Capture is total over the adopted span: every
-  output-pane node has an origin. The whole-suite gate
-  (`CAMBRA_PROVENANCE_GATE=1`) is the wider corpus and the narrower span — it
-  holds at zero over every program the caller compiles, at the second pane pair
-  only.
+  **`PaneSpec::gated` says whether a pair is asserted to carry neither class.**
+  Two checks read the same set at different widths:
+  `pane_pair_folds_have_no_structural_leaks` over the programs `corpus()` lists,
+  on every test run, and `CAMBRA_PROVENANCE_GATE=1` over whatever the caller
+  compiles, which is strictly stronger because the wider corpus reaches shapes
+  the eleven listed programs do not.
 
-## Known prerequisites for panes past `post-channelize`
+  **The flag does not license a nonzero residue where it is false.** A leak is a
+  bug wherever it appears; the flag says whether an assertion has been turned on.
+  A pair goes ungated only while some phase inside it does not record, where the
+  residue is a count of how little that phase records — a constant no correct
+  recording elsewhere can drive down, so gating it would pin churn rather than
+  catch a defect.
+
+  Where it stands: every pair from `pre-inference → post-inference` down to
+  `post-as-of-read → post-lambda-elim` is gated, so capture is total over that
+  span on whatever the caller compiles. `post-lambda-elim → post-planning` waits
+  on planning.
+
+## Known prerequisites for panes past `post-planning`
 
 A pane may be issued at **any** point during compilation — the current adoption
 point is an artifact of what has been built, not a statement about the design.
-Three things block extending it, all acknowledged and none blocking the two panes
-that exist:
+The panes stop at `post-planning`, whose pair is not yet gated. Two things stand
+in the way, neither of them touching the pairs that are gated:
 
-- **`lambda_elim` records nothing, and re-mints** nearly every pass-through
-  node, so a pane pair spanning it would have no id correspondence to join on.
-  Its catch-all traversal arm carries a `TODO(preserve)`, and `planning/groupby`
-  relies on that re-minting to launder the ids it lifts out of a refinement
-  predicate — `groupby_recognition_lifts_the_key_without_aliasing` pins the
-  reliance —
-  so a preserve there owes `groupby` an explicit freshen.
-- **Operator conversion has no identity.** `TileOperator` carries none and there
-  is no `OperatorId`, so a pane after it has nothing to resolve against.
-- **Planning does not record what it raises out of the predicate domain.** Three
-  sites cross: `planning/iterate`'s `fn_of_bare_predicate` lift, the group-by key
+- **Planning does not record what it raises out of the predicate domain**, which
+  is what keeps `post-lambda-elim → post-planning` ungated. Three sites
+  cross: `planning/iterate`'s `fn_of_bare_predicate` lift, the group-by key
   extraction, and the hash-join key morphisms. Each would record against its
   term-tree site, that being the node the raised material becomes, but the
   `on_copy` hook reports the *origin it freshened*, and no channel re-roots a
@@ -838,9 +891,12 @@ that exist:
   widening the audit's live set (`CAMBRA_PROVENANCE_PREDICATES=1`) took every gated
   class to zero. (The count is from before the endpoint moved and has not been
   re-taken.) That says the recording is total for the span and the narrow live
-  set is what makes the crossing read as a leak. It says nothing about the two
-  pane pairs, whose phases rebuild predicates through `PredMemo` and are
-  recorded there.
+  set is what makes the crossing read as a leak. It says nothing about the pane
+  pairs that are gated, whose phases rebuild predicates through `PredMemo` and
+  are recorded there.
+- **Operator conversion has no identity**, which is what stops a pane *after*
+  `post-planning`. `TileOperator` carries none and there is no `OperatorId`, so a
+  pane there has nothing to resolve against.
 
 ## Planned — inspector consumers (`src/inspector_model/`)
 

--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -5,7 +5,8 @@ source the user wrote.
 
 `src/ccl/provenance.rs` holds all of it — the node id, the phase tag, the
 recorder, the table, and the folds. `src/ccl/context.rs` is where the pipeline
-opens the sessions and materializes snapshots of the AST ([The seam](#the-seam-srccclcontextrs)).
+opens the sessions, and `src/ccl/panes.rs` is where the retained AST snapshots
+are declared and folded ([The seam](#the-seam)).
 
 **Status markers.** The provenance model, the recorder, some phases' adoption of it,
 the lowering projection, the [`NodeId`-keyed table](#the-provenance-model), and the
@@ -694,23 +695,21 @@ sample is what let two recording gaps live: `transact_phase` calling
 value-position writer hoist. Both are shapes the eleven listed programs do not
 have. CI runs with it on; it costs about 4% of the test step.
 
-It gates `gated_pane_pairs()`, not both, for the reason above: the first pair spans
-monomorphization and inference, and **inference's predicate producers do not record**.
-`specialize_use` clones a definition per instantiation, and the copies of a predicate term inside
-it row against interior ids no phase produced. Inference's own rewrites do sit inside a recording
-scope, so every post-inference node carries a row and the residue there is entirely
-`DanglingParent` and never `Unrecorded`: gating it today would report a constant, not a regression,
-and an `Unrecorded` arriving there would be a missed mint and a defect now. No program count is
-recorded here: a count over an uninstrumented phase measures how little that phase records, and
-churns with every unrelated change. **Add it to `gated_pane_pairs()` in the commit that makes
-inference record**, the same way an endpoint moves.
+It gates `gated_pane_pairs()`, which is every pair whose phases record. The two
+at the bottom are not there yet: `lambda_elim` and `planning` each mint with
+nothing open, and a gate over such a pair cannot reach zero however correct the
+recording is — it would report a count of how little that phase records, a
+constant rather than a regression. No program count is pinned for them either,
+for the same reason: it churns with every unrelated change. **Flip
+`PaneSpec::gated` in the commit that instruments the last phase in the pair**,
+the same way an endpoint moves.
 
 **Move the endpoint when a phase becomes instrumented, in the commit that
 instruments it:** to `post-lambda-elim` when the elim phase records, and to
 `join-planned` when planning does. Leaving it behind understates coverage; moving
 it ahead reintroduces the unreachable zero.
 
-## The seam (`src/ccl/context.rs`)
+## The seam
 
 - **The lowering log + fold.** Lowering records a `LoweringLog` under an
   always-on `LoweringSession` (installed in every build across `lower_stmts`,

--- a/src/ccl/infer/solver/scheme.rs
+++ b/src/ccl/infer/solver/scheme.rs
@@ -470,6 +470,12 @@ fn freshen_refinement_predicate(
     target: FreshenLevel,
     cache: &mut FreshenCache,
 ) -> Refinement {
+    // A pure duplication with nothing being rewritten: the scheme's predicate
+    // stays where it is and this is a second term with the same shape. A
+    // recording that names no node is the shape for that, and each captured copy
+    // carries its own origin from the hook, so every freshened node descends
+    // from the scheme node it was copied from.
+    let _f = crate::ccl::provenance::copy_frame("infer.freshen_predicate");
     let mut pred = (*r.predicate).clone();
     freshen_expr_type_slots(&mut pred, lim, target, cache);
     Refinement::born(Rc::new(pred))

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -48,6 +48,7 @@ use crate::ccl::ccl_utils::{
     typed_compose,
 };
 use crate::ccl::infer::{dbg_typecheck_mv, debug_typecheck};
+use crate::ccl::provenance;
 use crate::ccl::simplify::simplify;
 use crate::ccl::ty::FunKind;
 use crate::ccl::{BaseType, Branch, Builtin, FieldKey, Lit, Name, Refinement};
@@ -769,6 +770,16 @@ fn elim_lambda_impl(
 ) -> Result<Expr, LambdaElimError> {
     log::trace!("elim_lambda: eliminating λ {param}: {}", symbolic(&body));
     debug_typecheck(&body);
+    // Names the lambda **body**, not the enclosing `Lambda`: one call per body
+    // node, each replacing that node with its own scaffolding — naming the
+    // `Lambda` would collapse a whole body onto one parent. The four desugaring
+    // arms re-enter on an applied form they just minted, so the inner call names
+    // a node this one minted and the fold reaches the original in two hops.
+    let _g = provenance::enter(
+        body.node_id(),
+        "lambda_elim.abstract",
+        provenance::Nature::Machinery,
+    );
     // Capture the body's type before consuming it; the result of eliminating
     // `λ param → body` is a morphism `param_ty → body_ty`. When `param` is
     // still free in `body_ty` (a refinement predicate closes over it — the
@@ -1544,6 +1555,19 @@ fn elim_lambdas_impl(ctx: &mut ElimContext, expr: Expr) -> Result<Expr, LambdaEl
     }
     log::trace!("elim_lambdas: eliminating {}", symbolic(&expr));
     debug_typecheck(&expr);
+    // Names the node this call was handed. Every arm below rewrites it and every
+    // node the pass touches passes through here exactly once, so each arm's
+    // products — combinator scaffolding, the catch-all's structural rebuild —
+    // take it as their parent with no arm knowing. Two arms open a second
+    // recording on this same node: not a capture gap, but a recording carries one
+    // label and one nature for its whole extent, and those two expand a construct
+    // the user wrote.
+    let node_id = expr.node_id();
+    let _g = provenance::enter(
+        node_id,
+        "lambda_elim.point_free",
+        provenance::Nature::Machinery,
+    );
     let TypedExpr {
         node,
         ty,
@@ -1610,6 +1634,13 @@ fn elim_lambdas_impl(ctx: &mut ElimContext, expr: Expr) -> Result<Expr, LambdaEl
                     }) if is_filter_case_body(body)
                 ) =>
         {
+            // The recording names the whole `Compose`: the source this arm emits
+            // stands in for the composition *and* its trailing filter lambda. The
+            // `Compose` is the outermost of the two. A comprehension's `if` clause
+            // becoming a domain refinement is a `Nature::Expansion` of what the
+            // user wrote.
+            let _fg =
+                provenance::enter(node_id, "lambda_elim.filter", provenance::Nature::Expansion);
             let lambda = terms.pop().unwrap();
             let (param, filter_body) = match lambda.node {
                 TypedExprNode::Lambda { param, body, .. } => (param, *body),
@@ -1707,6 +1738,17 @@ fn elim_lambdas_impl(ctx: &mut ElimContext, expr: Expr) -> Result<Expr, LambdaEl
             scrutinee: None,
             branches,
         } if branches.iter().all(|b| b.pattern.is_none()) => {
+            // Names the `Case`: both builders' scaffolding — the C-form's gated
+            // lifts and `final_or_default`, the fan-out's restricted arms — stands
+            // in for this one node. Guards and bodies are walked by
+            // `elim_lambdas`/`elim_lambda` and named on their own ids, so what
+            // lands here is exactly the union scaffolding. `Nature::Expansion`:
+            // the user's `if`/`elif`/`else` is being expanded, not plumbed.
+            let _cg = provenance::enter(
+                node_id,
+                "lambda_elim.value_case",
+                provenance::Nature::Expansion,
+            );
             // Flatten `elif` chains to one partition first, so a nested
             // conditional collection collapses into a single N-choice fan-out.
             let branches = flatten_trailing_value_case(branches);
@@ -1757,9 +1799,9 @@ fn elim_lambdas_impl(ctx: &mut ElimContext, expr: Expr) -> Result<Expr, LambdaEl
             // property rather than as a mechanism. Settling mint-vs-preserve for
             // the catch-all arm wants its own change.
             //
-            // Neither choice writes a provenance row: this file opens no recording,
-            // and `compile_program` runs `lambda_elim::run` outside every pass
-            // scope it opens.
+            // Either way the mint is recorded: the traversal's recording is open
+            // here, so the rebuilt node claims parentage at the node it replaced.
+            // A preserve would add the id correspondence on top.
             let mut expr = Expr::new(node).with_ty(ty);
             expr.user_annotation = user_annotation;
             expr.try_map_children(|child| elim_lambdas(ctx, child))?;

--- a/src/ccl/lower/loops.rs
+++ b/src/ccl/lower/loops.rs
@@ -812,8 +812,7 @@ fn lower_loop_body_chain(
     // Every node this chain mints is recorded: an unrecorded lowering mint is a
     // `Leak::Unrecorded` at the lowering boundary. A statement's own image gets
     // `tag_image`; the `ExprStmt` that sequences one statement before the rest is
-    // manufactured plumbing (`src/ccl/design/provenance.md`, "The seam
-    // (`src/ccl/context.rs`)").
+    // manufactured plumbing (`src/ccl/design/provenance.md`, "The seam").
     let mut chain = ctx.tag_machinery(Expr::lit(Lit::Unit), for_span, "lower.loop_unit");
     for stmt in body_stmts.iter().rev() {
         chain = match &stmt.node {

--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -1502,8 +1502,7 @@ pub(super) fn lower_match(
     }
     // The `Case` images the `match` statement. A statement is not a
     // `Spanned<ChlExpr>`, so it has no `Source` node — `tag_image` is the image
-    // marker at `Nature::Machinery` (`src/ccl/design/provenance.md`, "The seam
-    // (`src/ccl/context.rs`)").
+    // marker at `Nature::Machinery` (`src/ccl/design/provenance.md`, "The seam").
     Ok(ctx.tag_image(
         Expr::new(TypedExprNode::Case {
             scrutinee: Some(Box::new(scrutinee_expr)),

--- a/src/ccl/mod.rs
+++ b/src/ccl/mod.rs
@@ -16,6 +16,7 @@ pub mod letrec;
 pub mod lower;
 pub mod mut_elim;
 pub mod names;
+pub mod panes;
 pub mod planning;
 pub mod provenance;
 pub mod scope;

--- a/src/ccl/panes.rs
+++ b/src/ccl/panes.rs
@@ -118,6 +118,12 @@ pub(crate) struct PaneSpec {
     /// pin churn rather than catch a defect. Flip it in the commit that
     /// instruments the last phase in the pair, the same way an audit span's
     /// endpoint moves. Unused on the anchor, which has no pair.
+    ///
+    /// TODO(provenance-audit-retire): this bit and
+    /// [`MaterializedPanes::gated_pane_pairs`] exist only to describe a
+    /// half-instrumented pipeline. Both go when the last phase records, leaving
+    /// [`gate_leaks`] over every pair. See `design/provenance.md`, "What retires
+    /// when the last phase records".
     pub(crate) gated: bool,
 }
 
@@ -129,13 +135,11 @@ pub(crate) struct PaneSpec {
 /// empty and its `gated` is unused — its projection is the lowering projection
 /// rather than a fold product.
 ///
-/// The two pairs at the bottom are ungated because their phases do not record
-/// yet: `lambda_elim` and `planning` each mint with nothing open. Every pair
-/// above them holds at zero on whatever the caller compiles — which the two
-/// commits below this one are what make true of `pre-inference →
-/// post-inference`, by widening the fold's id domain to the slot domain the
-/// passes rewrite and by giving inference's per-instantiation predicate freshen a
-/// copy recording.
+/// The bottom pair is ungated because `planning` mints with nothing open. Every
+/// pair above it holds at zero on whatever the caller compiles — true of
+/// `pre-inference → post-inference` only once the fold's id domain was widened to
+/// the slot domain the passes rewrite and inference's per-instantiation predicate
+/// freshen took a copy recording.
 pub(crate) const PANES: [PaneSpec; 6] = [
     PaneSpec {
         name: "pre-inference",
@@ -165,7 +169,7 @@ pub(crate) const PANES: [PaneSpec; 6] = [
     PaneSpec {
         name: "post-lambda-elim",
         phases: &[Phase::LambdaElim],
-        gated: false,
+        gated: true,
     },
     PaneSpec {
         name: "post-planning",
@@ -466,21 +470,32 @@ mod tests {
     /// reads the pane pair as pure identity. The pin is what makes that
     /// difference visible, so it lists names and not a total.
     const EXERCISED_BOUNDARIES: &[&str] = &[
+        "arithmetic / post-as-of-read → post-lambda-elim",
         "arithmetic / pre-inference → post-inference",
+        "feed_loop / post-as-of-read → post-lambda-elim",
         "feed_loop / post-inference → post-channelize",
         "feed_loop / pre-inference → post-inference",
+        "filter_and_aggregate / post-as-of-read → post-lambda-elim",
         "filter_and_aggregate / pre-inference → post-inference",
+        "for_accumulator / post-as-of-read → post-lambda-elim",
         "for_accumulator / post-inference → post-channelize",
         "for_accumulator / pre-inference → post-inference",
+        "generator_pipeline / post-as-of-read → post-lambda-elim",
         "generator_pipeline / post-inference → post-channelize",
         "generator_pipeline / pre-inference → post-inference",
+        "group_by / post-as-of-read → post-lambda-elim",
         "group_by / pre-inference → post-inference",
+        "inner_join / post-as-of-read → post-lambda-elim",
         "inner_join / pre-inference → post-inference",
+        "prefix_lines / post-as-of-read → post-lambda-elim",
         "prefix_lines / pre-inference → post-inference",
+        "streaming_echo / post-as-of-read → post-lambda-elim",
         "streaming_echo / pre-inference → post-inference",
+        "transaction / post-as-of-read → post-lambda-elim",
         "transaction / post-channelize → post-as-of-read",
         "transaction / post-inference → post-channelize",
         "transaction / pre-inference → post-inference",
+        "udf_chain / post-as-of-read → post-lambda-elim",
         "udf_chain / post-inference → post-channelize",
         "udf_chain / pre-inference → post-inference",
     ];
@@ -762,10 +777,11 @@ mod tests {
                 Phase::AsOfRead,
                 Phase::Channelize,
                 Phase::Infer,
+                Phase::LambdaElim,
                 Phase::Letrec,
                 Phase::Transact
             ],
-            "the transaction fixture is rewritten by exactly these five phases",
+            "the transaction fixture is rewritten by exactly these six phases",
         );
     }
 

--- a/src/ccl/panes.rs
+++ b/src/ccl/panes.rs
@@ -1,0 +1,924 @@
+//! The pipeline's **panes** — its retained AST snapshots — and what a fold
+//! between two adjacent ones produces.
+//!
+//! A pane is one snapshot of the tree, taken at a named point in
+//! [`compile_program`](crate::ccl::context::compile_program). [`PANES`] declares
+//! the topology once: every pane, the phases that produced it from the pane
+//! before it, and whether its pair is gated.
+//!
+//! Split out of [`context`](crate::ccl::context) because it is the inspector's
+//! half of the seam. `context` owns the pipeline and the [`Phase`] axis; this
+//! module owns what a pane pair is and what folding one yields, and none of it
+//! runs in a release compile except [`gate_leaks`], which `compile_program`
+//! calls only under `CAMBRA_PROVENANCE_GATE`. The inherent `impl
+//! CompiledProgram` below lives here rather than beside the struct for the same
+//! reason: the methods are the pane layer's, not the pipeline's. See
+//! `design/provenance.md`, "The seam".
+
+use crate::ccl::Expr;
+use crate::ccl::context::{CompiledProgram, Phase, collect_tree_ids};
+use crate::ccl::provenance::{Leak, NodeId, ProvenanceMap, SourceProjection, fold};
+
+impl CompiledProgram {
+    /// Fold [`provenance_table`](Self::provenance_table) across every adjacent
+    /// pane pair into the per-pane [`SourceProjection`]s, the pair
+    /// [`ProvenanceMap`]s, and each pair's [`Leak`]s. Cold path (snapshot-serve
+    /// only), never called by [`compile_program`].
+    ///
+    /// [`PANES`] is the topology: the anchor pane's projection is the lowering
+    /// projection, and each pane after it folds its own phases against the pane
+    /// before it. There is no catch-all pair — a node is explained by a recorded
+    /// row or it is not explained at all, and the gate is what says which.
+    ///
+    /// The leaks are **returned, not asserted**: a span reaches zero only once
+    /// every phase inside it records its rewrites, so [`gate_leaks`] is left to
+    /// the callers that fold an instrumented span. The deaths ride alongside them
+    /// as a product, since nothing declares a fate.
+    // Cold path: the inspector's snapshot serve, which is not in this workspace.
+    #[allow(dead_code)]
+    pub(crate) fn materialize_panes(&self) -> MaterializedPanes {
+        let trees = self.pane_trees();
+        let ids: Vec<_> = trees.iter().map(|t| collect_tree_ids(t)).collect();
+
+        // The anchor pane's projection is the lowering projection: `uniquify`
+        // preserves every id in place, so lowering's keys are still its keys.
+        let mut projections = Vec::with_capacity(PANES.len());
+        projections.push(self.lowering_projection.clone());
+        let mut pairs = Vec::with_capacity(PANES.len() - 1);
+
+        // Each pair folds against the projection of the pane before it, so the
+        // attributions compose down the pipeline in one pass.
+        for i in 1..PANES.len() {
+            let spec = &PANES[i];
+            let (map, projection, deaths, leaks) = fold(
+                &self.provenance_table,
+                spec.phases,
+                &ids[i - 1],
+                &ids[i],
+                &projections[i - 1],
+            );
+            pairs.push(PanePair {
+                name: format!("{} → {}", PANES[i - 1].name, spec.name),
+                phases: spec.phases,
+                map,
+                deaths,
+                leaks,
+                gated: spec.gated,
+            });
+            projections.push(projection);
+        }
+
+        MaterializedPanes { projections, pairs }
+    }
+
+    /// The retained pane trees, in pipeline order, element for element with
+    /// [`PANES`]. The length is [`PANES`]' own, so the two cannot disagree about
+    /// how many panes there are.
+    fn pane_trees(&self) -> [&Expr; PANES.len()] {
+        [
+            &self.pre_inference_ir,
+            &self.post_inference_ir,
+            &self.post_channelize_ir,
+            &self.post_as_of_read_ir,
+            &self.post_lambda_elim_ir,
+            &self.ast,
+        ]
+    }
+}
+
+/// One pane — a retained AST snapshot — and the phases that produced it from the
+/// pane before it.
+///
+/// [`PANES`] declares the whole topology in one place, so adding a pane is one
+/// entry there plus its tree in [`CompiledProgram::pane_trees`].
+pub(crate) struct PaneSpec {
+    /// The pane's name, e.g. `"post-channelize"`.
+    pub(crate) name: &'static str,
+    /// The phases that ran between the previous pane and this one — the set
+    /// [`CompiledProgram::materialize_panes`] restricts the whole-compile table
+    /// by.
+    ///
+    /// A pair's fold is defined by the phases that ran between its two panes,
+    /// not by a position in this list: a program that skips a phase must not
+    /// shift another pair's set, and a row produced outside a pair's phases has
+    /// to read to it as an ordinary un-produced id. A phase therefore belongs to
+    /// exactly one pair, which
+    /// `every_recorded_phase_belongs_to_exactly_one_pane_pair` asserts.
+    pub(crate) phases: &'static [Phase],
+    /// Whether the pair ending at this pane is asserted to carry no [`Leak`] of
+    /// either class — by `pane_pair_folds_have_no_structural_leaks` over the
+    /// programs `corpus()` lists, and by `CAMBRA_PROVENANCE_GATE` over whatever
+    /// the caller compiles.
+    ///
+    /// **This does not license a nonzero residue where it is false.** A [`Leak`]
+    /// is a bug wherever it appears; the flag says whether an assertion has been
+    /// turned on. A pair goes ungated only while some phase inside it does not
+    /// record, where the residue is a count of how little that phase records — a
+    /// constant no correct recording elsewhere can drive down, so gating it would
+    /// pin churn rather than catch a defect. Flip it in the commit that
+    /// instruments the last phase in the pair, the same way an audit span's
+    /// endpoint moves. Unused on the anchor, which has no pair.
+    pub(crate) gated: bool,
+}
+
+/// The pipeline's panes, in pipeline order, each naming the phases that produced
+/// it from its predecessor. Order matches [`CompiledProgram::pane_trees`]
+/// element for element.
+///
+/// The first entry is the anchor: it has no predecessor, so its `phases` is
+/// empty and its `gated` is unused — its projection is the lowering projection
+/// rather than a fold product.
+///
+/// The two pairs at the bottom are ungated because their phases do not record
+/// yet: `lambda_elim` and `planning` each mint with nothing open. Every pair
+/// above them holds at zero on whatever the caller compiles — which the two
+/// commits below this one are what make true of `pre-inference →
+/// post-inference`, by widening the fold's id domain to the slot domain the
+/// passes rewrite and by giving inference's per-instantiation predicate freshen a
+/// copy recording.
+pub(crate) const PANES: [PaneSpec; 6] = [
+    PaneSpec {
+        name: "pre-inference",
+        phases: &[],
+        gated: false,
+    },
+    PaneSpec {
+        name: "post-inference",
+        phases: &[Phase::Infer],
+        gated: true,
+    },
+    PaneSpec {
+        name: "post-channelize",
+        phases: &[
+            Phase::Inline,
+            Phase::Transact,
+            Phase::Letrec,
+            Phase::Channelize,
+        ],
+        gated: true,
+    },
+    PaneSpec {
+        name: "post-as-of-read",
+        phases: &[Phase::AsOfRead],
+        gated: true,
+    },
+    PaneSpec {
+        name: "post-lambda-elim",
+        phases: &[Phase::LambdaElim],
+        gated: false,
+    },
+    PaneSpec {
+        name: "post-planning",
+        phases: &[Phase::Planning],
+        gated: false,
+    },
+];
+
+/// One adjacent pair of panes and everything the fold derives for it.
+// Consumed by the inspector model; the compiler reads only `leaks` and `gated`.
+#[allow(dead_code)]
+pub(crate) struct PanePair {
+    /// `"post-inference → post-channelize"`, joined from the two pane names so
+    /// it cannot drift from the topology it describes.
+    pub(crate) name: String,
+    /// The phases that ran between the two panes — [`PaneSpec::phases`].
+    pub(crate) phases: &'static [Phase],
+    /// The dense bidirectional node↔node relation, a self-edge for every
+    /// survivor, each edge carrying its label set.
+    pub(crate) map: ProvenanceMap<NodeId, NodeId>,
+    /// The input-pane ids absent from the output pane — `input_ids ∖
+    /// output_ids`, which is the whole of what "died" means here. A product, not
+    /// a defect.
+    pub(crate) deaths: Vec<NodeId>,
+    /// Integrity defects, every one of them a bug.
+    pub(crate) leaks: Vec<Leak>,
+    /// Whether [`leaks`](Self::leaks) is asserted empty — [`PaneSpec::gated`].
+    pub(crate) gated: bool,
+}
+
+/// The per-pane projections and per-pair folds materialized from
+/// [`CompiledProgram::provenance_table`] — see
+/// [`CompiledProgram::materialize_panes`].
+// Consumed by the inspector model; unused within the compiler itself.
+#[allow(dead_code)]
+pub(crate) struct MaterializedPanes {
+    /// Each pane's projection, in pipeline order, parallel to [`PANES`].
+    pub(crate) projections: Vec<SourceProjection>,
+    /// The pairs between adjacent panes, in pipeline order — one shorter than
+    /// [`projections`](Self::projections).
+    pub(crate) pairs: Vec<PanePair>,
+}
+
+impl MaterializedPanes {
+    /// The projection of the pane named `pane`.
+    ///
+    /// Panics if no pane carries that name, which is a typo in a caller rather
+    /// than a runtime condition: the names are [`PANES`]' compile-time literals.
+    #[allow(dead_code)]
+    pub(crate) fn projection(&self, pane: &str) -> &SourceProjection {
+        let i = PANES
+            .iter()
+            .position(|p| p.name == pane)
+            .unwrap_or_else(|| panic!("no pane named {pane}"));
+        &self.projections[i]
+    }
+
+    /// The pair whose name is `pair`, e.g. `"post-inference → post-channelize"`.
+    ///
+    /// Panics if no pair carries that name, for the same reason as
+    /// [`projection`](Self::projection).
+    #[allow(dead_code)]
+    pub(crate) fn pair(&self, pair: &str) -> &PanePair {
+        self.pairs
+            .iter()
+            .find(|p| p.name == pair)
+            .unwrap_or_else(|| panic!("no pane pair named {pair}"))
+    }
+
+    /// The pane pairs held at zero on both leak classes — [`PaneSpec::gated`].
+    ///
+    /// Two checks read this same set at different widths:
+    /// `pane_pair_folds_have_no_structural_leaks` over the programs `corpus()`
+    /// lists, on every test run, and `CAMBRA_PROVENANCE_GATE` over whatever the
+    /// caller compiles, which is strictly stronger because the wider corpus
+    /// reaches shapes the listed programs do not.
+    pub(crate) fn gated_pane_pairs(&self) -> impl Iterator<Item = &PanePair> {
+        self.pairs.iter().filter(|p| p.gated)
+    }
+}
+
+/// The leak gate: **a fold's [`Leak`] vector must be empty**.
+///
+/// Both classes are asserted the same way. Each means a node reached the output
+/// pane with nothing recording where it came from, and neither localizes the site
+/// to fix on its own, so the gate reads the vector's emptiness and not its
+/// composition (see [`Leak`]). A death is not a leak and reaches a caller as its
+/// own collection, so there is nothing here to filter.
+///
+/// Debug/test only, single code path (`cfg!`, not `#[cfg]`).
+pub(crate) fn gate_leaks(leaks: &[Leak], pair: &str) {
+    if !cfg!(any(debug_assertions, test)) {
+        return;
+    }
+    assert!(
+        leaks.is_empty(),
+        "provenance capture defect between the {pair} panes ({} leaks): {leaks:?}",
+        leaks.len(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccl::context::{
+        GlobalContext, PERF_REPS_ENV, compile_program, predicate_id_collisions,
+        provenance_capture_enabled,
+    };
+    use crate::interpreter::Consumer;
+
+    /// The pane-measurement corpus: every demo-gallery program that compiles
+    /// today, plus four inline programs covering the phases the gallery does not
+    /// reach (a `with begin():` transaction, a group-by, a UDF chain, and a
+    /// nested comprehension).
+    ///
+    /// The gallery's remaining programs are excluded for reasons unrelated to
+    /// provenance: most are deliberate *failure* fixtures (`while`, record-term
+    /// syntax, `Feed(_)` types) that pin errors and so have no panes to fold,
+    /// and the three HTTP demos bind a real listening socket during lowering,
+    /// which collides with itself under a parallel test runner.
+    fn corpus() -> Vec<(&'static str, String)> {
+        vec![
+            (
+                "arithmetic",
+                include_str!("../../tests/programs/arithmetic/program.cambra").to_string(),
+            ),
+            (
+                "filter_and_aggregate",
+                include_str!("../../tests/programs/filter_and_aggregate/program.cambra").to_string(),
+            ),
+            (
+                "for_accumulator",
+                include_str!("../../tests/programs/for_accumulator/program.cambra").to_string(),
+            ),
+            (
+                "generator_pipeline",
+                include_str!("../../tests/programs/generator_pipeline/program.cambra").to_string(),
+            ),
+            (
+                "inner_join",
+                include_str!("../../tests/programs/inner_join/program.cambra").to_string(),
+            ),
+            (
+                "prefix_lines",
+                include_str!("../../tests/programs/prefix_lines/program.cambra").to_string(),
+            ),
+            (
+                "streaming_echo",
+                include_str!("../../tests/programs/streaming_echo/program.cambra").to_string(),
+            ),
+            (
+                "transaction",
+                "out = defer()\n\
+                 pool: Mut(Int, Txn) := 100\n\
+                 for r in [10, 20, 30]:\n\
+                 \x20   with begin():\n\
+                 \x20       pool := pool - r\n\
+                 with begin():\n\
+                 \x20   out << pool\n\
+                 out\n"
+                    .to_string(),
+            ),
+            (
+                "group_by",
+                "[sum(x) for x in groupby([y + 10 for y in [2,3,4,5,6] if y < 6], \\x -> x // 2)]\n"
+                    .to_string(),
+            ),
+            (
+                "udf_chain",
+                "def double(x):\n    x * 2\ndef bump(x):\n    double(x) + 1\n\
+                 xs = [1, 2, 3]\n[bump(x) for x in xs]\n"
+                    .to_string(),
+            ),
+            (
+                "feed_loop",
+                "out = defer()\nfor x in [1, 2, 3]:\n    out << x * 2\nout\n".to_string(),
+            ),
+        ]
+    }
+
+    /// Compile `code` through the full pipeline, panicking on error.
+    fn compile_ok(code: &str) -> CompiledProgram {
+        let mut ctx = GlobalContext::default();
+        let consumer: Box<dyn Consumer> = Box::new(|| {});
+        match compile_program(&mut ctx, code, consumer) {
+            Ok(p) => p,
+            Err(errs) => panic!("expected a successful compile, got {errs:?}"),
+        }
+    }
+
+    /// Per-leak-class counts, for reporting one fold.
+    #[derive(Default, Debug, PartialEq, Eq)]
+    struct LeakCounts {
+        unrecorded: usize,
+        dangling_parent: usize,
+    }
+
+    impl LeakCounts {
+        fn tally(leaks: &[Leak]) -> Self {
+            let mut c = LeakCounts::default();
+            for l in leaks {
+                match l {
+                    Leak::Unrecorded { .. } => c.unrecorded += 1,
+                    Leak::DanglingParent { .. } => c.dangling_parent += 1,
+                }
+            }
+            c
+        }
+
+        fn add(&mut self, o: &LeakCounts) {
+            self.unrecorded += o.unrecorded;
+            self.dangling_parent += o.dangling_parent;
+        }
+    }
+
+    /// **Capture totality**, as a corpus-wide property rather than a per-phase
+    /// assertion: both pane pairs materialize and fold over every corpus
+    /// program, every output-pane node has an origin (`Unrecorded == 0`), and
+    /// no node's ancestry dangles (`DanglingParent == 0`).
+    ///
+    /// The two invariants fail differently and are worth reading apart.
+    /// `dangling_parent == 0` says no node's ancestry stops at an id the fold
+    /// never heard of. `Unrecorded == 0` says no rewrite went
+    /// *unrecorded* — it is the gate the whole driver-capture design exists to
+    /// phase, and the number a newly-added rewrite site breaks first.
+    #[test]
+    fn pane_pair_folds_have_no_structural_leaks() {
+        let mut totals: std::collections::HashMap<String, LeakCounts> =
+            std::collections::HashMap::new();
+        for (name, code) in corpus() {
+            let program = compile_ok(&code);
+            let panes = program.materialize_panes();
+            for pair in panes.gated_pane_pairs() {
+                let c = LeakCounts::tally(&pair.leaks);
+                let pair_name = &pair.name;
+                assert_eq!(
+                    c.dangling_parent, 0,
+                    "{name}: structural leaks between the {pair_name} panes: {c:?}"
+                );
+                assert_eq!(
+                    c.unrecorded, 0,
+                    "{name}: unrecorded output nodes between the {pair_name} panes — a rewrite \
+                     that mints with nothing recording: {c:?}"
+                );
+                eprintln!("[pane {name} / {pair_name}] {c:?}");
+                totals.entry(pair.name.clone()).or_default().add(&c);
+            }
+            // The panes are the thing being materialized: each projection must
+            // hold entries for the tree it describes, and each map edges.
+            //
+            // Only down to the first uninstrumented pair. A pair folds against
+            // the projection of the pane above it, so the first pair whose
+            // phases do not record leaves every pane below it with nothing to
+            // carry forward — an empty projection there is the expected state,
+            // not a defect.
+            let reached = panes.pairs.iter().take_while(|p| p.gated).count();
+            for (i, projection) in panes.projections.iter().take(reached + 1).enumerate() {
+                assert!(!projection.is_empty(), "{name}: {}", PANES[i].name);
+            }
+            for pair in panes.pairs.iter().take(reached) {
+                assert!(!pair.map.edges().is_empty(), "{name}: {}", pair.name);
+            }
+        }
+        let mut names: Vec<_> = totals.keys().cloned().collect();
+        names.sort();
+        for pair in names {
+            eprintln!("[pane totals] {pair} {:?}", totals[&pair]);
+        }
+    }
+
+    /// Every phase that records rows in a normal compile belongs to exactly one
+    /// pane pair, so no rewrite is folded twice and none is silently dropped.
+    ///
+    /// [`PANES`]' phase sets are the only thing that decides which pane pair a
+    /// row reaches, so a phase that opens a scope without joining one would
+    /// record rows nothing ever folds, and a phase in two would be folded twice.
+    #[test]
+    fn every_recorded_phase_belongs_to_exactly_one_pane_pair() {
+        for (name, code) in corpus() {
+            let program = compile_ok(&code);
+            for p in program.provenance_table.recorded_phases() {
+                let pairs = PANES.iter().filter(|s| s.phases.contains(&p)).count();
+                assert_eq!(
+                    pairs, 1,
+                    "{name}: {p:?} belongs to {pairs} pane pairs, want exactly 1",
+                );
+            }
+        }
+    }
+
+    /// The `program / pane pair` names at which the provenance map is **not**
+    /// vacuous — where some node's origin is another node, so the fold had to
+    /// read a row. See
+    /// [`the_pane_folds_derive_a_non_vacuous_provenance_map`].
+    ///
+    /// Pinned rather than counted: a recording that opens after the clone that
+    /// produced its nodes captures nothing, and the fold still succeeds — it
+    /// reads the pane pair as pure identity. The pin is what makes that
+    /// difference visible, so it lists names and not a total.
+    const EXERCISED_BOUNDARIES: &[&str] = &[
+        "arithmetic / pre-inference → post-inference",
+        "feed_loop / post-inference → post-channelize",
+        "feed_loop / pre-inference → post-inference",
+        "filter_and_aggregate / pre-inference → post-inference",
+        "for_accumulator / post-inference → post-channelize",
+        "for_accumulator / pre-inference → post-inference",
+        "generator_pipeline / post-inference → post-channelize",
+        "generator_pipeline / pre-inference → post-inference",
+        "group_by / pre-inference → post-inference",
+        "inner_join / pre-inference → post-inference",
+        "prefix_lines / pre-inference → post-inference",
+        "streaming_echo / pre-inference → post-inference",
+        "transaction / post-channelize → post-as-of-read",
+        "transaction / post-inference → post-channelize",
+        "transaction / pre-inference → post-inference",
+        "udf_chain / post-inference → post-channelize",
+        "udf_chain / pre-inference → post-inference",
+    ];
+
+    /// **The provenance map is well-formed and non-vacuous** on every corpus
+    /// program: every edge runs from an input-pane id to an output-pane id,
+    /// every id present in both panes is its own dense self-edge, and the
+    /// pane pairs where the fold had to read a *row* are exactly the ones
+    /// pinned above.
+    ///
+    /// The non-vacuity half is what this test is for. Six of the twenty-two
+    /// corpus pane pairs are pure identity: no phase inside them minted, so the
+    /// map is the input pane's self-edges and holds for reasons that have
+    /// nothing to do with the recording. A corpus edit that
+    /// silently dropped the rewriting programs would otherwise leave a green
+    /// tautology behind.
+    #[test]
+    fn the_pane_folds_derive_a_non_vacuous_provenance_map() {
+        let mut exercised: Vec<String> = Vec::new();
+        for (name, code) in corpus() {
+            let program = compile_ok(&code);
+            let panes = program.materialize_panes();
+            let ids: Vec<_> = program
+                .pane_trees()
+                .iter()
+                .map(|t| collect_tree_ids(t))
+                .collect();
+
+            for (i, pane_pair) in panes.pairs.iter().enumerate() {
+                if !pane_pair.gated {
+                    continue;
+                }
+                let (pair, map) = (&pane_pair.name, &pane_pair.map);
+                let (input_ids, output_ids) = (&ids[i], &ids[i + 1]);
+                let edges = map.edges();
+                assert!(
+                    !edges.is_empty(),
+                    "{name}: the {pair} fold derived no edges at all",
+                );
+                for (u, d) in &edges {
+                    assert!(
+                        input_ids.contains(u),
+                        "{name}: {u:?} is an edge origin at {pair} but not an input-pane id",
+                    );
+                    assert!(
+                        output_ids.contains(&d.id),
+                        "{name}: {:?} is an edge target at {pair} but not an output-pane id",
+                        d.id,
+                    );
+                }
+                // Dense: a node present in both panes is its own self-edge, and
+                // a node descends from itself — so a consumer only ever follows
+                // edges, never reconstructs one, and reads ancestry off the
+                // label it finds there.
+                for id in input_ids.intersection(output_ids) {
+                    let self_edge = map.upstream(id).iter().find(|l| l.id == *id);
+                    assert!(
+                        self_edge.is_some_and(|l| l.labels.has_ancestry()),
+                        "{name}: {id:?} survives {pair} without an ancestry self-edge",
+                    );
+                }
+                // A non-self edge is the only proof a row was consulted: a
+                // pane pair whose phases rewrote nothing derives its whole
+                // map from the two pane id sets.
+                if edges.iter().any(|(u, d)| *u != d.id) {
+                    exercised.push(format!("{name} / {pair}"));
+                }
+            }
+        }
+        exercised.sort();
+        assert_eq!(
+            exercised, EXERCISED_BOUNDARIES,
+            "the pane pairs at which the fold actually reads a row have changed",
+        );
+    }
+
+    /// The `program / pane pair` names at which a **blame** edge reaches the
+    /// provenance map — where a rewrite named blame and the fold labelled the
+    /// edge it contributed. See
+    /// [`blame_reaches_the_provenance_map_labelled`].
+    const RELATING_BOUNDARIES: &[&str] = &[
+        "for_accumulator / post-inference → post-channelize",
+        "transaction / post-inference → post-channelize",
+    ];
+
+    /// **Blame reaches the provenance map, labelled**: the `blame` column is
+    /// closed transitively alongside `parents`, so a consumer receives the
+    /// blame edges and can render or prune them.
+    ///
+    /// Pinned as the set of pane pairs where such an edge exists, for the same
+    /// reason [`EXERCISED_BOUNDARIES`] is pinned: blame is named at a handful of
+    /// sites, all in the mutability phases and so all inside the second pane
+    /// pair, and a corpus or recording edit that stopped exercising them
+    /// would otherwise leave the labelled half of the map untested.
+    ///
+    /// A blame edge is *only* blame here: no corpus rewrite both
+    /// consumes a node and blames it, so nothing in the corpus pins the
+    /// both-labels case — the fold tests in `provenance.rs` do.
+    #[test]
+    fn blame_reaches_the_provenance_map_labelled() {
+        let mut relating: Vec<String> = Vec::new();
+        for (name, code) in corpus() {
+            let program = compile_ok(&code);
+            let panes = program.materialize_panes();
+            for pane_pair in panes.gated_pane_pairs() {
+                if pane_pair
+                    .map
+                    .edges()
+                    .iter()
+                    .any(|(_, d)| d.labels.has_blame())
+                {
+                    relating.push(format!("{name} / {}", pane_pair.name));
+                }
+            }
+        }
+        relating.sort();
+        assert_eq!(
+            relating, RELATING_BOUNDARIES,
+            "the pane pairs at which blame contributes an edge have changed",
+        );
+    }
+
+    /// The corpus programs whose definitions inference **generalizes and then
+    /// specializes** — the ones monomorphization actually clones a subtree for.
+    /// Everything else in the corpus is first-order, and mono mints nothing.
+    const SPECIALIZING: &[&str] = &["generator_pipeline", "udf_chain"];
+
+    /// Monomorphization — the one thing that mints between the first two panes —
+    /// explains every node it produces, on first-order and specializing
+    /// programs alike.
+    ///
+    /// Two recordings get it there, and both are needed: `specialize_use` sinks
+    /// the clone's `on_copy` pairs, and `coalesce_generalized_let` sinks the
+    /// chain of `let`s the binding rebuilds itself as. Without the second, a
+    /// specializing program leaves one unrecorded `let` per demanded
+    /// specialization — a per-program count that tracks how many types the body
+    /// asked for, which is why it read as a small constant on this corpus.
+    ///
+    /// Asserted both ways so the zero cannot be vacuous: a specializing program
+    /// must also *kill* nodes here, since its generalized definition is
+    /// replaced by clones. A regression that stopped running mono at all would
+    /// otherwise pass.
+    #[test]
+    fn monomorphization_explains_every_node_it_produces() {
+        for (name, code) in corpus() {
+            let panes = compile_ok(&code).materialize_panes();
+            let pair = panes.pair("pre-inference → post-inference");
+            let c = LeakCounts::tally(&pair.leaks);
+            assert_eq!(c.dangling_parent, 0, "{name}: {c:?}");
+            assert_eq!(
+                c.unrecorded, 0,
+                "{name}: pre-inference → post-inference is uncaptured: {c:?}"
+            );
+            if SPECIALIZING.contains(&name) {
+                assert!(
+                    !pair.deaths.is_empty(),
+                    "{name}: specializes, so the generalized definition must die"
+                );
+            }
+        }
+    }
+
+    /// All four phases inside the second pane pair explain what they produce.
+    ///
+    /// The interesting programs are the ones that drive a *whole-program*
+    /// rewrite, where naming one node is least obviously applicable: a
+    /// transaction is disassembled into a commit carrier whose pieces have no
+    /// single source node, and a defer cluster becomes a `LetRec` assembled from
+    /// contributions scattered across the body. Both are covered by recording
+    /// against the node each product stands in for — the `with begin():`
+    /// statement, the register declaration, the `let d = Defer`.
+    ///
+    /// Asserted with a non-vacuity guard for the same reason the first pane pair is: a
+    /// program that reaches one of these phases must also kill nodes, so a
+    /// regression that stopped running the phase cannot pass as capture.
+    #[test]
+    fn the_second_pane_pair_explains_every_node_its_phases_produce() {
+        /// Reaches `transact_phase` or `channelize` — the whole-program
+        /// rewrites, and the last two phases to adopt the recorder.
+        const WHOLE_PROGRAM_REWRITES: &[&str] = &["transaction", "feed_loop", "generator_pipeline"];
+        for (name, code) in corpus() {
+            let panes = compile_ok(&code).materialize_panes();
+            let pair = panes.pair("post-inference → post-channelize");
+            let c = LeakCounts::tally(&pair.leaks);
+            assert_eq!(c.dangling_parent, 0, "{name}: {c:?}");
+            assert_eq!(
+                c.unrecorded, 0,
+                "{name}: post-inference → post-channelize is uncaptured: {c:?}"
+            );
+            if WHOLE_PROGRAM_REWRITES.contains(&name) {
+                assert!(
+                    !pair.deaths.is_empty(),
+                    "{name}: rewrites its whole shape, so nodes must die"
+                );
+            }
+        }
+    }
+
+    /// Deaths are the live-set difference and nothing else: what the fold reports
+    /// between two panes is exactly `input_ids ∖ output_ids` on a real program,
+    /// with no phase having declared any of them. `for_accumulator` folds a
+    /// mutation loop into a `LetRec`, so the difference is non-empty.
+    #[test]
+    fn deaths_between_two_panes_are_the_set_difference() {
+        let program = compile_ok(include_str!(
+            "../../tests/programs/for_accumulator/program.cambra"
+        ));
+        let panes = program.materialize_panes();
+        let input = collect_tree_ids(&program.post_inference_ir);
+        let output = collect_tree_ids(&program.post_channelize_ir);
+        let mut expected: Vec<NodeId> = input.difference(&output).copied().collect();
+        expected.sort_unstable();
+        assert!(!expected.is_empty(), "the fixture must actually kill nodes");
+        assert_eq!(
+            panes.pair("post-inference → post-channelize").deaths,
+            expected
+        );
+    }
+
+    /// **Distinct predicate terms never share a `NodeId`** — with each other, or
+    /// with the main tree — on the three trees the panes retain.
+    ///
+    /// [`assert_unique_node_ids`] runs the same [`predicate_id_collisions`] walk
+    /// at every phase boundary, so what this adds is the panes: `pre_inference_ir`
+    /// is snapshotted after `uniquify`, between two boundaries, and no boundary
+    /// walk reaches it.
+    ///
+    /// What the walk catches is a rebuild that **preserves ids when it should
+    /// not**. A predicate cannot be mutated through its `Rc`, so every rewrite
+    /// builds a new `Rc` and repoints the refinement it was handed. That is a
+    /// *replacement* only if the walk reaches every occurrence; otherwise the
+    /// original survives on some type the walk missed, and preserving ids puts one
+    /// id-set on two live terms. `PredMemo::replacing` is the opt-in for walks
+    /// that do reach everything, and `uniquify` — the only one — asserts its own
+    /// 1:1 correspondence separately.
+    #[test]
+    fn distinct_predicate_terms_never_share_a_node_id() {
+        let mut found: Vec<(String, usize, &'static str)> = Vec::new();
+        for (name, code) in corpus() {
+            let program = compile_ok(&code);
+            for (pane, tree) in [
+                ("pre-inference", &program.pre_inference_ir),
+                ("post-inference", &program.post_inference_ir),
+                ("post-channelize", &program.post_channelize_ir),
+            ] {
+                for (_, kind) in predicate_id_collisions(tree) {
+                    found.push((format!("{name} / {pane}"), 1, kind));
+                }
+            }
+        }
+        assert!(
+            found.is_empty(),
+            "{} predicate id collisions: {found:?}",
+            found.len(),
+        );
+    }
+
+    /// A phase that rewrites the program records its rewrites under its own phase
+    /// tag — the tag being the one part of a row no recording site knows, and the
+    /// only thing that places a row in a pane pair's fold.
+    ///
+    /// A phase that rewrites *nothing* on a given program records nothing, which
+    /// is the preserve case and correct (most of the corpus preserves end to
+    /// end), so the fixture is one that drives three of the five: the
+    /// transaction, which `transact_phase` disassembles, `mut_elim` rebuilds as
+    /// a `LetRec`, and `channelize` rewrites.
+    #[test]
+    fn a_rewriting_phase_tags_its_rows_with_itself() {
+        let (_, code) = corpus()
+            .into_iter()
+            .find(|(name, _)| *name == "transaction")
+            .expect("the transaction fixture");
+        let program = compile_ok(&code);
+        let mut recorded = program.provenance_table.recorded_phases();
+        recorded.sort_by_key(|p| format!("{p:?}"));
+        assert_eq!(
+            recorded,
+            vec![
+                Phase::AsOfRead,
+                Phase::Channelize,
+                Phase::Infer,
+                Phase::Letrec,
+                Phase::Transact
+            ],
+            "the transaction fixture is rewritten by exactly these five phases",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Perf sanity for pane capture
+    // -----------------------------------------------------------------------
+
+    /// One generated program shape, parameterized by size.
+    ///
+    /// The shapes are chosen to hit the phases the panes span: `comprehension`
+    /// and `arith` are `inline`-light and mostly id-preserving, `udf` drives
+    /// inlining and monomorphization, `loop_acc` drives `mut_elim`, and `feed`
+    /// drives `channelize`.
+    ///
+    /// Sizes are deliberately small. Compile time here is **superlinear in
+    /// program size** for reasons that predate provenance capture (a UDF-heavy 63-line
+    /// program compiles in tens of seconds), so a corpus large enough to be a
+    /// benchmark would be too slow to run; this is a sanity check on the
+    /// *ratio* between capture on and capture off, not a benchmark.
+    fn generated(shape: &str, n: usize) -> String {
+        match shape {
+            "arith" => {
+                let terms: Vec<String> = (1..=n).map(|i| format!("{i} * {}", i + 1)).collect();
+                format!("x = {}\nx\n", terms.join(" + "))
+            }
+            "comprehension" => {
+                // Independent comprehensions summed, rather than a chain: a
+                // chained comprehension trips an unrelated substitution bug
+                // ("discharged binder still free after substitution into
+                // predicate") that has nothing to do with provenance.
+                let parts: Vec<String> = (0..n)
+                    .map(|i| format!("sum([y + {i} for y in xs if y > 0])"))
+                    .collect();
+                format!("xs = [1, 2, 3, 4, 5]\nt = {}\nt\n", parts.join(" + "))
+            }
+            "udf" => {
+                let mut src = String::new();
+                for i in 0..n {
+                    src.push_str(&format!("def f{i}(x):\n    x + {i}\n"));
+                }
+                src.push_str("xs = [1, 2, 3, 4, 5]\n");
+                let calls: Vec<String> = (0..n).map(|i| format!("f{i}(y)")).collect();
+                src.push_str(&format!("[{} for y in xs]\n", calls.join(" + ")));
+                src
+            }
+            "loop_acc" => {
+                let mut src = String::from("xs = [1, 2, 3, 4, 5]\n");
+                for i in 0..n {
+                    src.push_str(&format!("a{i}: Mut(Int) := 0\n"));
+                }
+                src.push_str("for v in xs:\n");
+                for i in 0..n {
+                    src.push_str(&format!("    a{i} += v + {i}\n"));
+                }
+                src.push_str(&format!("a{}\n", n - 1));
+                src
+            }
+            "feed" => {
+                let mut src = String::from("out = defer()\nxs = [1, 2, 3, 4, 5]\n");
+                for i in 0..n {
+                    src.push_str(&format!("for v in xs:\n    out << v + {i}\n"));
+                }
+                src.push_str("out\n");
+                src
+            }
+            other => panic!("unknown shape {other}"),
+        }
+    }
+
+    /// The perf corpus: `(shape, size)` pairs, sized to keep the whole run in
+    /// the low seconds per repetition.
+    const PERF_CORPUS: &[(&str, usize)] = &[
+        ("arith", 40),
+        ("arith", 80),
+        ("arith", 160),
+        ("comprehension", 6),
+        ("comprehension", 12),
+        ("comprehension", 20),
+        ("udf", 5),
+        ("udf", 8),
+        ("udf", 12),
+        ("loop_acc", 4),
+        ("loop_acc", 8),
+        ("loop_acc", 14),
+        ("feed", 3),
+        ("feed", 6),
+        ("feed", 12),
+    ];
+
+    /// Rough compile-time and retained-memory sanity for pane capture. Ignored
+    /// by default — it is a measurement, not an assertion.
+    ///
+    /// Run it as two interleaved processes so the two arms see the same machine
+    /// state, and take the min over repetitions:
+    ///
+    /// ```text
+    /// for i in 1 2 3; do
+    ///   CAMBRA_PROVENANCE=1 cargo test --release --lib provenance_pane_perf -- --ignored --nocapture
+    ///   CAMBRA_PROVENANCE=0 cargo test --release --lib provenance_pane_perf -- --ignored --nocapture
+    /// done
+    /// ```
+    ///
+    /// With capture on it also materializes and folds both panes, since that is
+    /// the cost the design actually incurs.
+    #[test]
+    #[ignore = "measurement, not an assertion; see the doc comment for the driver"]
+    fn provenance_pane_perf() {
+        let capture = provenance_capture_enabled();
+        let reps: usize = std::env::var(PERF_REPS_ENV)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(3);
+        let mut total_compile = std::time::Duration::ZERO;
+        let mut total_fold = std::time::Duration::ZERO;
+        for (shape, n) in PERF_CORPUS {
+            let code = generated(shape, *n);
+            let mut best_compile = std::time::Duration::MAX;
+            let mut best_fold = std::time::Duration::MAX;
+            let mut rows = 0usize;
+            let mut tags = 0usize;
+            // The three retained pane snapshots are unconditional — they are not
+            // part of what the capture switch turns off — so their size is the
+            // pane design's real memory floor, against which the logs are noise.
+            let mut panes_nodes = 0usize;
+            for _ in 0..reps {
+                let t0 = std::time::Instant::now();
+                let program = compile_ok(&code);
+                best_compile = best_compile.min(t0.elapsed());
+                rows = program.provenance_table.len();
+                tags = program.provenance_table.tag_count();
+                panes_nodes = collect_tree_ids(&program.pre_inference_ir).len()
+                    + collect_tree_ids(&program.post_inference_ir).len()
+                    + collect_tree_ids(&program.post_channelize_ir).len();
+                if capture {
+                    let t1 = std::time::Instant::now();
+                    let panes = program.materialize_panes();
+                    std::hint::black_box(panes.projection("post-channelize"));
+                    best_fold = best_fold.min(t1.elapsed());
+                }
+            }
+            if !capture {
+                best_fold = std::time::Duration::ZERO;
+            }
+            total_compile += best_compile;
+            total_fold += best_fold;
+            eprintln!(
+                "[perf capture={capture}] {shape}/{n}: compile {:?} fold {:?} rows {rows} \
+                 tags {tags} pane_nodes {panes_nodes} lines {}",
+                best_compile,
+                best_fold,
+                code.lines().count(),
+            );
+        }
+        eprintln!("[perf capture={capture}] TOTAL compile {total_compile:?} fold {total_fold:?}");
+    }
+}

--- a/src/ccl/provenance.rs
+++ b/src/ccl/provenance.rs
@@ -1652,26 +1652,31 @@ fn group_copies(copies: &[(NodeId, NodeId)]) -> Vec<(NodeId, Vec<NodeId>)> {
     out
 }
 
-/// Open a **lowering** copy-only recording: it consumes nothing, mints nothing,
-/// and exists to capture the `(origin, fresh)` pairs a clone's freshen reports,
-/// which are written as per-origin [`LoweringStep::Copy`]s (or, under a phase
-/// scope, as one row per copy).
+/// Open a copy-only recording: it consumes nothing, mints nothing, and exists to
+/// capture the `(origin, fresh)` pairs a clone's freshen reports, written as
+/// per-origin [`LoweringStep::Copy`]s under lowering or as one row per copy
+/// under a phase scope.
 ///
-/// This is the one recording that **names no node**, and lowering is where that
-/// shape fits: uncurry's template-interior freshens and the compare-chain
-/// operand freshens duplicate nodes with nothing being rewritten, so there is no
-/// id to name. Every captured copy carries its own origin from the hook, which
-/// is exactly why this one can afford to declare nothing at all. A *phase* that
-/// duplicates uses [`enter`] instead, naming the node the duplication is
-/// performed for.
+/// This is the one recording that **names no node**, and the shape it fits is a
+/// duplication with *nothing being rewritten*, where there is no id to name:
+/// lowering's uncurry template-interior and compare-chain operand freshens, and
+/// inference freshening a refinement predicate per scheme instantiation
+/// (`infer.freshen_predicate`). Every captured copy carries its own origin from
+/// the hook, which is why this one can afford to declare nothing at all —
+/// [`row_per_copy`](OpenRecording::row_per_copy) never reads the named node.
+///
+/// A duplication performed *as part of* a rewrite uses [`enter`] instead, naming
+/// the node the rewrite replaces, so the mints beside the copies have a parent.
+/// [`assert_copy_only`](OpenRecording::assert_copy_only) is what keeps the two
+/// apart: a mint captured here is a site that should have named a node.
 ///
 /// `nature` is fixed at [`Machinery`](Nature::Machinery) rather than taken as an
-/// argument because a lowering copy's nature is never read: a
+/// argument. Under lowering a copy's nature is never read — a
 /// [`LoweringStep::Copy`] mirrors the origin's already-folded attribution
-/// *verbatim*, so a nature here would be unobservable, and a wrong one (a
-/// `Nature::Source` on a copy) would look meaningful while being inert. A phase
-/// copy's row *does* carry a nature that reaches the attribution, which is one
-/// more reason a phase duplication belongs in [`enter`].
+/// *verbatim* — so a nature would be unobservable, and a wrong one (a
+/// `Nature::Source` on a copy) would look meaningful while being inert. Under a
+/// phase scope the fixed value is the honest one: a duplication that rewrites
+/// nothing is plumbing by construction.
 pub(crate) fn copy_frame(label: RewriteLabel) -> RecordingGuard {
     RECORDING_STACK.with(|s| {
         let mut stack = s.borrow_mut();
@@ -2007,16 +2012,32 @@ pub(crate) fn copy_id(origin: NodeId) -> NodeId {
 /// sides, as [`on_mint`] does: a placeholder origin would fold as
 /// [`Leak::DanglingParent`] against an id nothing ever records.
 ///
+/// Asserts the same coverage [`on_mint`] does, and for the same reason: a node
+/// reaches a tree by being minted or by being copied, so a check on one channel
+/// alone leaves the other silent. The silence was not hypothetical — copies
+/// outnumbered mints among the uncaptured nodes when the check was added.
+///
 /// [`PLACEHOLDER`]: NodeId::PLACEHOLDER
 pub(crate) fn on_copy(origin: NodeId, fresh: NodeId) {
     if origin == NodeId::PLACEHOLDER || fresh == NodeId::PLACEHOLDER {
         return;
     }
-    RECORDING_STACK.with(|s| {
+    let captured = RECORDING_STACK.with(|s| {
         if let Some(top) = s.borrow_mut().last_mut() {
             top.copies.push((origin, fresh));
+            true
+        } else {
+            false
         }
     });
+    debug_assert!(
+        captured || !rows_would_reach_the_table(),
+        "{fresh:?} was copied from {origin:?} with no recording open, under a \
+         phase scope that writes rows: the copy reaches no row and the fold \
+         reports it as Unrecorded. Open a recording over the duplication — \
+         `provenance::enter` when a rewrite is being performed, `copy_frame` \
+         when nothing is being rewritten and the copy is the whole of it."
+    );
 }
 
 /// RAII installer for **lowering's** log.

--- a/src/ccl/provenance.rs
+++ b/src/ccl/provenance.rs
@@ -190,8 +190,8 @@ pub type RewriteLabel = &'static str;
 /// [`Source`](Nature::Source) is listed first because it is the base case: the
 /// root of a lowered source expression. The rule for who gets it is *structural*
 /// and stated in one place — see `LoweringContext::tag_source` in
-/// `src/ccl/lower/mod.rs`, and `design/provenance.md`, "The seam
-/// (`src/ccl/context.rs`)". It is emitted **only by lowering**: [`attribute`]
+/// `src/ccl/lower/mod.rs`, and `design/provenance.md`, "The seam". It is emitted
+/// **only by lowering**: [`attribute`]
 /// debug-asserts that no *phase* rewrite carries it, and that is the one guard.
 /// On the wire a `Source`-nature tag null-compresses
 /// (serializes as

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -161,10 +161,10 @@ fn rewrite_as_of_reads_go(expr: &mut Expr) {
     // node mints nothing, so the recording writes nothing. The walk below sits
     // outside the recording, so a nested chain attributes to its own `let`.
     //
-    // These rows reach no table in a normal compile: `compile_program` calls
-    // `rewrite_as_of_reads` outside every pass scope it opens, so they land only
-    // under an audit window (`CAMBRA_PROVENANCE_AUDIT=full`, which ends at
-    // `post-as-of-read`).
+    // `compile_program` runs this rewrite under a `Phase::AsOfRead` scope, so
+    // these rows land in the table like any other phase's. The phase is its own
+    // rather than `Transact` because a phase is declared where the rewrite runs,
+    // and this one runs below the post-channelize pane.
     {
         let _g = provenance::enter(
             expr.node_id(),


### PR DESCRIPTION
Carries provenance capture down to a fifth pane, `post-lambda-elim`, and replaces
the hand-spelled pane wiring with one table. Four commits, each green on its own
under `CAMBRA_PROVENANCE_GATE=1`.

## What lands

**`ccl(provenance): assert the copy channel's coverage, not just the mint channel's`**
A node reaches a tree by being minted or by being copied. `on_mint` asserted that
a mint under a row-writing phase scope has a recording to land in; `on_copy`
asserted nothing, so a rewrite that only duplicates produced `Unrecorded` at the
fold with no panic anywhere. Over the suite, copies outnumbered mints among the
uncaptured nodes 4548 to 988. The one gap it found in an already-instrumented
phase is inference freshening a refinement predicate per scheme instantiation,
which takes a `copy_frame` — a duplication with nothing being rewritten and so no
node to name.

**`ccl(provenance): the fold's id domain is the slot domain the passes rewrite`**
`collect_tree_ids` reached `expr.ty`, `user_annotation` and a `Cast`'s target, but
never a binder's declared type or annotation. `TypedExpr::walk_type_slots` reaches
all five, and it is what the rewriting passes walk — so the fold's explanation
domain was narrower than the slot domain being rewritten. A predicate riding only
a `let` binder's annotation was never enumerated, and a rebuild of it named an id
the fold had not heard of: `DanglingParent` against an id the input pane
demonstrably holds. `f: (Int => {Int where _ == 9}) = …` is the shape.

Nothing in tree exercised it, because no instrumented phase rebuilt a predicate
parked in a binder slot. `lambda_elim` is the first that does, which is why this
sits below the pane that needs it: with the pane pair in place and this fix
absent, `CAMBRA_PROVENANCE_GATE=1` fails 16 group-by and dependent-group-by
programs.

**`ccl(provenance): declare the pipeline's pane topology in one place`**
Three panes and two pairs were spelled across six consts, six named
`MaterializedPanes` fields and two methods, which does not survive going to six
panes: five pairs times three fold products is fifteen fields. `PANES` declares
the topology once — each pane's name, the phases that produced it from the pane
before it, and whether its pair is gated — and `materialize_panes` folds a sliding
window over it.

`Phase::AsOfRead` is new, declared where the rewrite *runs* rather than where its
code sits: reusing `Phase::Transact` would have put one phase on both sides of the
post-channelize pane, and a fold restricting by it would resolve straight past
that pane.

All of it moves to `src/ccl/panes.rs`, along with `gate_leaks`, the two
`CompiledProgram` methods that fold and enumerate the panes, and the pane tests.
`context.rs` drops from ~2900 to ~1980 lines and keeps what it is about: the
pipeline, the `Phase` axis, and the env switches. The inherent
`impl CompiledProgram` sits in `panes.rs` rather than beside the struct because
the methods are the pane layer's — which is also why no call site changed.

**`ccl(lambda_elim): the point-free traversal records what it rewrites`**
Two recordings, one per recursive entry point, plus two arm relabels, and the
phase scope that makes them reach a table. `elim_lambdas_impl` names the node it
was handed; `elim_lambda_impl` names the lambda **body**, because `elim_lambda`
recurses over the body's structure and naming the enclosing `Lambda` would
collapse a whole body's combinator tree onto one parent. The filter and
value-`Case` arms open a second recording on the same node — not a capture gap,
but a recording carries one label and one nature for its whole extent, and those
two arms expand a construct the user wrote rather than re-mint plumbing.

## Where the gate stands

Every pair from `pre-inference → post-inference` down to
`post-as-of-read → post-lambda-elim` is gated: zero `Unrecorded` and zero
`DanglingParent` over the whole test suite under `CAMBRA_PROVENANCE_GATE=1`, not
merely over the eleven programs `corpus()` lists. `pre-inference →
post-inference` is gated here for the first time, the first two commits having
closed both gaps that held it back. `post-lambda-elim → post-planning` stays
ungated until planning records.

`PaneSpec::gated` is one bit per pair and it says whether an assertion has been
turned on, not how clean a pair is allowed to be — a leak is a bug wherever it
appears. What an uninstrumented phase leaves behind is a count of how little it
records, a constant no correct recording elsewhere can drive down, so gating it
would pin churn rather than catch a defect.

## What this does not do

`lambda_elim` is not made id-preserving here: the catch-all arm's
`TODO(preserve)` carries why, `planning/groupby` relying on the re-mint to launder
the key it lifts out of a refinement predicate. The pair holds at zero regardless
— every node is explained — but almost nothing in it gets a self-edge, so a
pass-through node reads to a consumer as a rewrite of its predecessor rather than
as itself. 323 deaths across the new pair over the corpus are the expected
consequence.

## Verification

- `cargo test` and `CAMBRA_PROVENANCE_GATE=1 cargo test` clean at each of the four
  commits; `cargo clippy --all-targets` and `cargo fmt --check` clean.
- The `full` audit span moves to `post-inference..post-lambda-elim` and reports no
  leaks on any corpus program.
- `design/provenance.md` follows throughout. "Gate and audit coverage" ends by
  naming what retires once the last phase records — the audit, its two switches,
  and `PaneSpec::gated` — against a `TODO(provenance-audit-retire)` at both sites,
  so the scaffolding for this campaign does not outlive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

