### PR TITLE
Walk `elim_lambda`'s result at the `match`-arm rule

### DIFF
--- a/src/ccl/design/optimization.md
+++ b/src/ccl/design/optimization.md
@@ -124,6 +124,19 @@ where `src_refined` is `src_elim` with its domain wrapped in `Type::Refinement` 
 
 The filter check happens at the `Compose` level (rather than inside the `Lambda` arm) because the refinement must be attached to the source, which is only visible alongside the lambda at the compose level.
 
+### The constant rule reaches through its body
+
+`λ 𝑥 → 𝑒` with `𝑥 ∉ fv(𝑒)` becomes `𝑒 ▷ const`, and `𝑒` is eliminated first. `const` lifts a
+*value*, and the value operator conversion accepts is point-free — a `BinOp` or a nested `Lambda`
+left inside a lifted body reaches conversion as written and is refused there.
+
+The `Lambda` arm of `elim_lambdas` re-enters on the rule's result, so it covers for a body the rule
+leaves alone. The `match`-arm rule calls `elim_lambda` directly and does not, which is the caller
+the descent is load-bearing for: an arm reaches the constant rule whenever it does not mention its
+payload binder, so an arm computing over a name bound outside the `match` needs it. So does every
+write in a `match` arm — the mutability phases lift the write onto the arm's spine and leave the arm
+computing ([mutability.md](mutability.md), "A write inside a `Case` bound by a `Let`").
+
 ### `Let` nodes after rule 7
 
 When the lambda-elimination rule 7 rewrites a `Let` inside a lambda body, the bound variable changes type from `T` to `ParamTy ⇒ T`. The rewritten `Let` node has `bound_ty: None` because the old annotation is stale and would be incorrect.

--- a/src/ccl/design/optimization.md
+++ b/src/ccl/design/optimization.md
@@ -124,18 +124,24 @@ where `src_refined` is `src_elim` with its domain wrapped in `Type::Refinement` 
 
 The filter check happens at the `Compose` level (rather than inside the `Lambda` arm) because the refinement must be attached to the source, which is only visible alongside the lambda at the compose level.
 
-### The constant rule reaches through its body
+### `elim_lambda`'s caller walks its result
 
-`λ 𝑥 → 𝑒` with `𝑥 ∉ fv(𝑒)` becomes `𝑒 ▷ const`, and `𝑒` is eliminated first. `const` lifts a
-*value*, and the value operator conversion accepts is point-free — a `BinOp` or a nested `Lambda`
-left inside a lifted body reaches conversion as written and is refused there.
+`elim_lambda` abstracts one binder and returns a morphism whose sub-terms may still need
+eliminating. Three of its rules lift a body under `const` without descending into it: `λ 𝑥 → 𝑒` with
+`𝑥 ∉ fv(𝑒)`, the same shape with `𝑥` free only in `𝑒`'s refinement, and the cast-wrapped form of
+that second one. Operator conversion accepts a point-free value only, so a `BinOp` or a nested
+`Lambda` left inside a lifted body is refused there.
 
-The `Lambda` arm of `elim_lambdas` re-enters on the rule's result, so it covers for a body the rule
-leaves alone. The `match`-arm rule calls `elim_lambda` directly and does not, which is the caller
-the descent is load-bearing for: an arm reaches the constant rule whenever it does not mention its
-payload binder, so an arm computing over a name bound outside the `match` needs it. So does every
-write in a `match` arm — the mutability phases lift the write onto the arm's spine and leave the arm
-computing ([mutability.md](mutability.md), "A write inside a `Case` bound by a `Let`").
+Every caller hands the result to `elim_lambdas`, whose structural descent reaches those bodies: the
+`Lambda`, filter and map arms of `elim_lambdas` itself, and the `match`-arm rule in
+`build_scrutinee_case_cform`. One walk at the caller covers all three rules, and `elim_lambda` calls
+nothing in `elim_lambdas`.
+
+The `match`-arm rule is the caller the walk is load-bearing for. An arm reaches the first rule
+whenever it does not mention its payload binder, so an arm computing over a name bound outside the
+`match` needs the walk, and so does every write in a `match` arm — the mutability phases lift the
+write onto the arm's spine and leave the arm computing ([mutability.md](mutability.md), "A write
+inside a `Case` bound by a `Let`").
 
 ### `Let` nodes after rule 7
 

--- a/src/ccl/design/optimization.md
+++ b/src/ccl/design/optimization.md
@@ -124,25 +124,6 @@ where `src_refined` is `src_elim` with its domain wrapped in `Type::Refinement` 
 
 The filter check happens at the `Compose` level (rather than inside the `Lambda` arm) because the refinement must be attached to the source, which is only visible alongside the lambda at the compose level.
 
