### PR TITLE
Gate the last pane pair by recording what planning rewrites

### DIFF
--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -1472,6 +1472,13 @@ impl<C: PartialEq + Clone> PredMemo<C> {
     /// merely walks past is never reallocated and stays pointer-shared with
     /// occurrences the pass never visits.
     ///
+    /// TODO(discarded-copy): a `false` report still pays for a full copy. `f`
+    /// takes `&mut Expr`, so the predicate is cloned before there is any way to
+    /// know whether `f` will change it, and a `false` answer discards the clone.
+    /// The copy is captured and recorded like any other, so the table gains
+    /// entries for nodes no tree ends up holding. Neither a correctness nor a
+    /// soundness gap — it bloats the table.
+    ///
     /// Returns whether the slot ended up pointing somewhere new — which is *not*
     /// just `f`'s answer. A nested reuse inside `f` can re-point a slot in the copy
     /// with `f` having nothing of its own to report; discarding the copy would then

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -563,7 +563,7 @@ pub struct CompiledProgram {
     /// `via` is what a fold between two panes restricts by. The phases that record are
     /// [`Phase::Infer`] (everything monomorphization mints inside `infer`, which
     /// bridges the pre-inference ⇄ post-inference panes) and [`Phase::Inline`],
-    /// [`Phase::Transact`], [`Phase::Letrec`], [`Phase::Channelize`] (the four phases
+    /// [`Phase::Transact`], [`Phase::Letrec`], [`Phase::Channelize`] (the phases
     /// between the post-inference and post-channelize snapshots) — see [`PANES`],
     /// which declares which phases each pane pair folds.
     ///
@@ -995,7 +995,7 @@ pub(crate) fn provenance_capture_enabled() -> bool {
     !std::env::var(PROVENANCE_ENV).is_ok_and(|v| v == "0") && provenance_audit_span().is_none()
 }
 
-/// Whether every compile folds both pane pairs and gates the leak classes,
+/// Whether every compile folds every pane pair and gates the leak classes,
 /// rather than only the programs a test asks about.
 ///
 /// **What this buys.** The always-on gate is
@@ -1006,7 +1006,7 @@ pub(crate) fn provenance_capture_enabled() -> bool {
 /// another loop's accumulator) and `flatten_spine`'s value-position writer hoist
 /// both sat outside it. With this on, the corpus is every program the caller
 /// compiles — point it at `tests/compilation_pipeline` and the gate covers the
-/// whole suite instead of eleven programs.
+/// whole suite instead of the programs `corpus()` lists.
 ///
 /// Off by default because it folds the table twice per compile, which is
 /// superlinear work the ordinary pipeline does not need; CI turns it on. It is
@@ -1040,15 +1040,16 @@ fn recorded<R>(capture: bool, phase: Phase, f: impl FnOnce() -> R) -> R {
 /// A driver-capture audit over one span of the pipeline: install a phase recorder at
 /// the input pane, fold at the output pane, and print what the capture explains.
 ///
-/// Opt-in via `CAMBRA_PROVENANCE_AUDIT=1` so the whole test suite can run either
+/// Opt-in by naming a span in `CAMBRA_PROVENANCE_AUDIT` — the spans opened below
+/// are `full`, `letrec` and `mutelim` — so the whole test suite can run either
 /// way. It is a **measurement**, not a gate: nothing declares a fate, so every
 /// genuinely-dead input id reaches the audit through the fold's death
 /// collection, which it counts apart from the [`Leak`]s that really are
 /// recording bugs.
 ///
 /// A span survives gating when its enclosing pair bundles more phases than the
-/// span does: the `letrec` and `mutelim` spans below isolate phases inside the
-/// four-phase `post-inference → post-channelize` pair. See
+/// span does: the `letrec` and `mutelim` spans below each isolate a phase inside
+/// the `post-inference → post-channelize` pair. See
 /// `src/ccl/design/provenance.md`, "What gating every pair does not retire".
 struct ProvenanceAudit {
     span: &'static str,
@@ -1407,8 +1408,8 @@ fn run_passes(
     lowering_projection: &SourceProjection,
     panes: &mut BTreeMap<Phase, Expr>,
 ) -> Result<Expr, Vec<CompileError>> {
-    // Phase recording for the rows the pane folds read. One scope per phase,
-    // opened and closed in place: a phase scope is per-thread and
+    // Phase recording for the rows the pane-pair folds read. One scope per
+    // phase, opened and closed in place: a phase scope is per-thread and
     // non-reentrant, so the scopes are sequential, never nested.
     let capture_provenance = record && provenance_capture_enabled();
 
@@ -1663,13 +1664,13 @@ fn run_passes(
     // Running post-elim is what keeps ONE letrec representation through
     // channelize and lambda_elim; the point-free guard matcher re-checks
     // causality at this wall. See the `mut_elim` recognition docs.
-    let recognized = recorded(capture_provenance, Phase::Planning, || {
-        planning::plan_loops(lambda_elim)
-    });
-    debug!("Letrec recognized CCL:\n{}", symbolic(&recognized));
-    typecheck(&recognized).expect("letrec recognition produced an ill-typed tree");
-
+    // One scope over both halves of planning: they tag identically, and the
+    // typecheck between them mints nothing, so splitting would buy a window in
+    // which a recording writes nothing and nothing says why.
     let join_planned = recorded(capture_provenance, Phase::Planning, || {
+        let recognized = planning::plan_loops(lambda_elim);
+        debug!("Letrec recognized CCL:\n{}", symbolic(&recognized));
+        typecheck(&recognized).expect("letrec recognition produced an ill-typed tree");
         planning::run(recognized)
     });
     // The last instrumented pane: see the span's own note at `ProvenanceAudit::start`.

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -1145,8 +1145,8 @@ impl ProvenanceAudit {
 /// definition the program never exercises at a concrete type (see
 /// `Type::Infer`'s invariant). That residue is an *ambiguous program* — a user
 /// error — so it is rendered as a diagnostic; anything else panics, naming
-/// `produced_by`.
-fn pre_channelize_wall(expr: &Expr, produced_by: &str) -> Result<(), Vec<CompileError>> {
+/// `boundary`.
+fn pre_channelize_wall(expr: &Expr, boundary: &str) -> Result<(), Vec<CompileError>> {
     check_pre_channelize(expr).map_err(|errs| {
         if errs
             .iter()
@@ -1154,9 +1154,48 @@ fn pre_channelize_wall(expr: &Expr, produced_by: &str) -> Result<(), Vec<Compile
         {
             errs.into_compile_errors()
         } else {
-            panic!("{produced_by} created invalid expr: {errs:?}")
+            panic!("{boundary} produced an invalid tree: {errs:?}")
         }
     })
+}
+
+/// Which consistency check a phase's output answers to.
+///
+/// The three differ in what they tolerate, not in how they run. The mutability
+/// phases still carry `Defer`/`Feed` nodes and the transient `Feed` /
+/// channel-domain types only channelization erases, so they answer to
+/// `check_pre_channelize`; everything from channelization on answers to the
+/// strict [`typecheck`].
+enum Check {
+    /// [`pre_channelize_wall`]: the relaxed check, with a residual `Type::Infer`
+    /// reported as an ambiguous program. The two boundaries that can still carry
+    /// one are inference's own output and the inlining that copies it.
+    PreChannelizeReportingAmbiguity,
+    /// `check_pre_channelize`. A failure is a compiler bug.
+    PreChannelize,
+    /// [`typecheck`]. A failure is a compiler bug.
+    Typed,
+}
+
+/// A phase boundary's post-conditions: ids unique, output dumped, tree valid for
+/// the stage.
+///
+/// None of the three is type-enforced, and each fails silently in its own way. A
+/// duplicated id collapses two nodes' provenance into one entry; a tree that
+/// misses its check reaches the next phase to be mis-read there rather than
+/// rejected here. `boundary` names the phase in whichever message fires, and is
+/// the name the panes and the `assert_unique_node_ids` messages already use.
+fn settle(ir: &Expr, boundary: &str, check: Check) -> Result<(), Vec<CompileError>> {
+    assert_unique_node_ids(ir, boundary);
+    debug!("{boundary} CCL:\n{}", symbolic(ir));
+    debug!("{boundary} CCL (typed):\n{}", symbolic_typed(ir));
+    let outcome = match check {
+        Check::PreChannelizeReportingAmbiguity => return pre_channelize_wall(ir, boundary),
+        Check::PreChannelize => check_pre_channelize(ir),
+        Check::Typed => typecheck(ir),
+    };
+    outcome.unwrap_or_else(|errs| panic!("{boundary} produced an invalid tree: {errs:?}"));
+    Ok(())
 }
 
 /// The two user-facing mutability rules, checked on the fully-typed,
@@ -1459,17 +1498,14 @@ fn run_passes(
             })
             .collect());
     }
-    debug!("Inferred:\n{}", symbolic(&expr));
-    debug!("Inferred (typed):\n{}", symbolic_typed(&expr));
-    // Consistency wall between `infer` and `channelize`. It is the relaxed
-    // *pre-channelize* check (`check_pre_channelize`), which permits the transient
-    // `Feed` / `Infer`-channel-domain types only channelize can erase. A failure
-    // here is a compiler bug — with one exception: residual `Type::Infer`
-    // variables, which inference deliberately tolerates for a generalized
-    // definition the program never exercises at a concrete type (see
-    // `Type::Infer`'s invariant). That residue is an *ambiguous program* — a
-    // user error — so it is rendered as a diagnostic; anything else panics.
-    pre_channelize_wall(&expr, "Inference")?;
+    // Inference mints predicates (`lit_singleton`) and clones a definition per
+    // instantiation (`specialize_use`), so its output is checked before the pane
+    // below is taken off it.
+    settle(
+        &expr,
+        "post-inference",
+        Check::PreChannelizeReportingAmbiguity,
+    )?;
 
     // Enforce the second-class `Mut` discipline (`src/ccl/design/mutability.md`,
     // "No aliasing: `Mut` values are second-class (downward-only)") on the
@@ -1499,11 +1535,6 @@ fn run_passes(
     // beta-reduction) and preserves defer-returning generators, so the
     // post-inline wall is the relaxed `check_pre_channelize`, not strict
     // `typecheck`.
-    // Inference mints predicates (`lit_singleton`) and clones a definition per
-    // instantiation (`specialize_use`), so its output is checked before the pane
-    // is taken off it.
-    assert_unique_node_ids(&expr, "post-inference");
-
     // Retain the post-inference IR for the inspector before `inline` consumes
     // `expr`. This is the source-shaped, fully-typed anchor (lambdas intact, not
     // yet point-free; inline/transact/letrec/channelize/lambda_elim/planning have
@@ -1536,9 +1567,7 @@ fn run_passes(
     expr = recorded(capture_provenance, Phase::Inline, || {
         inline::inline_capability_lambdas(expr)
     });
-    assert_unique_node_ids(&expr, "post-inline");
-    debug!("UDFs inlined CCL:\n{}", symbolic(&expr));
-    pre_channelize_wall(&expr, "UDF inlining")?;
+    settle(&expr, "post-inline", Check::PreChannelizeReportingAmbiguity)?;
     if at_phase_output(Phase::Inline, &expr, stop, capture, panes) {
         return Ok(expr);
     }
@@ -1569,9 +1598,7 @@ fn run_passes(
         transact_phase::run(expr, &txn_mut_vars)
     })
     .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
-    assert_unique_node_ids(&expr, "post-transact");
-    debug!("Transact phase CCL:\n{}", symbolic(&expr));
-    check_pre_channelize(&expr).expect("transact phase produced an inconsistent tree");
+    settle(&expr, "post-transact", Check::PreChannelize)?;
     if at_phase_output(Phase::Transact, &expr, stop, capture, panes) {
         return Ok(expr);
     }
@@ -1589,10 +1616,8 @@ fn run_passes(
     let audit_mutelim = ProvenanceAudit::start("mutelim", "post-transact..post-letrec", &expr);
     let phase_out = recorded(capture_provenance, Phase::Letrec, || mut_elim::run(expr));
     audit_mutelim.finish(&phase_out);
-    assert_unique_node_ids(&phase_out, "post-letrec-run");
+    settle(&phase_out, "post-letrec", Check::PreChannelize)?;
     audit_letrec.finish(&phase_out);
-    debug!("Letrec phase CCL:\n{}", symbolic(&phase_out));
-    check_pre_channelize(&phase_out).expect("letrec phase produced an inconsistent tree");
     if at_phase_output(Phase::Letrec, &phase_out, stop, capture, panes) {
         return Ok(phase_out);
     }
@@ -1611,9 +1636,7 @@ fn run_passes(
         channelize::run(phase_out)
     })
     .errs()?;
-    assert_unique_node_ids(&channelized, "post-channelize");
-    debug!("Channelized:\n{}", symbolic(&channelized));
-    typecheck(&channelized).expect("channelize produced an ill-typed tree");
+    settle(&channelized, "post-channelize", Check::Typed)?;
 
     // Retain the post-channelize tree for the inspector's downstream pane. On the
     // post-inference channelize order this snapshot is *downstream* of
@@ -1635,8 +1658,7 @@ fn run_passes(
         transact_phase::rewrite_as_of_reads(&mut channelized)
     })
     .map_err(|msg| vec![CompileError::Unsupported(msg)])?;
-    assert_unique_node_ids(&channelized, "post-as-of-read");
-    typecheck(&channelized).expect("as-of-read rewrite produced an ill-typed tree");
+    settle(&channelized, "post-as-of-read", Check::Typed)?;
     if at_phase_output(Phase::AsOfRead, &channelized, stop, capture, panes) {
         return Ok(channelized);
     }
@@ -1645,13 +1667,9 @@ fn run_passes(
         lambda_elim::run(channelized)
     })
     .errs()?;
-    assert_unique_node_ids(&lambda_elim, "post-lambda-elim");
-    debug!("λ-eliminated CCL:\n{}", symbolic(&lambda_elim));
-    debug!("λ-eliminated typed CCL:\n{}", symbolic_typed(&lambda_elim));
-
-    // `typecheck` enforces hole-freeness as its first phase, so this call
-    // alone covers both checks.
-    typecheck(&lambda_elim).expect("type error after lambda elimination");
+    // `typecheck` enforces hole-freeness as its first phase, so the check here
+    // covers both.
+    settle(&lambda_elim, "post-lambda-elim", Check::Typed)?;
     if at_phase_output(Phase::LambdaElim, &lambda_elim, stop, capture, panes) {
         return Ok(lambda_elim);
     }
@@ -1675,14 +1693,6 @@ fn run_passes(
     });
     // The last instrumented pane: see the span's own note at `ProvenanceAudit::start`.
     audit.finish(&join_planned);
-    assert_unique_node_ids(&join_planned, "post-planning");
-    debug!(
-        "Join-planned CCL:\n{} : {}",
-        symbolic(&join_planned),
-        join_planned.ty
-    );
-    debug!("Join-planned CCL:\n{}", symbolic_typed(&join_planned));
-
     // Planning is the one phase that introduces `iterate` / `restrict` /
     // `Compose` staging, so re-checking its output catches a malformed tile
     // graph an adjacency that doesn't chain would otherwise hide. Planning
@@ -1691,7 +1701,7 @@ fn run_passes(
     // matches the fresh refinements it mints by structural predicate
     // equality, so the staging shapes now validate without re-blinding the
     // check or peeling cast refinements.
-    typecheck(&join_planned).expect("type error after join planning");
+    settle(&join_planned, "post-planning", Check::Typed)?;
 
     // Invariant (debug): planning's `iterate`/`restrict` markers live in the
     // term tree, never inside a type's refinement predicates — the substitution

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -1046,11 +1046,10 @@ fn recorded<R>(capture: bool, phase: Phase, f: impl FnOnce() -> R) -> R {
 /// collection, which it counts apart from the [`Leak`]s that really are
 /// recording bugs.
 ///
-/// TODO(provenance-audit-retire): scaffolding for the instrumentation campaign.
-/// This, [`PROVENANCE_PREDICATES_ENV`] and the audit clause in
-/// [`provenance_capture_enabled`] all go once every pane pair is gated, at which
-/// point no span has a question left to ask. See `design/provenance.md`, "What
-/// retires when the last phase records".
+/// A span survives gating when its enclosing pair bundles more phases than the
+/// span does: the `letrec` and `mutelim` spans below isolate phases inside the
+/// four-phase `post-inference → post-channelize` pair. See
+/// `src/ccl/design/provenance.md`, "What gating every pair does not retire".
 struct ProvenanceAudit {
     span: &'static str,
     state: Option<(PhaseScope, HashSet<NodeId>)>,
@@ -1516,24 +1515,20 @@ fn run_passes(
     }
 
     // Driver-capture audit span: post-inference pane in, and out at the **last
-    // instrumented pane** — currently `post-lambda-elim`, covering inline,
-    // transact, mut_elim, channelize, the as-of-read rewrite and lambda
-    // elimination.
+    // instrumented pane**, which is now the last pane — `join-planned`, covering
+    // inline, transact, mut_elim, channelize, the as-of-read rewrite, lambda
+    // elimination and planning.
     //
     // The endpoint is chosen rather than inherited. An audit measures what the
     // recordings explain, so a span running past the last instrumented phase
     // reports every node the uninstrumented tail mints as a defect — a number
     // that cannot reach zero however correct the recording is, which makes the
-    // audit read as a broken gate instead of a measurement. `planning` is the
-    // next phase here, and its group-by and hash-join recognizers mint with
-    // nothing recording, so the span stops in front of it.
-    //
-    // **Move this endpoint when a phase becomes instrumented, in the same commit
-    // that instruments it** — to `join-planned` when planning records. Leaving
-    // it behind understates coverage; moving it ahead reintroduces the
-    // unreachable-zero problem.
-    let audit = ProvenanceAudit::start("full", "post-inference..post-lambda-elim", &expr);
-    // A narrower pane pair over just the mutability phases (inline, transact,
+    // audit read as a broken gate instead of a measurement. Every phase that
+    // rewrites expression nodes now records, so the span reaches the end of the
+    // pipeline; operator conversion is past it and has no node identity to
+    // record against.
+    let audit = ProvenanceAudit::start("full", "post-inference..join-planned", &expr);
+    // A narrower audit span over just the mutability phases (inline, transact,
     // mut_elim), which is where the fate-prediction question lives.
     let audit_letrec = ProvenanceAudit::start("letrec", "post-inference..post-letrec", &expr);
 
@@ -1588,8 +1583,8 @@ fn run_passes(
     // hoisted to an ordinary feed of the loop's history for channelize to route.
     // The tree still carries Defer/Feed here, so the check is the relaxed
     // pre-channelize one.
-    // Isolated pane pair over `mut_elim` alone — the phase whose fate prediction
-    // driver capture is meant to delete.
+    // An audit span over `mut_elim` alone — the phase whose fate prediction driver
+    // capture is meant to delete.
     let audit_mutelim = ProvenanceAudit::start("mutelim", "post-transact..post-letrec", &expr);
     let phase_out = recorded(capture_provenance, Phase::Letrec, || mut_elim::run(expr));
     audit_mutelim.finish(&phase_out);
@@ -1650,8 +1645,6 @@ fn run_passes(
     })
     .errs()?;
     assert_unique_node_ids(&lambda_elim, "post-lambda-elim");
-    // The last instrumented pane: see the span's own note at `ProvenanceAudit::start`.
-    audit.finish(&lambda_elim);
     debug!("λ-eliminated CCL:\n{}", symbolic(&lambda_elim));
     debug!("λ-eliminated typed CCL:\n{}", symbolic_typed(&lambda_elim));
 
@@ -1670,16 +1663,17 @@ fn run_passes(
     // Running post-elim is what keeps ONE letrec representation through
     // channelize and lambda_elim; the point-free guard matcher re-checks
     // causality at this wall. See the `mut_elim` recognition docs.
-    let recognized = planning::plan_loops(lambda_elim);
+    let recognized = recorded(capture_provenance, Phase::Planning, || {
+        planning::plan_loops(lambda_elim)
+    });
     debug!("Letrec recognized CCL:\n{}", symbolic(&recognized));
     typecheck(&recognized).expect("letrec recognition produced an ill-typed tree");
 
-    // Isolated pane pair over `planning::run` — the phases containing
-    // `simplify`'s 13 rules and `wrap_with_iterate`.
-    let audit_planning =
-        ProvenanceAudit::start("planning", "recognized..join-planned", &recognized);
-    let join_planned = planning::run(recognized);
-    audit_planning.finish(&join_planned);
+    let join_planned = recorded(capture_provenance, Phase::Planning, || {
+        planning::run(recognized)
+    });
+    // The last instrumented pane: see the span's own note at `ProvenanceAudit::start`.
+    audit.finish(&join_planned);
     assert_unique_node_ids(&join_planned, "post-planning");
     debug!(
         "Join-planned CCL:\n{} : {}",

--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -15,9 +15,9 @@ features: the inspector's consumption of the AST snapshots (panes), and adoption
 further phases. A reader can tell the two apart by the marker alone; unmarked prose
 describes code you can go read.
 
-Two sites record without reaching any table in a normal build, because
-`compile_program` opens no `PhaseScope` around them: `simplify` and
-`planning/iterate`. Operator conversion has no identity to record against; see
+Every phase that rewrites expression nodes records, and every recording reaches
+a table: `compile_program` opens a `PhaseScope` around each. Operator conversion
+has no identity to record against, which is what stops the panes there; see
 [Known prerequisites for panes past `post-planning`](#known-prerequisites-for-panes-past-post-planning).
 
 ## Mechanism at a glance
@@ -151,9 +151,14 @@ Three crossings, and each one has to record:
 2. **Transformation** — a predicate is rewritten. The rewritten term *replaces*
    the original in its `Refinement`, so it is the same logical node.
 3. **Raising** — a predicate is materialized back into the main tree, which
-   planning does. **Not yet recorded**, and not urgent here: those nodes are
-   minted below the last pane, so nothing gates them. Lands with the planning
-   commit upstack.
+   planning does at three sites: `planning/iterate`'s `fn_of_bare_predicate`
+   lift, the group-by key extraction, and the hash-join key morphisms. Each runs
+   under the recording its rewrite opened, and the raised material keeps the
+   *predicate's* parentage rather than the site's, because a clone's copy names
+   the node it was freshened from. `both_raising_paths_attribute_the_predicate_to_the_predicate`
+   pins that for both of `fn_of_bare_predicate`'s paths — including the slow one,
+   whose η-wrapper descends from the site but is consumed by the elimination
+   rather than placed, so it composes away as a transient.
 
 `Rc` sharing stays load-bearing and constrains how recording may be done. One
 predicate term rides many type slots as a shared `Rc`, and planning's compile
@@ -483,22 +488,19 @@ scope is open around them: `subst` (`subst.vacuous`, `subst.transport`,
 `subst.force_refinement`) and `ccl_utils`' `PredMemo::rebuild`
 (`predicate.rebuild`).
 
-Two sites record where nothing reads their rows: `simplify` (one combinator
-covering all thirteen `&mut` rule invocations, with no rule-body edits) and
-`planning/iterate`. `compile_program` opens no `PhaseScope` around either, and a
-recording outside a phase scope writes nothing at all — the hooks capture into a
-stack that is never routed to a table — so in a normal build these two cost an
-emptiness check and produce no rows.
+Every phase that rewrites expression nodes runs under a `PhaseScope`, so no
+recording is inert: `simplify`'s rule combinator and `planning/iterate` both sit
+inside `planning::run`, which `compile_program` runs under `Phase::Planning`, and
+`transact_phase`'s as-of-read rewrite and `lambda_elim` each carry a phase of
+their own and each end a pane.
 
-They become visible only when a developer sets `CAMBRA_PROVENANCE_AUDIT=planning`
-in the environment before running the compiler or its tests. That opens one scope
-spanning `recognized..join-planned` and prints a coverage and leak line to stderr
-when the span closes: a measurement, run by hand while a phase is being
-instrumented, of how much of that phase's rewriting its recordings explain. It is
-what the coverage figures below were measured with. Naming a span turns pane
-capture off (`provenance_capture_enabled`), so an audit never runs in a build
-that also serves panes. Both sites stop needing one in the commit that runs
-`planning` under a `Phase::Planning` scope.
+An **audit** is what remains for measuring, rather than for reaching a recording
+nothing reads. A developer sets `CAMBRA_PROVENANCE_AUDIT` in the environment
+before running the compiler or its tests; it opens one scope over the named span
+and prints a coverage and leak line to stderr when the span closes, which is how
+the figures below were measured. Naming a span turns pane capture off
+(`provenance_capture_enabled`), so an audit never runs in a build that also
+serves panes.
 
 ### Where to open a recording
 
@@ -701,13 +703,13 @@ record, which is what fixes both the audit spans and the set of gated pane pairs
 An audit's endpoint is **chosen**, because a span running past the last
 instrumented phase counts everything the uninstrumented tail mints as a defect — a
 number that cannot reach zero however correct the recording is, which makes the
-audit read as a broken gate rather than a measurement. The `full` span therefore
-ends at the last instrumented pane, `post-inference..post-lambda-elim`, stopping
-in front of `planning`, whose group-by and hash-join recognizers mint with
-nothing recording.
+audit read as a broken gate rather than a measurement. Every phase that rewrites
+expression nodes now records, so the `full` span reaches the end of the pipeline,
+`post-inference..join-planned`. Operator conversion is past it and has no node
+identity to measure against.
 
 **The same discipline governs the gate.** `CAMBRA_PROVENANCE_GATE=1` makes *every*
-compile fold both pane pairs and gate the leak classes, so the gate's corpus
+compile fold every pane pair and gate the leak classes, so the gate's corpus
 becomes whatever the caller compiles — point it at the test suite and it covers
 every program there instead of the handful `context.rs`'s `corpus()` lists. That
 sample is what let two recording gaps live: `transact_phase` calling
@@ -715,43 +717,35 @@ sample is what let two recording gaps live: `transact_phase` calling
 value-position writer hoist. Both are shapes the eleven listed programs do not
 have. CI runs with it on; it costs about 4% of the test step.
 
-It gates `gated_pane_pairs()`, which is every pair whose phases record. The
-bottom one is not there yet: `planning` mints with nothing open, and a gate over
-such a pair cannot reach zero however correct the recording is — it would report
-a count of how little that phase records, a constant rather than a regression. No
-program count is pinned for it either, for the same reason: it churns with every
-unrelated change. **Flip `PaneSpec::gated` in the commit that instruments the
-last phase in the pair**, the same way an endpoint moves.
+It gates `gated_pane_pairs()`, which is now every pair: the leak classes hold at
+zero from the lowering handoff to the end of the pipeline over whatever the
+caller compiles.
 
 **Move the endpoint when a phase becomes instrumented, in the commit that
-instruments it:** to `join-planned` when planning records. Leaving it behind
-understates coverage; moving
-it ahead reintroduces the unreachable zero.
+instruments it.** The rule has no outstanding move left in the CCL pipeline; the
+next one is operator conversion, which needs an identity first. Leaving an
+endpoint behind understates coverage; moving it ahead reintroduces the
+unreachable zero.
 
-#### What retires when the last phase records
+#### What gating every pair does not retire
 
-The audit is scaffolding for the instrumentation campaign and nothing else: with
-every pane pair gated, a span measuring how much of a phase's rewriting its
-recordings explain has no question left to ask.
-`TODO(provenance-audit-retire)` marks the sites, and it takes with it
+A span is redundant with a gated pair when the pair covers the same phases, and
+not otherwise. The `planning` span went for that reason: it ran
+`recognized..join-planned` inside `post-lambda-elim → post-planning`, whose phase
+list is `Planning` alone, so the wider gated pair measured the same phase and
+keeping both invited trusting the wrong one.
 
-- `ProvenanceAudit` and `CAMBRA_PROVENANCE_AUDIT`, along with the audit clause in
-  `provenance_capture_enabled` — capture becomes unconditional once nothing else
-  contends for the phase scopes;
-- `CAMBRA_PROVENANCE_PREDICATES`, whose only reader is the audit's live set;
-- `PaneSpec::gated` and `gated_pane_pairs`, one bit per pair existing only to
-  describe a half-instrumented pipeline — `gate_leaks` then covers every pair;
-- the paragraph in [The recorder](#the-recorder) about the two sites whose rows
-  nothing reads, and the by-hand coverage figures the spans were run to produce.
+`letrec` and `mutelim` stay because their pair bundles four phases. Both sit
+inside `post-inference → post-channelize`, over `Inline`, `Transact`, `Letrec` and
+`Channelize`, and `mutelim` runs `post-transact..post-letrec`, isolating `Letrec`.
+That pair holding at zero reports nothing about how much of `mut_elim` alone its
+recordings explain, and neither endpoint is a pane, so no pair can be gated to ask
+it. `ProvenanceAudit`, `CAMBRA_PROVENANCE_AUDIT`, `CAMBRA_PROVENANCE_PREDICATES`
+and the audit clause in `provenance_capture_enabled` stay with them.
 
-**What stays is the pane product and the validations over it.** None of it is
-scaffolding for the campaign; all of it is what the campaign was for:
-
-- the recordings at each phase;
-- `PANES`, the fold, and `gate_leaks`;
-- `CAMBRA_PROVENANCE=0`, which measures what capture costs, and
-  `CAMBRA_PROVENANCE_GATE=1`, which trades a second fold per compile for a corpus
-  of every program the caller compiles rather than the handful `corpus()` lists.
+`PaneSpec::gated` stays for a separate reason. A pane may be issued at any point
+during compilation, so the next pane added arrives with its pair ungated, and the
+bit is what says so until every phase in the pair records.
 
 ## The seam
 
@@ -866,39 +860,29 @@ scaffolding for the campaign; all of it is what the campaign was for:
   recording elsewhere can drive down, so gating it would pin churn rather than
   catch a defect.
 
-  Where it stands: every pair from `pre-inference → post-inference` down to
-  `post-as-of-read → post-lambda-elim` is gated, so capture is total over that
-  span on whatever the caller compiles. `post-lambda-elim → post-planning` waits
-  on planning.
+  Where it stands: **every pair is gated**, from `pre-inference → post-inference`
+  down to `post-lambda-elim → post-planning`. Capture is total across the whole
+  pipeline.
 
 ## Known prerequisites for panes past `post-planning`
 
 A pane may be issued at **any** point during compilation — the current adoption
 point is an artifact of what has been built, not a statement about the design.
-The panes stop at `post-planning`, whose pair is not yet gated. Two things stand
-in the way, neither of them touching the pairs that are gated:
+Every pair that exists is gated. One thing stands between the panes and the rest
+of the pipeline:
 
-- **Planning does not record what it raises out of the predicate domain**, which
-  is what keeps `post-lambda-elim → post-planning` ungated. Three sites
-  cross: `planning/iterate`'s `fn_of_bare_predicate` lift, the group-by key
-  extraction, and the hash-join key morphisms. Each would record against its
-  term-tree site, that being the node the raised material becomes, but the
-  `on_copy` hook reports the *origin it freshened*, and no channel re-roots a
-  captured copy onto the node the site named. Only `planning/iterate` records at
-  all, and no phase scope covers it.
-
-  Measured at `post-inference..join-planned`, when that was `full`'s span: over
-  the 11-program corpus the residue was 1184 `DanglingParent` edges and nothing
-  else, every unknown parent an id inside an input-tree refinement predicate, and
-  widening the audit's live set (`CAMBRA_PROVENANCE_PREDICATES=1`) took every gated
-  class to zero. (The count is from before the endpoint moved and has not been
-  re-taken.) That says the recording is total for the span and the narrow live
-  set is what makes the crossing read as a leak. It says nothing about the pane
-  pairs that are gated, whose phases rebuild predicates through `PredMemo` and
-  are recorded there.
-- **Operator conversion has no identity**, which is what stops a pane *after*
+- **Operator conversion has no identity**, which is what stops a pane after
   `post-planning`. `TileOperator` carries none and there is no `OperatorId`, so a
   pane there has nothing to resolve against.
+
+Planning's raising crossing was a second entry here and is resolved. The three
+sites that lift a term out of a type — `planning/iterate`'s `fn_of_bare_predicate`
+lift, the group-by key extraction, and the hash-join key morphisms — each keep the
+*predicate's* parentage, because a clone's copy names the node it was freshened
+from rather than the node the recording named. What had looked like a missing
+re-rooting channel was the predicate ids being outside the enumerated domain,
+which the binder-slot widening fixed;
+`both_raising_paths_attribute_the_predicate_to_the_predicate` pins it.
 
 ## Planned — inspector consumers (`src/inspector_model/`)
 

--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -357,9 +357,9 @@ even so, which is why a surviving node carries an ancestry self-edge
 Attribution resolves through **`parents` ∪ `blame`** — parentage first, then
 blame's distinct additions, so the span order is deterministic and blame is never
 dropped when it names a node the parents do not. Blame is named at a handful of
-sites, all in the mutability phases, so for almost every node this is simply the
-spans of what it was made from, which is why walking the parent edges recovers a
-source location at all.
+sites, in the mutability phases and at the hash-join recognizer, so for almost
+every node this is simply the spans of what it was made from, which is why
+walking the parent edges recovers a source location at all.
 
 **Two labels on one relation, which is why they stay separate columns.** Both
 relate a node to other nodes; what differs is what the relation *asserts* — a
@@ -453,9 +453,10 @@ a loud failure rather than a silent misattribution):
   second parent on a row and the only place any id is named at record time.
 - `blame(ids)` — nodes this rewrite is **related to but did not consume to
   produce** its outputs. Attribution unions them with the parents; the pane
-  relation carries them as *blame* edges. Blame is named at a handful of sites,
-  all in the mutability phases, so `parents` alone is what recovers a source
-  location for almost every node.
+  relation carries them as *blame* edges. Blame is named at a handful of sites —
+  the mutability phases' effect and begin nodes, and the refinement predicate
+  `planning.hash_join` reads its plan out of — so `parents` alone is what
+  recovers a source location for almost every node.
 
 `enter` is the constructor a phase uses to record a rewrite. `copy_frame` is the
 one recording that names **no** node, for a duplication with nothing being

--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -199,9 +199,11 @@ one id, which surfaces at a boundary assert far from the site, if at all.
 Freshening removes the decision rather than answering it.
 
 `assert_unique_node_ids` enforces it at every phase boundary in `compile_program`
-— post-lowering, -inference, -inline, -transact, -letrec-run, -channelize,
+— post-lowering, -inference, -inline, -transact, -letrec, -channelize,
 -as-of-read, -lambda-elim, -planning — gated on `cfg!(any(debug_assertions,
-test))`. The two walks are `O(nodes)` per phase boundary, and a release compile
+test))`. Every boundary but post-lowering reaches it through `settle`, which
+carries the boundary's three post-conditions: unique ids, the debug dumps, and
+the consistency check the stage answers to. The two walks are `O(nodes)` per phase boundary, and a release compile
 runs neither them nor the fold's leak classes: `gate_leaks` carries the same
 `cfg`. The check is a tree invariant and encodes no phase order, so a reordered
 phase carries its check with it. It also means a phase is implicated only at a

--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -510,7 +510,7 @@ serves panes.
 Every phase instrumented so far reduces to one of two forms.
 
 **Rule-table phase → one wrapper combinator.** `simplify::ruled` wraps all
-thirteen rule invocations, with **no rule body edited at all**:
+every rule invocation, with **no rule body edited at all**:
 
 ```rust
 fn ruled(label: RewriteLabel, expr: &mut Expr, rule: impl FnOnce(&mut Expr) -> bool) -> bool {
@@ -525,7 +525,7 @@ rather than every *firing* costs one push and pop when the rule declines. The
 
 **Recursive traversal → one recording at each traversal entry.**
 `planning::iterate` names the marker site it rewrites, and `transact_phase`'s
-fourteen recordings are one per rewrite it performs. A recording takes only an
+recordings are one per rewrite it performs. A recording takes only an
 **id**, so a site that has already moved `expr.node` out can still open one —
 read `expr.node_id()` before the destructure.
 
@@ -542,6 +542,35 @@ Three refinements the shapes above do not cover:
   the same node** inside the arm. The two write disjoint sets of rows on one
   parent, which is what two rewrites attributed to one node should look like. A
   recording carries one label and one nature for its whole extent by design.
+
+#### Choosing between `Expansion` and `Machinery`
+
+**`Expansion` when the products are what the source construct denotes;
+`Machinery` when they are one way of carrying it out.** The two are decided per
+site and nothing in the compiler branches on the answer, so a site that does not
+say which reading it took leaves the next reader to guess.
+
+Planning's two recognizers are the pair that makes the line concrete, and they
+land on opposite sides. `planning.groupby` is `Expansion`: the bucketize chain
+`converse(c ≫ key) ≫ map(c)` is what `groupby(c, key)` *means*, and a reader
+following the attribution back to the `groupby` call is seeing that call
+unfolded. `planning.hash_join` is `Machinery`: the user wrote a two-source
+comprehension with an equality guard, the join plan is one strategy for
+materialising it — picked off the domain's refinement structure, and replaced by
+`iterate`-then-`restrict` when the structure does not permit it — and nothing in
+the source names a join.
+
+The same line elsewhere: `lambda_elim.filter` is `Expansion` because a
+comprehension's `if` guard becoming a domain refinement is that guard; `simplify`
+is `Machinery` because an algebraic rewrite has no source counterpart at all.
+
+`Nature::Source` is not on this axis. It is structural and lowering-only — a node
+is `Source` exactly when it is the root of a lowered `Spanned<ChlExpr>` — so no
+phase ever chooses it (see [The seam](#the-seam)).
+
+`planning_labels_carry_their_declared_nature` (`src/ccl/panes.rs`) pins both
+planning answers, so flipping one is a test edit rather than a silent change to
+what the wire says.
 
 **And a caution about what the gate can tell you.** `Unrecorded == 0` is a
 *coverage* property — was anything recording when a node was minted — not a
@@ -714,8 +743,7 @@ becomes whatever the caller compiles — point it at the test suite and it cover
 every program there instead of the handful `context.rs`'s `corpus()` lists. That
 sample is what let two recording gaps live: `transact_phase` calling
 `mut_elim::fold_induction_loop` with nothing recording, and `flatten_spine`'s
-value-position writer hoist. Both are shapes the eleven listed programs do not
-have. CI runs with it on; it costs about 4% of the test step.
+value-position writer hoist. Both are shapes the listed programs do not have. CI runs with it on; it costs about 4% of the test step.
 
 It gates `gated_pane_pairs()`, which is now every pair: the leak classes hold at
 zero from the lowering handoff to the end of the pipeline over whatever the
@@ -735,7 +763,8 @@ not otherwise. The `planning` span went for that reason: it ran
 list is `Planning` alone, so the wider gated pair measured the same phase and
 keeping both invited trusting the wrong one.
 
-`letrec` and `mutelim` stay because their pair bundles four phases. Both sit
+`letrec` and `mutelim` stay because their pair bundles more phases than either
+span isolates. Both sit
 inside `post-inference → post-channelize`, over `Inline`, `Transact`, `Letrec` and
 `Channelize`, and `mutelim` runs `post-transact..post-letrec`, isolating `Letrec`.
 That pair holding at zero reports nothing about how much of `mut_elim` alone its
@@ -782,7 +811,7 @@ bit is what says so until every phase in the pair records.
   **`label`, unlike `nature`, has no rule: it is per-rule judgment, and carries no
   cross-site guarantee.** Making `Source` structural moved the judgment call from
   `nature` onto `label` rather than removing it, and the disagreement moved with
-  it: an `ExprStmt` at a statement's span is `"lower.image"` at five sites and
+  it: an `ExprStmt` at a statement's span is `"lower.image"` at several sites and
   `tag_machinery(…, "lower.stmt_seq")` at nine — the same node kind in the same
   span role, tagged both ways. So the guarantee is stated weakly on purpose.
   `"lower.image"` means *the rule that minted this node considered it an image*,
@@ -836,7 +865,7 @@ bit is what says so until every phase in the pair records.
   The first entry is the anchor — it has no predecessor, and its projection is
   the lowering projection rather than a fold product. Read `PANES` for the
   current set rather than a list here; today it runs `pre-inference` through
-  `post-planning`, six panes and five pairs. Projections chain: each pair folds
+  `post-planning`. Projections chain: each pair folds
   against the projection of the pane above it, so the first pair whose phases do
   not record leaves every pane below it with nothing to carry forward.
 - **The pane leak gate.** `gate_leaks` asserts the whole `Leak` vector empty at
@@ -851,7 +880,7 @@ bit is what says so until every phase in the pair records.
   `pane_pair_folds_have_no_structural_leaks` over the programs `corpus()` lists,
   on every test run, and `CAMBRA_PROVENANCE_GATE=1` over whatever the caller
   compiles, which is strictly stronger because the wider corpus reaches shapes
-  the eleven listed programs do not.
+  the listed programs do not.
 
   **The flag does not license a nonzero residue where it is false.** A leak is a
   bug wherever it appears; the flag says whether an assertion has been turned on.

--- a/src/ccl/lower/mod.rs
+++ b/src/ccl/lower/mod.rs
@@ -468,7 +468,7 @@ impl LoweringContext {
     /// `tag_machinery` is **the lowering author's judgment about their own rule**.
     /// There is no rule to apply, and the codebase does not agree with itself: the
     /// same node kind at the same span role is tagged both ways — an `ExprStmt` at
-    /// a statement's span is `"lower.image"` at five sites and
+    /// a statement's span is `"lower.image"` at several sites and
     /// `"lower.stmt_seq"` at nine.
     ///
     /// So the guarantee is deliberately weak, and stating it is the point:

--- a/src/ccl/panes.rs
+++ b/src/ccl/panes.rs
@@ -460,75 +460,23 @@ mod tests {
         }
     }
 
-    /// The `program / pane pair` names at which the provenance map is **not**
-    /// vacuous — where some node's origin is another node, so the fold had to
-    /// read a row. See
-    /// [`the_pane_folds_derive_a_non_vacuous_provenance_map`].
-    ///
-    /// Pinned rather than counted: a recording that opens after the clone that
-    /// produced its nodes captures nothing, and the fold still succeeds — it
-    /// reads the pane pair as pure identity. The pin is what makes that
-    /// difference visible, so it lists names and not a total.
-    const EXERCISED_BOUNDARIES: &[&str] = &[
-        "arithmetic / post-as-of-read → post-lambda-elim",
-        "arithmetic / post-lambda-elim → post-planning",
-        "arithmetic / pre-inference → post-inference",
-        "feed_loop / post-as-of-read → post-lambda-elim",
-        "feed_loop / post-inference → post-channelize",
-        "feed_loop / post-lambda-elim → post-planning",
-        "feed_loop / pre-inference → post-inference",
-        "filter_and_aggregate / post-as-of-read → post-lambda-elim",
-        "filter_and_aggregate / post-lambda-elim → post-planning",
-        "filter_and_aggregate / pre-inference → post-inference",
-        "for_accumulator / post-as-of-read → post-lambda-elim",
-        "for_accumulator / post-inference → post-channelize",
-        "for_accumulator / post-lambda-elim → post-planning",
-        "for_accumulator / pre-inference → post-inference",
-        "generator_pipeline / post-as-of-read → post-lambda-elim",
-        "generator_pipeline / post-inference → post-channelize",
-        "generator_pipeline / post-lambda-elim → post-planning",
-        "generator_pipeline / pre-inference → post-inference",
-        "group_by / post-as-of-read → post-lambda-elim",
-        "group_by / post-lambda-elim → post-planning",
-        "group_by / pre-inference → post-inference",
-        "inner_join / post-as-of-read → post-lambda-elim",
-        "inner_join / post-lambda-elim → post-planning",
-        "inner_join / pre-inference → post-inference",
-        "join_then_groupby / post-as-of-read → post-lambda-elim",
-        "join_then_groupby / post-lambda-elim → post-planning",
-        "join_then_groupby / pre-inference → post-inference",
-        "prefix_lines / post-as-of-read → post-lambda-elim",
-        "prefix_lines / post-lambda-elim → post-planning",
-        "prefix_lines / pre-inference → post-inference",
-        "streaming_echo / post-as-of-read → post-lambda-elim",
-        "streaming_echo / post-lambda-elim → post-planning",
-        "streaming_echo / pre-inference → post-inference",
-        "transaction / post-as-of-read → post-lambda-elim",
-        "transaction / post-channelize → post-as-of-read",
-        "transaction / post-inference → post-channelize",
-        "transaction / post-lambda-elim → post-planning",
-        "transaction / pre-inference → post-inference",
-        "udf_chain / post-as-of-read → post-lambda-elim",
-        "udf_chain / post-inference → post-channelize",
-        "udf_chain / post-lambda-elim → post-planning",
-        "udf_chain / pre-inference → post-inference",
-    ];
-
     /// **The provenance map is well-formed and non-vacuous** on every corpus
     /// program: every edge runs from an input-pane id to an output-pane id,
-    /// every id present in both panes is its own dense self-edge, and the
-    /// pane pairs where the fold had to read a *row* are exactly the ones
-    /// pinned above.
+    /// every id present in both panes is its own dense self-edge, and every
+    /// gated pane pair reads a *row* on at least one program.
     ///
-    /// The non-vacuity half is what this test is for. Six of the twenty-two
-    /// corpus pane pairs are pure identity: no phase inside them minted, so the
-    /// map is the input pane's self-edges and holds for reasons that have
-    /// nothing to do with the recording. A corpus edit that
-    /// silently dropped the rewriting programs would otherwise leave a green
-    /// tautology behind.
+    /// The non-vacuity half is what this test is for. A pane pair whose phases
+    /// minted nothing on a given program derives its whole map from the two
+    /// pane id sets, so the well-formedness assertions above hold there for
+    /// reasons that have nothing to do with the recording. Requiring one
+    /// witness per pair is what keeps a pair whose instrumentation stopped
+    /// firing — or a corpus that lost the only program exercising it — from
+    /// leaving a green tautology behind. Which programs supply the witness is
+    /// not pinned: a program rewrites where its own shape makes it rewrite, and
+    /// pinning that turns every corpus edit into a list edit.
     #[test]
     fn the_pane_folds_derive_a_non_vacuous_provenance_map() {
-        let mut exercised: Vec<String> = Vec::new();
+        let mut exercised: std::collections::HashSet<usize> = std::collections::HashSet::new();
         for (name, code) in corpus() {
             let program = compile_ok(&code);
             let panes = program.materialize_panes();
@@ -575,15 +523,19 @@ mod tests {
                 // pane pair whose phases rewrote nothing derives its whole
                 // map from the two pane id sets.
                 if edges.iter().any(|(u, d)| *u != d.id) {
-                    exercised.push(format!("{name} / {pair}"));
+                    exercised.insert(i);
                 }
             }
         }
-        exercised.sort();
-        assert_eq!(
-            exercised, EXERCISED_BOUNDARIES,
-            "the pane pairs at which the fold actually reads a row have changed",
-        );
+        for (i, spec) in PANES.iter().enumerate().skip(1).filter(|(_, s)| s.gated) {
+            assert!(
+                exercised.contains(&(i - 1)),
+                "no corpus program's fold reads a row at {} → {}: either the phases inside the \
+                 pair record nothing, or the corpus lost the program that exercised them",
+                PANES[i - 1].name,
+                spec.name,
+            );
+        }
     }
 
     /// The `program / pane pair` names at which a **blame** edge reaches the
@@ -592,6 +544,8 @@ mod tests {
     /// [`blame_reaches_the_provenance_map_labelled`].
     const RELATING_BOUNDARIES: &[&str] = &[
         "for_accumulator / post-inference → post-channelize",
+        "inner_join / post-lambda-elim → post-planning",
+        "join_then_groupby / post-lambda-elim → post-planning",
         "transaction / post-inference → post-channelize",
     ];
 
@@ -599,11 +553,13 @@ mod tests {
     /// closed transitively alongside `parents`, so a consumer receives the
     /// blame edges and can render or prune them.
     ///
-    /// Pinned as the set of pane pairs where such an edge exists, for the same
-    /// reason [`EXERCISED_BOUNDARIES`] is pinned: blame is named at a handful of
-    /// sites, all in the mutability phases and so all inside the second pane
-    /// pair, and a corpus or recording edit that stopped exercising them
-    /// would otherwise leave the labelled half of the map untested.
+    /// Pinned by name, unlike the per-pair witness
+    /// [`the_pane_folds_derive_a_non_vacuous_provenance_map`] asks for: blame is
+    /// named at a handful of sites — the mutability phases' effect and begin
+    /// nodes, and the refinement predicate `planning.hash_join` reads its plan
+    /// out of — so the pin is short, and a corpus or recording edit that stopped
+    /// exercising them would otherwise leave the labelled half of the map
+    /// untested.
     ///
     /// A blame edge is *only* blame here: no corpus rewrite both
     /// consumes a node and blames it, so nothing in the corpus pins the
@@ -630,6 +586,51 @@ mod tests {
             relating, RELATING_BOUNDARIES,
             "the pane pairs at which blame contributes an edge have changed",
         );
+    }
+
+    /// **Both of a nested join's conditions reach the map**, as blame edges from
+    /// `planning.hash_join`.
+    ///
+    /// The site's recording blames what the *domain type* carries rather than the
+    /// refinement the recogniser accepted, because `join_plan_to_expr` re-enters
+    /// `convert_refinement_to_join` on an arm's own refined type — three frames
+    /// below the recording, with no access to its guard. A one-condition join
+    /// cannot tell the two apart, which is what the flat control fixes: the
+    /// nested program must blame two distinct predicates where the flat one
+    /// blames one.
+    #[test]
+    fn a_nested_join_blames_both_join_conditions() {
+        let flat = "[x + y for x in [2] for y in [1, 2, 3] if x == y]";
+        let nested = "[x + y for x in [2] \
+                      for y in [a + b for a in [1, 2] for b in [1, 2, 3] if a == b] if x == y]";
+        for (name, code, want) in [("flat", flat, 1), ("nested", nested, 2)] {
+            let program = compile_ok(code);
+            let panes = program.materialize_panes();
+            let pair = panes
+                .pairs
+                .iter()
+                .find(|p| p.name == "post-lambda-elim → post-planning")
+                .expect("the planning pane pair");
+            let blamed: std::collections::HashSet<NodeId> = pair
+                .map
+                .edges()
+                .into_iter()
+                .filter(|(u, d)| {
+                    *u != d.id
+                        && d.labels.has_blame()
+                        && program
+                            .provenance_table
+                            .tag(d.id)
+                            .is_some_and(|t| t.label == "planning.hash_join")
+                })
+                .map(|(u, _)| u)
+                .collect();
+            assert_eq!(
+                blamed.len(),
+                want,
+                "{name}: distinct predicates blamed by planning.hash_join",
+            );
+        }
     }
 
     /// The corpus programs whose definitions inference **generalizes and then

--- a/src/ccl/panes.rs
+++ b/src/ccl/panes.rs
@@ -117,13 +117,10 @@ pub(crate) struct PaneSpec {
     /// constant no correct recording elsewhere can drive down, so gating it would
     /// pin churn rather than catch a defect. Flip it in the commit that
     /// instruments the last phase in the pair, the same way an audit span's
-    /// endpoint moves. Unused on the anchor, which has no pair.
-    ///
-    /// TODO(provenance-audit-retire): this bit and
-    /// [`MaterializedPanes::gated_pane_pairs`] exist only to describe a
-    /// half-instrumented pipeline. Both go when the last phase records, leaving
-    /// [`gate_leaks`] over every pair. See `design/provenance.md`, "What retires
-    /// when the last phase records".
+    /// endpoint moves. Unused on the anchor, which has no pair. A pane may be
+    /// issued at any point in the pipeline, so the bit outlives any one pair
+    /// becoming gated; see `src/ccl/design/provenance.md`, "What gating every
+    /// pair does not retire".
     pub(crate) gated: bool,
 }
 
@@ -135,11 +132,10 @@ pub(crate) struct PaneSpec {
 /// empty and its `gated` is unused — its projection is the lowering projection
 /// rather than a fold product.
 ///
-/// The bottom pair is ungated because `planning` mints with nothing open. Every
-/// pair above it holds at zero on whatever the caller compiles — true of
-/// `pre-inference → post-inference` only once the fold's id domain was widened to
-/// the slot domain the passes rewrite and inference's per-instantiation predicate
-/// freshen took a copy recording.
+/// Every pair is gated, so the leak classes hold at zero over whatever the caller
+/// compiles. `pre-inference → post-inference` reaches that only because the fold's
+/// id domain was widened to the slot domain the passes rewrite and inference's
+/// per-instantiation predicate freshen took a copy recording.
 pub(crate) const PANES: [PaneSpec; 6] = [
     PaneSpec {
         name: "pre-inference",
@@ -174,7 +170,7 @@ pub(crate) const PANES: [PaneSpec; 6] = [
     PaneSpec {
         name: "post-planning",
         phases: &[Phase::Planning],
-        gated: false,
+        gated: true,
     },
 ];
 
@@ -311,6 +307,10 @@ mod tests {
             (
                 "inner_join",
                 include_str!("../../tests/programs/inner_join/program.cambra").to_string(),
+            ),
+            (
+                "join_then_groupby",
+                include_str!("../../tests/programs/join_then_groupby/program.cambra").to_string(),
             ),
             (
                 "prefix_lines",
@@ -471,32 +471,46 @@ mod tests {
     /// difference visible, so it lists names and not a total.
     const EXERCISED_BOUNDARIES: &[&str] = &[
         "arithmetic / post-as-of-read → post-lambda-elim",
+        "arithmetic / post-lambda-elim → post-planning",
         "arithmetic / pre-inference → post-inference",
         "feed_loop / post-as-of-read → post-lambda-elim",
         "feed_loop / post-inference → post-channelize",
+        "feed_loop / post-lambda-elim → post-planning",
         "feed_loop / pre-inference → post-inference",
         "filter_and_aggregate / post-as-of-read → post-lambda-elim",
+        "filter_and_aggregate / post-lambda-elim → post-planning",
         "filter_and_aggregate / pre-inference → post-inference",
         "for_accumulator / post-as-of-read → post-lambda-elim",
         "for_accumulator / post-inference → post-channelize",
+        "for_accumulator / post-lambda-elim → post-planning",
         "for_accumulator / pre-inference → post-inference",
         "generator_pipeline / post-as-of-read → post-lambda-elim",
         "generator_pipeline / post-inference → post-channelize",
+        "generator_pipeline / post-lambda-elim → post-planning",
         "generator_pipeline / pre-inference → post-inference",
         "group_by / post-as-of-read → post-lambda-elim",
+        "group_by / post-lambda-elim → post-planning",
         "group_by / pre-inference → post-inference",
         "inner_join / post-as-of-read → post-lambda-elim",
+        "inner_join / post-lambda-elim → post-planning",
         "inner_join / pre-inference → post-inference",
+        "join_then_groupby / post-as-of-read → post-lambda-elim",
+        "join_then_groupby / post-lambda-elim → post-planning",
+        "join_then_groupby / pre-inference → post-inference",
         "prefix_lines / post-as-of-read → post-lambda-elim",
+        "prefix_lines / post-lambda-elim → post-planning",
         "prefix_lines / pre-inference → post-inference",
         "streaming_echo / post-as-of-read → post-lambda-elim",
+        "streaming_echo / post-lambda-elim → post-planning",
         "streaming_echo / pre-inference → post-inference",
         "transaction / post-as-of-read → post-lambda-elim",
         "transaction / post-channelize → post-as-of-read",
         "transaction / post-inference → post-channelize",
+        "transaction / post-lambda-elim → post-planning",
         "transaction / pre-inference → post-inference",
         "udf_chain / post-as-of-read → post-lambda-elim",
         "udf_chain / post-inference → post-channelize",
+        "udf_chain / post-lambda-elim → post-planning",
         "udf_chain / pre-inference → post-inference",
     ];
 
@@ -779,9 +793,10 @@ mod tests {
                 Phase::Infer,
                 Phase::LambdaElim,
                 Phase::Letrec,
+                Phase::Planning,
                 Phase::Transact
             ],
-            "the transaction fixture is rewritten by exactly these six phases",
+            "the transaction fixture is rewritten by exactly these seven phases",
         );
     }
 

--- a/src/ccl/panes.rs
+++ b/src/ccl/panes.rs
@@ -386,7 +386,7 @@ mod tests {
     }
 
     /// **Capture totality**, as a corpus-wide property rather than a per-phase
-    /// assertion: both pane pairs materialize and fold over every corpus
+    /// assertion: every pane pair materializes and folds over every corpus
     /// program, every output-pane node has an origin (`Unrecorded == 0`), and
     /// no node's ancestry dangles (`DanglingParent == 0`).
     ///
@@ -672,7 +672,7 @@ mod tests {
         }
     }
 
-    /// All four phases inside the second pane pair explain what they produce.
+    /// Every phase inside the second pane pair explains what it produces.
     ///
     /// The interesting programs are the ones that drive a *whole-program*
     /// rewrite, where naming one node is least obviously applicable: a
@@ -688,7 +688,7 @@ mod tests {
     #[test]
     fn the_second_pane_pair_explains_every_node_its_phases_produce() {
         /// Reaches `transact_phase` or `channelize` — the whole-program
-        /// rewrites, and the last two phases to adopt the recorder.
+        /// rewrites, where naming one node is least obviously applicable.
         const WHOLE_PROGRAM_REWRITES: &[&str] = &["transaction", "feed_loop", "generator_pipeline"];
         for (name, code) in corpus() {
             let panes = compile_ok(&code).materialize_panes();
@@ -796,7 +796,7 @@ mod tests {
                 Phase::Planning,
                 Phase::Transact
             ],
-            "the transaction fixture is rewritten by exactly these seven phases",
+            "the transaction fixture is rewritten by exactly these phases",
         );
     }
 
@@ -899,7 +899,7 @@ mod tests {
     /// done
     /// ```
     ///
-    /// With capture on it also materializes and folds both panes, since that is
+    /// With capture on it also materializes and folds the panes, since that is
     /// the cost the design actually incurs.
     #[test]
     #[ignore = "measurement, not an assertion; see the doc comment for the driver"]
@@ -951,5 +951,86 @@ mod tests {
             );
         }
         eprintln!("[perf capture={capture}] TOTAL compile {total_compile:?} fold {total_fold:?}");
+    }
+
+    /// **Planning's two recognizers carry the `Nature` they were assigned.**
+    /// Both replace a term-tree site that images a source construct, and they
+    /// answer the `Expansion`/`Machinery` question differently: a bucketize
+    /// chain is what `groupby` denotes, while a hash join is one way of
+    /// materialising a comprehension the user never wrote as a join. The tag
+    /// rides the wire, so a consumer reads the difference as meaningful and a
+    /// silent flip is a change to what the inspector claims about the source.
+    /// See `design/provenance.md`, "Choosing between `Expansion` and
+    /// `Machinery`".
+    ///
+    /// Asserting both labels are *present* is the second half: this fixture
+    /// exists to put both recognizers on one tree, and a program that stopped
+    /// reaching one would otherwise pass the nature check vacuously.
+    #[test]
+    fn planning_labels_carry_their_declared_nature() {
+        use crate::ccl::provenance::{Nature, RewriteLabel};
+
+        let program = compile_ok(include_str!(
+            "../../tests/programs/join_then_groupby/program.cambra"
+        ));
+        let mut seen: std::collections::BTreeMap<RewriteLabel, Nature> = Default::default();
+        for id in collect_tree_ids(&program.ast) {
+            let Some(tag) = program.provenance_table.tag_in(id, &[Phase::Planning]) else {
+                continue;
+            };
+            // One label, one nature: a recording carries both for its whole
+            // extent, so two natures under one label means two sites disagree.
+            if let Some(prev) = seen.insert(tag.label, tag.nature) {
+                assert_eq!(
+                    prev, tag.nature,
+                    "label {} is recorded at two different natures",
+                    tag.label,
+                );
+            }
+        }
+        assert_eq!(
+            seen.get("planning.groupby"),
+            Some(&Nature::Expansion),
+            "the bucketize chain is what `groupby` denotes, so its rewrite expands \
+             a source construct; labels seen: {:?}",
+            seen,
+        );
+        assert_eq!(
+            seen.get("planning.hash_join"),
+            Some(&Nature::Machinery),
+            "a hash join is a materialization strategy for a comprehension, not \
+             something the source names; labels seen: {:?}",
+            seen,
+        );
+    }
+
+    /// **One `Phase::Planning` scope covers both halves of planning.**
+    /// `compile_program` runs `plan_loops` and `planning::run` inside a single
+    /// scope. A regression that scoped `run` alone leaves `plan_loops`'
+    /// recognition rewrites writing into no table; the leak gate catches that as
+    /// a count of unexplained nodes, and this names which half stopped
+    /// recording.
+    ///
+    /// The two halves are told apart by label: `planning.recognize` is
+    /// `plan_loops` turning a causal `LetRec` into a `Transact`, and
+    /// `planning.iterate` is `run` wrapping an iteration site.
+    #[test]
+    fn one_planning_scope_covers_recognition_and_iteration() {
+        let (_, code) = corpus()
+            .into_iter()
+            .find(|(name, _)| *name == "transaction")
+            .expect("the corpus carries the transaction fixture");
+        let program = compile_ok(&code);
+        let labels: std::collections::BTreeSet<_> = collect_tree_ids(&program.ast)
+            .into_iter()
+            .filter_map(|id| program.provenance_table.tag_in(id, &[Phase::Planning]))
+            .map(|tag| tag.label)
+            .collect();
+        for expected in ["planning.recognize", "planning.iterate"] {
+            assert!(
+                labels.contains(expected),
+                "no `{expected}` row survives into the post-planning pane; labels seen: {labels:?}",
+            );
+        }
     }
 }

--- a/src/ccl/planning/groupby.rs
+++ b/src/ccl/planning/groupby.rs
@@ -24,12 +24,18 @@ pub(super) fn recognize_groupby_sites(expr: &mut Expr) {
     // what the user's `groupby(...)` became and what the chain now stands in
     // for; the lifted key keeps its own parentage, since a clone's copy carries
     // the predicate node it was freshened from rather than the node named here.
-    // `Nature::Expansion` for the same reason.
+    //
+    // `Nature::Expansion`: the bucketize chain is what `groupby` *denotes*, so
+    // the rewrite expands a construct the user wrote. Contrast
+    // `planning.hash_join`, which is `Machinery` because a hash join is a
+    // materialization strategy for a site the user wrote as a comprehension.
     //
     // Scoped to the *attempt* and closed before the child walk. Recursing under
-    // it would make a nested site's products descend from this one; a
-    // non-matching node mints nothing, so wrapping the attempt costs a push and
-    // a pop.
+    // it would make a nested site's products descend from this one. A
+    // non-matching node writes no rows here: the matcher bails on node shape
+    // before it reaches anything that mints, and the type work it does reach
+    // (`open_codomain`) opens its own `subst.*` recordings, so wrapping the
+    // attempt costs a push and a pop.
     let rewritten = {
         let _g = provenance::enter(
             expr.node_id(),

--- a/src/ccl/planning/groupby.rs
+++ b/src/ccl/planning/groupby.rs
@@ -18,10 +18,28 @@ use crate::ccl::ty::FunKind;
 /// `converse(c ≫ key) ≫ map(c)`. Walks the tree, rewriting every such site
 /// (a rewritten site's tail may contain further sites).
 pub(super) fn recognize_groupby_sites(expr: &mut Expr) {
-    if let Some(rewritten) = convert_groupby_pointful(expr) {
+    // The recording names the composition site — the term-tree node the
+    // bucketize chain replaces — and deliberately not the key morphism the
+    // rewrite lifts out of the refined domain's predicate. The composition is
+    // what the user's `groupby(...)` became and what the chain now stands in
+    // for; the lifted key keeps its own parentage, since a clone's copy carries
+    // the predicate node it was freshened from rather than the node named here.
+    // `Nature::Expansion` for the same reason.
+    //
+    // Scoped to the *attempt* and closed before the child walk. Recursing under
+    // it would make a nested site's products descend from this one; a
+    // non-matching node mints nothing, so wrapping the attempt costs a push and
+    // a pop.
+    let rewritten = {
+        let _g = provenance::enter(
+            expr.node_id(),
+            "planning.groupby",
+            provenance::Nature::Expansion,
+        );
+        convert_groupby_pointful(expr)
+    };
+    if let Some(rewritten) = rewritten {
         *expr = rewritten;
-        expr.walk_children_mut(recognize_groupby_sites);
-        return;
     }
     expr.walk_children_mut(recognize_groupby_sites);
 }

--- a/src/ccl/planning/iterate.rs
+++ b/src/ccl/planning/iterate.rs
@@ -394,11 +394,10 @@ pub(super) fn wrap_with_iterate(expr: &mut Expr) {
     let Some(domain_ty) = expr.ty.domain() else {
         return;
     };
-    // The recording names the site being wrapped.
-    //
-    // These rows reach no table in a normal compile: `compile_program` calls
-    // `planning::run` outside every pass scope it opens, so they land only under
-    // `CAMBRA_PROVENANCE_AUDIT=planning` (`recognized..join-planned`).
+    // The recording names the site being wrapped. The predicate lifted out of
+    // the type lands as a `Copy` of the term it was freshened from, so it keeps
+    // the predicate's parentage rather than taking this site's — see
+    // `both_raising_paths_attribute_the_predicate_to_the_predicate`.
     let _g = provenance::enter(
         expr.node_id(),
         "planning.iterate",

--- a/src/ccl/planning/iterate.rs
+++ b/src/ccl/planning/iterate.rs
@@ -394,10 +394,13 @@ pub(super) fn wrap_with_iterate(expr: &mut Expr) {
     let Some(domain_ty) = expr.ty.domain() else {
         return;
     };
-    // The recording names the site being wrapped. The predicate lifted out of
-    // the type lands as a `Copy` of the term it was freshened from, so it keeps
-    // the predicate's parentage rather than taking this site's — see
-    // `both_raising_paths_attribute_the_predicate_to_the_predicate`.
+    // The recording names the site being wrapped, so the staging minted under it
+    // — the chain-head `iterate(true)` and one `restrict` per refinement —
+    // descends from the site and not from the predicate each `restrict` applies.
+    // The predicate itself does not: it lands as a `Copy` of the term it was
+    // freshened from, so it keeps the predicate's parentage. See
+    // `both_raising_paths_attribute_the_predicate_to_the_predicate`, which pins
+    // that narrower claim.
     let _g = provenance::enter(
         expr.node_id(),
         "planning.iterate",

--- a/src/ccl/planning/join.rs
+++ b/src/ccl/planning/join.rs
@@ -1092,6 +1092,11 @@ pub(super) fn try_hash_join_rewrite(expr: &mut Expr, domain_ty: &Type) -> bool {
     // keeps that refinement's own parentage — a clone's copy carries the node it
     // was freshened from, not the node named here.
     //
+    // `Nature::Machinery`: a hash join is one *strategy* for materialising this
+    // site, chosen off the domain's type structure, and the user wrote a
+    // comprehension rather than a join. Contrast `planning.groupby`, which is
+    // `Expansion` because its bucketize chain is what `groupby` denotes.
+    //
     // Not a fusion: the site's original value-producer is kept rather than
     // consumed, spliced in as the second element of the compose below with its
     // id intact. The arms the plan reads come from the domain **type**, and a

--- a/src/ccl/planning/join.rs
+++ b/src/ccl/planning/join.rs
@@ -1081,6 +1081,44 @@ pub(super) fn try_hash_join_rewrite(expr: &mut Expr, domain_ty: &Type) -> bool {
         "Attempting hash-join rewrite at iteration site: {}",
         symbolic(expr),
     );
+    // The iteration site is what the recording names. Every product of the plan
+    // — the per-arm `iterate` leaves, the key morphisms, the
+    // `map_domain`/`permute_domain` scaffolding, the residual `restrict`s — is
+    // how *this* site is being materialised, so it is the node they all replace.
+    // Coarse by construction: an n-way plan, and a nested loop-join re-entering
+    // through `join_plan_to_expr`, all descend from this one node. The join
+    // conditions are read out of whichever of the domain's refinements
+    // `convert_refinement_to_join` accepts, and the material lifted from there
+    // keeps that refinement's own parentage — a clone's copy carries the node it
+    // was freshened from, not the node named here.
+    //
+    // Not a fusion: the site's original value-producer is kept rather than
+    // consumed, spliced in as the second element of the compose below with its
+    // id intact. The arms the plan reads come from the domain **type**, and a
+    // type carries no identity to consume.
+    //
+    // The recording spans the *attempts*, as simplify's rule combinator does:
+    // `convert_refinement_to_join` tries each refinement in turn, and both a
+    // rejected refinement and a wholly unmatched domain return through this one
+    // guard's `Drop`. What a half-built plan minted before bailing — the key
+    // copies `plan_loop_join` freshens before `spanning_tree_children` refuses
+    // the condition graph — composes away as a transient: a copy that never
+    // reaches the output tree is not `Unrecorded`, that class being found by
+    // walking that tree, and its parent is this site, so it is no
+    // `DanglingParent` either. Naming the firing instead would mean threading
+    // the site id down through `convert_refinement_to_join` into
+    // `convert_loop_join`.
+    //
+    // How many such transients a compile writes therefore depends on the order
+    // the refinement set is iterated in, which nothing about a set makes
+    // meaningful. That stays unobservable for the same reason they compose away:
+    // the rejected attempts reach no pane, and the accepted plan is the same
+    // whichever refinement supplied it.
+    let _g = provenance::enter(
+        expr.node_id(),
+        "planning.hash_join",
+        provenance::Nature::Machinery,
+    );
     let Some(transformed) = convert_refinement_to_join(domain_ty) else {
         trace!("Hash-join pattern did not match");
         return false;

--- a/src/ccl/planning/join.rs
+++ b/src/ccl/planning/join.rs
@@ -6,7 +6,7 @@
 //! ([`plan_loop_join`] / [`convert_loop_join`]) and emits a [`JoinPlan`] tree
 //! ([`join_plan_to_expr`]) whose leaves are iteration-bearing.
 
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeSet, HashSet, VecDeque};
 use std::fmt::Debug;
 use std::mem::take;
 
@@ -1084,25 +1084,28 @@ pub(super) fn try_hash_join_rewrite(expr: &mut Expr, domain_ty: &Type) -> bool {
     // The iteration site is what the recording names. Every product of the plan
     // — the per-arm `iterate` leaves, the key morphisms, the
     // `map_domain`/`permute_domain` scaffolding, the residual `restrict`s — is
-    // how *this* site is being materialised, so it is the node they all replace.
+    // how this site is being materialised, so it is the node they all replace.
     // Coarse by construction: an n-way plan, and a nested loop-join re-entering
-    // through `join_plan_to_expr`, all descend from this one node. The join
-    // conditions are read out of whichever of the domain's refinements
-    // `convert_refinement_to_join` accepts, and the material lifted from there
-    // keeps that refinement's own parentage — a clone's copy carries the node it
-    // was freshened from, not the node named here.
+    // through `join_plan_to_expr`, all descend from this one node.
     //
-    // `Nature::Machinery`: a hash join is one *strategy* for materialising this
+    // `Nature::Machinery`: a hash join is one strategy for materialising this
     // site, chosen off the domain's type structure, and the user wrote a
     // comprehension rather than a join. Contrast `planning.groupby`, which is
     // `Expansion` because its bucketize chain is what `groupby` denotes.
     //
-    // Not a fusion: the site's original value-producer is kept rather than
-    // consumed, spliced in as the second element of the compose below with its
-    // id intact. The arms the plan reads come from the domain **type**, and a
-    // type carries no identity to consume.
+    // The domain's refinement predicates are blamed rather than consumed. They
+    // are the terms the plan is read out of — the accepted one decomposes into
+    // the join conditions, the rest ride into the plan's base type as leaf
+    // refinements and residual `restrict`s — and this rewrite leaves them alive:
+    // the site's original value-producer is spliced into the compose below with
+    // its id and its refined type intact, and `predicate.rebuild` consumes them
+    // later in this same phase. Naming them parents here would have one node
+    // consumed twice. What the plan does consume is recorded a level down, where
+    // `split_join_conditions` clones the equality's two sides into key morphisms
+    // and each clone carries the subterm it was freshened from; blame is the only
+    // edge the scaffolding around those keys has to a predicate.
     //
-    // The recording spans the *attempts*, as simplify's rule combinator does:
+    // The recording spans the attempts, as simplify's rule combinator does:
     // `convert_refinement_to_join` tries each refinement in turn, and both a
     // rejected refinement and a wholly unmatched domain return through this one
     // guard's `Drop`. What a half-built plan minted before bailing — the key
@@ -1110,16 +1113,13 @@ pub(super) fn try_hash_join_rewrite(expr: &mut Expr, domain_ty: &Type) -> bool {
     // the condition graph — composes away as a transient: a copy that never
     // reaches the output tree is not `Unrecorded`, that class being found by
     // walking that tree, and its parent is this site, so it is no
-    // `DanglingParent` either. Naming the firing instead would mean threading
-    // the site id down through `convert_refinement_to_join` into
-    // `convert_loop_join`.
-    //
-    // How many such transients a compile writes therefore depends on the order
-    // the refinement set is iterated in, which nothing about a set makes
-    // meaningful. That stays unobservable for the same reason they compose away:
-    // the rejected attempts reach no pane, and the accepted plan is the same
-    // whichever refinement supplied it.
-    let _g = provenance::enter(
+    // `DanglingParent` either. How many transients a compile writes depends on
+    // the order the refinement set is iterated in, and stays unobservable for
+    // the same reason they compose away: the rejected attempts reach no pane,
+    // and the accepted plan is the same whichever refinement supplied it. Naming
+    // the firing instead would mean threading the site id down through
+    // `convert_refinement_to_join` into `convert_loop_join`.
+    let g = provenance::enter(
         expr.node_id(),
         "planning.hash_join",
         provenance::Nature::Machinery,
@@ -1128,6 +1128,15 @@ pub(super) fn try_hash_join_rewrite(expr: &mut Expr, domain_ty: &Type) -> bool {
         trace!("Hash-join pattern did not match");
         return false;
     };
+    // The whole domain, not the refinement the recogniser accepted:
+    // `join_plan_to_expr` re-enters `convert_refinement_to_join` on an arm's own
+    // refinement for a nested join, three frames below this guard and with no
+    // access to it. Pinned by `a_nested_join_blames_both_join_conditions` in
+    // `src/ccl/panes.rs`.
+    let mut visited = HashSet::new();
+    let mut read = Vec::new();
+    ccl_utils::walk_refined_predicates(domain_ty, &mut visited, &mut |p, _| read.push(p.node_id()));
+    g.blame(&read);
     trace!(
         "Hash-join rewrite succeeded: {} : {}",
         symbolic(&transformed),

--- a/src/ccl/planning/loops.rs
+++ b/src/ccl/planning/loops.rs
@@ -17,6 +17,7 @@ use crate::ccl::{
     ccl_utils::{commit_payload_ty, count_free, strip_refinements},
     letrec::check_letrec_causal,
     mut_elim::{binding, fun_parts, tvar},
+    provenance,
     symbolic::symbolic,
 };
 
@@ -49,6 +50,14 @@ use crate::ccl::{
 pub(crate) fn plan_loops(expr: Expr) -> Expr {
     let mut expr = expr;
     if let TypedExprNode::LetRec { .. } = &expr.node {
+        // Read before the destructure moves `expr.node` out: a recording needs
+        // the id, never the node, so a site that no longer holds its input can
+        // still open one. The `LetRec` is what every recognition arm below
+        // replaces — the `Transact` carrier, the `let __hist = …` binding it, and
+        // the plain `let` chain a channel group flattens to. The group's
+        // bindings that vanish into the carrier are deaths, which the pane
+        // difference reports without anyone naming them.
+        let letrec_id = expr.node_id();
         let TypedExprNode::LetRec { bindings, body } = expr.node else {
             unreachable!("causal above")
         };
@@ -70,12 +79,30 @@ pub(crate) fn plan_loops(expr: Expr) -> Expr {
         // with no guards, is exactly an acyclicity check), so flatten it back
         // to plain `let`s in dependency order for planning.
         if !group_has_causal(&bindings) {
+            // Recurse into the definitions before opening the recording: a
+            // nested group inside a definition is its own rewrite and names its
+            // own `LetRec`.
             let bindings = bindings
                 .into_iter()
                 .map(|(b, def)| (b, plan_loops(def)))
                 .collect();
+            let _g = provenance::enter(
+                letrec_id,
+                "planning.channel_group",
+                provenance::Nature::Machinery,
+            );
             return flatten_channel_group(bindings, body);
         }
+        // `Nature::Machinery` for both recognition arms: a `LetRec` becoming a
+        // `Transact` is a change of carrier, not the expansion of a source
+        // construct. The loop or `with begin():` block the user wrote was
+        // expanded into this `LetRec` by `mut_elim` / `transact_phase`, and
+        // those recordings are where the fidelity claim belongs.
+        let _g = provenance::enter(
+            letrec_id,
+            "planning.recognize",
+            provenance::Nature::Machinery,
+        );
         if is_txn_group(&bindings) {
             return recognize_txn_group(bindings, body);
         }
@@ -520,6 +547,15 @@ fn rewrite_txn_reads(
     if let TypedExprNode::Var(n) = &e.node
         && let Some((field, field_ty)) = read_map.get(n)
     {
+        // The projection replaces *this* reference, so the reference is what the
+        // recording names — finer than the enclosing `planning.recognize`, which
+        // would otherwise make every continuation read descend from the `LetRec`
+        // and lose which read went where.
+        let _g = provenance::enter(
+            e.node_id(),
+            "planning.txn_read",
+            provenance::Nature::Machinery,
+        );
         *e = hist_field_read(hist, hist_ty, field.clone(), field_ty.clone());
         return;
     }
@@ -549,6 +585,16 @@ fn collapse_snapshot_sources(e: &mut Expr, hist: &Name, hist_ty: &Type) {
         // Stamp the source with the mutable variable's *own* type (all keys + taps), not
         // just the read subset — the `Var(__hist)` must agree with its binder,
         // and op-conversion's snapshot read projects the fields it needs by name.
+        //
+        // The record literal is what the recording names: the mutable variable
+        // is exactly what it collapses to, and its per-field reads die with it.
+        // Scoped to this arm rather than the function, because the child walk
+        // below runs whether or not this arm fired.
+        let _g = provenance::enter(
+            source.node_id(),
+            "planning.snapshot_source",
+            provenance::Nature::Machinery,
+        );
         *source = tvar(hist, hist_ty.clone());
         // The argument tuple\'s recorded type keeps its shape; re-stamp the
         // source slot.
@@ -659,7 +705,10 @@ fn recognize_group(h: TypedBinding, def: Expr, letrec_body: Expr) -> Expr {
         source,
         body: writer_body,
     };
-    let keys_for_reads = keys.clone();
+    // Only the key *names* are read downstream. Cloning the `TransactKey`s
+    // would deep-clone every seed expression and then discard the copies, which
+    // costs a stranded row per node of every accumulator seed.
+    let key_names_for_reads: Vec<Name> = keys.iter().map(|k| k.name.clone()).collect();
     let mut transact = Expr::new(TypedExprNode::Transact {
         keys,
         writers: vec![writer],
@@ -674,7 +723,7 @@ fn recognize_group(h: TypedBinding, def: Expr, letrec_body: Expr) -> Expr {
         &h.name,
         &hist,
         &hist_ty,
-        &keys_for_reads,
+        &key_names_for_reads,
         &acc_tys,
         &domain_ty,
     );
@@ -708,7 +757,7 @@ fn rewrite_hist_reads(
     h: &Name,
     hist: &Name,
     hist_ty: &Type,
-    keys: &[TransactKey],
+    keys: &[Name],
     acc_tys: &[Type],
     domain_ty: &Type,
 ) {
@@ -723,6 +772,15 @@ fn rewrite_hist_reads(
             Some(TypedExprNode::Builtin(Builtin::VariantProject(_)))
         )
     {
+        // The whole compose is what the recording names: the history-record read
+        // replaces its matched prefix and, when a tail survives, the rebuilt
+        // compose replaces the compose itself, so both products stand in for
+        // this one node.
+        let _g = provenance::enter(
+            e.node_id(),
+            "planning.hist_read",
+            provenance::Nature::Machinery,
+        );
         // The history-record read replacing the matched prefix, plus how many compose
         // elements the prefix covered (the `variant_project` step included).
         let replacement: Option<(Expr, usize)> =
@@ -731,7 +789,7 @@ fn rewrite_hist_reads(
                     Some(TypedExprNode::Proj(ProjKey::Field(f))),
                     Some(TypedExprNode::Proj(ProjKey::Index(i))),
                 ) if f == F_WRITES => {
-                    let field = keys[*i].name.field_key();
+                    let field = keys[*i].field_key();
                     let field_ty = Type::fun(domain_ty.clone(), acc_tys[*i].clone());
                     Some((hist_field_read(hist, hist_ty, field, field_ty), 4))
                 }

--- a/src/ccl/planning/map_filter.rs
+++ b/src/ccl/planning/map_filter.rs
@@ -50,6 +50,21 @@ pub(super) fn insert_map_filters(expr: &mut Expr) {
     let TypedExprNode::Compose(elts) = &expr.node else {
         return;
     };
+    // The compose is what the recording names: the `map_filter` is spliced into it,
+    // and the site it narrows keeps its own id, re-typed in place. `Machinery`, for
+    // the reason `planning.iterate` is — a `map_filter` is how a refinement the site's
+    // type already carries gets materialised, and the user wrote an inner
+    // comprehension with an `if`.
+    //
+    // The recording spans the *match*: `map_filter_site` clones a candidate's value
+    // predicate out of its refinements while probing, so a scan that rewrites nothing
+    // still copies. Those copies reach no output tree and compose away as transients
+    // of this node, as `planning.hash_join`'s rejected attempts do.
+    let _g = provenance::enter(
+        expr.node_id(),
+        "planning.map_filter",
+        provenance::Nature::Machinery,
+    );
     let Some(site) = elts.iter().position(|e| map_filter_site(e).is_some()) else {
         return;
     };

--- a/src/ccl/planning/mod.rs
+++ b/src/ccl/planning/mod.rs
@@ -30,6 +30,7 @@ use crate::ccl::{
     ccl_utils::apply_primitive,
     infer::typecheck,
     lambda_elim::{self, compose, id},
+    provenance,
     simplify::simplify,
     symbolic::{symbolic, symbolic_typed},
 };

--- a/src/ccl/planning/predicates.rs
+++ b/src/ccl/planning/predicates.rs
@@ -223,3 +223,111 @@ fn compile_refinements(refinements: &mut RefinementSet, base: &Type, memo: &Pred
         });
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccl::ccl_utils::trivially_true_predicate;
+    use crate::ccl::context::Phase;
+    use crate::ccl::provenance::{NodeId, PhaseScope, ProvenanceTable, TableSession};
+    use crate::ccl::{BaseType, Lit, Name};
+    use std::collections::HashSet;
+
+    /// Every id reachable from `e`, main tree only.
+    fn ids_of(e: &Expr) -> HashSet<NodeId> {
+        let mut out = HashSet::new();
+        fn go(e: &Expr, out: &mut HashSet<NodeId>) {
+            out.insert(e.node_id());
+            e.walk_children(&mut |c| go(c, out));
+        }
+        go(e, &mut out);
+        out
+    }
+
+    /// Walk `parents` back from `id` until it reaches an id in `roots`, or runs
+    /// out of rows. `None` when the ancestry never reaches one.
+    fn resolves_into(table: &ProvenanceTable, id: NodeId, roots: &HashSet<NodeId>) -> bool {
+        let mut frontier = vec![id];
+        let mut seen = HashSet::new();
+        while let Some(n) = frontier.pop() {
+            if roots.contains(&n) {
+                return true;
+            }
+            if !seen.insert(n) {
+                continue;
+            }
+            frontier.extend_from_slice(table.parents(n));
+        }
+        false
+    }
+
+    /// Raise `bare` out of a predicate under a recording naming `site`, and
+    /// report which of the result's nodes reach the predicate and which reach
+    /// the site.
+    fn raise(bare: &Expr, site: NodeId) -> (ProvenanceTable, Expr, HashSet<NodeId>) {
+        let pred_ids = ids_of(bare);
+        let session = TableSession::install();
+        let raised = {
+            let _scope = PhaseScope::enter(Phase::Planning);
+            let _g = provenance::enter(site, "test.raise", provenance::Nature::Machinery);
+            fn_of_bare_predicate(&Type::Base(BaseType::Int), bare)
+        };
+        (session.into_table(), raised, pred_ids)
+    }
+
+    /// **Both paths of `fn_of_bare_predicate` attribute the raised predicate to
+    /// the predicate**, never to the term-tree site the recording names.
+    ///
+    /// The fast path clones, and a clone's copy names the node it was freshened
+    /// from, so the predicate's parentage rides along by construction. The slow
+    /// path η-expands and lambda-eliminates, minting a `Lambda` that descends
+    /// from the site — but that wrapper is consumed by the elimination rather
+    /// than placed, so it composes away as a transient and every node that
+    /// reaches the output still resolves into the predicate.
+    ///
+    /// This is what makes the two agree. Before `lambda_elim` recorded, the
+    /// slow path's whole product landed on the site, because the sub-run's
+    /// mints fell through to the enclosing recording.
+    #[test]
+    fn both_raising_paths_attribute_the_predicate_to_the_predicate() {
+        let int_ty = Type::Base(BaseType::Int);
+        let bool_ty = Type::Base(BaseType::Bool);
+        let elem = || Expr::var(Name::elem()).with_ty(int_ty.clone());
+        // A real `𝐷 ⇒ Bool`, so the deep typechecker accepts the η-expansion the
+        // slow path builds.
+        let pred_fn = |domain: Type| trivially_true_predicate(domain);
+
+        // Fast path: already `__elem ▷ p`, so the raise is a single clone of `p`.
+        let fast = Expr::apply(elem(), pred_fn(int_ty.clone())).with_ty(bool_ty.clone());
+        // Slow path, constant: `__elem` is not free, so elimination emits
+        // `const(e)` and the η-wrapper never reaches the output.
+        let slow_const = Expr::lit(Lit::Bool(false)).with_ty(bool_ty.clone());
+        // Slow path, `__elem` free: `__elem ▷ p ▷ q`, whose outer argument is an
+        // application rather than the bare `__elem`, so the fast path declines.
+        let slow_free = Expr::apply(
+            Expr::apply(elem(), pred_fn(int_ty.clone())).with_ty(bool_ty.clone()),
+            pred_fn(bool_ty.clone()),
+        )
+        .with_ty(bool_ty.clone());
+
+        for (name, bare) in [
+            ("fast", fast),
+            ("slow/constant", slow_const),
+            ("slow/free", slow_free),
+        ] {
+            let site = NodeId::fresh();
+            let (table, raised, pred_ids) = raise(&bare, site);
+            let site_only = HashSet::from([site]);
+            for id in ids_of(&raised) {
+                assert!(
+                    resolves_into(&table, id, &pred_ids),
+                    "{name}: {id:?} does not resolve into the predicate",
+                );
+                assert!(
+                    !resolves_into(&table, id, &site_only),
+                    "{name}: {id:?} resolves to the term-tree site instead",
+                );
+            }
+        }
+    }
+}

--- a/src/ccl/planning/predicates.rs
+++ b/src/ccl/planning/predicates.rs
@@ -244,8 +244,8 @@ mod tests {
         out
     }
 
-    /// Walk `parents` back from `id` until it reaches an id in `roots`, or runs
-    /// out of rows. `None` when the ancestry never reaches one.
+    /// Whether walking `parents` back from `id` reaches an id in `roots` before
+    /// running out of rows.
     fn resolves_into(table: &ProvenanceTable, id: NodeId, roots: &HashSet<NodeId>) -> bool {
         let mut frontier = vec![id];
         let mut seen = HashSet::new();

--- a/src/ccl/provenance.rs
+++ b/src/ccl/provenance.rs
@@ -579,7 +579,7 @@ pub type SourceProjection = HashMap<NodeId, SourceAttribution>;
 /// span. A `DanglingParent` count over a zero `Unrecorded` count says the scopes
 /// are open and that some producer upstream of the span never rowed the ids
 /// those recordings name. That reading is what holds the first pane pair out of
-/// the gate; see `MaterializedPanes::gated_pane_pairs` in `crate::ccl::context`.
+/// the gate; see `MaterializedPanes::gated_pane_pairs` in `crate::ccl::panes`.
 ///
 /// Each class is reported once per distinct id. [`fold`] sorts and dedups its
 /// vector, so a dangling parent that four rows name is one entry.
@@ -1123,21 +1123,20 @@ struct Row {
 /// enumerates them — so the fold must explain them and this table must hold their
 /// rows (`design/provenance.md`, "Walking the ids").
 ///
-/// This was a `TODO(predicate-rows)` and is now done for two of the three
-/// crossings: a term entering a predicate is recorded (lowering sweeps the
-/// finished term; inference records `singleton_predicate` against its literal),
-/// and a
-/// predicate being rewritten is recorded. The third — planning **raising** a
-/// predicate back into the main tree — is not, and lands with the planning
-/// commit; those nodes are minted below the last pane, so no pane pair gates them
-/// yet.
+/// **All three crossings of the predicate boundary record.** *Entry*: lowering
+/// sweeps the finished term, and inference records `singleton_predicate` against
+/// its literal. *Transformation*: `PredMemo::rebuild` either carries the ids or
+/// records against the node whose type holds the predicate. *Raising* — planning
+/// lifting a term back into the main tree — attributes the raised material to the
+/// predicate rather than to the term-tree site, because a clone's copy names the
+/// node it was freshened from (`design/provenance.md`, "Walking the ids").
 ///
-/// It was a **population** change, not a schema change: these ids already had
-/// addresses here, so no column moved. The prior measurement that justified it
-/// stands as the attribution evidence — over the eleven-program corpus at the
-/// `post-inference..join-planned` audit span the residue was 1184
-/// [`Leak::DanglingParent`] edges and nothing else, every one a predicate-interior
-/// id of the input tree, and admitting them took every gated class to zero.
+/// Admitting these ids was a **population** change, not a schema change: they
+/// already had addresses here, so no column moved. The measurement that justified
+/// it, at the `post-inference..join-planned` audit span: the residue was
+/// [`Leak::DanglingParent`] edges and nothing else, every one a
+/// predicate-interior id of the input tree, and admitting them took every gated
+/// class to zero.
 ///
 /// The backing store is a plain map on purpose: the row *semantics* above are
 /// what a reader has to check, and a paged/interned column encoding would be a

--- a/src/ccl/simplify.rs
+++ b/src/ccl/simplify.rs
@@ -52,8 +52,7 @@ use crate::ccl::infer::debug_typecheck;
 use crate::ccl::lambda_elim::{id, zip_pair};
 use crate::ccl::ty::FunKind;
 use crate::ccl::{
-    ArithmeticKind, BaseType, BinOpKind, Builtin, Expr, Lit, ProjKey, Type, TypedExpr,
-    TypedExprNode,
+    ArithmeticKind, BaseType, BinOpKind, Builtin, Expr, ProjKey, Type, TypedExpr, TypedExprNode,
 };
 
 // ---------------------------------------------------------------------------
@@ -212,8 +211,15 @@ fn recurse_simplify(expr: &mut Expr, memo: &PredMemo) -> (bool, bool) {
 ///
 /// The caller **must** write a valid expression back to `*expr` before
 /// returning; the placeholder is never externally observable.
+///
+/// `mem::take` rather than a literal, because `Default for TypedExpr` builds at
+/// [`NodeId::PLACEHOLDER`](crate::ccl::provenance::NodeId::PLACEHOLDER) without
+/// going through `Expr::new`. Minting one here would fire `on_mint` inside
+/// whichever rule is recording and claim parentage for a node no tree ever
+/// holds — a spent id and a row no query reaches, once per rule firing, and
+/// `simplify` runs to fixpoint.
 fn take(expr: &mut Expr) -> Expr {
-    std::mem::replace(expr, Expr::lit(Lit::Int(0)))
+    std::mem::take(expr)
 }
 
 /// Whether `ty` is `String`, **ignoring refinements**. A refined string
@@ -1231,12 +1237,11 @@ fn try_flatten_compose(expr: &mut Expr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ccl::FieldKey;
     use crate::ccl::ccl_utils::{
         apply_primitive, make_iterate, make_restrict, trivially_true_predicate,
     };
     use crate::ccl::lambda_elim::{curry_at, zip_pair};
-    use crate::ccl::{BaseType, Expr, Name};
+    use crate::ccl::{BaseType, Expr, FieldKey, Lit, Name};
 
     fn var(s: &str) -> Expr {
         Expr::var(s)

--- a/src/ccl/simplify.rs
+++ b/src/ccl/simplify.rs
@@ -360,7 +360,7 @@ fn apply_simplification_rules(expr: &mut Expr, contains_iteration: bool) -> bool
 /// keyed on the node the rule is about to rewrite.
 ///
 /// This is the whole of simplify's provenance instrumentation: **one combinator,
-/// applied uniformly to all thirteen rules**, and no rule body changes at all.
+/// applied uniformly to every rule**, and no rule body changes at all.
 /// That is possible because a recording declares nothing — it names the node in
 /// the slot and lets the construction hooks report the rest. In particular:
 ///

--- a/tests/programs/join_then_groupby/mod.rs
+++ b/tests/programs/join_then_groupby/mod.rs
@@ -1,0 +1,23 @@
+//! A hash join and a group-by in one program — the fixture that puts both
+//! planning recognizers on a single tree.
+//!
+//! `planning/join.rs` rewrites the two-source comprehension with its
+//! `u.id == o.user_id` guard into a keyed lookup, and `planning/groupby.rs`
+//! rewrites the `groupby` into its bucketize chain. The `post-lambda-elim →
+//! post-planning` pane pair therefore has both rewrites to explain on one tree,
+//! which is what makes this the program to point the inspector at.
+//!
+//! The two are summed rather than chained: grouping directly over a join's
+//! product domain panics in `transform_by_map` today, so a chained form would
+//! pin an engine limitation rather than the planning rewrites.
+//!
+//! `425` is the join — every order's user id matches, so all four amounts
+//! survive (100 + 50 + 200 + 75). `14` is the group-by: `x // 2` buckets
+//! `[2,3]` and `[4,5]`, summing to 5 and 9.
+
+use super::common::expect_scalar;
+
+#[test]
+fn join_then_groupby() {
+    expect_scalar(include_str!("program.cambra"), "439");
+}

--- a/tests/programs/join_then_groupby/program.cambra
+++ b/tests/programs/join_then_groupby/program.cambra
@@ -1,0 +1,29 @@
+# One program, both planning recognizers. The two-source comprehension with an
+# `u.id == o.user_id` guard is what `planning/join.rs` rewrites into a keyed
+# lookup; the `groupby` is what `planning/groupby.rs` rewrites into its
+# bucketize chain. They are summed rather than chained: grouping directly over a
+# join's product domain is not supported by the engine yet.
+
+users = [
+    (id=1, region="west"),
+    (id=2, region="east"),
+    (id=3, region="west"),
+]
+
+orders = [
+    (user_id=1, amount=100),
+    (user_id=2, amount=50),
+    (user_id=1, amount=200),
+    (user_id=3, amount=75),
+]
+
+joined = sum([
+    o.amount
+    for u in users
+    for o in orders
+    if u.id == o.user_id
+])
+
+grouped = sum([sum(x) for x in groupby([2, 3, 4, 5], \x -> x // 2)])
+
+joined + grouped

--- a/tests/programs/main.rs
+++ b/tests/programs/main.rs
@@ -25,6 +25,7 @@ mod http_accumulator;
 mod http_counter;
 mod http_greeter;
 mod inner_join;
+mod join_then_groupby;
 mod ledger_balance;
 mod nonneg_inventory;
 mod prefix_lines;


### PR DESCRIPTION
Planning was the last phase rewriting expression nodes with nothing recording, which held `post-lambda-elim → post-planning` ungated and capped the `full` audit span short of the pipeline's end. This opens one `Phase::Planning` scope over planning and a recording at each of its rewrite sites, so **every pane pair is gated** and capture is total from the lowering handoff to the end of the CCL pipeline. `DEEP_TYPECHECK=1 CAMBRA_PROVENANCE_GATE=1 ./ci.sh test` is green, so both leak classes are zero over every compile the suite performs rather than over the programs `corpus()` lists.

## What each recording names

The node its products replace, with two choices worth a pointer. Continuation reads take a recording *finer* than the recognition one enclosing them — without it every read descends from the `LetRec` and which read went where is lost. The group-by and hash-join recordings are coarse by construction, which is [Where to open a recording](src/ccl/design/provenance.md#where-to-open-a-recording)'s rule for a product spanning several nodes. `Nature` is stated at each site and ruled in [Choosing between `Expansion` and `Machinery`](src/ccl/design/provenance.md#choosing-between-expansion-and-machinery).

## The hash join blames the predicates it plans from

`planning.hash_join` named its iteration site and nothing else, so the refinement predicates its plan is read out of reached the map only where a clone happened to carry one. It now blames every refinement predicate the site's domain carries, through `ccl_utils::walk_refined_predicates`. Blame rather than a parent: the rewrite leaves those predicates alive — the original value-producer is spliced into the compose with its type intact — and `predicate.rebuild` consumes them later in the same phase, where the ancestry is already recorded.

The walk reaches what a return value cannot. `join_plan_to_expr` re-enters `convert_refinement_to_join` on an arm's own refinement to plan a nested join, three frames below the guard and with no access to it. Across the suite the walk names exactly the predicates the recogniser read: 40 of 42 hash-join sites carry one refinement, and the two that carry two are the nested cases, whose second entry is the id the inner read consumed. `a_nested_join_blames_both_join_conditions` pins that against a flat control.

## Raising needed no new channel

The three sites that lift a term out of a type keep the *predicate's* parentage, because a clone's copy names the node it was freshened from. The channel that looked missing was predicate ids sitting outside the enumerated domain, which `main`'s binder-slot widening already fixed. The staging around a lifted predicate does not: the chain-head `iterate` and each `restrict` descend from the site they materialise.

Two pre-existing sites minted into whichever recording was open, invisible until a scope existed: `simplify::take`'s placeholder literal, now `mem::take`, and `recognize_group`'s deep clone of every accumulator seed.

## One statement of a phase boundary's post-conditions

Every phase ended with the same three assertions written out by hand: `assert_unique_node_ids`, the debug dumps, and the stage's consistency check with its own panic string. `settle(ir, boundary, check)` is now the one place they live, so each phase's tail is one line and `pre_channelize_wall` is reached through it. `Check` names which check the stage answers to — the relaxed one for the mutability phases, the strict one from channelization on, and the relaxed one reporting a residual `Type::Infer` as an ambiguous program at the two boundaries that can still carry one.

## Review guide

**Start here:** `try_hash_join_rewrite` in `src/ccl/planning/join.rs`.

`tests/programs/join_then_groupby` is a new fixture putting both recognizers on one tree, and joins the provenance corpus. Two unit tests pin the planning labels' `Nature` and the single scope. `the_pane_folds_derive_a_non_vacuous_provenance_map` asks for one witness per gated pane pair rather than pinning which `program / pane pair` names rewrote: which programs supply the witness is a fact about the corpus, and pinning it made every corpus edit a list edit. `planning.map_filter` is instrumented alongside the rest — `main`'s per-group filter planning mints under the planning scope.

The `planning` audit span retires as redundant with the pair that now gates the same phase; `letrec` and `mutelim` stay, per [What gating every pair does not retire](src/ccl/design/provenance.md#what-gating-every-pair-does-not-retire). Comments and docs stop enumerating the corpus, the panes and the rule table — each count restated a population another file owns.