### PR TITLE
Iterate a `mut` accumulator over the positions its filtered source delivers

### DIFF
--- a/docs/mutability-walkthrough.md
+++ b/docs/mutability-walkthrough.md
@@ -755,7 +755,7 @@ What differs is only what *decides* a position:
 
 | | `InductionStore` | commit operator |
 |---|---|---|
-| what decides a position | the next contiguous iteration position | a proposal that survives validation |
+| what decides a position | the next iteration position the source delivers | a proposal that survives validation |
 | ordering | strict predecessor dependence | any serialization the model admits |
 | conflicts | impossible: single writer | validated read sets, skip and retry |
 | what advances the cursor | the store's decided frontier, which is in the tile | the commit-ack, which is not — a commit is what *moves* the frontier |

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -306,16 +306,13 @@ fn is_builtin_applied(e: &Expr, b: Builtin) -> bool {
     matches!(&e.node, TypedExprNode::Apply { function, .. } if is_builtin(function, b))
 }
 
-/// Debug-only invariant walk over a whole expression tree: every node's type
-/// (and a `Cast`'s target) is checked marker-free by
+/// Debug-only invariant walk over a whole expression tree: every type slot a node
+/// carries ([`Expr::walk_type_slots`]) is checked marker-free by
 /// [`debug_assert_no_iteration_markers_in_type`]. Called at the planning→
 /// op-conversion boundary to catch a marker that leaked into a predicate.
 #[cfg(debug_assertions)]
 pub(crate) fn debug_assert_no_iteration_markers(expr: &Expr) {
-    debug_assert_no_iteration_markers_in_type(&expr.ty);
-    if let TypedExprNode::Cast { target, .. } = &expr.node {
-        debug_assert_no_iteration_markers_in_type(target);
-    }
+    expr.walk_type_slots(debug_assert_no_iteration_markers_in_type);
     expr.walk_children(debug_assert_no_iteration_markers);
 }
 

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -780,7 +780,6 @@ pub(crate) fn collect_main_tree_ids(expr: &Expr) -> HashSet<NodeId> {
 /// Explanation and uniqueness are two questions with two answers; see
 /// `design/provenance.md`, "Walking the ids".
 pub(crate) fn collect_tree_ids(expr: &Expr) -> HashSet<NodeId> {
-    use crate::ccl::TypedExprNode;
     use crate::ccl::ty::Type;
 
     fn from_ty(t: &Type, acc: &mut HashSet<NodeId>) {
@@ -791,29 +790,14 @@ pub(crate) fn collect_tree_ids(expr: &Expr) -> HashSet<NodeId> {
 
     fn from_expr(e: &Expr, acc: &mut HashSet<NodeId>) {
         acc.insert(e.node_id());
-        from_ty(&e.ty, acc);
-        if let Some(ann) = &e.user_annotation {
-            from_ty(ann, acc);
-        }
-        // A `Cast`'s target is a type slot `walk_children` skips, and it is where
-        // lowering parks the predicate it just built.
-        if let TypedExprNode::Cast { target, .. } = &e.node {
-            from_ty(target, acc);
-        }
-        // A binder's declared type and its annotation are type slots too. This
-        // walk and `TypedExpr::walk_type_slots` enumerate the same domain, and
-        // must: the rewriting passes reach predicates through `walk_type_slots`,
-        // so anything it covers and this does not is a predicate a pass may
-        // rebuild while the fold has never enumerated the original — which reads
-        // as `DanglingParent` against an id the input pane demonstrably holds.
+        // Delegating to `walk_type_slots` is what keeps the two in step, and they
+        // must be: the rewriting passes reach predicates through that walk, so a
+        // slot it covers and this does not is a predicate a pass may rebuild while
+        // the fold has never enumerated the original — which reads as
+        // `DanglingParent` against an id the input pane demonstrably holds.
         // `f: (Int => {Int where _ == 9}) = …` is the shape: the predicate rides
         // the `let` binder's annotation and nothing else.
-        e.walk_binders(|b| {
-            from_ty(&b.ty, acc);
-            if let Some(ann) = &b.user_annotation {
-                from_ty(ann, acc);
-            }
-        });
+        e.walk_type_slots(|t| from_ty(t, acc));
         e.walk_children(|c| from_expr(c, acc));
     }
 

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -698,6 +698,12 @@ pub enum Phase {
 /// cannot tell the sharing apart from the collision — which is why the main-tree
 /// walk stays `Rc`-blind and this one does not.
 ///
+/// Coverage is [`TypedExpr::walk_type_slots`]', which is what reaches a predicate
+/// riding a binder's **annotation** and nothing else. `f: (Int => {Int where _ ==
+/// 9}) = …` is that shape, and it is live at the `post-lowering` boundary: the
+/// annotation holds the only occurrence until inference consumes it, so a walk
+/// over node types alone enumerates none of the predicate's ids there.
+///
 /// Both walks run at every boundary, from [`assert_unique_node_ids`].
 pub(crate) fn predicate_id_collisions(expr: &Expr) -> Vec<(NodeId, &'static str)> {
     use crate::ccl::ty::Type;
@@ -724,13 +730,7 @@ pub(crate) fn predicate_id_collisions(expr: &Expr) -> Vec<(NodeId, &'static str)
         });
     }
     fn from_expr_ty(e: &Expr, acc: &mut HashMap<usize, HashSet<NodeId>>) {
-        from_ty(&e.ty, acc);
-        if let Some(a) = &e.user_annotation {
-            from_ty(a, acc);
-        }
-        if let crate::ccl::TypedExprNode::Cast { target, .. } = &e.node {
-            from_ty(target, acc);
-        }
+        e.walk_type_slots(|t| from_ty(t, acc));
         e.walk_children(|c| from_expr_ty(c, acc));
     }
     let mut terms: HashMap<usize, HashSet<NodeId>> = HashMap::new();

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -66,22 +66,13 @@ carry-forward, so channels never close a causal cycle — see [merge laws](#the-
 | `with begin():` transaction | `Txn`, an anonymous total order issued by the runtime | `get_prev_txn` |
 | `while` loop *(future)* | a prefix of `Nat` bounded by the running condition | `get_prev_seq` over a self-ceiling domain |
 
-A **filtered** loop source is the same row read literally: its domain is the refined extent
-`{[0, 𝑁] | 𝑝}`, so the recurrence runs at the positions that survived the filter and at no
-others. `restrict` keeps an element at its original position, so those positions are a subset
-of the extent's rather than a renumbering of them, and the induction store's ticks follow them
-(position `𝑝` decides tick `𝑝 + 1`, and an excluded position's tick is never occupied). A read
-of the accumulator's history still spans the whole extent: at an excluded position it folds to
-the latest write below it, the value the accumulator held there. The alternative — iterating
-the extent densely and gating the write, which is how an in-body `if` compiles — would put the
-store at odds with the domain the type carries.
-
-A **product** loop source is rejected at op-conversion. A comprehension across two sources
+A **product** loop source is unsupported. A comprehension across two sources
 (`[e for x in xs for y in ys]`, join or not) is keyed by `(𝑖, 𝑗)`, and the induction recurrence is
 sequenced by `UInt` position throughout: the driver pairs items with `UInt` domain keys, the commit
-engine's ticks are positions, and the dense read folds tick `𝑝 + 1` at each. The rejection is at the
-boundary rather than deeper because the driver's decode drops a non-`UInt` key instead of failing on
-it, so an unguarded product domain would be a loop that runs zero times.
+engine's ticks are positions, and the dense read folds tick `𝑝 + 1` at each. Supporting one means
+giving the recurrence a sequencing order over `(𝑖, 𝑗)`. Op-conversion rejects such a source until
+it has one, because the driver's decode drops a non-`UInt` key instead of failing on it, so an
+unguarded product domain is a loop that runs zero times.
 
 A mutable variable's domain is the domain of the context that **writes** it (`Txn` excepted — never
 inferred, always spelled at the introduction). What the **introduction** site fixes is not that

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -76,6 +76,13 @@ the latest write below it, the value the accumulator held there. The alternative
 the extent densely and gating the write, which is how an in-body `if` compiles — would put the
 store at odds with the domain the type carries.
 
+A **product** loop source is rejected at op-conversion. A comprehension across two sources
+(`[e for x in xs for y in ys]`, join or not) is keyed by `(𝑖, 𝑗)`, and the induction recurrence is
+sequenced by `UInt` position throughout: the driver pairs items with `UInt` domain keys, the commit
+engine's ticks are positions, and the dense read folds tick `𝑝 + 1` at each. The rejection is at the
+boundary rather than deeper because the driver's decode drops a non-`UInt` key instead of failing on
+it, so an unguarded product domain would be a loop that runs zero times.
+
 A mutable variable's domain is the domain of the context that **writes** it (`Txn` excepted — never
 inferred, always spelled at the introduction). What the **introduction** site fixes is not that
 domain but the constraint that it must sit *outside* the context that would sequence the mutable variable.

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -66,6 +66,16 @@ carry-forward, so channels never close a causal cycle — see [merge laws](#the-
 | `with begin():` transaction | `Txn`, an anonymous total order issued by the runtime | `get_prev_txn` |
 | `while` loop *(future)* | a prefix of `Nat` bounded by the running condition | `get_prev_seq` over a self-ceiling domain |
 
+A **filtered** loop source is the same row read literally: its domain is the refined extent
+`{[0, 𝑁] | 𝑝}`, so the recurrence runs at the positions that survived the filter and at no
+others. `restrict` keeps an element at its original position, so those positions are a subset
+of the extent's rather than a renumbering of them, and the induction store's ticks follow them
+(position `𝑝` decides tick `𝑝 + 1`, and an excluded position's tick is never occupied). A read
+of the accumulator's history still spans the whole extent: at an excluded position it folds to
+the latest write below it, the value the accumulator held there. The alternative — iterating
+the extent densely and gating the write, which is how an in-body `if` compiles — would put the
+store at odds with the domain the type carries.
+
 A mutable variable's domain is the domain of the context that **writes** it (`Txn` excepted — never
 inferred, always spelled at the introduction). What the **introduction** site fixes is not that
 domain but the constraint that it must sit *outside* the context that would sequence the mutable variable.

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -615,15 +615,15 @@ in the `provenance-design` note under projects/program-inspector in the internal
 vault.
 
 A pass reaches predicates through **every type slot a node carries**, not just
-`expr.ty`: the node's own type, its `user_annotation`, a `Cast`'s `target`, and —
-per binder — both the binder's declared type *and* its annotation. Each holds an
-independent predicate `Rc`. `Expr::walk_type_slots{,_mut}` is the single source of
-truth for that set, precisely because hand-rolling it per pass is how a pass
-silently acquires a blind spot — `Cast.target`, where a comprehension filter's
-predicate actually lives, is the one that costs most. `count_free`/`is_free` are on
-it too, and that is not cosmetic: several passes *skip work* when `is_free` says
-no, so a slot the free-variable walk cannot see is a slot those passes decline to
-rewrite.
+`expr.ty`: the node's own type, its `user_annotation`, a `Cast`'s `target`, a
+`Transact`'s `domain`, and — per binder — both the binder's declared type *and* its
+annotation. Each holds an independent predicate `Rc`. `Expr::walk_type_slots{,_mut}`
+is the single source of truth for that set, precisely because hand-rolling it per
+pass is how a pass silently acquires a blind spot — `Cast.target`, where a
+comprehension filter's predicate actually lives, is the one that costs most.
+`count_free`/`is_free` are on it too, and that is not cosmetic: several passes *skip
+work* when `is_free` says no, so a slot the free-variable walk cannot see is a slot
+those passes decline to rewrite.
 
 A binder's **annotation** is the subtle member of that set, and it is the only one
 with a bounded lifetime: it is where lowering writes a mutable variable's
@@ -635,13 +635,18 @@ A walk over the slot set must still cover it, because the passes that use
 `subst`), and — because an erasure and its own post-condition share that walk — a
 slot the walk misses is a slot the check cannot report on.
 
+A `Transact`'s **sequencing domain** is on the walk for the same reason. The node is
+born by `plan_loops` and its domain is the extent of the source it iterates,
+refinements and all, so a `mut` accumulator over a filtered collection carries that
+filter's predicate there as well as on every other slot the same extent reaches.
+Planning's predicate compilation runs through this walk and the post-planning
+`typecheck` compares refinements structurally, so a domain the walk skipped would
+hold the bare predicate while its siblings held the compiled one, and the carrier
+would contradict its own type.
+
 The claim is *checked*, not asserted: `walk_type_slots_covers_every_carried_type_slot`
-stamps a distinct marker into every directly-carried `Type` in the AST and pins
-which ones the walk reaches. One is deliberately excluded — `Transact`'s `domain` —
-because that node is born by `plan_loops` after every pass on the walk, so covering
-it would newly expose the sequencing extent to planning's predicate compilation.
-That is a behavioural change in the recurrence engine, and the test pins the
-exclusion so it stays a decision rather than drift.
+stamps a distinct marker into every directly-carried `Type` in the AST and pins that
+the walk reaches all of them.
 
 #### The memo key is the predicate *and the conditions it was rebuilt under*
 

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -615,15 +615,15 @@ in the `provenance-design` note under projects/program-inspector in the internal
 vault.
 
 A pass reaches predicates through **every type slot a node carries**, not just
-`expr.ty`: the node's own type, its `user_annotation`, a `Cast`'s `target`, a
-`Transact`'s `domain`, and — per binder — both the binder's declared type *and* its
-annotation. Each holds an independent predicate `Rc`. `Expr::walk_type_slots{,_mut}`
-is the single source of truth for that set, precisely because hand-rolling it per
-pass is how a pass silently acquires a blind spot — `Cast.target`, where a
-comprehension filter's predicate actually lives, is the one that costs most.
-`count_free`/`is_free` are on it too, and that is not cosmetic: several passes *skip
-work* when `is_free` says no, so a slot the free-variable walk cannot see is a slot
-those passes decline to rewrite.
+`expr.ty`: the node's own type, its `user_annotation`, a `Cast`'s `target`, and —
+per binder — both the binder's declared type *and* its annotation. Each holds an
+independent predicate `Rc`. `Expr::walk_type_slots{,_mut}` is the single source of
+truth for that set, precisely because hand-rolling it per pass is how a pass
+silently acquires a blind spot — `Cast.target`, where a comprehension filter's
+predicate actually lives, is the one that costs most. `count_free`/`is_free` are on
+it too, and that is not cosmetic: several passes *skip work* when `is_free` says
+no, so a slot the free-variable walk cannot see is a slot those passes decline to
+rewrite.
 
 A binder's **annotation** is the subtle member of that set, and it is the only one
 with a bounded lifetime: it is where lowering writes a mutable variable's
@@ -634,15 +634,6 @@ A walk over the slot set must still cover it, because the passes that use
 `walk_type_slots` include ones that run before and during inference (`uniquify`,
 `subst`), and — because an erasure and its own post-condition share that walk — a
 slot the walk misses is a slot the check cannot report on.
-
-A `Transact`'s **sequencing domain** is on the walk for the same reason. The node is
-born by `plan_loops` and its domain is the extent of the source it iterates,
-refinements and all, so a `mut` accumulator over a filtered collection carries that
-filter's predicate there as well as on every other slot the same extent reaches.
-Planning's predicate compilation runs through this walk and the post-planning
-`typecheck` compares refinements structurally, so a domain the walk skipped would
-hold the bare predicate while its siblings held the compiled one, and the carrier
-would contradict its own type.
 
 The claim is *checked*, not asserted: `walk_type_slots_covers_every_carried_type_slot`
 stamps a distinct marker into every directly-carried `Type` in the AST and pins that

--- a/src/ccl/expr.rs
+++ b/src/ccl/expr.rs
@@ -1801,10 +1801,10 @@ impl TypedExpr {
     }
 
     /// Invoke `f` on every [`Type`] slot this node carries **directly**: its own
-    /// `ty`, its `user_annotation`, a [`TypedExprNode::Cast`]'s `target`, and — for
-    /// every binder it introduces ([`walk_binders`](Self::walk_binders)) — both
-    /// that binder's `ty` **and** its `user_annotation`. Does not recurse into
-    /// child expressions.
+    /// `ty`, its `user_annotation`, a [`TypedExprNode::Cast`]'s `target`, a
+    /// [`TypedExprNode::Transact`]'s `domain`, and — for every binder it introduces
+    /// ([`walk_binders`](Self::walk_binders)) — both that binder's `ty` **and** its
+    /// `user_annotation`. Does not recurse into child expressions.
     ///
     /// This is the single source of truth for "which type slots a node carries",
     /// and it exists because those slots are **independent** values: a refinement
@@ -1825,15 +1825,18 @@ impl TypedExpr {
     /// binder annotation to reach, and a walk that visits only `b.ty` misses every
     /// predicate riding one.
     ///
-    /// **Coverage is exact for every variant except
-    /// [`TypedExprNode::Transact`]**, whose `domain` — the sequencing extent, or
-    /// `Txn` — is the one directly-carried `Type` this does not visit. `Transact`
-    /// is born by `planning::plan_loops`, *after* every pass that uses this walk,
-    /// so no caller can observe the omission today; covering it would newly expose
-    /// the domain to `planning::compile_refinement_predicates`, which runs later.
-    /// That is a real behavioural change in the recurrence engine and wants its
-    /// own change rather than riding along here. The exhaustiveness this claims is
-    /// checked, not asserted: `walk_type_slots_covers_every_carried_type_slot`.
+    /// **Coverage is exact — every variant, no exceptions**, including a
+    /// [`TypedExprNode::Transact`]'s `domain`. A `Transact` is born by
+    /// `planning::plan_loops` and its sequencing domain is the extent of the source
+    /// it iterates, refinements and all, so a `mut` accumulator over a filtered
+    /// collection carries that filter's predicate there as well as on every other
+    /// slot the same extent reaches. `planning::compile_refinement_predicates`
+    /// rewrites predicates through this walk, and the post-planning `typecheck`
+    /// compares refinements by structural equality, so a domain this walk skipped
+    /// would hold the bare predicate while its siblings hold the compiled one and
+    /// the carrier's own type would contradict its `domain`. The exhaustiveness
+    /// this claims is checked, not asserted:
+    /// `walk_type_slots_covers_every_carried_type_slot`.
     ///
     /// Callers that also need slots reachable *through* a type (a `Fun` domain, a
     /// refinement predicate's own type slots) compose this with
@@ -1846,6 +1849,9 @@ impl TypedExpr {
         }
         if let TypedExprNode::Cast { target, .. } = &self.node {
             f(target);
+        }
+        if let TypedExprNode::Transact { domain, .. } = &self.node {
+            f(domain);
         }
         self.walk_binders(|b| {
             f(&b.ty);
@@ -1865,6 +1871,9 @@ impl TypedExpr {
         }
         if let TypedExprNode::Cast { target, .. } = &mut self.node {
             f(target);
+        }
+        if let TypedExprNode::Transact { domain, .. } = &mut self.node {
+            f(domain);
         }
         self.walk_binders_mut(|b| {
             f(&mut b.ty);
@@ -2154,8 +2163,7 @@ mod tests {
     /// The full inventory of directly-carried `Type`s in the AST: `TypedExpr.ty`,
     /// `TypedExpr.user_annotation`, `TypedBinding.ty`, `TypedBinding.user_annotation`,
     /// `TypedExprNode::Cast.target`, and `TypedExprNode::Transact.domain`. The walk
-    /// covers the first five; `Transact.domain` is excluded for the reason on
-    /// `walk_type_slots`, and this pins that exclusion so it cannot become silent.
+    /// covers all six.
     #[test]
     fn walk_type_slots_covers_every_carried_type_slot() {
         fn marker(name: &str) -> Type {
@@ -2195,19 +2203,15 @@ mod tests {
         cast.ty = marker("node_ty");
         assert_eq!(reached(&cast), vec!["cast_target", "node_ty"]);
 
-        // `Transact.domain` is the one directly-carried `Type` deliberately not
-        // covered. Asserted so the exclusion stays a decision rather than drift:
-        // if this starts failing, the walk grew to cover it and the doc must too.
+        // A `Transact` carries its sequencing domain beyond its own type, and that
+        // domain holds the iterated source's refinements — the predicates
+        // `planning::compile_refinement_predicates` rewrites through this walk.
         let mut txn = TypedExpr::new(TypedExprNode::Transact {
             keys: Vec::new(),
             writers: Vec::new(),
             domain: marker("transact_domain"),
         });
         txn.ty = marker("node_ty");
-        assert_eq!(
-            reached(&txn),
-            vec!["node_ty"],
-            "`Transact.domain` is excluded on purpose; see `walk_type_slots`"
-        );
+        assert_eq!(reached(&txn), vec!["node_ty", "transact_domain"]);
     }
 }

--- a/src/interpreter/commit_operator.rs
+++ b/src/interpreter/commit_operator.rs
@@ -1375,18 +1375,24 @@ impl TileProducer for InductionStoreProducer {
         let body_tile = self
             .body_producer
             .get(self.body_producer.tiling().universal_guard());
-        // Consume the body's decisions **in contiguous order** from `processed`,
-        // stopping at the first position it has not decided. Tick 0 is the
-        // seeded init, so iteration `pos` occupies tick `pos + 1`; the decision
-        // gates commit (append the change) vs carry (`step(_, None)` — the value
-        // inherits from tick 0 / the latest earlier change). The driver emits one
-        // position per pull, so this normally steps once; consuming a run costs
-        // nothing extra and keeps the store's rule independent of that rate.
+        // Consume the body's decisions **in ascending position order** from
+        // `processed`, stopping at the first position it has not decided. Tick 0 is
+        // the seeded init and the iteration at position `pos` occupies tick
+        // `pos + 1`, so `processed` — the engine's watermark — is a *lower bound* on
+        // the next position rather than the position itself: a restricted loop
+        // source skips the extent positions its filter excluded, and those ticks are
+        // never occupied. The decision gates commit (append the change) vs carry
+        // (`step(_, None)` — the value inherits from tick 0 / the latest earlier
+        // change). The driver emits one position per pull, so this normally steps
+        // once; consuming a run costs nothing extra and keeps the store's rule
+        // independent of that rate.
         let started_at = self.processed();
-        while let Some((commit, writes, tap_fired)) =
-            body_decision_at(&body_tile, self.processed(), &self.tap_fields)
-        {
-            let pos = self.processed();
+        while let Some(pos) = next_decided_position(&body_tile, self.processed()) {
+            let Some((commit, writes, tap_fired)) =
+                body_decision_at(&body_tile, pos, &self.tap_fields)
+            else {
+                break;
+            };
             let write_set: Option<HashMap<Value, Value>> = if commit {
                 debug_assert_eq!(
                     writes.len(),
@@ -1435,7 +1441,7 @@ impl TileProducer for InductionStoreProducer {
             debug_assert_eq!(
                 self.processed(),
                 pos + 1,
-                "a step at iteration {pos} advances the decided count to {}",
+                "a step at position {pos} advances the watermark to its tick {}",
                 pos + 1
             );
         }
@@ -1462,16 +1468,15 @@ impl TileProducer for InductionStoreProducer {
         // extent is decided.
         let done = body_tile.is_terminal();
         // Reading a terminal body stream as "the whole extent is decided" rests on
-        // that stream being **gapless**. The loop above stops at the first undecided
-        // position, so a terminal stream with a hole at `processed` and decisions past
-        // it would close the frontier an iteration short and drop them without a
-        // sound. The driver emits contiguously (and asserts its source's gaplessness),
-        // so this holds by construction — asserted here because it is here that it is
-        // relied on.
+        // the loop above having consumed all of it. It stops at the first position it
+        // cannot decode as a decision, so a terminal stream with an undecodable row
+        // and decisions past it would close the frontier early and drop them without
+        // a sound.
         debug_assert!(
-            !done || !decides_beyond(&body_tile, self.processed()),
-            "induction store: the body's decision stream is terminal with a hole at \
-             position {} and decisions past it",
+            !done || next_decided_position(&body_tile, self.processed()).is_none(),
+            "induction store: the body's decision stream is terminal but still decides \
+             position {:?}, at or past the watermark {}",
+            next_decided_position(&body_tile, self.processed()),
             self.processed()
         );
         self.render_store(done)
@@ -2569,37 +2574,44 @@ impl TileProducer for AsOfProducer {
 }
 
 /// One emitted body-input row: the snapshot the decision reads, the source item
-/// it is for, and that item's index.
+/// it is for, that item's index, and the domain position the row occupies.
 ///
 /// The index is what makes a release interpretable on the transaction side (it
-/// says *which* item a reclaimed row belongs to). On the induction side it is
-/// the emit position itself, kept for uniformity — the window is a row or two,
-/// so the duplication costs nothing and having one row type is what lets both
-/// drivers share the rendering below.
+/// says *which* item a reclaimed row belongs to). It is distinct from `position`
+/// there — a retried item occupies several attempt positions — and equal to it
+/// on the induction side, where a position *is* its source position.
 struct DriverRow {
     snapshot: Vec<Value>,
     item: Value,
     item_index: usize,
+    /// The row's absolute domain position, which the body's decision is looked
+    /// up by ([`body_decision_at`]). Ascending across the window, and on the
+    /// induction side not necessarily contiguous: a restricted loop source
+    /// delivers a subset of its extent's positions and the recurrence runs over
+    /// exactly those.
+    position: usize,
 }
 
 /// The live window of emitted `(read…, item)` rows, and the body-input tile it
 /// renders.
 ///
-/// Both drivers own one. What differs between them is *which* row to emit next —
-/// the induction driver takes it from the store's decided frontier, the
-/// transaction driver from its acked item cursor — not how a window of rows
-/// becomes the body's input, how positions stay absolute across compaction, or
-/// what a release reclaims. Those are here, once.
+/// Both drivers own one. What differs between them is *which* position to emit
+/// next — the induction driver takes it from its source's delivered positions,
+/// the transaction driver counts attempts — not how a window of rows becomes the
+/// body's input, how positions stay absolute across compaction, or what a release
+/// reclaims. Those are here, once.
 ///
-/// Positions are **absolute**: `rows[i]` is position `base + i`, and released
+/// Positions are **absolute and ascending**, each carried on its row: released
 /// rows compact off the front without renumbering the rest, because the body
-/// looks a decision up by domain *value* ([`body_decision_at`]).
+/// looks a decision up by domain *value* ([`body_decision_at`]). They need not be
+/// contiguous — a restricted induction source has positions its extent does not.
 struct DriverWindow {
     read_extents: Vec<Extent>,
     item_extent: Extent,
-    /// Absolute position of `rows[0]`; released rows are compacted away, so the
-    /// retained window stays bounded on a long-running loop.
-    base: usize,
+    /// One past the highest position ever pushed — the transaction driver's next
+    /// attempt position. Held across compaction, so a window emptied by a release
+    /// still knows where it is.
+    next_position: usize,
     rows: Vec<DriverRow>,
     /// Highest absolute position a consumer has released. The body fans this
     /// input through a `Memo` that pulls it several times per round, so an
@@ -2613,37 +2625,44 @@ impl DriverWindow {
         Self {
             read_extents,
             item_extent,
-            base: 0,
+            next_position: 0,
             rows: Vec::new(),
             release_cursor: PrefixReleaseCursor::default(),
         }
     }
 
-    /// The next absolute position to emit at — one past the window's end.
+    /// One past the highest position pushed — the next position of a driver whose
+    /// positions are contiguous.
     fn next_position(&self) -> usize {
-        self.base + self.rows.len()
+        self.next_position
     }
 
-    /// Append a row, returning the absolute position it landed at.
-    fn push(&mut self, snapshot: Vec<Value>, item: Value, item_index: usize) -> usize {
+    /// Append a row at absolute position `position`.
+    fn push(&mut self, snapshot: Vec<Value>, item: Value, item_index: usize, position: usize) {
         debug_assert_eq!(
             snapshot.len(),
             self.read_extents.len(),
             "a body-input row carries one snapshot value per read key"
         );
-        let pos = self.next_position();
+        debug_assert!(
+            position >= self.next_position,
+            "body-input positions ascend: pushing {position} at or below the highest \
+             already pushed ({})",
+            self.next_position
+        );
         self.rows.push(DriverRow {
             snapshot,
             item,
             item_index,
+            position,
         });
-        pos
+        self.next_position = position + 1;
     }
 
     /// The newest live row with its absolute position, or `None` when the window
     /// is empty.
     fn newest(&self) -> Option<(usize, &DriverRow)> {
-        self.rows.last().map(|r| (self.next_position() - 1, r))
+        self.rows.last().map(|r| (r.position, r))
     }
 
     /// Reclaim the prefix a release covers, keeping the survivors' positions
@@ -2655,13 +2674,10 @@ impl DriverWindow {
         let drop_through = match extent {
             ReleasedExtent::Nothing => return extent,
             ReleasedExtent::All => self.rows.len(),
-            ReleasedExtent::Through(w) if w >= self.base => {
-                (w + 1 - self.base).min(self.rows.len())
-            }
-            ReleasedExtent::Through(_) => return extent,
+            // Positions ascend, so the released ones are a prefix of the window.
+            ReleasedExtent::Through(w) => self.rows.partition_point(|r| r.position <= w),
         };
         self.rows.drain(..drop_through);
-        self.base += drop_through;
         extent
     }
 
@@ -2690,7 +2706,7 @@ impl DriverWindow {
             Tile::Scalar(ColumnValue::from_values(column, ext))
         });
         Tile::SealedFunction {
-            domain: ColumnValue::from_uints((self.base..self.next_position()).collect()),
+            domain: ColumnValue::from_uints(self.rows.iter().map(|r| r.position).collect()),
             codomain: Box::new(Tile::Record(fields)),
             domain_predicate: if done {
                 Predicate::True
@@ -2820,6 +2836,7 @@ impl TileOperator for InductionDriver {
             wakeups: scheduler.wakeup_queue(),
             read_keys: self.read_keys.clone(),
             window: DriverWindow::new(self.read_extents.clone(), self.item_extent.clone()),
+            emitted_through: None,
             source_released_through: None,
             source_fully_released: false,
         })
@@ -2843,6 +2860,12 @@ struct InductionDriverProducer {
     /// producer's own output, not recurrence state: a row is never read back to
     /// compute a later one.
     window: DriverWindow,
+    /// Highest source position emitted, or `None` before the first. This is the
+    /// item cursor, and it is not recoverable from the window (a release compacts
+    /// emitted rows away) nor from the store's frontier (a *tick* cursor, which
+    /// only counts iterations — a restricted source's positions are sparser than
+    /// its ticks).
+    emitted_through: Option<usize>,
     /// Highest source position released back upstream. The driver never re-reads
     /// a position it has emitted, so that prefix is reclaimable; a co-iterated
     /// reader keeps its own positions live through the source's cross-producer
@@ -2872,24 +2895,23 @@ impl TileProducer for InductionDriverProducer {
         // An async source's domain arrives unordered, so drive by absolute
         // position rather than by the codomain's column order.
         let by_pos: HashMap<usize, Value> = decode_source_positioned(&src).into_iter().collect();
-        // Invariant: an induction source domain has **no interior hole** — a finite
-        // list `[0, N)` or an async `DataSource`'s UInt domain only ever gaps at the
-        // *trailing* end (positions not yet arrived). Both of this driver's rules rest
-        // on it: it stops at the first missing position and resumes when that one
-        // arrives, so a permanent interior hole would stall forever; and `done` below
-        // reads "the next position is absent" as "there is no next", which a hole
-        // would turn into a loop that ends early and drops the rest in silence. The
-        // arrived set is a suffix rather than a prefix from 0 — the consumed prefix is released
-        // below, so a later pull sees a shifted window (e.g. `{5, 6, 7}`) — so the
-        // check is that the sorted positions run contiguously from whatever base is
-        // retained.
+        // Invariant: an induction source delivers its positions in **ascending
+        // order** — a position at or below one already emitted never arrives later.
+        // The driver takes the smallest delivered position above its cursor and
+        // never looks back, so a late arrival below the cursor would be dropped in
+        // silence. A position at or below the cursor is still legitimate *here*: the
+        // release below is what removes the consumed prefix, and the source is free
+        // to honour it a pull late. The domain need not be contiguous — a restricted
+        // source (`for l in [x for x in xs if p(x)]`) delivers a subset of its
+        // extent's positions and the recurrence runs over exactly those.
         debug_assert!(
-            !source_complete || {
-                let mut ks: Vec<usize> = by_pos.keys().copied().collect();
-                ks.sort_unstable();
-                ks.windows(2).all(|w| w[1] == w[0] + 1)
-            },
-            "induction source domain has an interior gap: {:?}",
+            by_pos.keys().all(|&p| {
+                self.emitted_through.is_none_or(|e| p > e)
+                    || self.source_released_through.is_some_and(|r| p <= r)
+            }),
+            "induction source delivered a position at or below the emitted cursor {:?} \
+             that was never released: {:?}",
+            self.emitted_through,
             {
                 let mut ks: Vec<usize> = by_pos.keys().copied().collect();
                 ks.sort_unstable();
@@ -2900,26 +2922,42 @@ impl TileProducer for InductionDriverProducer {
             .store_producer
             .get(self.store_producer.tiling().universal_guard());
 
-        // Emit the frontier's position, if the source has delivered it. At most
+        // Emit the next iterated position, if the source has delivered it. At most
         // one position per pull: the cyclic `FanOut` serves this store tile from
         // a snapshot taken before the traversal began, so a position decided
         // *during* this pull is not visible until the next one. That is the
         // one-step-per-pull cycle driver every cyclic operator here runs on.
         //
-        // The store's decided frontier *is* the next position to iterate, so it
-        // is also the item cursor: unlike the transaction driver, this one keeps
-        // no cursor of its own.
+        // Two cursors, because the store counts *ticks* while the source delivers
+        // *positions*, and a restricted source has fewer of the former than its
+        // extent has of the latter. The frontier is the tick cursor: tick 0 seeds
+        // the accumulators and the iteration at position `p` occupies tick `p + 1`,
+        // so a frontier equal to `tick_cursor` says every emitted position has been
+        // decided and the next may go. `emitted_through` is the item cursor, and the
+        // next position to iterate is the smallest delivered position above it —
+        // the frontier itself for a contiguous source, and for a restricted one the
+        // next position that survived the filter.
         let frontier = store_frontier(&store);
-        let mut next = self.window.next_position();
+        let next_delivered = |after: Option<usize>| -> Option<usize> {
+            by_pos
+                .keys()
+                .copied()
+                .filter(|&p| after.is_none_or(|e| p > e))
+                .min()
+        };
+        let tick_cursor = self.emitted_through.map_or(0, |p| p + 1);
         if let Some(frontier) = frontier {
             debug_assert!(
-                frontier <= next,
-                "the store decided position {frontier} but the driver has only emitted through \
-                 {next} — a decision cannot precede the input it decides"
+                frontier <= tick_cursor,
+                "the store decided through tick {frontier} but the driver has only emitted \
+                 through tick {tick_cursor} — a decision cannot precede the input it decides"
             );
-            if frontier == next
-                && let Some(item) = by_pos.get(&frontier)
+            if frontier == tick_cursor
+                && let Some(pos) = next_delivered(self.emitted_through)
             {
+                // The previous accumulator is that key's value as of the frontier:
+                // the tick the predecessor iteration's decision occupies, whichever
+                // position ran there.
                 let prev: Vec<Value> = self
                     .read_keys
                     .iter()
@@ -2929,8 +2967,8 @@ impl TileProducer for InductionDriverProducer {
                         )
                     })
                     .collect();
-                self.window.push(prev, item.clone(), frontier);
-                next += 1;
+                self.window.push(prev, by_pos[&pos].clone(), pos, pos);
+                self.emitted_through = Some(pos);
             }
         }
 
@@ -2948,18 +2986,23 @@ impl TileProducer for InductionDriverProducer {
         }
         // Reclaim the source prefix this driver has consumed. It only ever reads
         // the position it is about to emit and never re-reads an earlier one.
-        if next > 0 && !self.source_released_through.is_some_and(|r| r + 1 >= next) {
+        if let Some(through) = self.emitted_through
+            && !self.source_released_through.is_some_and(|r| r >= through)
+        {
             self.source_producer
                 .release(TileGuard::Function(FunctionGuard::Domain(
-                    Predicate::LessThanEq(Value::UInt(next - 1)),
+                    Predicate::LessThanEq(Value::UInt(through)),
                 )));
-            self.source_released_through = Some(next - 1);
+            self.source_released_through = Some(through);
         }
         // Every position of a complete source has been emitted: the body input
         // is final, and that terminality propagates through the body's decision
-        // stream to close the store's frontier. A terminal source's domain is
-        // gapless, so "the next position is absent" means "there is no next".
-        let done = source_complete && !by_pos.contains_key(&next);
+        // stream to close the store's frontier. Positions arrive in ascending
+        // order, so "no delivered position above the cursor" means "there is no
+        // next" — the question a restricted source needs asked, since the position
+        // one past the cursor may simply not be in its domain.
+        let pending = next_delivered(self.emitted_through);
+        let done = source_complete && pending.is_none();
         // Re-arm while the cycle still has work only it can trigger: a position
         // has arrived that is not yet emitted. That is the whole condition — it
         // is *not* "a row is awaiting its decision", because a row emitted this
@@ -2975,8 +3018,8 @@ impl TileProducer for InductionDriverProducer {
         // self-contained and always decides on the pull (unlike a transaction
         // body, which can read a still-converging broadcast), so the store never
         // leaves a position undecided — asserted there, where the store's
-        // contiguous consume-from-`processed` loop makes it checkable.
-        if !done && by_pos.contains_key(&next) {
+        // consume-in-ascending-order loop makes it checkable.
+        if !done && pending.is_some() {
             self.wakeups.request(self.consumer.clone());
         }
         if done && !self.source_fully_released {
@@ -3219,7 +3262,11 @@ impl TileProducer for TransactDriverProducer {
                 .iter()
                 .map(|o| o.clone().unwrap_or_else(|| item.clone()))
                 .collect();
-            self.window.push(snap_in, item, self.current);
+            // An attempt occupies the next contiguous position: a retried item
+            // takes a fresh one, which is why `item_index` and the position are
+            // separate here.
+            self.window
+                .push(snap_in, item, self.current, self.window.next_position());
             self.latest_emit = Some((self.current, frontier));
         }
         self.debug_assert_window_invariants();
@@ -3326,13 +3373,22 @@ fn newest_body_position(tile: &Tile) -> Option<usize> {
         .max()
 }
 
-/// Whether `tile` decides any position strictly after `pos` — the hole a consumer
-/// that stops at the first undecided position would silently truncate on.
-fn decides_beyond(tile: &Tile, pos: usize) -> bool {
+/// The lowest position `tile` decides at or after `pos`, or `None` when it decides
+/// none.
+///
+/// The induction store consumes decisions in ascending position order rather than
+/// at consecutive positions: a restricted loop source iterates a subset of its
+/// extent, so the position after `p` in the decision stream need not be `p + 1`.
+fn next_decided_position(tile: &Tile, pos: usize) -> Option<usize> {
     let Tile::SealedFunction { domain, .. } = tile else {
-        return false;
+        return None;
     };
-    (0..domain.len()).any(|i| matches!(domain.index_at(i), Value::UInt(p) if p > pos))
+    (0..domain.len())
+        .filter_map(|i| match domain.index_at(i) {
+            Value::UInt(p) if p >= pos => Some(p),
+            _ => None,
+        })
+        .min()
 }
 
 /// Extract a writer body's grant/deny *decision* at position `pos` of its input.

--- a/src/interpreter/design-operators.md
+++ b/src/interpreter/design-operators.md
@@ -445,10 +445,18 @@ of one loop, wired as a cycle: store → body → driver → `FanOut::new_cyclic
 The **store** owns a `CommitEngine` seeded at tick 0 with the accumulators' inits (so the
 changelog is self-describing — a read below the first *iteration* change folds to the seed).
 It consumes the body's `` {`commit{writes} | `abort} `` decisions (`body_decision_at` decodes
-the union tag) contiguously from its decided watermark (which counts the positions already
-stepped — the store keeps no separate cursor for them) and `step`s the engine: a `` `commit `` position
-appends a change (tick `pos + 1`), an `` `abort `` (a failed guard) is a **carry** (no change;
-the value inherits). It closes its frontier when the decision stream goes terminal.
+the union tag) in **ascending position order** from its decided watermark, and `step`s the
+engine: a `` `commit `` position appends a change (tick `pos + 1`), an `` `abort `` (a failed
+guard) is a **carry** (no change; the value inherits). It closes its frontier when the
+decision stream goes terminal.
+
+Ascending rather than contiguous, because the positions are the *source's*. A restricted loop
+source (`for l in [x for x in xs if p(x)]`) delivers a subset of its extent's positions and
+the recurrence runs over exactly those, so the watermark is a lower bound on the next position
+rather than the position itself, and the ticks a filtered-out position would have occupied are
+never occupied. The alternative — iterating the extent densely and gating the write — was not
+taken: the domain the pipeline hands the store is the refined extent, and a store that
+disagreed with it would have to recover the filter the type already carries.
 
 That last clause is an **obligation on the body chain**, and worth stating because it is
 easy to violate without noticing. The driver owns the source and closes its body-input tile,
@@ -456,18 +464,22 @@ so the store learns the loop is over only if every operator between the two forw
 `domain_predicate`. An operator that
 renders a decision column but hardcodes a non-terminal predicate leaves the loop running
 forever with the right values in it — a hang, not a wrong answer. The store asserts the
-matching gaplessness property (a terminal decision stream with a hole in it) but cannot
-assert this one, since "the body never went terminal" is indistinguishable from "the body
-is not done yet".
+matching property (a terminal decision stream it has not fully consumed) but cannot assert
+this one, since "the body never went terminal" is indistinguishable from "the body is not
+done yet".
 
 The **driver** owns the iteration source and produces the body's `(prev…, item)` input. It
-holds no part of the recurrence: the store's decided frontier already names the next position to
-iterate (`step` advances the watermark unconditionally, so a carry decides its position
-without appending a change), and the previous accumulator is that key's value *at* the
-frontier (`store_value_at`, one fold per read key — folding *at* the position being fed,
-which is what the recurrence means, rather than taking the key's latest write). So an
-emitted row is a pure function of the store tile and the source tile, with nothing cached
-that could drift. It decodes the source
+holds no part of the recurrence, and reads the store on two axes. The frontier is a **tick**
+cursor: `step` advances the watermark unconditionally (so a carry decides its position without
+appending a change), and a frontier equal to `emitted_through + 1` says every emitted position
+has been decided and the next may go. The previous accumulator is that key's value *at* the
+frontier (`store_value_at`, one fold per read key — folding *at* the tick the predecessor's
+decision occupies, which is what the recurrence means, rather than taking the key's latest
+write). What the driver does keep is the **item** cursor `emitted_through`, because a
+restricted source's positions are sparser than its extent's and the frontier therefore does
+not name one; the next position to iterate is the smallest delivered position above it. An
+emitted row is otherwise a pure function of the store tile and the source tile, with nothing
+cached that could drift. It decodes the source
 into `(absolute position, item)` pairs (`decode_source_positioned`), since an async source's
 domain arrives *unordered* and *compacts* as its consumed prefix is released; it reclaims
 that prefix incrementally and releases the whole source (`True`) once the loop is done. It
@@ -510,6 +522,13 @@ an accumulator threaded into another store, e.g. `for r in …: cnt += 1; with b
 sorting is correct for both.) One reader serves both shapes, and a downstream release of loop
 positions is forwarded to the trigger so the source is reclaimed. Reading by fold rather
 than by indexed projection is what unifies induction reads with transactional-variable reads.
+
+The trigger enumerates the loop **extent**, which for a restricted source is wider than the
+set of positions the recurrence ran at. That needs no special case: a position the filter
+excluded occupies no tick, so `store_value_at` folds it to the latest write below it — the
+accumulator's value as of that position, which is what a history over the extent means. A
+scalar-final read still lands on the last iterated write, and a tap (`carry_forward: false`)
+still appears only at the positions that fired.
 
 Folding by position keeps the read independent of the store's own length — the positions
 come from the trigger, the values from the fold. And the trailing-carry undercount that

--- a/src/interpreter/design-operators.md
+++ b/src/interpreter/design-operators.md
@@ -450,6 +450,10 @@ engine: a `` `commit `` position appends a change (tick `pos + 1`), an `` `abort
 guard) is a **carry** (no change; the value inherits). It closes its frontier when the
 decision stream goes terminal.
 
+Positions are `UInt` throughout — the engine's ticks are them, and `build_induction_store` refuses
+a source whose extent is not position-indexed rather than letting a product domain reach the driver,
+which drops a non-`UInt` key silently.
+
 Ascending rather than contiguous, because the positions are the *source's*. A restricted loop
 source (`for l in [x for x in xs if p(x)]`) delivers a subset of its extent's positions and
 the recurrence runs over exactly those, so the watermark is a lower bound on the next position

--- a/src/interpreter/operator_conversion.rs
+++ b/src/interpreter/operator_conversion.rs
@@ -1694,6 +1694,18 @@ fn build_commit_store(
     })
 }
 
+/// Whether `extent` enumerates `UInt` positions, the only shape the induction
+/// recurrence can sequence.
+///
+/// A filtered source needs no case of its own: [`OpConversionContext::extent_of`]
+/// strips refinements at every level, so a restricted loop source arrives here as
+/// the extent it restricts. [`Extent::Restricted`] cannot arrive at all — nothing
+/// outside `extent.rs` constructs one, and iterating one panics
+/// ([`crate::interpreter::tile_operators::IterateExtent`]).
+fn induction_extent_is_positional(extent: &Extent) -> bool {
+    matches!(extent, Extent::UIntRange(_) | Extent::DataSourceDomain(_))
+}
+
 /// Build an induction-domain store (a `mut` loop). Every induction store — plain,
 /// conditional, or feed-carrying, over a finite or async extent — is single-writer
 /// (recognition folds a conditional write to one carry-complete writer), so this
@@ -1800,6 +1812,23 @@ fn build_induction_store_single(
         ))
     })?;
     let induction_extent = ctx.extent_of(&crate::ccl::ccl_utils::strip_refinements(&raw_domain))?;
+    // The recurrence is sequenced by `UInt` position end to end: the driver pairs
+    // items with `UInt` domain keys, `CommitEngine` ticks are positions, and
+    // `StoreDenseRead` folds tick `p + 1` at each. A product domain (a
+    // comprehension over two sources, whose keys are `(i, j)` records) satisfies
+    // none of that. Rejected here rather than deeper, because the deeper failures
+    // are a tile-shape panic and an `unreachable!` in the dense read, and because
+    // the driver's own decode drops a non-`UInt` key silently — an empty position
+    // set reads to it as an exhausted source, so an unguarded product domain is a
+    // loop that runs zero times rather than one that fails.
+    if !induction_extent_is_positional(&induction_extent) {
+        return Err(ConversionError::Unsupported(format!(
+            "a `mut` loop's source must be indexed by iteration position, but this \
+             one is indexed by `{raw_domain}` — a comprehension over two sources \
+             (`[e for x in xs for y in ys]`) has a product domain, which the \
+             induction recurrence cannot sequence"
+        )));
+    }
     let source_op = convert_impl(&w.source, None, ctx)?;
     let read_extents: Vec<Extent> = w
         .read_keys

--- a/tests/compilation_pipeline/mutability.rs
+++ b/tests/compilation_pipeline/mutability.rs
@@ -495,6 +495,76 @@ o"#,
         deleted: BitSet::new(),
     }
 )]
+// A `mut` accumulator over a **filtered** source. `restrict` keeps an element at
+// its original position, so `kept`'s domain is the subset `{1, 2}` of the
+// extent `[0, 2]` — the recurrence runs over exactly those two positions and
+// never over the filtered-out 0. The iteration ticks are the positions' (a
+// position `p` decides tick `p + 1`), so the changelog skips tick 1 the way the
+// domain skips position 0.
+#[case(
+    indoc! {r#"
+        kept = [x for x in [1, 2, 3] if x > 1]
+        n := 0
+        for l in kept:
+            n := n + 1
+        n"#},
+    Tile::Scalar(ColumnValue::Ints(vec![2]))
+)]
+// The same source un-bound, so planning materializes the filter at the loop's own
+// iteration site rather than at a `let`.
+#[case(
+    indoc! {r#"
+        n := 0
+        for l in [x for x in [1, 2, 3] if x > 1]:
+            n := n + 1
+        n"#},
+    Tile::Scalar(ColumnValue::Ints(vec![2]))
+)]
+// A filter with an **interior** gap that keeps position 0: the domain is
+// `{0, 2, 4}`, so the driver's next position is neither its predecessor's
+// successor nor the store's tick cursor. 1 + 3 + 5.
+#[case(
+    indoc! {r#"
+        kept = [x for x in [1, 2, 3, 4, 5] if x != 2 if x != 4]
+        n := 0
+        for l in kept:
+            n := n + l
+        n"#},
+    Tile::Scalar(ColumnValue::Ints(vec![9]))
+)]
+// A filter that keeps nothing: the loop runs zero iterations over a non-empty
+// extent and the read falls back to the seed. Distinct from an empty extent —
+// the source is complete with no position above the cursor from the first pull,
+// which is the shape a driver that read "position 0 absent" as "source ended"
+// could not tell apart from a filtered-out leading position.
+#[case(
+    indoc! {r#"
+        kept = [x for x in [1, 2, 3] if x > 10]
+        n := 0
+        for l in kept:
+            n := n + 1
+        n"#},
+    Tile::Scalar(ColumnValue::Ints(vec![0]))
+)]
+// A feed inside a filtered loop: the tap fires once per *iterated* position, so
+// its stream is keyed by the source's positions (2, 3, 4) rather than by a count
+// of iterations. Running sums 3, 3+4, 3+4+5.
+#[case(
+    indoc! {r#"
+        kept = [x for x in [1, 2, 3, 4, 5] if x > 2]
+        n := 0
+        o = defer()
+        for l in kept:
+            n := n + l
+            o << n
+        o"#},
+    Tile::SealedFunction {
+        domain: ColumnValue::UInts(vec![2, 3, 4]),
+        codomain: Box::new(Tile::Scalar(ColumnValue::Ints(vec![3, 7, 12]))),
+        domain_predicate: Predicate::True,
+        deleted: BitSet::new(),
+    }
+)]
 #[ignore] // TODO support nested loops with mutations.
 #[case(
     r#"

--- a/tests/compilation_pipeline/mutability.rs
+++ b/tests/compilation_pipeline/mutability.rs
@@ -1597,6 +1597,69 @@ fn nested_for_loops_stay_rejected() {
     );
 }
 
+/// A `mut` loop over a **product** domain is rejected at op-conversion, at every
+/// spelling: let-bound, inline, joined, and over a source. A comprehension across
+/// two sources is keyed by `(i, j)`, and the induction recurrence is sequenced by
+/// `UInt` position end to end — the driver pairs items with `UInt` domain keys,
+/// `CommitEngine` ticks are positions, and `StoreDenseRead` folds tick `p + 1`.
+///
+/// Pinned because the failure is otherwise silent-adjacent. The driver's decode
+/// (`decode_source_positioned`) drops a non-`UInt` key rather than failing on it,
+/// so an unguarded product domain is an empty position set, which the driver reads
+/// as an exhausted source: a loop that runs zero times. What stopped that before
+/// this check was a tile-shape panic and an `unreachable!` further downstream —
+/// loud, but neither names the construct and neither is guaranteed to be reached
+/// first.
+#[rstest]
+#[case(
+    indoc! {r#"
+        xs = [1, 2]
+        ys = [10, 20]
+        prod = [x + y for x in xs for y in ys]
+        n := 0
+        for l in prod:
+            n := n + 1
+        n
+    "#}
+)]
+#[case(
+    indoc! {r#"
+        xs = [1, 2]
+        ys = [10, 20]
+        n := 0
+        for l in [x + y for x in xs for y in ys]:
+            n := n + 1
+        n
+    "#}
+)]
+// The join spelling. Its domain is *refined* as well as a product, and it is the
+// case that reaches this check only because the filtered-source fix lets it past
+// the post-planning `typecheck`.
+#[case(
+    indoc! {r#"
+        xs = [1, 2, 3]
+        ys = [2, 3, 4]
+        n := 0
+        for l in [x for x in xs for y in ys if x == y]:
+            n := n + 1
+        n
+    "#}
+)]
+// One side a live source: the product is `([0, 1], source(stdin))`, so neither
+// factor being a `UIntRange` is what decides it.
+#[case(
+    indoc! {r#"
+        xs = ["a", "b"]
+        n := 0
+        for l in [x + y for x in xs for y in stdin()]:
+            n := n + 1
+        n
+    "#}
+)]
+fn a_mut_loop_over_a_product_domain_is_rejected(#[case] code: &str) {
+    expect_compile_error(code, "must be indexed by iteration position");
+}
+
 /// A `Lambda` param may still bind a mutable variable — that is pass-by-reference, where
 /// the mutable variable genuinely crosses a function boundary. Pinned because `emit_let`
 /// now reads through an initializer that is a mutable variable, and widening that to argument


### PR DESCRIPTION
A `mut` accumulator over a filtered collection — `kept = [l for l in stdin() if l != "skip"]` then `for l in kept: n := n + 1` — panicked in the post-planning `typecheck`, with no test covering the shape. Two defects stacked, so fixing the first alone turned the panic into a silent `0`. The shape now compiles and computes the right value, batched or streaming.

## The sequencing domain is a type slot

`Transact.domain` was excluded from `TypedExpr::walk_type_slots{,_mut}` by a documented decision that predicted this failure: `planning::compile_refinement_predicates` rewrites predicates through that walk, so the domain kept its bare predicate while every sibling slot took the compiled one, and the post-planning `typecheck` compares refinements structurally.

## Positions, not a step counter

`restrict` keeps an element at its original position, so a filtered source's domain is a subset of its extent's. `InductionDriver` conflated the store's tick cursor with its item cursor and read the absent position 0 as end-of-source; it now keeps `emitted_through` and takes the smallest delivered position above it, while `InductionStore` consumes decisions in ascending position order rather than at consecutive ones. Ticks still follow positions (`p` decides tick `p + 1`), so `StoreDenseRead` needs no change: an excluded position folds to the last write below it.

## Two consequences

Commit 2 puts the last two hand-rolled copies of the type-slot set on the shared walk. `predicate_id_collisions` was blind to a predicate riding only a binder annotation — the live shape at the `post-lowering` boundary, where that tripwire runs.

Commit 3 rejects a `mut` loop over a **product** domain at op-conversion. Positions are `UInt` throughout the recurrence, and a comprehension across two sources is keyed by `(i, j)`; the join spelling of it reaches that check only because commit 1 lets it past the `typecheck` it used to fail at. `decode_source_positioned` drops a non-`UInt` key rather than failing on it, so without the check a product domain is a loop that runs zero times.

Reasoning is in [`type-inference.md`](src/ccl/design/type-inference.md), [`mutability.md`](src/ccl/design/mutability.md) and [`design-operators.md`](src/interpreter/design-operators.md). Five pipeline cases cover the filtered sources (let-bound, inline, interior gap, empty filter, feed) and four the product rejection.