-### `elim_lambda`'s caller walks its result
-
-`elim_lambda` abstracts one binder and returns a morphism whose sub-terms may still need
-eliminating. Three of its rules lift a body under `const` without descending into it: `λ 𝑥 → 𝑒` with
-`𝑥 ∉ fv(𝑒)`, the same shape with `𝑥` free only in `𝑒`'s refinement, and the cast-wrapped form of
-that second one. Operator conversion accepts a point-free value only, so a `BinOp` or a nested
-`Lambda` left inside a lifted body is refused there.
-
-Every caller hands the result to `elim_lambdas`, whose structural descent reaches those bodies: the
-`Lambda`, filter and map arms of `elim_lambdas` itself, and the `match`-arm rule in
-`build_scrutinee_case_cform`. One walk at the caller covers all three rules, and `elim_lambda` calls
-nothing in `elim_lambdas`.
-
-The `match`-arm rule is the caller the walk is load-bearing for. An arm reaches the first rule
-whenever it does not mention its payload binder, so an arm computing over a name bound outside the
-`match` needs the walk, and so does every write in a `match` arm — the mutability phases lift the
-write onto the arm's spine and leave the arm computing ([mutability.md](mutability.md), "A write
-inside a `Case` bound by a `Let`").
-
 ### `Let` nodes after rule 7
 
 When the lambda-elimination rule 7 rewrites a `Let` inside a lambda body, the bound variable changes type from `T` to `ParamTy ⇒ T`. The rewritten `Let` node has `bound_ty: None` because the old annotation is stale and would be incorrect.

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -552,11 +552,10 @@ fn build_scrutinee_case_cform(
         )))
         .with_ty(Type::fun(consumed.clone(), payload_ty.clone()));
         // eᵢ as a point-free morphism `Pᵢ ⇒ Vᵢ`, reading the projected payload.
-        // `elim_lambda` abstracts the binder and leaves the walk to its caller
-        // (`src/ccl/design/optimization.md`, "`elim_lambda`'s caller walks its
-        // result"). An arm not mentioning its payload binder takes a `const`
-        // rule, which lifts the body whole, and operator conversion refuses a
-        // `BinOp` or a nested `Lambda` inside a lifted value.
+        // `elim_lambda` abstracts the binder and leaves the walk to its caller.
+        // An arm not mentioning its payload binder takes a `const` rule, which
+        // lifts the body whole, and operator conversion refuses a `BinOp` or a
+        // nested `Lambda` inside a lifted value.
         let arm_fn = elim_lambda(ctx, &pat.binding.name, &payload_ty, br.body)?;
         let arm_fn = elim_lambdas(ctx, arm_fn)?;
         arms.push(arm_compose(

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -552,7 +552,13 @@ fn build_scrutinee_case_cform(
         )))
         .with_ty(Type::fun(consumed.clone(), payload_ty.clone()));
         // eᵢ as a point-free morphism `Pᵢ ⇒ Vᵢ`, reading the projected payload.
+        // `elim_lambda` abstracts the binder and leaves the walk to its caller
+        // (`src/ccl/design/optimization.md`, "`elim_lambda`'s caller walks its
+        // result"). An arm not mentioning its payload binder takes a `const`
+        // rule, which lifts the body whole, and operator conversion refuses a
+        // `BinOp` or a nested `Lambda` inside a lifted value.
         let arm_fn = elim_lambda(ctx, &pat.binding.name, &payload_ty, br.body)?;
