### PR TITLE
Add refinement templates to trait instances, refined ^+ operator

### DIFF
--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -455,8 +455,9 @@ a loud failure rather than a silent misattribution):
 `enter` is the constructor a phase uses to record a rewrite. `copy_frame` is the
 one recording that names **no** node, for a duplication with nothing being
 rewritten and so no id to name: lowering's uncurry template-interior and
-compare-chain operand freshens, and inference freshening a refinement predicate
-per scheme instantiation. Each captured copy carries its own origin from the
+compare-chain operand freshens, and inference's two freshens — a refinement
+predicate per scheme instantiation, and a trait obligation's stored operand
+expressions per obligation copy. Each captured copy carries its own origin from the
 hook, so the named node is never read. A recording that names no node has nowhere
 to attach a mint or a consume, which `OpenRecording::assert_copy_only` enforces —
 which is also what keeps the two constructors apart, since a mint captured in a
@@ -466,8 +467,9 @@ copy-only recording is a site that should have named a node.
 every recording a pane pair's fold reads — each of the phases below runs inside a
 `PhaseScope` that `compile_program` opens, and sits between two retained AST
 snapshots: `infer/solve` (`mono.specialize`,
-`mono.coalesce_let`), `infer/emit` (`infer.lit_singleton`),
-`infer/solver/scheme` (`infer.freshen_predicate`), `inline`
+`mono.coalesce_let`), `infer/emit` (`infer.lit_singleton`), `infer/context`
+(`infer.require_trait`), `infer/solver/scheme` (`infer.freshen_predicate`),
+`infer/solver/traits` (`infer.freshen_obligation`), `inline`
 (`inline.alias`, `inline.udf`, `inline.beta`), `mut_elim` (`letrec.loop`,
 `letrec.bare_write`, `letrec.hoist_writer_body`, `letrec.terminalize_write`),
 `transact_phase` (strip, unwrap block, writer, commit record, history binding,

--- a/src/ccl/infer/check.rs
+++ b/src/ccl/infer/check.rs
@@ -8,6 +8,7 @@ use crate::ccl::infer::solver::{
 };
 use crate::ccl::infer::{InferError, LocatedInferError};
 use crate::ccl::infer_var::{Telescope, TelescopeWalk};
+use crate::ccl::provenance;
 use crate::ccl::provenance::NodeId;
 use crate::ccl::symbolic::symbolic;
 use crate::ccl::{
@@ -143,7 +144,7 @@ impl Typing for CheckCtx {
     fn require_trait(
         &mut self,
         trait_: Trait,
-        _operator_node_id: NodeId,
+        operator_node_id: NodeId,
         operand_types: &[&Type],
         operand_exprs: &[&Expr],
         assoc: Option<Assoc>,
@@ -187,6 +188,11 @@ impl Typing for CheckCtx {
                         let base = Type::Base(b.clone());
                         match template {
                             Some(template) => {
+                                let _f = provenance::enter(
+                                    operator_node_id,
+                                    "check.require_trait",
+                                    provenance::Nature::Machinery,
+                                );
                                 let args: Vec<TypedExpr> =
                                     operand_exprs.iter().map(|e| (*e).clone()).collect();
                                 Type::Refinement(

--- a/src/ccl/infer/check.rs
+++ b/src/ccl/infer/check.rs
@@ -143,6 +143,7 @@ impl Typing for CheckCtx {
     fn require_trait(
         &mut self,
         trait_: Trait,
+        _operator_node_id: NodeId,
         operand_types: &[&Type],
         operand_exprs: &[&Expr],
         assoc: Option<Assoc>,
@@ -436,6 +437,7 @@ fn check_node(expr: &mut Expr, ctx: &mut CheckCtx) -> Result<Type, LocatedInferE
 /// recorded `Type`.
 fn check_node_rule(expr: &mut Expr, ctx: &mut CheckCtx) -> Result<Type, LocatedInferError> {
     let label = symbolic(expr);
+    let node_id = expr.node_id();
     // The `Lambda` rule reads the node's own type for its kind (see
     // `emit_lambda`), taken before the walk borrows the node.
     let recorded_ty = expr.ty.clone();
@@ -477,17 +479,17 @@ fn check_node_rule(expr: &mut Expr, ctx: &mut CheckCtx) -> Result<Type, LocatedI
 
         TypedExprNode::BinOp { left, op, right } => {
             let sig = ctx.schemes.binop(*op);
-            emit_binop(left, right, &sig, ctx)?
+            emit_binop(node_id, left, right, &sig, ctx)?
         }
 
         TypedExprNode::UnaryOp(op, inner) => {
             let sig = ctx.schemes.unary(*op);
-            emit_unary(inner, &sig, ctx)?
+            emit_unary(inner, node_id, &sig, ctx)?
         }
 
         TypedExprNode::Aggregate { input, kind } => {
             let scheme = ctx.schemes.aggregate(*kind).clone();
-            emit_aggregate(input, &scheme, *kind, ctx)?
+            emit_aggregate(input, node_id, &scheme, *kind, ctx)?
         }
 
         // Check never generalizes (`is_generalizable` is `false`), so every

--- a/src/ccl/infer/check.rs
+++ b/src/ccl/infer/check.rs
@@ -10,7 +10,9 @@ use crate::ccl::infer::{InferError, LocatedInferError};
 use crate::ccl::infer_var::{Telescope, TelescopeWalk};
 use crate::ccl::provenance::NodeId;
 use crate::ccl::symbolic::symbolic;
-use crate::ccl::{BaseType, Expr, Level, Name, Type, TypedExprNode};
+use crate::ccl::{
+    BaseType, Expr, Level, Name, Refinement, RefinementSet, Type, TypedExpr, TypedExprNode,
+};
 
 use super::emit::{
     emit_aggregate, emit_apply, emit_begin, emit_binop, emit_case, emit_cast, emit_compose,
@@ -141,7 +143,8 @@ impl Typing for CheckCtx {
     fn require_trait(
         &mut self,
         trait_: Trait,
-        operands: &[&Type],
+        operand_types: &[&Type],
+        operand_exprs: &[&Expr],
         assoc: Option<Assoc>,
         at: &dyn Fn() -> String,
     ) -> Result<Option<Type>, LocatedInferError> {
@@ -163,7 +166,7 @@ impl Typing for CheckCtx {
         // [`Typing::require_sub`] reuses `TypeMismatch` here: the error vocabulary
         // describes the inconsistency, the wall supplies the interpretation. Measured
         // across the suite: it never fires.
-        let bases: Option<Vec<&BaseType>> = operands.iter().map(|t| offered_base(t)).collect();
+        let bases: Option<Vec<&BaseType>> = operand_types.iter().map(|t| offered_base(t)).collect();
         let Some(bases) = bases else {
             // Pre-channelize residue (a `Feed` handle, an un-eliminated `Mut`, a
             // still-`Infer` position under `Strictness::PreChannelize`) is not something
@@ -179,7 +182,22 @@ impl Typing for CheckCtx {
             Some(matched) => Ok(assoc.map(|name| {
                 matched
                     .assoc_ty(name)
-                    .map(|b| Type::Base(b.clone()))
+                    .map(|(b, template)| {
+                        let base = Type::Base(b.clone());
+                        match template {
+                            Some(template) => {
+                                let args: Vec<TypedExpr> =
+                                    operand_exprs.iter().map(|e| (*e).clone()).collect();
+                                Type::Refinement(
+                                    Box::new(base),
+                                    RefinementSet::one(Refinement::born_from_template(
+                                        template, &args,
+                                    )),
+                                )
+                            }
+                            None => base,
+                        }
+                    })
                     .unwrap_or_else(|| fresh_var(self.level))
             })),
             None => {

--- a/src/ccl/infer/context.rs
+++ b/src/ccl/infer/context.rs
@@ -371,21 +371,39 @@ impl Typing for InferCtx {
     fn require_trait(
         &mut self,
         trait_: Trait,
-        operands: &[&Type],
+        operand_types: &[&Type],
+        operand_exprs: &[&Expr],
         assoc: Option<Assoc>,
         at: &dyn Fn() -> String,
     ) -> Result<Option<Type>, LocatedInferError> {
         debug_assert_eq!(
-            operands.len(),
+            operand_types.len(),
             trait_.arity(),
             "{trait_} is over {} type(s); an operator wired to it must supply that many",
             trait_.arity(),
         );
-        let positions: Vec<Type> = operands.iter().map(|_| self.fresh()).collect();
+        let positions: Vec<Type> = operand_types.iter().map(|_| self.fresh()).collect();
         // Only a requested association gets a variable for the obligation to settle;
         // a pure requirement determines nothing and mints none.
         let wanted = assoc.map(|name| (name, self.fresh()));
-        let obligation = TraitObligation::new(trait_, wanted.clone().into_iter().collect());
+        // The recording covers two things this rule produces: the operand
+        // expressions cloned into the obligation, and the nodes a deposit reached
+        // from here mints — an instance whose association carries a
+        // `RefinementTemplate` builds its predicate out of those operands
+        // (`Refinement::born_from_template`), and a deposit fires both at
+        // construction and from the `require_sub` narrowing below. So it names the
+        // node being typed, as the `Lit` rule's singleton recording does: a mint has
+        // nowhere to attach in a recording that names nothing.
+        let _f = crate::ccl::provenance::enter(
+            self.current_node_id,
+            "infer.require_trait",
+            crate::ccl::provenance::Nature::Machinery,
+        );
+        let obligation = TraitObligation::new(
+            trait_,
+            wanted.clone().into_iter().collect(),
+            operand_exprs.iter().map(|e| (*e).clone()).collect(),
+        );
         for (i, position) in positions.iter().enumerate() {
             obligation.watch(position, i as u8);
         }
@@ -397,7 +415,7 @@ impl Typing for InferCtx {
             .map_err(|e| self.raise(map_constrain_err(e, &at())))?;
         // Operands flow in as ordinary lower bounds, refinements and all. The
         // narrowing hook peels them where the base actually arrives.
-        for (operand, position) in operands.iter().zip(&positions) {
+        for (operand, position) in operand_types.iter().zip(&positions) {
             self.require_sub(operand, position, at)?;
         }
         Ok(wanted.map(|(_, ty)| ty))

--- a/src/ccl/infer/context.rs
+++ b/src/ccl/infer/context.rs
@@ -371,6 +371,7 @@ impl Typing for InferCtx {
     fn require_trait(
         &mut self,
         trait_: Trait,
+        operator_node_id: NodeId,
         operand_types: &[&Type],
         operand_exprs: &[&Expr],
         assoc: Option<Assoc>,
@@ -402,6 +403,7 @@ impl Typing for InferCtx {
         let obligation = TraitObligation::new(
             trait_,
             wanted.clone().into_iter().collect(),
+            operator_node_id,
             operand_exprs.iter().map(|e| (*e).clone()).collect(),
         );
         for (i, position) in positions.iter().enumerate() {

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -10,6 +10,7 @@ use crate::ccl::FieldKey;
 use crate::ccl::ccl_utils::cast_target_refinement;
 use crate::ccl::infer::solver::{PolyScheme, fun, prim};
 use crate::ccl::infer::{InferError, LocatedInferError};
+use crate::ccl::provenance::NodeId;
 use crate::ccl::symbolic::symbolic;
 use crate::ccl::ty::FunKind;
 use crate::ccl::{
@@ -128,17 +129,17 @@ fn emit_node_inner(expr: &mut Expr, ctx: &mut InferCtx) -> Result<Type, LocatedI
         // are `Rc`-shaped, so the clone is cheap.
         TypedExprNode::BinOp { left, op, right } => {
             let sig = ctx.schemes.binop(*op);
-            emit_binop(left, right, &sig, ctx)?
+            emit_binop(node_id, left, right, &sig, ctx)?
         }
 
         TypedExprNode::UnaryOp(op, inner) => {
             let sig = ctx.schemes.unary(*op);
-            emit_unary(inner, &sig, ctx)?
+            emit_unary(inner, node_id, &sig, ctx)?
         }
 
         TypedExprNode::Aggregate { input, kind } => {
             let scheme = ctx.schemes.aggregate(*kind).clone();
-            emit_aggregate(input, &scheme, *kind, ctx)?
+            emit_aggregate(input, node_id, &scheme, *kind, ctx)?
         }
 
         TypedExprNode::Let {
@@ -853,6 +854,7 @@ pub(super) fn emit_apply<C: Typing>(
 fn require_single_obligation<C: Typing>(
     ctx: &mut C,
     trait_: Trait,
+    operator_node_id: NodeId,
     operand_types: &[&Type],
     operand_exprs: &[&Expr],
     result: &OperatorResult,
@@ -860,11 +862,25 @@ fn require_single_obligation<C: Typing>(
 ) -> Result<Type, LocatedInferError> {
     match result {
         OperatorResult::Associated(name) => {
-            let ty = ctx.require_trait(trait_, operand_types, operand_exprs, Some(*name), at)?;
+            let ty = ctx.require_trait(
+                trait_,
+                operator_node_id,
+                operand_types,
+                operand_exprs,
+                Some(*name),
+                at,
+            )?;
             Ok(ty.expect("an operator asking for an association gets its position back"))
         }
         OperatorResult::Fixed(base) => {
-            ctx.require_trait(trait_, operand_types, operand_exprs, None, at)?;
+            ctx.require_trait(
+                trait_,
+                operator_node_id,
+                operand_types,
+                operand_exprs,
+                None,
+                at,
+            )?;
             Ok(Type::Base(base.clone()))
         }
     }
@@ -906,6 +922,7 @@ fn parameter_type<'t>(function: &'t Expr, fn_ty: &'t Type) -> Option<&'t Type> {
 }
 
 pub(super) fn emit_binop<C: Typing>(
+    operator_node_id: NodeId,
     left: &mut Expr,
     right: &mut Expr,
     sig: &OpSignature,
@@ -919,6 +936,7 @@ pub(super) fn emit_binop<C: Typing>(
         OpSignature::SingleObligation { trait_, result } => require_single_obligation(
             ctx,
             *trait_,
+            operator_node_id,
             &[&left_ty, &right_ty],
             &[left, right],
             result,
@@ -929,6 +947,7 @@ pub(super) fn emit_binop<C: Typing>(
 
 pub(super) fn emit_unary<C: Typing>(
     inner: &mut Expr,
+    operator_node_id: NodeId,
     sig: &OpSignature,
     ctx: &mut C,
 ) -> Result<Type, LocatedInferError> {
@@ -936,9 +955,15 @@ pub(super) fn emit_unary<C: Typing>(
     let at = || "UnaryOp".to_string();
     match sig {
         OpSignature::Scheme(scheme) => apply_unary_scheme(ctx, scheme, &inner_ty, &at),
-        OpSignature::SingleObligation { trait_, result } => {
-            require_single_obligation(ctx, *trait_, &[&inner_ty], &[inner], result, &at)
-        }
+        OpSignature::SingleObligation { trait_, result } => require_single_obligation(
+            ctx,
+            *trait_,
+            operator_node_id,
+            &[&inner_ty],
+            &[inner],
+            result,
+            &at,
+        ),
     }
 }
 
@@ -1257,6 +1282,7 @@ pub(super) fn emit_disjoint_join<C: Typing>(
 /// its codomain.
 pub(super) fn emit_aggregate<C: Typing>(
     input: &mut Expr,
+    operator_node_id: NodeId,
     scheme: &PolyScheme,
     kind: AggregateKind,
     ctx: &mut C,
@@ -1269,7 +1295,14 @@ pub(super) fn emit_aggregate<C: Typing>(
     // is a pure requirement — `Comparable` associates nothing, and the result type
     // stays the scheme's.
     if kind == AggregateKind::Max {
-        ctx.require_trait(Trait::Comparable, &[&result], &[input], None, &at)?;
+        ctx.require_trait(
+            Trait::Comparable,
+            operator_node_id,
+            &[&result],
+            &[input],
+            None,
+            &at,
+        )?;
     }
     Ok(result)
 }

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -853,17 +853,18 @@ pub(super) fn emit_apply<C: Typing>(
 fn require_single_obligation<C: Typing>(
     ctx: &mut C,
     trait_: Trait,
-    operands: &[&Type],
+    operand_types: &[&Type],
+    operand_exprs: &[&Expr],
     result: &OperatorResult,
     at: &dyn Fn() -> String,
 ) -> Result<Type, LocatedInferError> {
     match result {
         OperatorResult::Associated(name) => {
-            let ty = ctx.require_trait(trait_, operands, Some(*name), at)?;
+            let ty = ctx.require_trait(trait_, operand_types, operand_exprs, Some(*name), at)?;
             Ok(ty.expect("an operator asking for an association gets its position back"))
         }
         OperatorResult::Fixed(base) => {
-            ctx.require_trait(trait_, operands, None, at)?;
+            ctx.require_trait(trait_, operand_types, operand_exprs, None, at)?;
             Ok(Type::Base(base.clone()))
         }
     }
@@ -915,9 +916,14 @@ pub(super) fn emit_binop<C: Typing>(
     let at = || "BinOp".to_string();
     match sig {
         OpSignature::Scheme(scheme) => apply_binary_scheme(ctx, scheme, &left_ty, &right_ty, &at),
-        OpSignature::SingleObligation { trait_, result } => {
-            require_single_obligation(ctx, *trait_, &[&left_ty, &right_ty], result, &at)
-        }
+        OpSignature::SingleObligation { trait_, result } => require_single_obligation(
+            ctx,
+            *trait_,
+            &[&left_ty, &right_ty],
+            &[left, right],
+            result,
+            &at,
+        ),
     }
 }
 
@@ -931,7 +937,7 @@ pub(super) fn emit_unary<C: Typing>(
     match sig {
         OpSignature::Scheme(scheme) => apply_unary_scheme(ctx, scheme, &inner_ty, &at),
         OpSignature::SingleObligation { trait_, result } => {
-            require_single_obligation(ctx, *trait_, &[&inner_ty], result, &at)
+            require_single_obligation(ctx, *trait_, &[&inner_ty], &[inner], result, &at)
         }
     }
 }
@@ -1263,7 +1269,7 @@ pub(super) fn emit_aggregate<C: Typing>(
     // is a pure requirement — `Comparable` associates nothing, and the result type
     // stays the scheme's.
     if kind == AggregateKind::Max {
-        ctx.require_trait(Trait::Comparable, &[&result], None, &at)?;
+        ctx.require_trait(Trait::Comparable, &[&result], &[input], None, &at)?;
     }
     Ok(result)
 }

--- a/src/ccl/infer/schemes.rs
+++ b/src/ccl/infer/schemes.rs
@@ -271,6 +271,7 @@ impl OperatorSchemes {
         };
         match op {
             BinOpKind::Arithmetic(ArithmeticKind::Add) => arithmetic(Trait::Addable),
+            BinOpKind::Arithmetic(ArithmeticKind::AddRefined) => arithmetic(Trait::AddableRefined),
             BinOpKind::Arithmetic(ArithmeticKind::Sub) => arithmetic(Trait::Subtractable),
             BinOpKind::Arithmetic(ArithmeticKind::Mul) => arithmetic(Trait::Multipliable),
             BinOpKind::Arithmetic(ArithmeticKind::FloorDiv) => arithmetic(Trait::Divisible),

--- a/src/ccl/infer/solver/traits.rs
+++ b/src/ccl/infer/solver/traits.rs
@@ -74,9 +74,13 @@ use std::fmt;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use crate::ccl::{BaseType, FieldKey, InferVar, InferVarId, Type};
+use crate::ccl::{
+    ArithmeticKind, BaseType, BinOpKind, CompareKind, FieldKey, InferVar, InferVarId, Name,
+    Refinement, RefinementSet, RefinementTemplate, Type, TypedExpr,
+};
 
 use super::constrain::{ConstrainCache, ConstrainError, constrain_subtype};
+use super::prim;
 
 /// A trait: a named requirement on types, together with any types it associates
 /// with them.
@@ -92,6 +96,11 @@ pub enum Trait {
     /// why surface `+` on strings types through arithmetic; `simplify` rewrites it to
     /// `Concat` later.
     Addable,
+    /// `^+` over `(𝐴, 𝐵)`, associating `Output`.
+    ///
+    /// This is an experimental version of Addable that gives the
+    /// output type an input-dependent refinement.
+    AddableRefined,
     /// `-` over `(𝐴, 𝐵)`, associating `Output`.
     Subtractable,
     /// `*` over `(𝐴, 𝐵)`, associating `Output`.
@@ -127,21 +136,26 @@ pub enum Assoc {
 }
 
 /// One instance: the types it accepts, and what it associates with them.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct TraitInstance {
     /// The accepted types, positionally. A slice rather than a fixed array because
     /// arity is the trait's business — every operator trait is binary today, and an
     /// `Orderable` over one type is the obvious next one.
     pub args: &'static [BaseType],
-    /// The types this instance associates, by name. Empty for a trait that is
-    /// a pure requirement.
-    pub assoc: &'static [(Assoc, BaseType)],
+    /// The types this instance associates, by name. Empty for a trait
+    /// that is a pure requirement. Each associated type has an
+    /// optional RefinementTemplate, which builds a refinement from
+    /// operator's input argument expressions.
+    pub assoc: &'static [(Assoc, BaseType, Option<RefinementTemplate>)],
 }
 
 impl TraitInstance {
     /// The type this instance associates with `name`, if any.
-    pub fn assoc_ty(&self, name: Assoc) -> Option<&BaseType> {
-        self.assoc.iter().find(|(n, _)| *n == name).map(|(_, t)| t)
+    pub fn assoc_ty(&self, name: Assoc) -> Option<(&BaseType, Option<RefinementTemplate>)> {
+        self.assoc
+            .iter()
+            .find(|(n, _, _)| *n == name)
+            .map(|(_, t, r)| (t, *r))
     }
 }
 
@@ -150,27 +164,59 @@ impl TraitInstance {
 const NUMERIC: &[TraitInstance] = &[
     TraitInstance {
         args: &[BaseType::Int, BaseType::Int],
-        assoc: &[(Assoc::Output, BaseType::Int)],
+        assoc: &[(Assoc::Output, BaseType::Int, None)],
     },
     TraitInstance {
         args: &[BaseType::UInt, BaseType::UInt],
-        assoc: &[(Assoc::Output, BaseType::UInt)],
+        assoc: &[(Assoc::Output, BaseType::UInt, None)],
     },
 ];
+
+/// The bare predicate `__elem == a1 ^+ a2` for the `AddableRefined(Int, Int ⇝ Int)`
+/// row: the result is the sum of the operands the instance accepted.
+///
+/// Bare in the sense of [`crate::ccl::ccl_utils::refine_with_bare`] — [`Name::elem`] is
+/// free, and the refinement it lands in is what binds it. Every node is typed at
+/// construction because the row fixes both operand bases and the associated base at
+/// `Int`, leaving nothing for inference to resolve, the same reason
+/// [`crate::ccl::infer::singleton_predicate`]'s term is ground.
+fn refinement_for_add(args: &[TypedExpr]) -> TypedExpr {
+    let [a1, a2] = args else {
+        panic!("AddableRefined is binary, so its instance's refinement receives two operands");
+    };
+    let int = prim(BaseType::Int);
+    TypedExpr::binop(
+        TypedExpr::var(Name::elem()).with_ty(int.clone()),
+        BinOpKind::Compare(CompareKind::Equals),
+        TypedExpr::binop(
+            a1.clone(),
+            BinOpKind::Arithmetic(ArithmeticKind::AddRefined),
+            a2.clone(),
+        )
+        .with_ty(int),
+    )
+    .with_ty(prim(BaseType::Bool))
+}
+
+/// `(Int, Int) ⇝ {Int | __elem == 𝑎₁ ^+ 𝑎₂}` — the one row of `^+`.
+const ADDITION_REFINED: &[TraitInstance] = &[TraitInstance {
+    args: &[BaseType::Int, BaseType::Int],
+    assoc: &[(Assoc::Output, BaseType::Int, Some(refinement_for_add))],
+}];
 
 /// The numeric rows plus `(String, String) ⇝ String`.
 const NUMERIC_OR_STRING: &[TraitInstance] = &[
     TraitInstance {
         args: &[BaseType::Int, BaseType::Int],
-        assoc: &[(Assoc::Output, BaseType::Int)],
+        assoc: &[(Assoc::Output, BaseType::Int, None)],
     },
     TraitInstance {
         args: &[BaseType::UInt, BaseType::UInt],
-        assoc: &[(Assoc::Output, BaseType::UInt)],
+        assoc: &[(Assoc::Output, BaseType::UInt, None)],
     },
     TraitInstance {
         args: &[BaseType::String, BaseType::String],
-        assoc: &[(Assoc::Output, BaseType::String)],
+        assoc: &[(Assoc::Output, BaseType::String, None)],
     },
 ];
 
@@ -204,7 +250,7 @@ const COMPARABLE: &[TraitInstance] = &[
 /// arity and association shape `Addable` and `Equatable` between them do not have.
 const NEGATABLE: &[TraitInstance] = &[TraitInstance {
     args: &[BaseType::Int],
-    assoc: &[(Assoc::Output, BaseType::Int)],
+    assoc: &[(Assoc::Output, BaseType::Int, None)],
 }];
 
 /// The bases an aggregate can order, matching `max`'s merge in `ccl/mod.rs`. Unary
@@ -238,6 +284,7 @@ impl Trait {
     pub fn instances(self) -> &'static [TraitInstance] {
         match self {
             Trait::Addable => NUMERIC_OR_STRING,
+            Trait::AddableRefined => ADDITION_REFINED,
             Trait::Subtractable | Trait::Multipliable | Trait::Divisible => NUMERIC,
             Trait::Equatable | Trait::Orderable => COMPARABLE,
             Trait::Negatable => NEGATABLE,
@@ -267,7 +314,7 @@ impl Trait {
             .expect("every trait has at least one instance");
         (
             first.args.len(),
-            first.assoc.iter().map(|(n, _)| *n).collect(),
+            first.assoc.iter().map(|(n, _, _)| *n).collect(),
         )
     }
 
@@ -275,6 +322,7 @@ impl Trait {
     pub fn name(self) -> &'static str {
         match self {
             Trait::Addable => "Addable",
+            Trait::AddableRefined => "AddableRefined",
             Trait::Subtractable => "Subtractable",
             Trait::Multipliable => "Multipliable",
             Trait::Divisible => "Divisible",
@@ -326,6 +374,9 @@ pub struct TraitObligation {
     /// declares. Empty for a trait that is a pure requirement — the mechanism then
     /// still narrows and still rejects, it simply determines nothing.
     assoc: Vec<AssocPosition>,
+    /// The input arguments' actual expressions, to be substituted
+    /// into the output type if it has a refinement template.
+    input_exprs: Vec<TypedExpr>,
 }
 
 /// One associated position of an obligation: the name, the type standing in for it,
@@ -344,7 +395,11 @@ struct AssocPosition {
 impl TraitObligation {
     /// Record an instance of `trait_` whose associated names stand at the given type
     /// positions, with every instance still a candidate.
-    pub fn new(trait_: Trait, assoc: Vec<(Assoc, Type)>) -> Rc<TraitObligation> {
+    pub fn new(
+        trait_: Trait,
+        assoc: Vec<(Assoc, Type)>,
+        input_exprs: Vec<TypedExpr>,
+    ) -> Rc<TraitObligation> {
         Rc::new(TraitObligation {
             uid: TraitObligationId(OBLIGATION_COUNTER.fetch_add(1, Ordering::Relaxed)),
             trait_,
@@ -357,6 +412,7 @@ impl TraitObligation {
                     deposited: Cell::new(false),
                 })
                 .collect(),
+            input_exprs,
         })
     }
 
@@ -374,6 +430,9 @@ impl TraitObligation {
     /// deposit already made rides the freshened bound onto the copy, so redoing it
     /// would record the same fact twice.
     pub(super) fn new_from(original: &Rc<TraitObligation>) -> Rc<TraitObligation> {
+        // We need a provenance recording here for the cloning of
+        // input_exprs into the new obligation.
+        let _f = crate::ccl::provenance::copy_frame("infer.freshen_obligation");
         Rc::new(TraitObligation {
             uid: TraitObligationId(OBLIGATION_COUNTER.fetch_add(1, Ordering::Relaxed)),
             trait_: original.trait_,
@@ -387,6 +446,7 @@ impl TraitObligation {
                     deposited: Cell::new(p.deposited.get()),
                 })
                 .collect(),
+            input_exprs: original.input_exprs.clone(),
         })
     }
 
@@ -515,12 +575,20 @@ impl TraitObligation {
             if position.deposited.get() {
                 continue;
             }
-            let Some(settled) = self.agreed_assoc(position.name) else {
+            let Some((settled, maybe_refinement)) = self.agreed_assoc(position.name) else {
                 continue;
             };
             position.deposited.set(true);
             let target = position.ty.borrow().clone();
-            constrain_subtype(&Type::Base(settled), &target, cache)?;
+            let ty_base = Type::Base(settled);
+            let ty = match maybe_refinement {
+                Some(template) => Type::Refinement(
+                    Box::new(ty_base),
+                    RefinementSet::one(Refinement::born_from_template(template, &self.input_exprs)),
+                ),
+                None => ty_base,
+            };
+            constrain_subtype(&ty, &target, cache)?;
         }
         Ok(())
     }
@@ -550,15 +618,15 @@ impl TraitObligation {
 
     /// The type every surviving instance associates with `name`, or `None` if
     /// they disagree — the condition a deposit waits on.
-    fn agreed_assoc(&self, name: Assoc) -> Option<BaseType> {
+    fn agreed_assoc(&self, name: Assoc) -> Option<(BaseType, Option<RefinementTemplate>)> {
         let candidates = self.candidates.borrow();
         let (first, rest) = candidates
             .split_first()
             .expect("a candidate set is never empty: emptying it is the error");
-        let settled = first.assoc_ty(name)?;
+        let (settled_ty, settled_rf) = first.assoc_ty(name)?;
         rest.iter()
-            .all(|i| i.assoc_ty(name) == Some(settled))
-            .then(|| settled.clone())
+            .all(|i| i.assoc_ty(name).map(|(t, _)| t) == Some(settled_ty))
+            .then(|| (settled_ty.clone(), settled_rf))
     }
 }
 
@@ -1386,6 +1454,15 @@ mod tests {
     use super::*;
     use crate::ccl::infer::solver::fresh_var;
 
+    /// The operand expressions an obligation substitutes into an instance's
+    /// refinement template.
+    fn operands() -> Vec<TypedExpr> {
+        vec![
+            TypedExpr::lit(crate::ccl::Lit::Int(1)),
+            TypedExpr::lit(crate::ccl::Lit::Int(2)),
+        ]
+    }
+
     /// Both narrowing orders reach the same answer — the property that lets the
     /// obligation be resolved incrementally instead of by a final sweep.
     #[rstest::rstest]
@@ -1393,7 +1470,11 @@ mod tests {
     #[case(&[(1, BaseType::Int), (0, BaseType::Int)])]
     fn narrowing_is_order_independent(#[case] steps: &[(u8, BaseType)]) {
         let out = fresh_var(0);
-        let ob = TraitObligation::new(Trait::Addable, vec![(Assoc::Output, out.clone())]);
+        let ob = TraitObligation::new(
+            Trait::Addable,
+            vec![(Assoc::Output, out.clone())],
+            operands(),
+        );
         let mut cache = ConstrainCache::new();
 
         for (pos, base) in steps {
@@ -1408,7 +1489,7 @@ mod tests {
                 .borrow()
                 .lower()
                 .iter()
-                .any(|b| b.ty == Type::Base(BaseType::Int)),
+                .any(|b| b.ty.peel_refinements() == &Type::Base(BaseType::Int)),
             "the settled output type is deposited as a lower bound on O",
         );
     }
@@ -1419,23 +1500,51 @@ mod tests {
     #[test]
     fn one_known_operand_settles_an_agreed_output() {
         let out = fresh_var(0);
-        let ob = TraitObligation::new(Trait::Addable, vec![(Assoc::Output, out.clone())]);
+        let ob = TraitObligation::new(
+            Trait::Addable,
+            vec![(Assoc::Output, out.clone())],
+            operands(),
+        );
         let mut cache = ConstrainCache::new();
 
         ob.narrow(1, &BaseType::Int, &mut cache)
             .expect("Int is addable");
 
-        assert_eq!(
-            ob.agreed_assoc(Assoc::Output),
-            Some(BaseType::Int),
-            "(Int, Int) ⇝ Int is the only row left, so its Output is settled",
+        assert!(
+            matches!(ob.agreed_assoc(Assoc::Output), Some((BaseType::Int, None))),
+            "(Int, Int) ⇝ Int is the only row left, so its Output is settled, and \
+             `+` leaves that output unrefined",
         );
+        let candidates = ob.candidates();
+        let [only] = candidates.as_slice() else {
+            panic!("(Int, Int) ⇝ Int is the only Addable row left, got {candidates:?}");
+        };
+        assert_eq!(only.args, &[BaseType::Int, BaseType::Int]);
+        assert!(matches!(only.assoc, [(Assoc::Output, BaseType::Int, None)]));
+    }
+
+    /// `^+` deposits the sum on its output; `+` deposits a bare `Int`. The two
+    /// traits differ in exactly this, so one obligation of each pins it.
+    #[test]
+    fn only_the_refining_addition_carries_a_predicate() {
+        let deposited = |trait_| {
+            let out = fresh_var(0);
+            let ob = TraitObligation::new(trait_, vec![(Assoc::Output, out.clone())], operands());
+            ob.narrow(0, &BaseType::Int, &mut ConstrainCache::new())
+                .expect("Int adds to Int under either trait");
+            let Type::Infer(v) = &out else { unreachable!() };
+            let bounds = v.bounds.borrow();
+            bounds
+                .lower()
+                .iter()
+                .map(|b| b.ty.to_string())
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(deposited(Trait::Addable), vec!["Int"]);
         assert_eq!(
-            ob.candidates(),
-            vec![TraitInstance {
-                args: &[BaseType::Int, BaseType::Int],
-                assoc: &[(Assoc::Output, BaseType::Int)],
-            }]
+            deposited(Trait::AddableRefined),
+            vec!["{Int | __elem == 1 ^+ 2}"],
         );
     }
 
@@ -1448,7 +1557,7 @@ mod tests {
     /// not just here.
     #[test]
     fn a_comparison_associates_nothing() {
-        let ob = TraitObligation::new(Trait::Equatable, Vec::new());
+        let ob = TraitObligation::new(Trait::Equatable, Vec::new(), operands());
         let mut cache = ConstrainCache::new();
 
         ob.try_deposit(&mut cache).expect("nothing to deposit");
@@ -1468,7 +1577,7 @@ mod tests {
     #[test]
     fn incompatible_operands_have_no_instance() {
         let out = fresh_var(0);
-        let ob = TraitObligation::new(Trait::Orderable, vec![(Assoc::Output, out)]);
+        let ob = TraitObligation::new(Trait::Orderable, vec![(Assoc::Output, out)], operands());
         let mut cache = ConstrainCache::new();
 
         ob.narrow(0, &BaseType::Int, &mut cache)
@@ -1503,6 +1612,7 @@ mod tests {
     fn every_trait_has_a_consistent_shape() {
         for trait_ in [
             Trait::Addable,
+            Trait::AddableRefined,
             Trait::Subtractable,
             Trait::Multipliable,
             Trait::Divisible,
@@ -1518,7 +1628,7 @@ mod tests {
                     arity,
                     "{trait_} has rows of differing arity: {row:?}",
                 );
-                let names: Vec<Assoc> = row.assoc.iter().map(|(n, _)| *n).collect();
+                let names: Vec<Assoc> = row.assoc.iter().map(|(n, _, _)| *n).collect();
                 assert_eq!(
                     names, assocs,
                     "{trait_} has rows associating different names: {row:?}",
@@ -1534,9 +1644,7 @@ mod tests {
     fn a_refinement_narrows_as_its_base() {
         let refined = Type::refined_one(
             Type::Base(BaseType::String),
-            crate::ccl::Refinement::born(Rc::new(crate::ccl::TypedExpr::lit(
-                crate::ccl::Lit::Bool(true),
-            ))),
+            Refinement::born(Rc::new(TypedExpr::lit(crate::ccl::Lit::Bool(true)))),
         );
         assert_eq!(offered_base(&refined), Some(&BaseType::String));
     }

--- a/src/ccl/infer/solver/traits.rs
+++ b/src/ccl/infer/solver/traits.rs
@@ -76,7 +76,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::ccl::{
     ArithmeticKind, BaseType, BinOpKind, CompareKind, FieldKey, InferVar, InferVarId, Name,
-    Refinement, RefinementSet, RefinementTemplate, Type, TypedExpr,
+    Refinement, RefinementSet, RefinementTemplate, Type, TypedExpr, provenance,
 };
 
 use super::constrain::{ConstrainCache, ConstrainError, constrain_subtype};
@@ -377,6 +377,9 @@ pub struct TraitObligation {
     /// The input arguments' actual expressions, to be substituted
     /// into the output type if it has a refinement template.
     input_exprs: Vec<TypedExpr>,
+    /// The ID of the operator node that spawned this obligation, to
+    /// be used as provenance for any resulting refinement body.
+    operator_node_id: provenance::NodeId,
 }
 
 /// One associated position of an obligation: the name, the type standing in for it,
@@ -398,6 +401,7 @@ impl TraitObligation {
     pub fn new(
         trait_: Trait,
         assoc: Vec<(Assoc, Type)>,
+        operator_node_id: provenance::NodeId,
         input_exprs: Vec<TypedExpr>,
     ) -> Rc<TraitObligation> {
         Rc::new(TraitObligation {
@@ -413,6 +417,7 @@ impl TraitObligation {
                 })
                 .collect(),
             input_exprs,
+            operator_node_id,
         })
     }
 
@@ -432,7 +437,7 @@ impl TraitObligation {
     pub(super) fn new_from(original: &Rc<TraitObligation>) -> Rc<TraitObligation> {
         // We need a provenance recording here for the cloning of
         // input_exprs into the new obligation.
-        let _f = crate::ccl::provenance::copy_frame("infer.freshen_obligation");
+        let _f = provenance::copy_frame("infer.freshen_obligation");
         Rc::new(TraitObligation {
             uid: TraitObligationId(OBLIGATION_COUNTER.fetch_add(1, Ordering::Relaxed)),
             trait_: original.trait_,
@@ -447,6 +452,7 @@ impl TraitObligation {
                 })
                 .collect(),
             input_exprs: original.input_exprs.clone(),
+            operator_node_id: original.operator_node_id,
         })
     }
 
@@ -579,6 +585,11 @@ impl TraitObligation {
                 continue;
             };
             position.deposited.set(true);
+            let _f = provenance::enter(
+                self.operator_node_id,
+                "infer.try_deposit",
+                provenance::Nature::Machinery,
+            );
             let target = position.ty.borrow().clone();
             let ty_base = Type::Base(settled);
             let ty = match maybe_refinement {
@@ -1469,10 +1480,12 @@ mod tests {
     #[case(&[(0, BaseType::Int), (1, BaseType::Int)])]
     #[case(&[(1, BaseType::Int), (0, BaseType::Int)])]
     fn narrowing_is_order_independent(#[case] steps: &[(u8, BaseType)]) {
+        let node_id = provenance::NodeId::fresh();
         let out = fresh_var(0);
         let ob = TraitObligation::new(
             Trait::Addable,
             vec![(Assoc::Output, out.clone())],
+            node_id,
             operands(),
         );
         let mut cache = ConstrainCache::new();
@@ -1499,10 +1512,12 @@ mod tests {
     /// operand, which stays open for a future heterogeneous instance.
     #[test]
     fn one_known_operand_settles_an_agreed_output() {
+        let node_id = provenance::NodeId::fresh();
         let out = fresh_var(0);
         let ob = TraitObligation::new(
             Trait::Addable,
             vec![(Assoc::Output, out.clone())],
+            node_id,
             operands(),
         );
         let mut cache = ConstrainCache::new();
@@ -1528,8 +1543,14 @@ mod tests {
     #[test]
     fn only_the_refining_addition_carries_a_predicate() {
         let deposited = |trait_| {
+            let node_id = provenance::NodeId::fresh();
             let out = fresh_var(0);
-            let ob = TraitObligation::new(trait_, vec![(Assoc::Output, out.clone())], operands());
+            let ob = TraitObligation::new(
+                trait_,
+                vec![(Assoc::Output, out.clone())],
+                node_id,
+                operands(),
+            );
             ob.narrow(0, &BaseType::Int, &mut ConstrainCache::new())
                 .expect("Int adds to Int under either trait");
             let Type::Infer(v) = &out else { unreachable!() };
@@ -1557,7 +1578,8 @@ mod tests {
     /// not just here.
     #[test]
     fn a_comparison_associates_nothing() {
-        let ob = TraitObligation::new(Trait::Equatable, Vec::new(), operands());
+        let node_id = provenance::NodeId::fresh();
+        let ob = TraitObligation::new(Trait::Equatable, Vec::new(), node_id, operands());
         let mut cache = ConstrainCache::new();
 
         ob.try_deposit(&mut cache).expect("nothing to deposit");
@@ -1576,8 +1598,14 @@ mod tests {
     /// says what the position could still have taken.
     #[test]
     fn incompatible_operands_have_no_instance() {
+        let node_id = provenance::NodeId::fresh();
         let out = fresh_var(0);
-        let ob = TraitObligation::new(Trait::Orderable, vec![(Assoc::Output, out)], operands());
+        let ob = TraitObligation::new(
+            Trait::Orderable,
+            vec![(Assoc::Output, out)],
+            node_id,
+            operands(),
+        );
         let mut cache = ConstrainCache::new();
 
         ob.narrow(0, &BaseType::Int, &mut cache)

--- a/src/ccl/infer/typing.rs
+++ b/src/ccl/infer/typing.rs
@@ -84,6 +84,7 @@ pub(super) trait Typing {
     fn require_trait(
         &mut self,
         trait_: Trait,
+        operator_node_id: NodeId,
         operand_types: &[&Type],
         operand_exprs: &[&Expr],
         assoc: Option<Assoc>,

--- a/src/ccl/infer/typing.rs
+++ b/src/ccl/infer/typing.rs
@@ -84,7 +84,8 @@ pub(super) trait Typing {
     fn require_trait(
         &mut self,
         trait_: Trait,
-        operands: &[&Type],
+        operand_types: &[&Type],
+        operand_exprs: &[&Expr],
         assoc: Option<Assoc>,
         at: &dyn Fn() -> String,
     ) -> Result<Option<Type>, LocatedInferError>;

--- a/src/ccl/lower/exprs.rs
+++ b/src/ccl/lower/exprs.rs
@@ -338,6 +338,7 @@ pub(super) fn lower_binop(
 fn chl_binop_to_ccl(op: ChlBinOp) -> BinOpKind {
     match op {
         ChlBinOp::Add => BinOpKind::Arithmetic(ArithmeticKind::Add),
+        ChlBinOp::AddRefined => BinOpKind::Arithmetic(ArithmeticKind::AddRefined),
         ChlBinOp::Sub => BinOpKind::Arithmetic(ArithmeticKind::Sub),
         ChlBinOp::Mul => BinOpKind::Arithmetic(ArithmeticKind::Mul),
         ChlBinOp::FloorDiv => BinOpKind::Arithmetic(ArithmeticKind::FloorDiv),

--- a/src/ccl/ops.rs
+++ b/src/ccl/ops.rs
@@ -86,6 +86,14 @@ pub enum Lit {
 pub enum ArithmeticKind {
     /// Integer addition (`+`).
     Add,
+    /// Integer addition whose result type records the sum (`^+`).
+    ///
+    /// Computes exactly what [`Add`](Self::Add) computes; the two differ only in
+    /// the trait each states, and so in the type the result takes. `+` is
+    /// `Addable` — `Int`, `UInt` or `String` operands, and an unrefined result.
+    /// `^+` is `AddableRefined`, whose one row accepts `Int` operands and refines
+    /// the result by `__elem == a₁ + a₂` (`src/ccl/infer/solver/traits.rs`).
+    AddRefined,
     /// Integer subtraction (`-`).
     Sub,
     /// Integer multiplication (`*`).
@@ -150,6 +158,7 @@ impl BinOpKind {
     pub fn sym(&self) -> &'static str {
         match self {
             Self::Arithmetic(ArithmeticKind::Add) => "+",
+            Self::Arithmetic(ArithmeticKind::AddRefined) => "^+",
             Self::Arithmetic(ArithmeticKind::Sub) => "-",
             Self::Arithmetic(ArithmeticKind::Mul) => "*",
             Self::Arithmetic(ArithmeticKind::FloorDiv) => "//",
@@ -179,6 +188,7 @@ impl BinOpKind {
     pub fn fn_name(&self) -> &'static str {
         match self {
             Self::Arithmetic(ArithmeticKind::Add) => "add",
+            Self::Arithmetic(ArithmeticKind::AddRefined) => "add_refined",
             Self::Arithmetic(ArithmeticKind::Sub) => "sub",
             Self::Arithmetic(ArithmeticKind::Mul) => "mul",
             Self::Arithmetic(ArithmeticKind::FloorDiv) => "floor_div",

--- a/src/ccl/provenance.rs
+++ b/src/ccl/provenance.rs
@@ -1660,9 +1660,11 @@ fn group_copies(copies: &[(NodeId, NodeId)]) -> Vec<(NodeId, Vec<NodeId>)> {
 /// This is the one recording that **names no node**, and the shape it fits is a
 /// duplication with *nothing being rewritten*, where there is no id to name:
 /// lowering's uncurry template-interior and compare-chain operand freshens, and
-/// inference freshening a refinement predicate per scheme instantiation
-/// (`infer.freshen_predicate`). Every captured copy carries its own origin from
-/// the hook, which is why this one can afford to declare nothing at all —
+/// inference's two freshens — a refinement predicate per scheme instantiation
+/// (`infer.freshen_predicate`) and a trait obligation's stored operand
+/// expressions per obligation copy (`infer.freshen_obligation`). Every captured
+/// copy carries its own origin from the hook, which is why this one can afford to
+/// declare nothing at all —
 /// [`row_per_copy`](OpenRecording::row_per_copy) never reads the named node.
 ///
 /// A duplication performed *as part of* a rewrite uses [`enter`] instead, naming

--- a/src/ccl/symbolic.rs
+++ b/src/ccl/symbolic.rs
@@ -676,9 +676,10 @@ fn binop_prec(op: &BinOpKind) -> Precedence {
         }
         BinOpKind::BoolLogic(LogicKind::And | LogicKind::Nand) => Precedence::And,
         BinOpKind::Compare(_) => Precedence::Cmp,
-        BinOpKind::Arithmetic(ArithmeticKind::Add | ArithmeticKind::Sub) | BinOpKind::Concat => {
-            Precedence::Add
-        }
+        BinOpKind::Arithmetic(
+            ArithmeticKind::Add | ArithmeticKind::AddRefined | ArithmeticKind::Sub,
+        )
+        | BinOpKind::Concat => Precedence::Add,
         BinOpKind::Arithmetic(ArithmeticKind::Mul | ArithmeticKind::FloorDiv) => Precedence::Mul,
     }
 }

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -1779,6 +1779,12 @@ pub type PredicateId = *const TypedExpr;
 /// it); nested refinements share it and shadow positionally.
 pub const REFINEMENT_BINDER: &str = "__elem";
 
+/// A predicate over an operator's result, as a function of the operand terms of
+/// one use. A trait instance's associated type may carry one, and depositing that
+/// type applies it to the operands the obligation recorded
+/// ([`TraitInstance`](crate::ccl::infer::solver::traits::TraitInstance)).
+pub type RefinementTemplate = fn(&[TypedExpr]) -> TypedExpr;
+
 impl Refinement {
     /// Construct a refinement over a **genuinely new** predicate term — one this
     /// call site is *creating*, with no prior refinement identity to preserve
@@ -1790,6 +1796,12 @@ impl Refinement {
     /// `Rc` sharing one `Rc` (see the note on [`Refinement::predicate`]).
     pub fn born(predicate: Rc<TypedExpr>) -> Self {
         Refinement { predicate }
+    }
+
+    /// Construct a refinement by applying a template function to a
+    /// list of argument expressions.
+    pub fn born_from_template(template: RefinementTemplate, args: &[TypedExpr]) -> Self {
+        Self::born(Rc::new(template(args)))
     }
 
     /// Construct a refinement **deliberately sharing** an existing predicate

--- a/src/chl_parser/ast.rs
+++ b/src/chl_parser/ast.rs
@@ -708,6 +708,9 @@ pub enum CompClause {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BinOp {
     Add,
+    /// `^+` — addition whose result type records the sum. Same arithmetic as
+    /// [`Add`](Self::Add), a different trait (`src/ccl/ops.rs`, `ArithmeticKind`).
+    AddRefined,
     Sub,
     Mul,
     FloorDiv,

--- a/src/chl_parser/lexer.rs
+++ b/src/chl_parser/lexer.rs
@@ -109,6 +109,14 @@ pub enum Token {
     PlusPlus,
     #[token("+=")]
     PlusEq,
+    /// Refining addition `^+` — addition whose result type records the sum
+    /// (`ArithmeticKind::AddRefined`, in `src/ccl/ops.rs`). Two chars, so maximal
+    /// munch takes it over `Caret` then `Plus`; CHL has no unary `+`, so `a ^ +b`
+    /// is not a competing parse.
+    ///
+    /// Experimental, and so absent from `docs/chl-spec.md`.
+    #[token("^+")]
+    CaretPlus,
     #[token("-=")]
     MinusEq,
     /// Lambda body arrow `->`. Also the planned pair / map-entry arrow — `a -> b`
@@ -248,6 +256,7 @@ impl fmt::Display for Token {
             Token::GtE => ">=",
             Token::PlusPlus => "++",
             Token::PlusEq => "+=",
+            Token::CaretPlus => "^+",
             Token::MinusEq => "-=",
             Token::Arrow => "->",
             Token::DoubleArrow => "=>",
@@ -519,7 +528,7 @@ mod tests {
     #[test]
     fn multi_char_operators() {
         assert_eq!(
-            tokens("<< <<= == != <= >= // //= += -= *="),
+            tokens("<< <<= == != <= >= // //= += -= *= ^+"),
             vec![
                 Token::LShift,
                 Token::LShiftEq,
@@ -532,6 +541,26 @@ mod tests {
                 Token::PlusEq,
                 Token::MinusEq,
                 Token::StarEq,
+                Token::CaretPlus,
+                Token::Newline,
+            ]
+        );
+    }
+
+    /// `^+` is one token and `^` is another; the two operators share a first
+    /// character, and maximal munch is what separates them.
+    #[test]
+    fn caret_plus_wins_over_caret_then_plus() {
+        assert_eq!(
+            tokens("a ^+ b ^ c + d"),
+            vec![
+                Token::Ident("a".into()),
+                Token::CaretPlus,
+                Token::Ident("b".into()),
+                Token::Caret,
+                Token::Ident("c".into()),
+                Token::Plus,
+                Token::Ident("d".into()),
                 Token::Newline,
             ]
         );

--- a/src/chl_parser/parser.rs
+++ b/src/chl_parser/parser.rs
@@ -753,6 +753,7 @@ where
             .foldl_with(
                 choice((
                     just(Token::Plus).to(BinOp::Add),
+                    just(Token::CaretPlus).to(BinOp::AddRefined),
                     just(Token::Minus).to(BinOp::Sub),
                 ))
                 .then(product.clone())

--- a/src/interpreter/operator_conversion.rs
+++ b/src/interpreter/operator_conversion.rs
@@ -2287,7 +2287,9 @@ fn builtin_to_binop(b: Builtin) -> Option<InterpreterBinOp> {
         return None;
     };
     Some(match op {
-        B::Arithmetic(A::Add) => InterpreterBinOp::Arithmetic(ArithmeticKind::Add),
+        // `^+` and `+` compute the same sum, so they share one runtime operation;
+        // the refinement `^+` carries is spent by the time op-conversion runs.
+        B::Arithmetic(A::Add | A::AddRefined) => InterpreterBinOp::Arithmetic(ArithmeticKind::Add),
         B::Arithmetic(A::Sub) => InterpreterBinOp::Arithmetic(ArithmeticKind::Sub),
         B::Arithmetic(A::Mul) => InterpreterBinOp::Arithmetic(ArithmeticKind::Mul),
         B::Arithmetic(A::FloorDiv) => InterpreterBinOp::Arithmetic(ArithmeticKind::FloorDiv),

--- a/tests/compilation_pipeline/scalars_collections.rs
+++ b/tests/compilation_pipeline/scalars_collections.rs
@@ -65,6 +65,11 @@ fn test_list_literals(#[case] code: &str, #[case] expected: Tile) {
 #[case("1 + 2 * 3 - 4", Value::Int(3))]
 #[case("1 + 2 * (3 - 4)", Value::Int(-1))]
 #[case("7 // 2", Value::Int(3))]
+// `^+` computes the sum `+` computes; the two differ only in the result type
+// (`tests/type_check.rs`, `refining_addition_records_the_sum`), and op-conversion
+// maps both to the one runtime addition.
+#[case("2 ^+ 3", Value::Int(5))]
+#[case("1 ^+ 2 * 3 - 4", Value::Int(3))]
 fn test_arithmetic(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }

--- a/tests/compilation_pipeline/type_annotations.rs
+++ b/tests/compilation_pipeline/type_annotations.rs
@@ -338,3 +338,8 @@ def test(a: String, b: Int):
 fn type_annotation_naming_a_parameter_is_unbound(#[case] code: &str, #[case] name: &str) {
     check_compile_error(code, &format!("type inference: Unbound variable: '{name}'"));
 }
+
+#[test]
+fn refined_add() {
+    check_scalar("z: {Int where _ == 1 ^+ 3} = 1 ^+ 3\n()", Value::Unit)
+}

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -209,6 +209,39 @@ fn an_operator_result_carries_no_operand_refinement(#[case] code: &str) {
     assert_eq!(infer_program(code), int());
 }
 
+/// `^+` records the sum in its result type. The refinement names the operand
+/// *terms* rather than their types, so it says what `+` cannot: the operands
+/// carry no refinement into it (the case above), and the equation is the
+/// instance's, from `AddableRefined`'s one row.
+#[rstest]
+#[case::literals("2 ^+ 3", "{Int | __elem == 2 ^+ 3}")]
+#[case::parameters(
+    indoc! {r#"
+        def f(a: Int, b: Int):
+            a ^+ b
+
+        f
+    "#},
+    "((__arg_tuple_0: (Int, Int)) ⇒ {Int | __elem == __arg_tuple_0.0 ^+ __arg_tuple_0.1})"
+)]
+fn refining_addition_records_the_sum(#[case] code: &str, #[case] expected: &str) {
+    assert_eq!(format!("{}", infer_program(code)), expected);
+}
+
+/// `^+` accepts `Int` and nothing else: `AddableRefined` has one row, where
+/// `Addable` has three. A `String` operand `+` accepts is a missing instance here,
+/// not a silently unrefined result.
+#[test]
+fn refining_addition_is_int_only() {
+    let errs = infer_program_err(r#""a" ^+ "b""#);
+    assert!(
+        errs.iter()
+            .map(|e| format!("{e:?}"))
+            .any(|m| m.contains("No AddableRefined instance")),
+        "expected a missing-instance diagnostic for AddableRefined, got {errs:?}",
+    );
+}
+
 /// The three shapes a trait can take are each exercised by a real program, which is
 /// what keeps the machinery from being fitted to one of them.
 ///


### PR DESCRIPTION
This PR adds an optional `RefinementTemplate` to each associated type of a `TraitInstance`. The `RefinementTemplate` is a function that produces a refinement for the associated type, when applied to the input operands of an operator.

This means that `TraitObligation` now carries the input expressions of the operator that produced it, so that those can eventually be passed into any relevant `RefinementTemplate` when a trait instance is finally chosen.

This PR also adds a `^+` operator, to be used temporarily to experiment with refined operators. `^+` mirrors `+` in every way, except it can only be used on `Int`, and the output type of `x ^+ y` is refined to `{Int where _ == x ^+ y}` using the trait refinement system described above.