+        let arm_fn = elim_lambdas(ctx, arm_fn)?;
         arms.push(arm_compose(
             vec![scrut_stream.clone(), vp, arm_fn],
             driver_dom.clone(),
@@ -789,17 +795,7 @@ fn elim_lambda_impl(
     // Constant: λ x → e  ⟹  const(e)  when x ∉ fv(e)
     // Checked before pattern-matching because a nested lambda that does not
     // reference param should also be treated as a constant.
-    //
-    // `e` is eliminated first. `const` lifts a *value*, and the value operator
-    // conversion accepts is point-free, so a `BinOp` or a nested `Lambda` left
-    // inside a lifted body reaches conversion as written and is refused there.
-    //
-    // The `Lambda` arm of `elim_lambdas` re-enters on whatever this returns, so
-    // it covered for the omission; the `match`-arm rule calls here directly and
-    // does not. That is what left every `match` arm not mentioning its payload
-    // binder unconverted, in all three `match` spellings.
     if !is_free(param, &body) {
-        let body = elim_lambdas(ctx, body)?;
         // const: T → (A → T) where T = body.ty and result_ty = A → T
         let const_fn_ty = Type::compute_fun_or_hole(&body.ty, &result_ty);
         let const_var = Expr::builtin(Builtin::Const).with_ty(const_fn_ty);
@@ -978,12 +974,8 @@ fn elim_lambda_impl(
             // `param` occurs only in the refinement (the group-by shape): the value
             // is closed, so it lifts under `const` and the dependence rides the
             // refinement, materialized as a `Restrict` at the iteration boundary.
-            let inner_pf = elim_lambdas(ctx, *value)?;
-            let cast_val = Expr::new(TypedExprNode::Cast {
-                value: Box::new(inner_pf),
-                target,
-            })
-            .with_ty(body_ty.clone());
+            let cast_val =
+                Expr::new(TypedExprNode::Cast { value, target }).with_ty(body_ty.clone());
             let const_fn = Expr::builtin(Builtin::Const)
                 .with_ty(Type::fun(body_ty.clone(), result_pi.clone()));
             return Ok(Expr::apply(cast_val, const_fn).with_ty(result_pi));

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -789,7 +789,17 @@ fn elim_lambda_impl(
     // Constant: λ x → e  ⟹  const(e)  when x ∉ fv(e)
     // Checked before pattern-matching because a nested lambda that does not
     // reference param should also be treated as a constant.
+    //
+    // `e` is eliminated first. `const` lifts a *value*, and the value operator
+    // conversion accepts is point-free, so a `BinOp` or a nested `Lambda` left
+    // inside a lifted body reaches conversion as written and is refused there.
+    //
+    // The `Lambda` arm of `elim_lambdas` re-enters on whatever this returns, so
+    // it covered for the omission; the `match`-arm rule calls here directly and
+    // does not. That is what left every `match` arm not mentioning its payload
+    // binder unconverted, in all three `match` spellings.
     if !is_free(param, &body) {
+        let body = elim_lambdas(ctx, body)?;
         // const: T → (A → T) where T = body.ty and result_ty = A → T
         let const_fn_ty = Type::compute_fun_or_hole(&body.ty, &result_ty);
         let const_var = Expr::builtin(Builtin::Const).with_ty(const_fn_ty);

--- a/tests/compilation_pipeline/mutability.rs
+++ b/tests/compilation_pipeline/mutability.rs
@@ -1940,24 +1940,40 @@ fn test_a_branch_value_reads_what_the_branch_wrote(#[case] code: &str, #[case] e
     check_scalar(code, expected);
 }
 
-/// A `match` arm that computes over a name bound outside the `match` reaches
-/// operator conversion as a bare `BinOp`. The program below writes nothing, so
-/// the bound is below the mutability layer rather than in it: every `match`
-/// shape a write reaches ends up with a computed arm, which is why the writing
-/// cases above are `if` only.
-#[test]
-#[ignore = "a `match` arm computing over an outer name is not point-free by \
-            operator conversion; no write is involved"]
-fn test_match_arm_computing_over_an_outer_name() {
-    check_scalar(
-        indoc! {"
-            base = 3
-            t = match `some(3):
-                    case `some(n):
-                        base + n
-                    case `none:
-                        base + 0
-            t"},
-        Value::Int(6),
-    );
+// A write in a `match` arm reaches the same normalization an `if` branch's
+// does. Lifting the write onto the arm's spine leaves the arm computing over a
+// name bound outside the `match`, which is point-free by the `const` lift in
+// `elim_lambda` — see `test_const_lifted_arm_is_point_free` in `variants.rs`
+// for the write-free shape that bounds it.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case(indoc! {"
+    acc := 0
+    match `some(3):
+        case `some(n):
+            acc += n
+        case `none:
+            acc += 0
+    acc"}, Value::Int(3))]
+#[case(indoc! {"
+    acc := 0
+    t = match `some(3):
+            case `some(n):
+                acc += n
+                0
+            case `none:
+                acc += 0
+                0
+    acc"}, Value::Int(3))]
+// The arm the scrutinee does not take is the one that writes.
+#[case(indoc! {"
+    acc := 1
+    match `none:
+        case `some(n):
+            acc += n
+        case `none:
+            acc += 6
+    acc"}, Value::Int(7))]
+fn test_match_arm_write_carries(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
 }

--- a/tests/compilation_pipeline/variants.rs
+++ b/tests/compilation_pipeline/variants.rs
@@ -1387,11 +1387,10 @@ p"#;
 
 // A `match` arm that does not mention its payload binder is a constant function
 // of it, and `elim_lambda`'s constant rule lifts the body whole. The `match`-arm
-// rule walks what `elim_lambda` returns, as every caller does
-// (`src/ccl/design/optimization.md`, "`elim_lambda`'s caller walks its result");
-// without that walk an arm computing over a name bound outside the `match`
-// reaches operator conversion as the `BinOp` it was written as. All three
-// `match` spellings route through that rule.
+// rule walks what `elim_lambda` returns, as every caller does; without that
+// walk an arm computing over a name bound outside the `match` reaches operator
+// conversion as the `BinOp` it was written as. All three `match` spellings
+// route through that rule.
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 // On the right of an assignment.

--- a/tests/compilation_pipeline/variants.rs
+++ b/tests/compilation_pipeline/variants.rs
@@ -1384,3 +1384,62 @@ q = unwrap(`a("s"))
 p"#;
     check_scalar(code, Value::Int(1));
 }
+
+// A `match` arm that does not mention its payload binder is a constant function
+// of it, and `elim_lambda`'s constant rule lifts it with `const`. The rule
+// eliminates the body it lifts, which the `match`-arm rule depends on: unlike
+// the `Lambda` arm of `elim_lambdas`, it does not re-enter on the result, so an
+// arm computing over a name bound outside the `match` would otherwise reach
+// operator conversion as the `BinOp` it was written as
+// (`src/ccl/design/optimization.md`, "The constant rule reaches through its
+// body"). All three `match` spellings route through that rule.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+// On the right of an assignment.
+#[case(indoc! {"
+    base = 3
+    t = match `some(3):
+            case `some(n):
+                base + n
+            case `none:
+                base + 0
+    t"}, Value::Int(6))]
+// As the program's final expression.
+#[case(indoc! {"
+    base = 3
+    match `some(3):
+        case `some(n):
+            base + n
+        case `none:
+            base + 0"}, Value::Int(6))]
+// The one-line form.
+#[case(indoc! {"
+    base = 3
+    t = (match `none: case `some(n): base + n case `none: base * 2)
+    t"}, Value::Int(6))]
+// The arm the scrutinee does not take is the computing one.
+#[case(indoc! {"
+    base = 10
+    t = match `none:
+            case `some(n):
+                base + n
+            case `none:
+                base * 2
+    t"}, Value::Int(20))]
+// Nested: the outer arm is binder-free, and the `match` inside it is what the
+// lift has to reach.
+#[case(indoc! {"
+    base = 4
+    t = match `some(1):
+            case `some(n):
+                match `none:
+                    case `some(m):
+                        m
+                    case `none:
+                        base + 1
+            case `none:
+                0
+    t"}, Value::Int(5))]
+fn test_const_lifted_arm_is_point_free(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}

--- a/tests/compilation_pipeline/variants.rs
+++ b/tests/compilation_pipeline/variants.rs
@@ -1386,13 +1386,12 @@ p"#;
 }
 
 // A `match` arm that does not mention its payload binder is a constant function
-// of it, and `elim_lambda`'s constant rule lifts it with `const`. The rule
-// eliminates the body it lifts, which the `match`-arm rule depends on: unlike
-// the `Lambda` arm of `elim_lambdas`, it does not re-enter on the result, so an
-// arm computing over a name bound outside the `match` would otherwise reach
-// operator conversion as the `BinOp` it was written as
-// (`src/ccl/design/optimization.md`, "The constant rule reaches through its
-// body"). All three `match` spellings route through that rule.
+// of it, and `elim_lambda`'s constant rule lifts the body whole. The `match`-arm
+// rule walks what `elim_lambda` returns, as every caller does
+// (`src/ccl/design/optimization.md`, "`elim_lambda`'s caller walks its result");
+// without that walk an arm computing over a name bound outside the `match`
+// reaches operator conversion as the `BinOp` it was written as. All three
+// `match` spellings route through that rule.
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 // On the right of an assignment.


### PR DESCRIPTION
`elim_lambda` abstracts one binder and leaves the walk to its caller. `build_scrutinee_case_cform` passed its scrutinee, its guard-`Case` siblings and its default arm through `elim_lambdas` but not the arm morphism, so a `match` arm reaching a `const` rule kept whatever the rule lifted and operator conversion refused it. Every arm not mentioning its payload binder was affected, in all three `match` spellings.

```python
base = 3
t = match `some(3):
        case `some(n):
            base + n           # fine — the payload binder is free here
        case `none:
            base + 0           # refused at operator conversion
t
```

Adding the walk at the caller covers all three rules that lift a body under `const` — the plain constant rule, the Pi-const rule beside it, and the cast-const arm — where fixing one rule reaches one. It also leaves `elim_lambda` calling nothing in `elim_lambdas`, so the cast-const arm's own call goes: `Cast` has no arm in `elim_lambdas`, and the catch-all's `try_map_children` reaches its value. [optimization.md](src/ccl/design/optimization.md), "`elim_lambda`'s caller walks its result" records the contract.

It unblocks a write in a `match` arm: the mutability phases in #136 lift the write onto the arm's spine and leave the arm computing over the accumulator, which is that shape, so `match` joins `if` in carrying writes past a conditional. `test_match_arm_write_carries` covers those and replaces the ignored test that recorded the bound; `test_const_lifted_arm_is_point_free` covers the write-free shapes, including a `match` nested inside a binder-free arm.