### PR TITLE
Compile a `match` in a loop body and a transaction block, and tag a reply tap with its firing

### DIFF
--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -1826,8 +1826,9 @@ type-checked as one.
 Patterns are **shallow**: an arm matches one tag and binds the whole
 payload, with no nesting, no literal patterns, and no per-arm guard.
 
-**A `for`-loop body admits a `match`.** An arm may `yield` or `<<`, and the fed
-value may read the arm's payload, the loop's accumulators, or both.
+**Both statement contexts admit a `match`** — a `for`-loop body and a `with
+begin():` block. An arm may `yield` or `<<`, and the fed value may read the arm's
+payload, the loop's accumulators, or both.
 
 #### The one-line form
 

--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -1826,13 +1826,8 @@ type-checked as one.
 Patterns are **shallow**: an arm matches one tag and binds the whole
 payload, with no nesting, no literal patterns, and no per-arm guard.
 
-**A `for`-loop body admits a `match`.** An arm may `yield` or `<<`; the loop's
-feeds then fan out one channel per feeding arm, so an arm's fed value may read
-its payload.
-
-Where the same loop also writes an accumulator, a fed value built from the arm's
-payload is rejected (**[Planned]**). Feed the scrutinee and project it
-downstream, or write the accumulator in a second `for` over the same source.
+**A `for`-loop body admits a `match`.** An arm may `yield` or `<<`, and the fed
+value may read the arm's payload, the loop's accumulators, or both.
 
 #### The one-line form
 

--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -1826,7 +1826,13 @@ type-checked as one.
 Patterns are **shallow**: an arm matches one tag and binds the whole
 payload, with no nesting, no literal patterns, and no per-arm guard.
 
-**A `for`-loop body admits a `match`.** An arm may not `yield` or `<<`.
+**A `for`-loop body admits a `match`.** An arm may `yield` or `<<`; the loop's
+feeds then fan out one channel per feeding arm, so an arm's fed value may read
+its payload.
+
+Where the same loop also writes an accumulator, a fed value built from the arm's
+payload is rejected (**[Planned]**). Feed the scrutinee and project it
+downstream, or write the accumulator in a second `for` over the same source.
 
 #### The one-line form
 

--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -2846,12 +2846,17 @@ for req in incr_reqs:
   (a disguised nested transaction).
 - **Nested transactions are rejected** — a block commits as one unit, so a
   `with` inside it has no coherent meaning.
-- **Deny guard.** A block may carry a single bare `if p:` guard; the
-  transaction commits iff `p` holds over its snapshot, and a denied
-  transaction contributes no write and no reply. An `elif`, an `else` that
-  writes, or more than one `if` guard in one block is **[Planned]**
-  (rejected today with a diagnostic) — the general path-based conditional
-  model is worked through in the design doc.
+- **Branch guards and tag dispatch.** A block may carry `if`/`elif`/`else`
+  guards, more than one of them, and `match` dispatch. Each branch's
+  writes are scoped to its own path and the transaction commits on the
+  disjunction of the writing paths, so a write on the spine beside a
+  guard commits unconditionally. A bare `if p:` with no `else` is the
+  deny idiom: where `p` fails over the snapshot the transaction
+  contributes no write and no reply.
+- **An induction accumulator may not be written under a branch inside a
+  block** (rejected with a diagnostic). Write it after the block, or, if
+  it should be shared across the transaction, declare it `Mut(…, Txn)`
+  and write it on the spine.
 - **Transaction handle — `with t = begin():` [Decided].** Binds `t` to the
   transaction's commit time (a `Txn` value); designed but rejected at
   lowering today.

--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -1826,27 +1826,7 @@ type-checked as one.
 Patterns are **shallow**: an arm matches one tag and binds the whole
 payload, with no nesting, no literal patterns, and no per-arm guard.
 
-**Inside a `for`-loop body a `match` dispatches a write**, as an `if` guard
-does: each arm is a write path, and an arm may read its payload. An arm that
-writes nothing carries the entering value, exactly as an `if` with no `else`
-does.
-
-```python
-acc := 0
-for m in msgs:
-    match m:
-        case `ping(seq):
-            acc += seq
-        case `close:
-            acc += 1
-acc
-```
-
-An arm may not `yield` or `<<`. A conditional feed fires on its path's
-predicate, and an arm is selected by its tag; dispatching a *feed* per element
-is still written as a `def` that matches on its parameter and is called from
-the loop or a comprehension, which is the same first-match rule reached through
-a call.
+**A `for`-loop body admits a `match`.** An arm may not `yield` or `<<`.
 
 #### The one-line form
 

--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -1826,11 +1826,27 @@ type-checked as one.
 Patterns are **shallow**: an arm matches one tag and binds the whole
 payload, with no nesting, no literal patterns, and no per-arm guard.
 
-A `match` is not yet accepted **inside a `for`-loop body**, which admits
-only assignments, `<<` feeds, `yield`, `if` guards, `with begin():` blocks
-and bare calls. Dispatching per element is written as a `def` that matches
-on its parameter and is called from the loop or a comprehension, which is
-the same first-match rule reached through a call.
+**Inside a `for`-loop body a `match` dispatches a write**, as an `if` guard
+does: each arm is a write path, and an arm may read its payload. An arm that
+writes nothing carries the entering value, exactly as an `if` with no `else`
+does.
+
+```python
+acc := 0
+for m in msgs:
+    match m:
+        case `ping(seq):
+            acc += seq
+        case `close:
+            acc += 1
+acc
+```
+
+An arm may not `yield` or `<<`. A conditional feed fires on its path's
+predicate, and an arm is selected by its tag; dispatching a *feed* per element
+is still written as a `def` that matches on its parameter and is called from
+the loop or a comprehension, which is the same first-match rule reached through
+a call.
 
 #### The one-line form
 

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -321,6 +321,37 @@ pub fn commit_project(decision_ty: &Type) -> Expr {
     ))
 }
 
+/// Rewrite every tag-dispatching `Case` in `expr` into the guard-`Case` its
+/// consumers read ([`tag_case_to_guard_case`]).
+///
+/// Applied to a whole body when that body has more than one consumer, rather than
+/// at each consumption point: the induction writer converts as it walks
+/// ([`crate::ccl::mut_elim`]'s `transform_chain`), but a feed-only loop body goes
+/// to `channelize`'s fan-out and a transaction block goes to both a footprint scan
+/// and a decision walk, and a consumer left un-taught reads a `Pattern` it has no
+/// arm for.
+///
+/// **Statement position only**, which the `Unit` type identifies: an arm in
+/// statement position is a chain of effects ending in `unit`, and a `match`
+/// without a `case _:` gains a `true → unit` arm in the rewrite, which types only
+/// against arms that are themselves `unit`. A value-position `match` keeps the
+/// projection fan-out `lambda_elim` compiles it to.
+pub(crate) fn statement_tag_cases_to_guards(expr: Expr) -> Expr {
+    let mut expr = expr;
+    expr.map_children(statement_tag_cases_to_guards);
+    if matches!(
+        &expr.node,
+        TypedExprNode::Case {
+            scrutinee: Some(_),
+            ..
+        }
+    ) && matches!(expr.ty, Type::Base(BaseType::Unit))
+    {
+        return tag_case_to_guard_case(expr);
+    }
+    expr
+}
+
 /// The point-free one-arm eliminator ``variant_project(`fired) : {`fired{𝑉} |
 /// `idle} ⇒ 𝑉`` reading a tap stream's fed value — appended after a `.to_<defer>`
 /// read so the channel carries the positions the tap fired at.

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::ccl::scope::{ScopedItem, for_each_scoped_item};
+use crate::ccl::subst::Subst;
 use crate::ccl::{
     BaseType, BinOpKind, Branch, Builtin, Expr, F_FIRE_SUFFIX, F_WRITES, FieldKey, Lit, LogicKind,
     Name, PredicateId, ProjKey, Refinement, RefinementSet, Type, TypedExprNode, UnaryOpKind,
@@ -45,6 +46,104 @@ pub fn disjoin(paths: impl IntoIterator<Item = Expr>, empty: bool, bool_ty: &Typ
         });
     }
     acc.unwrap_or_else(|| lit(empty))
+}
+
+/// A `Unit` literal stamped with `Base(Unit)` — the value of a mutable write, and
+/// of the `true` arm a `match` without a `case _:` gains.
+pub(crate) fn unit_expr() -> Expr {
+    let mut u = Expr::new(TypedExprNode::Lit(Lit::Unit));
+    u.ty = Type::Base(BaseType::Unit);
+    u
+}
+
+/// Rewrite a tag-dispatching `Case` into the boolean-guard `Case` its two
+/// consumers are built from ([`Builtin::VariantIs`](crate::ccl::Builtin::VariantIs)
+/// for why the guard is a total test rather than a projection).
+///
+/// Each arm's `Pattern` becomes a `variant_is(tag)` guard over the scrutinee, and
+/// the arm's `variant_project(tag)` is substituted for its payload binder, so the
+/// arm reads as `if` does. A `match` without a `case _:` arm gains the trailing
+/// `true → unit` carry every lowered guard-`Case` ends in — the position where
+/// the accumulators keep their previous value. The arms partition the tags, so
+/// the decision commits at every position where a guard-`Case` leaves the
+/// changelog sparse.
+///
+/// Both consumers dispatch on a guard and neither reads a `Pattern`: the
+/// induction writer merges the arms into one decision ([`crate::ccl::mut_elim`]'s
+/// `transform_chain`), and the feed fan-out refines the loop source once per
+/// feeding arm ([`crate::ccl::channelize`]'s `try_extract_fanout_feed`). The
+/// rewrite runs in a phase rather than at lowering because both builtins are
+/// minted after inference.
+///
+/// The scrutinee is substituted too, not bound. Each consumer lifts a
+/// sub-expression out of the arm — the fan-out composes the arm's feed value onto
+/// a refined source, the writer hoists it into a `to_<feed>` decision field — so a
+/// `let` inside the arm strands its binder there, and a `let` around the `Case`
+/// puts its name in the write set, where it escapes the writer lambda. A loop's
+/// `match` scrutinee is the iteration variable or a projection of it, so the
+/// copies are reads.
+pub(crate) fn tag_case_to_guard_case(case: Expr) -> Expr {
+    let case_ty = case.ty.clone();
+    let TypedExprNode::Case {
+        scrutinee,
+        branches,
+    } = case.node
+    else {
+        unreachable!("caller guarantees a Case")
+    };
+    let scrut = *scrutinee.expect("caller guarantees a tag-dispatching Case");
+    let scrut_ty = scrut.ty.clone();
+    let bool_ty = Type::Base(BaseType::Bool);
+    let mut has_default = false;
+    let mut out: Vec<Branch> = Vec::with_capacity(branches.len() + 1);
+    for br in branches {
+        let Some(pat) = br.pattern else {
+            // A `case _:` arm is already the fallback the trailing `true` guard
+            // names, and lowering has placed it last.
+            has_default = true;
+            out.push(Branch {
+                pattern: None,
+                guard: br.guard,
+                body: br.body,
+            });
+            continue;
+        };
+        let tag = FieldKey::Name(pat.tag.clone().into());
+        let payload_ty = pat.binding.ty.clone();
+        let mut guard = Expr::apply(
+            scrut.clone(),
+            Expr::builtin(Builtin::VariantIs(tag.clone()))
+                .with_ty(Type::fun(scrut_ty.clone(), bool_ty.clone())),
+        );
+        guard.ty = bool_ty.clone();
+        let mut payload = Expr::apply(
+            scrut.clone(),
+            Expr::builtin(Builtin::VariantProject(tag))
+                .with_ty(Type::fun(scrut_ty.clone(), payload_ty.clone())),
+        );
+        payload.ty = payload_ty;
+        let payload_subst = Subst::discharge(pat.binding.name.clone(), payload);
+        out.push(Branch {
+            pattern: None,
+            guard,
+            body: payload_subst.apply_expr(&br.body),
+        });
+    }
+    if !has_default {
+        let mut t = Expr::new(TypedExprNode::Lit(Lit::Bool(true)));
+        t.ty = bool_ty;
+        out.push(Branch {
+            pattern: None,
+            guard: t,
+            body: unit_expr(),
+        });
+    }
+    let mut rebuilt = Expr::new(TypedExprNode::Case {
+        scrutinee: None,
+        branches: out,
+    });
+    rebuilt.ty = case_ty;
+    rebuilt
 }
 
 /// Assemble a writer **decision record** `{commit, writes, (to_<feed>__fire,)?

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -146,8 +146,8 @@ pub(crate) fn tag_case_to_guard_case(case: Expr) -> Expr {
     rebuilt
 }
 
-/// Assemble a writer **decision record** `{commit, writes, (to_<feed>__fire,)?
-/// to_<feed>, …}` — the single encoding of the tap protocol shared by the
+/// Assemble a writer **decision record** `{commit, writes, to_<feed>, …}` — the
+/// single encoding of the tap protocol shared by the
 /// transaction writer ([`crate::ccl::transact_phase`]) and the induction writer
 /// ([`crate::ccl::mut_elim`]). Both feed it to the interpreter through the same
 /// `body_decision_at` decoder, so the shape must be built in exactly one place.

--- a/src/ccl/ccl_utils.rs
+++ b/src/ccl/ccl_utils.rs
@@ -7,9 +7,9 @@ use std::rc::Rc;
 use crate::ccl::scope::{ScopedItem, for_each_scoped_item};
 use crate::ccl::subst::Subst;
 use crate::ccl::{
-    BaseType, BinOpKind, Branch, Builtin, Expr, F_FIRE_SUFFIX, F_WRITES, FieldKey, Lit, LogicKind,
-    Name, PredicateId, ProjKey, Refinement, RefinementSet, Type, TypedExprNode, UnaryOpKind,
-    V_ABORT, V_COMMIT,
+    BaseType, BinOpKind, Branch, Builtin, Expr, F_WRITES, FieldKey, Lit, LogicKind, Name,
+    PredicateId, ProjKey, Refinement, RefinementSet, Type, TypedExprNode, UnaryOpKind, V_ABORT,
+    V_COMMIT, V_FIRED, V_IDLE,
 };
 
 /// The `commit` selector field of the **intermediate** decision record the two
@@ -147,17 +147,24 @@ pub(crate) fn tag_case_to_guard_case(case: Expr) -> Expr {
 }
 
 /// Assemble a writer **decision record** `{commit, writes, (to_<feed>__fire,)?
-/// to_<feed>, …}` — the single encoding of the tap/`__fire` protocol shared by the
+/// to_<feed>, …}` — the single encoding of the tap protocol shared by the
 /// transaction writer ([`crate::ccl::transact_phase`]) and the induction writer
 /// ([`crate::ccl::mut_elim`]). Both feed it to the interpreter through the same
 /// `body_decision_at` decoder, so the shape must be built in exactly one place.
 ///
-/// `feeds` are `(field, value, fire)` in tap order. A tap whose `fire` path is
-/// structurally the writer's `commit` — a spine or sole-committer feed that fires
-/// with *every* committing position — carries **no** gate (the engine treats an
-/// ungated tap as firing with the commit). A **narrower** `fire` carries a
-/// `to_<feed>__fire` gate the engine reads to fire the reply only on its own route,
-/// so a sibling route's commit does not over-fire it.
+/// `feeds` are `(field, value, fire)` in tap order. Each tap's field holds
+/// `` {`fired{𝑉} | `idle} `` ([`V_FIRED`](crate::ccl::V_FIRED)): the value at the
+/// positions its `fire` path admits, and `` `idle `` elsewhere. A tap whose `fire`
+/// is structurally the writer's `commit` — a spine or sole-committer feed that
+/// fires with every committing position — wraps unconditionally; a **narrower**
+/// `fire` becomes the guard of a two-arm value-`Case`, so a sibling route's commit
+/// leaves this tap `` `idle ``.
+///
+/// The tag rather than a companion `Bool` is what lets a tap value be
+/// domain-restricted. A gate beside a same-position value obliges the value to
+/// answer wherever the record commits, and an arm's `variant_project` answers only
+/// on its own arm's positions; under the tag, the non-firing positions are
+/// `` `idle `` and the value is asked for nowhere else.
 ///
 /// `commit` must already be the writer's *final* commit gate — including every
 /// feed's fire path, so a feed-only committing position appends a change carrying
@@ -168,15 +175,16 @@ pub fn writer_decision_record(commit: Expr, writes: Expr, feeds: &[(String, Expr
     fields.push((COMMIT_SELECTOR.to_string(), commit.clone()));
     fields.push((F_WRITES.to_string(), writes));
     for (field, value, fire) in feeds {
-        // Gate iff the fire path is *narrower* than the commit — a structural test
-        // (no Boolean simplification); the engine handles both an ungated tap
-        // (fires with commit) and a gated one (fires on its route) correctly, so
-        // the two shapes are observationally equal, this only decides which is
-        // emitted.
-        if *fire != commit {
-            fields.push((format!("{field}{F_FIRE_SUFFIX}"), fire.clone()));
-        }
-        fields.push((field.clone(), value.clone()));
+        // Wrap unconditionally iff the fire path *is* the commit — a structural
+        // test (no Boolean simplification). Such a tap fires at every position the
+        // record exists at, so the `` `idle `` arm would be unreachable; a narrower
+        // fire keeps it as the arm the non-firing positions take.
+        let tap = if *fire == commit {
+            tap_fired(value.clone())
+        } else {
+            tap_gated(fire.clone(), value.clone())
+        };
+        fields.push((field.clone(), tap));
     }
     let ty = Type::Record(
         fields
@@ -185,6 +193,71 @@ pub fn writer_decision_record(commit: Expr, writes: Expr, feeds: &[(String, Expr
             .collect(),
     );
     Expr::new(TypedExprNode::Record(fields)).with_ty(ty)
+}
+
+/// The tap variant type `` {`fired{𝑉} | `idle} `` over a fed value type `𝑉`.
+///
+/// Tag order is `fired`=0, `idle`=1 — the positions [`tap_fired`]/[`tap_idle`]
+/// inject and `body_decision_at` decodes.
+pub fn tap_variant_ty(value_ty: Type) -> Type {
+    Type::variant(vec![
+        (FieldKey::Name(V_FIRED.into()), value_ty),
+        (FieldKey::Name(V_IDLE.into()), Type::Base(BaseType::Unit)),
+    ])
+}
+
+/// `` `fired(value) `` — a tap carrying its fed value.
+pub fn tap_fired(value: Expr) -> Expr {
+    let ty = tap_variant_ty(value.ty.clone());
+    let wrap = Expr::builtin(Builtin::VariantWrap(FieldKey::Name(V_FIRED.into())))
+        .with_ty(Type::fun(value.ty.clone(), ty.clone()));
+    Expr::apply(value, wrap).with_ty(ty)
+}
+
+/// `` `idle `` — a tap that did not fire, at the fed value type `𝑉` the firing
+/// positions carry.
+pub fn tap_idle(value_ty: Type) -> Expr {
+    let ty = tap_variant_ty(value_ty);
+    let wrap = Expr::builtin(Builtin::VariantWrap(FieldKey::Name(V_IDLE.into())))
+        .with_ty(Type::fun(Type::Base(BaseType::Unit), ty.clone()));
+    Expr::apply(unit_expr(), wrap).with_ty(ty)
+}
+
+/// A tap under a `fire` path narrower than the record's commit:
+/// `` { fire → `fired(value); true → `idle } ``.
+///
+/// A two-arm value-`Case`, the shape a conditional write already takes, so
+/// `lambda_elim`'s C-form compiles it with no new machinery — and the `` `idle ``
+/// arm is what re-totals the tap over the positions `value` does not answer at.
+fn tap_gated(fire: Expr, value: Expr) -> Expr {
+    let fired = tap_fired(value);
+    let ty = fired.ty.clone();
+    let mut t = Expr::new(TypedExprNode::Lit(Lit::Bool(true)));
+    t.ty = Type::Base(BaseType::Bool);
+    let mut case = Expr::new(TypedExprNode::Case {
+        scrutinee: None,
+        branches: vec![
+            Branch {
+                pattern: None,
+                guard: fire,
+                body: fired,
+            },
+            Branch {
+                pattern: None,
+                guard: t,
+                body: tap_idle(match &ty {
+                    Type::Variant(tags, _) => tags
+                        .iter()
+                        .find(|(k, _)| matches!(k, FieldKey::Name(n) if n == V_FIRED))
+                        .map(|(_, v)| v.clone())
+                        .unwrap_or(Type::Hole),
+                    _ => Type::Hole,
+                }),
+            },
+        ],
+    });
+    case.ty = ty;
+    case
 }
 
 /// The decision **variant** type `` {`commit{𝑃} | `abort} `` over a (dense) payload
@@ -246,6 +319,21 @@ pub fn commit_project(decision_ty: &Type) -> Expr {
         decision_ty.clone(),
         commit_payload_ty(decision_ty),
     ))
+}
+
+/// The point-free one-arm eliminator ``variant_project(`fired) : {`fired{𝑉} |
+/// `idle} ⇒ 𝑉`` reading a tap stream's fed value — appended after a `.to_<defer>`
+/// read so the channel carries the positions the tap fired at.
+///
+/// The restriction is the point: a channel assembled from a tap holds what the
+/// program fed and nothing at the positions it fed nothing, which is the same
+/// domain a fanned-out conditional feed produces
+/// ([`crate::ccl::channelize`]). `` `idle `` positions drop out of the eliminated
+/// stream, so the `` `fired `` payload need answer nowhere else.
+pub fn fired_project(value_ty: Type) -> Expr {
+    let tap_ty = tap_variant_ty(value_ty.clone());
+    Expr::builtin(Builtin::VariantProject(FieldKey::Name(V_FIRED.into())))
+        .with_ty(Type::fun(tap_ty, value_ty))
 }
 
 /// Wrap a writer **decision record** `{commit, writes, to_<defer>*}` (the

--- a/src/ccl/channelize.rs
+++ b/src/ccl/channelize.rs
@@ -227,15 +227,27 @@ impl fmt::Display for DeferError {
 /// Returns each arm's `(guard, feed_value?)` in source order — `feed_value` is
 /// `None` for a non-feeding arm, whose guard still participates in later arms'
 /// predicate synthesis ([`synthesize_arm_predicate`]). Returns `None` (not
-/// fannable) if there is a scrutinee, the trailing guard is not `true`, an arm
-/// binds a pattern, or an arm body is neither this defer's feed nor `Unit` — so a
-/// `Case` mixing this defer's feeds with other effects falls through to the
-/// generic handling rather than being silently collapsed.
+/// fannable) if the trailing guard is not `true` or an arm body is neither this
+/// defer's feed nor `Unit` — so a `Case` mixing this defer's feeds with other
+/// effects falls through to the generic handling rather than being silently
+/// collapsed.
 fn try_extract_fanout_feed(body: &Expr, defer_name: &Name) -> Option<Vec<(Expr, Option<Expr>)>> {
+    // A `match` arm dispatches on a tag, so it reaches the fan-out as a
+    // `Pattern` against a scrutinee. Convert it to the guard form first — the
+    // same rewrite the induction writer applies at its own consumption point —
+    // and match on the result, so the arms below are guards either way.
+    let converted = matches!(
+        &body.node,
+        TypedExprNode::Case {
+            scrutinee: Some(_),
+            ..
+        }
+    )
+    .then(|| crate::ccl::ccl_utils::tag_case_to_guard_case(body.clone()));
     let TypedExprNode::Case {
         scrutinee: None,
         branches,
-    } = &body.node
+    } = &converted.as_ref().unwrap_or(body).node
     else {
         return None;
     };

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -682,6 +682,40 @@ Input: a typed, inlined, surface-CCL tree. Output: pure CCL (`let`/`letrec` alge
 
 Stateless programs never build a letrec — the phase degenerates to plain feed routing.
 
+### A `match` in a for-loop body
+
+`lower_loop_body_chain` lowers a statement `match` in a loop body to a scrutinee-`Case`, sharing the
+tag rules and `Pattern` construction with every other `match` through `lower_match_over`, and
+`transform_chain` reads it: each accumulator's value after the `match` is a `Case` over the same
+scrutinee, one arm per path, which the chain carries as its read-your-writes value. A `match` so
+compiled commits at every position and writes the entering value on the arms that do not write —
+dense where a guard-`Case` leaves the changelog sparse, and correct for the same reason the
+guard-`Case`'s carry arm is.
+
+A `yield` or `<<` inside an arm is rejected at lowering: a conditional feed rides its path's
+predicate as a `to_<defer>__fire` gate, and an arm is selected by its tag rather than by a
+predicate.
+
+`tag_case_to_guard_case` then rewrites it into the boolean-guard `Case` the writer decision is built
+from: each arm's `Pattern` becomes a `variant_is(tag)` guard over the scrutinee and a `let` binding
+its payload to that arm's `variant_project(tag)`, and a `match` without a `case _:` arm gains the
+trailing `true → unit` carry. From there `synthesize_arm_predicate` gives each arm its first-match
+predicate exactly as it does for an `elif` chain, and nothing about the decision is
+`match`-specific.
+
+**Why not select by reading the arm.** Everywhere else a `match` compiles to a fan-out of
+`variant_project`s re-totalled by a flat union — reading an arm *is* the tag restriction, so no test
+is needed. A writer decision takes a boolean at every position instead: its commit selector is a
+disjunction of the arms' guards, and `synthesize_arm_predicate` complements each guard against the
+ones before it. Both are operations on a predicate over the whole driver domain, and a projection
+restricts that domain rather than answering over it. `variant_is` answers the same question
+**totally**, one `Bool` per driver position, which is what the decision consumes.
+
+An arm reading its payload projects it out of the scrutinee, inside the writer body. That works for
+a separate reason: the projection narrows the domain but preserves keys, so a domain release — which
+names keys rather than a count — forwards to the scrutinee verbatim, and the projection sits inside
+a writer body like any other operator.
+
 ## Worked example
 
 A transactional mutable variable and an induction counter shared across two HTTP endpoints:

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -682,40 +682,6 @@ Input: a typed, inlined, surface-CCL tree. Output: pure CCL (`let`/`letrec` alge
 
 Stateless programs never build a letrec — the phase degenerates to plain feed routing.
 
-### A `match` in a for-loop body
-
-`lower_loop_body_chain` lowers a statement `match` in a loop body to a scrutinee-`Case`, sharing the
-tag rules and `Pattern` construction with every other `match` through `lower_match_over`, and
-`transform_chain` reads it: each accumulator's value after the `match` is a `Case` over the same
-scrutinee, one arm per path, which the chain carries as its read-your-writes value. A `match` so
-compiled commits at every position and writes the entering value on the arms that do not write —
-dense where a guard-`Case` leaves the changelog sparse, and correct for the same reason the
-guard-`Case`'s carry arm is.
-
-A `yield` or `<<` inside an arm is rejected at lowering: a conditional feed rides its path's
-predicate as a `to_<defer>__fire` gate, and an arm is selected by its tag rather than by a
-predicate.
-
-`tag_case_to_guard_case` then rewrites it into the boolean-guard `Case` the writer decision is built
-from: each arm's `Pattern` becomes a `variant_is(tag)` guard over the scrutinee and a `let` binding
-its payload to that arm's `variant_project(tag)`, and a `match` without a `case _:` arm gains the
-trailing `true → unit` carry. From there `synthesize_arm_predicate` gives each arm its first-match
-predicate exactly as it does for an `elif` chain, and nothing about the decision is
-`match`-specific.
-
-**Why not select by reading the arm.** Everywhere else a `match` compiles to a fan-out of
-`variant_project`s re-totalled by a flat union — reading an arm *is* the tag restriction, so no test
-is needed. A writer decision takes a boolean at every position instead: its commit selector is a
-disjunction of the arms' guards, and `synthesize_arm_predicate` complements each guard against the
-ones before it. Both are operations on a predicate over the whole driver domain, and a projection
-restricts that domain rather than answering over it. `variant_is` answers the same question
-**totally**, one `Bool` per driver position, which is what the decision consumes.
-
-An arm reading its payload projects it out of the scrutinee, inside the writer body. That works for
-a separate reason: the projection narrows the domain but preserves keys, so a domain release — which
-names keys rather than a count — forwards to the scrutinee verbatim, and the projection sits inside
-a writer body like any other operator.
-
 ## Worked example
 
 A transactional mutable variable and an induction counter shared across two HTTP endpoints:

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -1228,12 +1228,15 @@ The value-`Case` positions ride the same union-of-restricts:
 
 ### General in-transaction conditionals (and conditional writes)
 
-A `with begin():` block admits `if`/`elif`/`else` and multiple sibling `if` guards, compiled by a
-uniform **path-based** walk (`transact_phase::walk_block`/`walk_case`).
+A `with begin():` block admits `if`/`elif`/`else`, multiple sibling `if` guards, and `match`
+dispatch, compiled by a uniform **path-based** walk
+(`transact_phase::walk_block`/`walk_case`). A `match` reaches the walk as a guard-`Case`: the phase
+rewrites its arms to `variant_is` tests at the strip
+(`ccl_utils::statement_tag_cases_to_guards`), so an arm is a path like any other.
 
 A **path** is one straight-line route through the block's branch structure: the statements a single
-execution runs, given a choice of arm at every `if`/`elif`/`else` it passes through. Nested and
-sibling conditionals multiply, so a block with two independent `if`s has four paths. Each path
+execution runs, given a choice of arm at every branch it passes through. Nested and sibling
+conditionals multiply, so a block with two independent `if`s has four paths. Each path
 carries a **path condition** — the conjunction of the guards it took, each `elif` guard first-match
 adjusted (`π̂ᵢ = 𝑔ᵢ ∧ ¬𝑔₀ ∧ … ∧ ¬𝑔ᵢ₋₁`). A path condition is a `Bool` expression over the
 transaction's *snapshot* alone — resolved through whatever the path has already written
@@ -1244,8 +1247,9 @@ mutually exclusive and, taken together with the implicit empty arm of a guard th
 exhaustive: exactly one path runs per transaction.
 
 Paths are a *compile-time* enumeration, not a runtime branch: the walk visits every path and emits
-one decision variant, whose `` `commit ``/`` `abort `` tag and per-tap fire fields are path conditions
-and whose per-key writes are `Case`s over the local branch guards — so every path is evaluated in
+one decision variant, whose `` `commit ``/`` `abort `` tag is a path condition, whose per-tap
+`` `fired ``/`` `idle `` tag is that tap's own path condition, and whose per-key writes are `Case`s
+over the local branch guards — so every path is evaluated in
 one straight-line writer body and one transaction is still one decision. Walking a block threads
 `(path, env)` (read-your-writes) and the block denotes
 `` snapshot ⇒ {`commit{writes, to_<defer>*} | `abort} `` — a decision **variant**

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -1135,8 +1135,8 @@ today rather than silently mishandled.
 > below and `../../interpreter/design-operators.md`). That desugar also resolves the former residual —
 > a value-selecting `Case` inside a lambda with no visible iteration source (a UDF body, or a
 > comprehension `if`-filter beside the element `Case`). A conditional *feed* on an induction path
-> (`if 𝑝: out << e`) is **implemented** — it rides the same decision as a `to_<defer>__fire`-gated tap
-> (below).
+> (`if 𝑝: out << e`) is **implemented** — it rides the same decision as a tap whose value is
+> `` `fired `` on its own path (below).
 
 The *filter* `Case` (`[𝑔 → action; true → unit]` → `Restrict`), the value-selecting `Case`, and the
 conditional induction write all compile. The value-`Case` compilation is a **literal union of
@@ -1176,8 +1176,8 @@ model treats a finite domain as a stream that terminates (§Liveness) — and ev
 uses one realization: the changelog `InductionStore`. Plain, conditional, and feed-carrying loops
 over finite or async extents all route through it. The
 driver reads its source by absolute domain position (async domains arrive unordered), reclaims the
-consumed prefix as it advances, and carries reply feeds as `__fire`-gated taps — see *Induction
-stores as a changelog* in `../../interpreter/design-operators.md`.
+consumed prefix as it advances, and carries reply feeds as taps tagged `` `fired ``/`` `idle `` — see
+*Induction stores as a changelog* in `../../interpreter/design-operators.md`.
 
 The value-`Case` positions ride the same union-of-restricts:
 
@@ -1273,11 +1273,18 @@ serialization point; multi-key read-your-writes needs one snapshot and one write
 
 A conditional feed under genuine cross-key *routing* fires only on its own route. A feed under one
 arm would otherwise ride the transaction's (broader) commit and over-fire on a sibling route's
-commit, so each such tap carries a **per-tap fire field** — `to_<defer>_k__fire : Bool`, its own
-control-flow path (`F_FIRE_SUFFIX`) — that the commit engine (`body_decision_at`) checks: a committed
-transaction appends the tap only where its fire gate holds. A single-guard feed (`if 𝑝: w; out << 𝑒`,
-path == commit) and a spine feed omit the field and fire with their transaction — so unconditional
-programs keep their fire-field-free shape.
+commit, so a tap's value is `` {`fired{𝑉} | `idle} `` (`V_FIRED`): the fed value on the positions its
+own control-flow path admits, `` `idle `` on the rest. The commit engine (`body_decision_at`) reads
+the tag and appends the tap only where it is `` `fired ``. A single-guard feed (`if 𝑝: w; out << 𝑒`,
+path == commit) and a spine feed wrap unconditionally, since every position the decision exists at is
+one they fire at.
+
+The tag rather than a companion `Bool` is what lets a tap value be **domain-restricted**. A gate
+beside a same-position value obliges the value to answer wherever the record commits; a `match` arm's
+payload is a `variant_project`, which restricts the domain rather than answering over it, so a fed
+value reading the payload answers on its own arm's positions only. Under the tag those are the
+`` `fired `` positions and the value is asked for nowhere else, so `` out << v `` inside
+`` case `data(v): `` compiles beside an accumulator the other arms write.
 
 A write key written conditionally and never read (an absolute `k := 𝑒` inside a `Case` arm) is
 finalized into the *read* set by `collect_footprint`, so it has a snapshot to **carry** on the paths
@@ -1292,19 +1299,16 @@ reduces the whole history whatever order the commits land in
 
 **Not yet implemented**: `with t = begin():` (the handle) is still rejected.
 
-**Future work (deferred optimizations).** The `` `commit `` payload is currently **dense**:
-an unwritten key on a committing path carries its snapshot value (a no-op re-write), and a routed
-reply tap carries a `to_<defer>_k__fire : Bool` gate (`F_FIRE_SUFFIX`) the engine checks. Two deferred
-refinements, scoped by the review as "worth doing later, not now":
+**Future work (deferred optimization).** The `` `commit `` payload is **dense**: an unwritten key on
+a committing path carries its snapshot value, a no-op re-write.
 
-1. ***Partial* writes** — materialize only the keys a committing path actually changed, encoding an
-   absent key as carry directly (e.g. a `Some | None` per write key), rather than re-writing the
-   snapshot. This needs a dense presence encoding: a naive sparse per-key column is silently dropped
-   by the record `zip`'s inner-join (it deletes the committing positions where any conditionally-
-   written key is absent), so it cannot be a bare non-exhaustive `Case`.
-2. **Folding `__fire` into payload presence** — a routed reply would be *present in the `` `commit ``
-   payload iff its route fired*, retiring the separate `to_<defer>_k__fire` gate. Same dense-presence
-   requirement as (1).
+***Partial* writes** would materialize only the keys a committing path actually changed, encoding an
+absent key as carry directly rather than re-writing the snapshot. A naive sparse per-key column is
+silently dropped by the record `zip`'s inner-join — it deletes the committing positions where any
+conditionally-written key is absent — so the encoding has to keep a value at every committing
+position while saying which of them changed. The tap variant above is that encoding for a reply, and
+a per-write-key `` {`wrote{𝑉} | `carried} `` is the same shape: dense in the record, restricted at the
+read.
 
 **An off-path partial op cannot fault.** Both induction and transaction value-`Case`s compile through
 the lazy `filter_values` union-of-restricts, so a guard-protected `//`/`%` is never evaluated on the

--- a/src/ccl/expr.rs
+++ b/src/ccl/expr.rs
@@ -21,16 +21,22 @@ pub const V_ABORT: &str = "abort";
 /// tuple of proposed per-key new values (`writes.i` for `write_keys[i]`), one
 /// element even for a single-key write set.
 pub const F_WRITES: &str = "writes";
-/// Suffix of a **per-tap fire field** on a decision record. A reply tap
-/// `to_<defer>_k` fed under one arm of cross-key *routing* (its control-flow
-/// path is narrower than the transaction's overall `commit`) carries a companion
-/// `to_<defer>_k__fire : Bool` field — its own path condition. The commit engine
-/// appends the tap's value to the durable log only when the transaction commits
-/// **and** the tap's fire field holds, so a feed under one route does not
-/// over-fire on a sibling route's commit. Omitted when the tap's path *is* the
-/// commit (a single-guard or spine feed always fires with its transaction), so
-/// unconditional/single-guard programs keep their fire-field-free shape.
-pub const F_FIRE_SUFFIX: &str = "__fire";
+// Tags of a **reply tap** on a decision record. A tap `to_<defer>_k` has a value
+// exactly at the positions it fires, and its type says so: `` {`fired{𝑉} | `idle}
+// ``. A feed under one arm of cross-key routing fires on its own route only, so a
+// sibling route's commit leaves the tap `` `idle `` rather than appending a value
+// the program never fed.
+//
+// The tag carries what a companion `Bool` gate used to, and carries it in the one
+// place that cannot disagree with the value. A gate beside a same-position value
+// required the value to answer at every committing position, which a
+// domain-restricting feed value (an arm's `variant_project`) cannot do — see
+// `feed_reading_payload_error` in `src/ccl/lower/loops.rs`.
+/// The tag of a tap that fired at this position, carrying the fed value.
+pub const V_FIRED: &str = "fired";
+/// The tag of a tap that did not fire at this position. Nullary: a tap that did
+/// not fire has no value, which is what the gate it replaces only implied.
+pub const V_IDLE: &str = "idle";
 
 // Field names of a **commit-record** binding — the intermediate representation
 // [`crate::ccl::transact_phase`] emits and [`crate::ccl::planning::plan_loops`]

--- a/src/ccl/lambda_elim.rs
+++ b/src/ccl/lambda_elim.rs
@@ -1463,9 +1463,12 @@ fn elim_lambda_impl(
         //
         // Unreachable from source today: nothing puts a `match` inside a lambda that
         // survives to here — a UDF body is inlined at its call sites, a comprehension
-        // element cannot hold a statement, and a for-loop body rejects `match` at
-        // lowering. Named rather than left to the catch-all below, so that whichever
-        // of those opens up first reports this instead of a debug dump.
+        // element cannot hold a statement, and a for-loop body's `match` is a
+        // statement-position tag-`Case` that
+        // [`tag_case_to_guard_case`](crate::ccl::ccl_utils::tag_case_to_guard_case)
+        // has already turned into guards. Named rather than left to the catch-all
+        // below, so that whichever of those opens up first reports this instead of a
+        // debug dump.
         TypedExprNode::Case {
             scrutinee: Some(_),
             branches,

--- a/src/ccl/lower/loops.rs
+++ b/src/ccl/lower/loops.rs
@@ -289,6 +289,20 @@ fn in_loop_mut_var_error(span: Span, name: &str) -> LoweringError {
     )
 }
 
+/// Rejection for a `yield` or `<<` inside a `match` arm in a for-loop body.
+///
+/// A conditional feed rides its path's predicate as a `to_<defer>__fire` gate,
+/// and a `match` arm has no predicate to ride: it is selected by its tag, which
+/// the writer decision reads as a `Case` over the scrutinee rather than as a
+/// boolean (`src/ccl/design/mutability.md`, "A `match` in a for-loop body").
+fn feed_in_match_arm_error(span: Span) -> LoweringError {
+    LoweringError::unsupported(
+        span,
+        "a `yield` or `<<` feed inside a `match` arm in a for-loop body is not \
+         supported; move it after the `match`, where it fires once per iteration",
+    )
+}
+
 /// Rejection for `x op= e` inside a for-loop body where `x` is not a mutable
 /// variable declared before the loop.
 ///
@@ -698,6 +712,11 @@ fn collect_mutation_loop_vars(
                 collect_mutation_loop_vars(else_body, scope, vars, seen);
             }
         }
+        if let ChlStmt::Match { arms, .. } = &stmt.node {
+            for arm in arms {
+                collect_mutation_loop_vars(&arm.body, scope, vars, seen);
+            }
+        }
         if let Some(inner) = block_value_stmt(stmt) {
             collect_mutation_loop_vars(std::slice::from_ref(inner), scope, vars, seen);
         }
@@ -758,6 +777,13 @@ pub(super) fn find_nested_mutation_var(
                     && let Some(n) = find_nested_mutation_var(else_body, mutation_scope)
                 {
                     return Some(n);
+                }
+            }
+            ChlStmt::Match { arms, .. } => {
+                for arm in arms {
+                    if let Some(n) = find_nested_mutation_var(&arm.body, mutation_scope) {
+                        return Some(n);
+                    }
                 }
             }
             ChlStmt::For { body, .. } => {
@@ -1017,6 +1043,40 @@ fn lower_loop_body_chain(
                 let lowered = lower_expr(y, ctx)?;
                 let feed = ctx.tag_image(Expr::feed(defer_name.to_string(), lowered), value.span);
                 ctx.tag_machinery(Expr::expr_stmt(feed, chain), stmt.span, "lower.stmt_seq")
+            }
+            // ``match m: case `tag(w): …`` — tag dispatch over a conditional
+            // write path, the `match` counterpart of the `if` below. Every arm
+            // is a write path; there is no complement, because the arms
+            // partition the scrutinee's tags. See
+            // `src/ccl/design/mutability.md`, "A `match` in a for-loop body".
+            ChlStmt::Match { scrutinee, arms } => {
+                if let Some(bad) = arms
+                    .iter()
+                    .find(|a| for_body_has_yield(&a.body) || for_body_has_feed(&a.body))
+                {
+                    return Err(feed_in_match_arm_error(
+                        bad.body.first().map_or(stmt.span, |s| s.span),
+                    ));
+                }
+                let case = lower_match_over(
+                    stmt.span,
+                    scrutinee,
+                    arms,
+                    outer_bindings,
+                    ctx,
+                    |body, scope, ctx| {
+                        lower_loop_body_chain(
+                            body,
+                            acc_names,
+                            yield_defer,
+                            true,
+                            scope,
+                            stmt.span,
+                            ctx,
+                        )
+                    },
+                )?;
+                ctx.tag_machinery(Expr::expr_stmt(case, chain), stmt.span, "lower.stmt_seq")
             }
             // `if p: … [else: …]` — a conditional write path. Lowered to a
             // statement-position filter-`Case` (`[gᵢ → branchᵢ; true → else|unit]`)

--- a/src/ccl/lower/loops.rs
+++ b/src/ccl/lower/loops.rs
@@ -3,8 +3,6 @@
 
 use std::collections::HashSet;
 
-use crate::ccl::Name;
-
 use super::*;
 use crate::{
     ccl::{Branch, Expr, Lit, Type, TypedBinding, TypedExprNode},
@@ -291,92 +289,6 @@ fn in_loop_mut_var_error(span: Span, name: &str) -> LoweringError {
              value immutably with `{name} = …`"
         ),
     )
-}
-
-/// Rejection for a `yield` or `<<` whose value is built from the arm's payload,
-/// in a `match` arm of a for-loop body that also writes an accumulator.
-///
-/// The decision record's density is the bound, not the `match`. An accumulator
-/// makes the loop a single writer, and a feed inside it becomes a `to_<defer>`
-/// field of that writer's decision record, where every field answers at every
-/// committing position — the interpreter's `body_decision_at` reads each tap
-/// field before consulting its `__fire` gate, so a committing position that
-/// supplies none has no decision at all. An arm's payload is a
-/// [`variant_project`](crate::ccl::Builtin::VariantProject), which restricts the
-/// domain rather than answering over it, so a value built from it answers on its
-/// own arm's positions while the record commits on every arm's, and the writer
-/// waits for a decision that never assembles.
-///
-/// Lifting the restriction means encoding in the tap what its `__fire` gate
-/// already implies — a tap has a value exactly where it fires — so the value may
-/// be restricted to the positions the gate names.
-///
-/// The shapes around it compile. Without an accumulator the loop's feeds fan out
-/// one channel per arm ([`crate::ccl::channelize`]) and reach no decision record,
-/// so a fed value may read its payload there. With one, a fed value reading the
-/// accumulator or the whole scrutinee answers everywhere and rides the tap.
-fn feed_reading_payload_error(span: Span, binder: &str) -> LoweringError {
-    LoweringError::unsupported(
-        span,
-        format!(
-            "a `yield` or `<<` feed whose value is built from the arm's payload \
-             (`{binder}`) is not supported in a `match` arm of a for-loop body \
-             that also writes an accumulator: feed the scrutinee itself and \
-             project it downstream, or move the accumulator into a second \
-             for-loop over the same source, where the feeds fan out per arm"
-        ),
-    )
-}
-
-/// The payload binder whose value reaches a feed in the same `match` arm, if
-/// any.
-///
-/// Walks the lowered arms rather than the CHL statements so the question is asked
-/// of the binder [`super::stmts::lower_match_over`] actually introduced — an arm
-/// that names no payload gets a reserved spelling, which nothing in the arm can
-/// read, and so can never answer here.
-fn arm_feed_reads_payload(case: &Expr) -> Option<Name> {
-    let TypedExprNode::Case { branches, .. } = &case.node else {
-        return None;
-    };
-    branches.iter().find_map(|br| {
-        let binder = &br.pattern.as_ref()?.binding.name;
-        let mut derived = vec![binder.clone()];
-        arm_feeds_payload_derived(&br.body, &mut derived).then(|| binder.clone())
-    })
-}
-
-/// Whether a `Feed` in `expr` has a value built from any name in `derived`,
-/// which the walk grows with each `let` that reads one.
-///
-/// The rejection covers the value, not the spelling: `v = w` then `o << v` puts
-/// the same restricted projection in the tap as `o << w` does, so asking only
-/// about the binder would accept it.
-///
-/// A `MutWrite` does not extend `derived`. Writing the payload into an
-/// accumulator commits it under the arm's own guard and the decision totals that
-/// write against the carry, so the accumulator slot a later feed reads answers at
-/// every position.
-fn arm_feeds_payload_derived(expr: &Expr, derived: &mut Vec<Name>) -> bool {
-    match &expr.node {
-        TypedExprNode::Feed { value, .. } => {
-            return derived
-                .iter()
-                .any(|n| crate::ccl::ccl_utils::is_free(n, value));
-        }
-        TypedExprNode::Let {
-            binding,
-            bound_expr,
-            ..
-        } if derived
-            .iter()
-            .any(|n| crate::ccl::ccl_utils::is_free(n, bound_expr)) =>
-        {
-            derived.push(binding.name.clone());
-        }
-        _ => {}
-    }
-    expr.any_child(|c| arm_feeds_payload_derived(c, derived))
 }
 
 /// Rejection for `x op= e` inside a for-loop body where `x` is not a mutable
@@ -1160,15 +1072,6 @@ fn lower_loop_body_chain(
                         )
                     },
                 )?;
-                // An accumulator puts this loop's feeds on the writer's decision
-                // record, which a payload-reading value cannot answer over
-                // ([`feed_reading_payload_error`]). Without one the feeds fan out
-                // per arm, where a restricted value is the expected shape.
-                if !acc_names.is_empty()
-                    && let Some(binder) = arm_feed_reads_payload(&case)
-                {
-                    return Err(feed_reading_payload_error(stmt.span, binder.base()));
-                }
                 ctx.tag_machinery(Expr::expr_stmt(case, chain), stmt.span, "lower.stmt_seq")
             }
             // `if p: … [else: …]` — a conditional write path. Lowered to a

--- a/src/ccl/lower/loops.rs
+++ b/src/ccl/lower/loops.rs
@@ -294,7 +294,7 @@ fn in_loop_mut_var_error(span: Span, name: &str) -> LoweringError {
 /// A conditional feed rides its path's predicate as a `to_<defer>__fire` gate,
 /// and a `match` arm has no predicate to ride: it is selected by its tag, which
 /// the writer decision reads as a `Case` over the scrutinee rather than as a
-/// boolean (`src/ccl/design/mutability.md`, "A `match` in a for-loop body").
+/// boolean.
 fn feed_in_match_arm_error(span: Span) -> LoweringError {
     LoweringError::unsupported(
         span,
@@ -1047,8 +1047,7 @@ fn lower_loop_body_chain(
             // ``match m: case `tag(w): …`` — tag dispatch over a conditional
             // write path, the `match` counterpart of the `if` below. Every arm
             // is a write path; there is no complement, because the arms
-            // partition the scrutinee's tags. See
-            // `src/ccl/design/mutability.md`, "A `match` in a for-loop body".
+            // partition the scrutinee's tags.
             ChlStmt::Match { scrutinee, arms } => {
                 if let Some(bad) = arms
                     .iter()

--- a/src/ccl/lower/loops.rs
+++ b/src/ccl/lower/loops.rs
@@ -3,6 +3,8 @@
 
 use std::collections::HashSet;
 
+use crate::ccl::Name;
+
 use super::*;
 use crate::{
     ccl::{Branch, Expr, Lit, Type, TypedBinding, TypedExprNode},
@@ -33,6 +35,7 @@ fn stmt_has_yield(stmt: &Spanned<ChlStmt>) -> bool {
                 || else_body.as_deref().is_some_and(for_body_has_yield)
         }
         ChlStmt::For { body, .. } => for_body_has_yield(body),
+        ChlStmt::Match { arms, .. } => arms.iter().any(|a| for_body_has_yield(&a.body)),
         _ => false,
     }
 }
@@ -60,6 +63,7 @@ fn stmt_has_feed(stmt: &Spanned<ChlStmt>) -> bool {
                 || else_body.as_deref().is_some_and(for_body_has_feed)
         }
         ChlStmt::For { body, .. } => for_body_has_feed(body),
+        ChlStmt::Match { arms, .. } => arms.iter().any(|a| for_body_has_feed(&a.body)),
         _ => false,
     }
 }
@@ -289,18 +293,90 @@ fn in_loop_mut_var_error(span: Span, name: &str) -> LoweringError {
     )
 }
 
-/// Rejection for a `yield` or `<<` inside a `match` arm in a for-loop body.
+/// Rejection for a `yield` or `<<` whose value is built from the arm's payload,
+/// in a `match` arm of a for-loop body that also writes an accumulator.
 ///
-/// A conditional feed rides its path's predicate as a `to_<defer>__fire` gate,
-/// and a `match` arm has no predicate to ride: it is selected by its tag, which
-/// the writer decision reads as a `Case` over the scrutinee rather than as a
-/// boolean.
-fn feed_in_match_arm_error(span: Span) -> LoweringError {
+/// The decision record's density is the bound, not the `match`. An accumulator
+/// makes the loop a single writer, and a feed inside it becomes a `to_<defer>`
+/// field of that writer's decision record, where every field answers at every
+/// committing position — the interpreter's `body_decision_at` reads each tap
+/// field before consulting its `__fire` gate, so a committing position that
+/// supplies none has no decision at all. An arm's payload is a
+/// [`variant_project`](crate::ccl::Builtin::VariantProject), which restricts the
+/// domain rather than answering over it, so a value built from it answers on its
+/// own arm's positions while the record commits on every arm's, and the writer
+/// waits for a decision that never assembles.
+///
+/// Lifting the restriction means encoding in the tap what its `__fire` gate
+/// already implies — a tap has a value exactly where it fires — so the value may
+/// be restricted to the positions the gate names.
+///
+/// The shapes around it compile. Without an accumulator the loop's feeds fan out
+/// one channel per arm ([`crate::ccl::channelize`]) and reach no decision record,
+/// so a fed value may read its payload there. With one, a fed value reading the
+/// accumulator or the whole scrutinee answers everywhere and rides the tap.
+fn feed_reading_payload_error(span: Span, binder: &str) -> LoweringError {
     LoweringError::unsupported(
         span,
-        "a `yield` or `<<` feed inside a `match` arm in a for-loop body is not \
-         supported; move it after the `match`, where it fires once per iteration",
+        format!(
+            "a `yield` or `<<` feed whose value is built from the arm's payload \
+             (`{binder}`) is not supported in a `match` arm of a for-loop body \
+             that also writes an accumulator: feed the scrutinee itself and \
+             project it downstream, or move the accumulator into a second \
+             for-loop over the same source, where the feeds fan out per arm"
+        ),
     )
+}
+
+/// The payload binder whose value reaches a feed in the same `match` arm, if
+/// any.
+///
+/// Walks the lowered arms rather than the CHL statements so the question is asked
+/// of the binder [`super::stmts::lower_match_over`] actually introduced — an arm
+/// that names no payload gets a reserved spelling, which nothing in the arm can
+/// read, and so can never answer here.
+fn arm_feed_reads_payload(case: &Expr) -> Option<Name> {
+    let TypedExprNode::Case { branches, .. } = &case.node else {
+        return None;
+    };
+    branches.iter().find_map(|br| {
+        let binder = &br.pattern.as_ref()?.binding.name;
+        let mut derived = vec![binder.clone()];
+        arm_feeds_payload_derived(&br.body, &mut derived).then(|| binder.clone())
+    })
+}
+
+/// Whether a `Feed` in `expr` has a value built from any name in `derived`,
+/// which the walk grows with each `let` that reads one.
+///
+/// The rejection covers the value, not the spelling: `v = w` then `o << v` puts
+/// the same restricted projection in the tap as `o << w` does, so asking only
+/// about the binder would accept it.
+///
+/// A `MutWrite` does not extend `derived`. Writing the payload into an
+/// accumulator commits it under the arm's own guard and the decision totals that
+/// write against the carry, so the accumulator slot a later feed reads answers at
+/// every position.
+fn arm_feeds_payload_derived(expr: &Expr, derived: &mut Vec<Name>) -> bool {
+    match &expr.node {
+        TypedExprNode::Feed { value, .. } => {
+            return derived
+                .iter()
+                .any(|n| crate::ccl::ccl_utils::is_free(n, value));
+        }
+        TypedExprNode::Let {
+            binding,
+            bound_expr,
+            ..
+        } if derived
+            .iter()
+            .any(|n| crate::ccl::ccl_utils::is_free(n, bound_expr)) =>
+        {
+            derived.push(binding.name.clone());
+        }
+        _ => {}
+    }
+    expr.any_child(|c| arm_feeds_payload_derived(c, derived))
 }
 
 /// Rejection for `x op= e` inside a for-loop body where `x` is not a mutable
@@ -505,7 +581,7 @@ fn lower_for_body_terminal(
             _ => Err(LoweringError::unsupported(
                 value.span,
                 "for-loop body must end in a yield, `<<` feed, nested for, \
-                 or if-guard",
+                 if-guard, or match",
             )),
         },
         ChlStmt::If {
@@ -591,6 +667,23 @@ fn lower_for_body_terminal(
                 ctx,
             ))
         }
+        // ``match m: case `tag(w): …`` — tag dispatch, the `match` counterpart of
+        // the `if` above. The arms share one first-match rule over one `Case`, so
+        // a feeding arm fans out as an `if` arm does. The arm also binds a
+        // payload, which `lower_match_over` puts in the scope its statements are
+        // lowered under; that scope is the arm's mutation scope, because a payload
+        // binder is bound outside the arm's statements and writing it is rejected
+        // for the reason writing the iteration variable is.
+        ChlStmt::Match { scrutinee, arms } => lower_match_over(
+            stmt.span,
+            scrutinee,
+            arms,
+            mutation_scope,
+            ctx,
+            |body, scope, ctx| {
+                lower_for_body_stmts(body, defer_name, scope, frame_introduced.clone(), ctx)
+            },
+        ),
         // A `with begin():` transaction as a *generator* loop-body terminal is a
         // later increment; top-level and simple `for … with begin():` loops are
         // lowered in `stmts.rs`/`transactions.rs`.
@@ -601,7 +694,7 @@ fn lower_for_body_terminal(
         )),
         _ => Err(LoweringError::unsupported(
             stmt.span,
-            "for-loop body must end in a yield, `<<` feed, nested for, or if-guard",
+            "for-loop body must end in a yield, `<<` feed, nested for, if-guard, or match",
         )),
     }
 }
@@ -1049,14 +1142,6 @@ fn lower_loop_body_chain(
             // is a write path; there is no complement, because the arms
             // partition the scrutinee's tags.
             ChlStmt::Match { scrutinee, arms } => {
-                if let Some(bad) = arms
-                    .iter()
-                    .find(|a| for_body_has_yield(&a.body) || for_body_has_feed(&a.body))
-                {
-                    return Err(feed_in_match_arm_error(
-                        bad.body.first().map_or(stmt.span, |s| s.span),
-                    ));
-                }
                 let case = lower_match_over(
                     stmt.span,
                     scrutinee,
@@ -1075,6 +1160,15 @@ fn lower_loop_body_chain(
                         )
                     },
                 )?;
+                // An accumulator puts this loop's feeds on the writer's decision
+                // record, which a payload-reading value cannot answer over
+                // ([`feed_reading_payload_error`]). Without one the feeds fan out
+                // per arm, where a restricted value is the expected shape.
+                if !acc_names.is_empty()
+                    && let Some(binder) = arm_feed_reads_payload(&case)
+                {
+                    return Err(feed_reading_payload_error(stmt.span, binder.base()));
+                }
                 ctx.tag_machinery(Expr::expr_stmt(case, chain), stmt.span, "lower.stmt_seq")
             }
             // `if p: … [else: …]` — a conditional write path. Lowered to a
@@ -1133,8 +1227,9 @@ fn lower_loop_body_chain(
                 return Err(LoweringError::unsupported(
                     stmt.span,
                     "only assignments (`x = …`, `x op= …`), `<<` feeds, \
-                     `yield`, `if` guards, `with begin():` transactions, and bare \
-                     side-effect calls are supported inside a for-loop body",
+                     `yield`, `if` guards, `match` dispatch, `with begin():` \
+                     transactions, and bare side-effect calls are supported \
+                     inside a for-loop body",
                 ));
             }
         };

--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -1646,6 +1646,35 @@ pub(super) fn lower_match(
     outer_bindings: &HashSet<String>,
     ctx: &mut LoweringContext,
 ) -> Result<Expr, LoweringError> {
+    lower_match_over(
+        match_span,
+        scrutinee,
+        arms,
+        outer_bindings,
+        ctx,
+        |body, scope, ctx| lower_stmts_inner(body, scope, ctx, false),
+    )
+}
+
+/// [`lower_match`] over how an arm's body is lowered.
+///
+/// The tag rules — one arm per tag, `case _:` last and unique — and the
+/// `Pattern` each arm carries belong to `match` wherever it is written, and a
+/// for-loop body differs only in what a statement in an arm may be
+/// ([`lower_loop_body_chain`]). This is the production the two share, in the
+/// shape `match_arms` has in the parser.
+pub(super) fn lower_match_over(
+    match_span: Span,
+    scrutinee: &Spanned<ChlExpr>,
+    arms: &[MatchArm],
+    outer_bindings: &HashSet<String>,
+    ctx: &mut LoweringContext,
+    mut lower_body: impl FnMut(
+        &[Spanned<ChlStmt>],
+        &HashSet<String>,
+        &mut LoweringContext,
+    ) -> Result<Expr, LoweringError>,
+) -> Result<Expr, LoweringError> {
     // The parser's `.at_least(1)` guarantees this; a zero-arm `match` would
     // lower to a `Case` with no branches, which has no value to denote.
     assert!(
@@ -1685,7 +1714,7 @@ pub(super) fn lower_match(
     // back from it is simply the value. Sequencing it after the scrutinee keeps
     // the scrutinee typed without letting it decide anything.
     if arms.len() == 1 && defaults == 1 {
-        let body = lower_stmts_inner(&arms[0].body, outer_bindings, ctx, false)?;
+        let body = lower_body(&arms[0].body, outer_bindings, ctx)?;
         return Ok(ctx.tag_image(Expr::expr_stmt(scrutinee_expr, body), match_span));
     }
     let mut branches = Vec::with_capacity(arms.len());
@@ -1694,7 +1723,7 @@ pub(super) fn lower_match(
             // The default arm binds nothing — the tags it covers have different
             // payload types, so there is no single thing to bind — and lowers to a
             // tag-less `Branch`, which is what makes it the fallback.
-            let body = lower_stmts_inner(&arm.body, outer_bindings, ctx, false)?;
+            let body = lower_body(&arm.body, outer_bindings, ctx)?;
             branches.push(Branch {
                 pattern: None,
                 // Tag dispatch carries no boolean test, so every arm's guard is
@@ -1726,7 +1755,7 @@ pub(super) fn lower_match(
         let mut arm_scope = outer_bindings.clone();
         arm_scope.insert(binder.clone());
         let body = ctx.with_shadowed(vec![binder.clone()], |ctx| {
-            lower_stmts_inner(&arm.body, &arm_scope, ctx, false)
+            lower_body(&arm.body, &arm_scope, ctx)
         })?;
         branches.push(Branch {
             pattern: Some(Pattern {

--- a/src/ccl/lower/transactions.rs
+++ b/src/ccl/lower/transactions.rs
@@ -177,8 +177,9 @@ fn contains_feed(e: &Expr) -> bool {
 
 /// Build the block's statement chain right-to-left. Assignments to
 /// transactional mutable variables become `MutWrite` markers (reads stay bare `Var`
-/// snapshots); `if cond:` guards become `Case` (the no-else deny branch); other
-/// assignments are per-iteration `Let`s.
+/// snapshots); `if cond:` guards and `match` dispatch become `Case` (an `if`
+/// without an `else` carries the deny branch); other assignments are
+/// per-iteration `Let`s.
 ///
 /// `fallback_span` anchors the manufactured chain terminal when the statement
 /// list is empty (the block's own statement spans win when present).
@@ -188,11 +189,12 @@ fn lower_tx_block_inner(
     fallback_span: Span,
     ctx: &mut LoweringContext,
 ) -> Result<Expr, LoweringError> {
-    // Multiple `if` guards, `elif` chains, and `else` branches are all supported:
-    // `transact_phase`'s path walk scopes each write to its own control-flow path,
-    // rejoins each key with a carry-forward `Case`, and commits on the disjunction
-    // of the write paths (see `src/ccl/design/mutability.md`). A guard is no longer
-    // transaction-scoped — a spine write beside an `if` commits unconditionally.
+    // Multiple `if` guards, `elif` chains, `else` branches and `match` arms are all
+    // supported: `transact_phase`'s path walk scopes each write to its own
+    // control-flow path, rejoins each key with a carry-forward `Case`, and commits
+    // on the disjunction of the write paths (see `src/ccl/design/mutability.md`).
+    // A guard is not transaction-scoped — a spine write beside a branch commits
+    // unconditionally.
     //
     // The chain terminal is manufactured sequencing (spanned to the block's
     // statements — the `with` construct when the block is empty).
@@ -271,6 +273,26 @@ fn lower_tx_block_inner(
                 let feed = lower_expr(value, ctx)?;
                 ctx.tag_machinery(Expr::expr_stmt(feed, chain), stmt.span, "lower.stmt_seq")
             }
+            // ``match m: case `tag(w): <writes>`` — tag dispatch, the `match`
+            // counterpart of the `if` above. The arms share one first-match rule
+            // over one `Case`, and `transact_phase` scopes each arm's writes to
+            // its own path exactly as it does an `if` arm's. Arms partition the
+            // tags, so there is no deny complement of the kind a bare `if cond:`
+            // leaves — the trailing `true → unit` a `match` without a `case _:`
+            // gains is minted by
+            // [`tag_case_to_guard_case`](crate::ccl::ccl_utils::tag_case_to_guard_case),
+            // not here.
+            ChlStmt::Match { scrutinee, arms } => {
+                let case = lower_match_over(
+                    stmt.span,
+                    scrutinee,
+                    arms,
+                    outer_bindings,
+                    ctx,
+                    |body, scope, ctx| lower_tx_block_inner(body, scope, stmt.span, ctx),
+                )?;
+                ctx.tag_machinery(Expr::expr_stmt(case, chain), stmt.span, "lower.stmt_seq")
+            }
             ChlStmt::With { .. } => {
                 return Err(LoweringError::unsupported(
                     stmt.span,
@@ -281,7 +303,8 @@ fn lower_tx_block_inner(
                 return Err(LoweringError::unsupported(
                     stmt.span,
                     "a `with begin():` block supports mutable writes (`x := …`, `x += …`), \
-                     local bindings (`x = …`), `if cond:` guards, and feeds (`out << e`)",
+                     local bindings (`x = …`), `if cond:` guards, `match` dispatch, \
+                     and feeds (`out << e`)",
                 ));
             }
         };

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -1517,14 +1517,18 @@ pub(crate) fn fold_induction_loop(
         .iter()
         .map(|f| {
             let _g = f.site.enter(FEED_LABEL, provenance::Nature::Expansion);
-            let view = hist_field_view(
-                &h,
-                &hist_ty,
-                &domain_ty,
-                &f.field,
-                &f.value.ty,
-                &decision_ty,
-            );
+            // The decision carries the tap as `` {`fired{𝑉} | `idle} ``, so the
+            // view reads the field at that type and eliminates `` `fired ``:
+            // the channel is the fired positions with their values
+            // ([`fired_project`](crate::ccl::ccl_utils::fired_project)).
+            let tap_ty = crate::ccl::ccl_utils::tap_variant_ty(f.value.ty.clone());
+            let field_view =
+                hist_field_view(&h, &hist_ty, &domain_ty, &f.field, &tap_ty, &decision_ty);
+            let mut view = Expr::compose(vec![
+                field_view,
+                crate::ccl::ccl_utils::fired_project(f.value.ty.clone()),
+            ]);
+            view.ty = Type::fun_like(&hist_ty, domain_ty.clone(), f.value.ty.clone());
             (f.defer.clone(), view)
         })
         .collect();

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -46,9 +46,11 @@
 use std::collections::HashMap;
 
 use crate::ccl::{
-    BaseType, Branch, Builtin, Expr, F_WRITES, FieldKey, HistoryKind, Lit, Name, Type,
-    TypedBinding, TypedExprNode,
-    ccl_utils::{COMMIT_SELECTOR, strip_refinements, synthesize_arm_predicate, typed_compose},
+    BaseType, Branch, Builtin, Expr, F_WRITES, HistoryKind, Lit, Name, Type, TypedBinding,
+    TypedExprNode,
+    ccl_utils::{
+        COMMIT_SELECTOR, strip_refinements, synthesize_arm_predicate, typed_compose, unit_expr,
+    },
     letrec::check_letrec_causal,
     provenance::{self, NodeId, RecordingGuard, RewriteLabel},
     subst::Subst,
@@ -236,13 +238,6 @@ fn erase_mut_in_type(ty: &mut Type) {
 fn erase_mut(expr: &mut Expr) {
     expr.walk_type_slots_mut(erase_mut_in_type);
     expr.walk_children_mut(erase_mut);
-}
-
-/// A `Unit` literal stamped with `Base(Unit)` — the value of a mutable write.
-fn unit_expr() -> Expr {
-    let mut u = Expr::new(TypedExprNode::Lit(Lit::Unit));
-    u.ty = Type::Base(BaseType::Unit);
-    u
 }
 
 /// Whether `e` is a bare mutable write.
@@ -1210,7 +1205,7 @@ fn transform_loop(
                 // paths that split per feed. One lambda carries the whole body
                 // here, however many arms feed, so there is no product to hand to
                 // any one feed statement.
-                let body = strip_trailing_unit(loop_body.clone());
+                let body = guard_cases_only(strip_trailing_unit(loop_body.clone()));
                 let mut lambda = Expr::lambda(target.name.clone(), target.ty.clone(), body);
                 lambda.ty = Type::fun(target.ty.clone(), loop_body.ty.clone());
                 let map = typed_compose(vec![iter, lambda]);
@@ -1801,15 +1796,33 @@ fn strip_trailing_unit(expr: Expr) -> Expr {
 /// feed/write. Distinguishes a conditional feed loop (fanned out by `channelize`)
 /// from a straight-line feed loop (hoisted by `transform_feed_only_loop`). Ignores
 /// *value*-position `Case`s (a ternary in a feed value is straight-line).
+/// Rewrite every tag-dispatching `Case` in a generator body into the guard-`Case`
+/// [`channelize::try_extract_fanout_feed`](crate::ccl::channelize) fans out.
+///
+/// The feed-only path hands its body to `channelize` rather than to
+/// [`transform_chain`], so the rewrite that walker performs at its own
+/// consumption point has to happen here too: the fan-out matches a boolean guard
+/// against a bare `Feed`, and a `match` arm carries a `Pattern` and a tag until
+/// [`tag_case_to_guard_case`] turns them into a `variant_is` test and a
+/// substituted `variant_project`.
+fn guard_cases_only(expr: Expr) -> Expr {
+    let mut expr = expr;
+    expr.map_children(guard_cases_only);
+    if matches!(
+        &expr.node,
+        TypedExprNode::Case {
+            scrutinee: Some(_),
+            ..
+        }
+    ) {
+        return crate::ccl::ccl_utils::tag_case_to_guard_case(expr);
+    }
+    expr
+}
+
 fn body_has_statement_case(expr: &Expr) -> bool {
     if let TypedExprNode::ExprStmt { expr: effect, .. } = &expr.node
-        && matches!(
-            &effect.node,
-            TypedExprNode::Case {
-                scrutinee: None,
-                ..
-            }
-        )
+        && matches!(&effect.node, TypedExprNode::Case { .. })
     {
         return true;
     }
@@ -1887,8 +1900,9 @@ fn transform_chain(
         // A statement-position tag-`Case` (``match m: case `t(w): acc += e``,
         // lowered by `lower_loop_body_chain`). Rewrite it into the guard-`Case`
         // the arm below already merges into a writer decision, and re-enter. The
-        // payload stays a projection, bound at the head of its arm where
-        // `decision_writes` inlines it.
+        // payload is substituted into the arm rather than bound, so it carries no
+        // binder into a value this walker lifts out of the arm
+        // ([`tag_case_to_guard_case`](crate::ccl::ccl_utils::tag_case_to_guard_case)).
         TypedExprNode::ExprStmt { expr: effect, body }
             if matches!(
                 &effect.node,
@@ -1898,7 +1912,10 @@ fn transform_chain(
                 }
             ) =>
         {
-            let rewritten = Expr::expr_stmt(tag_case_to_guard_case(*effect), *body);
+            let rewritten = Expr::expr_stmt(
+                crate::ccl::ccl_utils::tag_case_to_guard_case(*effect),
+                *body,
+            );
             transform_chain(rewritten, env, accs, writes_ty, entering, path, feeds)
         }
         // A statement-position guard-`Case` (`if p: acc += e`, lowered by
@@ -2201,85 +2218,6 @@ fn conditional_decision(
         })
         .collect();
     decision_record(commit, write_elts, writes_ty)
-}
-
-/// Rewrite a tag-dispatching `Case` into the boolean-guard `Case` a writer
-/// decision is built from ([`Builtin::VariantIs`](crate::ccl::Builtin::VariantIs)
-/// for why the guard is a total test rather than a projection).
-///
-/// Each arm's `Pattern` becomes a `variant_is(tag)` guard over the scrutinee and
-/// a `let` binding its payload to the same arm's `variant_project(tag)`, so the
-/// arm reads as `if` does. A `match` without a `case _:` arm gains the trailing
-/// `true → unit` carry every lowered guard-`Case` ends in — the position where
-/// the accumulators keep their previous value. The arms partition the tags, so
-/// the decision commits at every position where a guard-`Case` leaves the
-/// changelog sparse.
-///
-/// The scrutinee is duplicated once per arm rather than bound: a `let` around
-/// the `Case` would put its name in the write set, where it escapes the writer
-/// lambda. A loop's `match` scrutinee is the iteration variable or a projection
-/// of it, so the copies are reads.
-fn tag_case_to_guard_case(case: Expr) -> Expr {
-    let case_ty = case.ty.clone();
-    let TypedExprNode::Case {
-        scrutinee,
-        branches,
-    } = case.node
-    else {
-        unreachable!("caller guarantees a Case")
-    };
-    let scrut = *scrutinee.expect("caller guarantees a tag-dispatching Case");
-    let scrut_ty = scrut.ty.clone();
-    let bool_ty = Type::Base(BaseType::Bool);
-    let mut has_default = false;
-    let mut out: Vec<Branch> = Vec::with_capacity(branches.len() + 1);
-    for br in branches {
-        let Some(pat) = br.pattern else {
-            // A `case _:` arm is already the fallback the trailing `true` guard
-            // names, and lowering has placed it last.
-            has_default = true;
-            out.push(Branch {
-                pattern: None,
-                guard: br.guard,
-                body: br.body,
-            });
-            continue;
-        };
-        let tag = FieldKey::Name(pat.tag.clone().into());
-        let payload_ty = pat.binding.ty.clone();
-        let mut guard = Expr::apply(
-            scrut.clone(),
-            Expr::builtin(Builtin::VariantIs(tag.clone()))
-                .with_ty(Type::fun(scrut_ty.clone(), bool_ty.clone())),
-        );
-        guard.ty = bool_ty.clone();
-        let mut payload = Expr::apply(
-            scrut.clone(),
-            Expr::builtin(Builtin::VariantProject(tag))
-                .with_ty(Type::fun(scrut_ty.clone(), payload_ty.clone())),
-        );
-        payload.ty = payload_ty;
-        out.push(Branch {
-            pattern: None,
-            guard,
-            body: Expr::let_in(pat.binding, payload, br.body),
-        });
-    }
-    if !has_default {
-        let mut t = Expr::new(TypedExprNode::Lit(Lit::Bool(true)));
-        t.ty = bool_ty;
-        out.push(Branch {
-            pattern: None,
-            guard: t,
-            body: unit_expr(),
-        });
-    }
-    let mut rebuilt = Expr::new(TypedExprNode::Case {
-        scrutinee: None,
-        branches: out,
-    });
-    rebuilt.ty = case_ty;
-    rebuilt
 }
 
 /// Assemble a writer decision record `{commit, writes: (write_elts…)}`.

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -1886,18 +1886,9 @@ fn transform_chain(
         }
         // A statement-position tag-`Case` (``match m: case `t(w): acc += e``,
         // lowered by `lower_loop_body_chain`). Rewrite it into the guard-`Case`
-        // the arm below already merges into a writer decision, and re-enter.
-        //
-        // Selecting an arm by reading it — the fan-out of `variant_project`s a
-        // `match` compiles to everywhere else — cannot drive a writer body: the
-        // decision selects on a predicate over its whole driver domain, and a
-        // projection restricts that domain rather than answering over it.
-        // `variant_is` answers every position, so the arms become ordinary
-        // boolean guards and `synthesize_arm_predicate` gives each its
-        // first-match predicate, exactly as for an `elif` chain.
-        // The payload stays a projection, bound at the head of its arm where
-        // `decision_writes` inlines it. See `src/ccl/design/mutability.md`,
-        // "A `match` in a for-loop body".
+        // the arm below already merges into a writer decision, and re-enter. The
+        // payload stays a projection, bound at the head of its arm where
+        // `decision_writes` inlines it.
         TypedExprNode::ExprStmt { expr: effect, body }
             if matches!(
                 &effect.node,
@@ -2213,13 +2204,16 @@ fn conditional_decision(
 }
 
 /// Rewrite a tag-dispatching `Case` into the boolean-guard `Case` a writer
-/// decision is built from.
+/// decision is built from ([`Builtin::VariantIs`](crate::ccl::Builtin::VariantIs)
+/// for why the guard is a total test rather than a projection).
 ///
 /// Each arm's `Pattern` becomes a `variant_is(tag)` guard over the scrutinee and
 /// a `let` binding its payload to the same arm's `variant_project(tag)`, so the
 /// arm reads as `if` does. A `match` without a `case _:` arm gains the trailing
 /// `true → unit` carry every lowered guard-`Case` ends in — the position where
-/// the accumulators keep their previous value.
+/// the accumulators keep their previous value. The arms partition the tags, so
+/// the decision commits at every position where a guard-`Case` leaves the
+/// changelog sparse.
 ///
 /// The scrutinee is duplicated once per arm rather than bound: a `let` around
 /// the `Case` would put its name in the write set, where it escapes the writer

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -46,8 +46,8 @@
 use std::collections::HashMap;
 
 use crate::ccl::{
-    BaseType, Branch, Builtin, Expr, F_WRITES, HistoryKind, Lit, Name, Type, TypedBinding,
-    TypedExprNode,
+    BaseType, Branch, Builtin, Expr, F_WRITES, FieldKey, HistoryKind, Lit, Name, Type,
+    TypedBinding, TypedExprNode,
     ccl_utils::{COMMIT_SELECTOR, strip_refinements, synthesize_arm_predicate, typed_compose},
     letrec::check_letrec_causal,
     provenance::{self, NodeId, RecordingGuard, RewriteLabel},
@@ -1884,6 +1884,32 @@ fn transform_chain(
             let rest = transform_chain(*body, env, accs, writes_ty, entering, path, feeds);
             Expr::let_in(b, bound, rest)
         }
+        // A statement-position tag-`Case` (``match m: case `t(w): acc += e``,
+        // lowered by `lower_loop_body_chain`). Rewrite it into the guard-`Case`
+        // the arm below already merges into a writer decision, and re-enter.
+        //
+        // Selecting an arm by reading it — the fan-out of `variant_project`s a
+        // `match` compiles to everywhere else — cannot drive a writer body: the
+        // decision selects on a predicate over its whole driver domain, and a
+        // projection restricts that domain rather than answering over it.
+        // `variant_is` answers every position, so the arms become ordinary
+        // boolean guards and `synthesize_arm_predicate` gives each its
+        // first-match predicate, exactly as for an `elif` chain.
+        // The payload stays a projection, bound at the head of its arm where
+        // `decision_writes` inlines it. See `src/ccl/design/mutability.md`,
+        // "A `match` in a for-loop body".
+        TypedExprNode::ExprStmt { expr: effect, body }
+            if matches!(
+                &effect.node,
+                TypedExprNode::Case {
+                    scrutinee: Some(_),
+                    ..
+                }
+            ) =>
+        {
+            let rewritten = Expr::expr_stmt(tag_case_to_guard_case(*effect), *body);
+            transform_chain(rewritten, env, accs, writes_ty, entering, path, feeds)
+        }
         // A statement-position guard-`Case` (`if p: acc += e`, lowered by
         // `lower_loop_body_chain` to `{gᵢ → branch; true → carry}`): merge its
         // branches into a single always-commit decision whose write set is a
@@ -2184,6 +2210,82 @@ fn conditional_decision(
         })
         .collect();
     decision_record(commit, write_elts, writes_ty)
+}
+
+/// Rewrite a tag-dispatching `Case` into the boolean-guard `Case` a writer
+/// decision is built from.
+///
+/// Each arm's `Pattern` becomes a `variant_is(tag)` guard over the scrutinee and
+/// a `let` binding its payload to the same arm's `variant_project(tag)`, so the
+/// arm reads as `if` does. A `match` without a `case _:` arm gains the trailing
+/// `true → unit` carry every lowered guard-`Case` ends in — the position where
+/// the accumulators keep their previous value.
+///
+/// The scrutinee is duplicated once per arm rather than bound: a `let` around
+/// the `Case` would put its name in the write set, where it escapes the writer
+/// lambda. A loop's `match` scrutinee is the iteration variable or a projection
+/// of it, so the copies are reads.
+fn tag_case_to_guard_case(case: Expr) -> Expr {
+    let case_ty = case.ty.clone();
+    let TypedExprNode::Case {
+        scrutinee,
+        branches,
+    } = case.node
+    else {
+        unreachable!("caller guarantees a Case")
+    };
+    let scrut = *scrutinee.expect("caller guarantees a tag-dispatching Case");
+    let scrut_ty = scrut.ty.clone();
+    let bool_ty = Type::Base(BaseType::Bool);
+    let mut has_default = false;
+    let mut out: Vec<Branch> = Vec::with_capacity(branches.len() + 1);
+    for br in branches {
+        let Some(pat) = br.pattern else {
+            // A `case _:` arm is already the fallback the trailing `true` guard
+            // names, and lowering has placed it last.
+            has_default = true;
+            out.push(Branch {
+                pattern: None,
+                guard: br.guard,
+                body: br.body,
+            });
+            continue;
+        };
+        let tag = FieldKey::Name(pat.tag.clone().into());
+        let payload_ty = pat.binding.ty.clone();
+        let mut guard = Expr::apply(
+            scrut.clone(),
+            Expr::builtin(Builtin::VariantIs(tag.clone()))
+                .with_ty(Type::fun(scrut_ty.clone(), bool_ty.clone())),
+        );
+        guard.ty = bool_ty.clone();
+        let mut payload = Expr::apply(
+            scrut.clone(),
+            Expr::builtin(Builtin::VariantProject(tag))
+                .with_ty(Type::fun(scrut_ty.clone(), payload_ty.clone())),
+        );
+        payload.ty = payload_ty;
+        out.push(Branch {
+            pattern: None,
+            guard,
+            body: Expr::let_in(pat.binding, payload, br.body),
+        });
+    }
+    if !has_default {
+        let mut t = Expr::new(TypedExprNode::Lit(Lit::Bool(true)));
+        t.ty = bool_ty;
+        out.push(Branch {
+            pattern: None,
+            guard: t,
+            body: unit_expr(),
+        });
+    }
+    let mut rebuilt = Expr::new(TypedExprNode::Case {
+        scrutinee: None,
+        branches: out,
+    });
+    rebuilt.ty = case_ty;
+    rebuilt
 }
 
 /// Assemble a writer decision record `{commit, writes: (write_elts…)}`.

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -1205,7 +1205,7 @@ fn transform_loop(
                 // paths that split per feed. One lambda carries the whole body
                 // here, however many arms feed, so there is no product to hand to
                 // any one feed statement.
-                let body = guard_cases_only(strip_trailing_unit(loop_body.clone()));
+                let body = strip_trailing_unit(loop_body.clone());
                 let mut lambda = Expr::lambda(target.name.clone(), target.ty.clone(), body);
                 lambda.ty = Type::fun(target.ty.clone(), loop_body.ty.clone());
                 let map = typed_compose(vec![iter, lambda]);
@@ -1800,33 +1800,15 @@ fn strip_trailing_unit(expr: Expr) -> Expr {
 /// feed/write. Distinguishes a conditional feed loop (fanned out by `channelize`)
 /// from a straight-line feed loop (hoisted by `transform_feed_only_loop`). Ignores
 /// *value*-position `Case`s (a ternary in a feed value is straight-line).
-/// Rewrite every tag-dispatching `Case` in a generator body into the guard-`Case`
-/// [`channelize::try_extract_fanout_feed`](crate::ccl::channelize) fans out.
-///
-/// The feed-only path hands its body to `channelize` rather than to
-/// [`transform_chain`], so the rewrite that walker performs at its own
-/// consumption point has to happen here too: the fan-out matches a boolean guard
-/// against a bare `Feed`, and a `match` arm carries a `Pattern` and a tag until
-/// [`tag_case_to_guard_case`] turns them into a `variant_is` test and a
-/// substituted `variant_project`.
-fn guard_cases_only(expr: Expr) -> Expr {
-    let mut expr = expr;
-    expr.map_children(guard_cases_only);
-    if matches!(
-        &expr.node,
-        TypedExprNode::Case {
-            scrutinee: Some(_),
-            ..
-        }
-    ) {
-        return crate::ccl::ccl_utils::tag_case_to_guard_case(expr);
-    }
-    expr
-}
-
 fn body_has_statement_case(expr: &Expr) -> bool {
     if let TypedExprNode::ExprStmt { expr: effect, .. } = &expr.node
-        && matches!(&effect.node, TypedExprNode::Case { .. })
+        && matches!(
+            &effect.node,
+            TypedExprNode::Case {
+                scrutinee: None,
+                ..
+            }
+        )
     {
         return true;
     }

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -994,10 +994,10 @@ struct FeedSite {
     site: StmtSite,
     /// The control-flow path under which this feed fires — `true` for a feed on
     /// the loop spine, a conjunction of enclosing guards for a feed inside an
-    /// `if`. A conditional feed (`fire != true`) rides the decision as a
-    /// `to_<feed>__fire` gate the engine reads to emit the reply only on its own
-    /// route; its path also joins the commit gate so the firing position appends a
-    /// change carrying the tap.
+    /// `if`. A conditional feed (`fire != true`) rides the decision as a tap that
+    /// is `` `fired `` on its own route and `` `idle `` elsewhere, so the engine
+    /// emits the reply only there; its path also joins the commit gate so the
+    /// firing position appends a change carrying the tap.
     fire: Expr,
 }
 
@@ -1427,8 +1427,8 @@ pub(crate) fn fold_induction_loop(
 
     // The decision codomain is exactly the record `attach_feed_fields` built (its
     // type propagates through the RYW `let`s), so `hist_ty`/the body lambda match
-    // it by construction — no separate reconstruction of the `to_<feed>`/`__fire`
-    // field set (which would have to re-derive the same gate condition).
+    // it by construction — no separate reconstruction of the `to_<feed>` field set
+    // (which would have to re-derive the same fire conditions).
     let decision_ty = chain.ty.clone();
     // The recurrence binds the loop's history, so it is a collection — and a `Type::fun`
     // here rode down into everything lambda elimination mints out of the position binder,
@@ -1948,8 +1948,8 @@ fn transform_chain(
                 let mut branch_env = env.clone();
                 // Each branch walks under `path ∧ πᵢ`, collecting its feeds into the
                 // shared `feeds` (unique field names, per-branch fire paths) — so a
-                // feed under a guard becomes a `to_<feed>__fire`-gated tap that fires
-                // only on its route. The post-`Case` remainder is spliced into every
+                // feed under a guard becomes a tap that is `` `fired `` on its own
+                // route only. The post-`Case` remainder is spliced into every
                 // branch, so a feed after the `if` is collected once per path with
                 // that path's predicate: mutually exclusive, exactly one fires per
                 // position. The write set is merged separately below (carry from the
@@ -2056,9 +2056,9 @@ fn transform_chain(
         TypedExprNode::Lit(Lit::Unit) => {
             // Terminal: the bare always-commit decision `{commit: true, writes:
             // (…)}` — the latest value of each accumulator as the positional write
-            // set (one element even for a single accumulator). Feed (`to_<feed>`)
-            // and fire (`to_<feed>__fire`) fields are attached once at the top from
-            // the fully-collected `feeds` (see `attach_feed_fields`), which also
+            // set (one element even for a single accumulator). The `to_<feed>` tap
+            // fields are attached once at the top from the fully-collected `feeds`
+            // (see `attach_feed_fields`), which also
             // folds each conditional feed's fire path into the commit gate — so a
             // spine feed on a plain loop is unchanged, and a feed reached only under
             // a guard still appends a change carrying its tap.
@@ -2242,12 +2242,13 @@ fn is_true_lit(e: &Expr) -> bool {
 }
 
 /// Attach the collected feeds to a writer decision `let* in {commit, writes}`,
-/// producing `let* in {commit', writes, to_<feed>*(, to_<feed>__fire)*}`:
+/// producing `let* in {commit', writes, to_<feed>*}`:
 ///
-/// - each feed contributes a `to_<feed>` tap value field;
-/// - a **conditional** feed (`fire ≠ true`) also contributes a `to_<feed>__fire`
-///   gate the engine reads (`body_decision_at`) to emit the reply only on its
-///   route; a spine feed (`fire == true`) fires with every committing position and
+/// - each feed contributes a `to_<feed>` tap field, holding
+///   `` {`fired{𝑉} | `idle} ``;
+/// - a **conditional** feed (`fire ≠ true`) is `` `fired `` only on its own route,
+///   which the engine reads (`body_decision_at`) to emit the reply there; a spine
+///   feed (`fire == true`) fires with every committing position and
 ///   needs no gate, keeping a plain feed loop's shape unchanged;
 /// - `commit` is widened to `commit ∨ ⋁ fire` so a position that only *feeds*
 ///   (no accumulator write) still appends a change carrying the tap.
@@ -2287,8 +2288,8 @@ fn attach_feed_fields(decision: Expr, feeds: &[FeedSite]) -> Expr {
                 .clone();
             // Widen commit to also fire on every feed's path, so a feed-only
             // committing position appends a change carrying the tap; then hand off
-            // to the shared decision builder (the one place the `__fire` encoding
-            // lives — see `ccl_utils::writer_decision_record`).
+            // to the shared decision builder (the one place the tap encoding lives
+            // — see `ccl_utils::writer_decision_record`).
             let commit = crate::ccl::ccl_utils::disjoin(
                 std::iter::once(commit_base).chain(feeds.iter().map(|f| f.fire.clone())),
                 false,

--- a/src/ccl/ops.rs
+++ b/src/ccl/ops.rs
@@ -588,6 +588,10 @@ pub enum Builtin {
     /// reading the arm *is* the restriction; there is no separate boolean
     /// `Restrict` step and no tag-discriminating `Predicate`.
     ///
+    /// The projection narrows the domain but preserves keys, so a domain release
+    /// forwards to the scrutinee verbatim and it can sit inside an induction
+    /// writer body.
+    ///
     /// **A tag the scrutinee does not carry is not an error** — it projects empty.
     /// That is what makes a width-subtype scrutinee well-formed here.
     ///
@@ -682,6 +686,30 @@ pub enum Builtin {
     /// stamped on the node at emission and the post-phase CHECK-mode `typecheck`
     /// validates it directly, as [`Self::BeginTxn`]'s is.
     Insert,
+    /// ``variant_is(c) : Union({cᵢ: Pᵢ}) ⇒ Bool`` — whether a union value carries
+    /// the arm named `c`. **Total** where [`Self::VariantProject`] restricts:
+    /// every position of the scrutinee's domain gets an answer, `true` on the
+    /// rows the arm holds and `false` on the rest.
+    ///
+    /// Reading an arm *is* the tag restriction, so a `match` compiled as a
+    /// fan-out of projections needs no predicate — but an induction writer
+    /// decision selects on a predicate
+    /// over its whole driver domain: its commit selector is a disjunction of the
+    /// arms' guards, and each guard is complemented against the ones before it
+    /// into a first-match predicate. A projection restricts that domain rather
+    /// than answering over it, so it cannot stand there. A total boolean test
+    /// answers every position, so a `match` in a for-loop body dispatches on
+    /// `variant_is` guards and rides the same first-match `Case` machinery an
+    /// `if` chain does
+    /// (`src/ccl/design/mutability.md`, "A `match` in a for-loop body").
+    ///
+    /// **A tag the scrutinee does not carry is not an error** — it answers `false`
+    /// everywhere, matching [`Self::VariantProject`]'s empty projection.
+    ///
+    /// Minted after inference, so it carries no [`crate::ccl::infer::OperatorSchemes`]
+    /// scheme: its type `Union ⇒ Bool` is stamped on the node and the post-phase
+    /// CHECK-mode `typecheck` trusts it (like [`Self::VariantProject`]).
+    VariantIs(FieldKey),
 }
 
 impl Builtin {
@@ -730,6 +758,7 @@ impl Builtin {
             Self::CollectionContains => "collection_contains",
             Self::LookupChecked => "lookup?",
             Self::Insert => "insert",
+            Self::VariantIs(_) => "variant_is",
         }
     }
 

--- a/src/ccl/ops.rs
+++ b/src/ccl/ops.rs
@@ -693,15 +693,13 @@ pub enum Builtin {
     ///
     /// Reading an arm *is* the tag restriction, so a `match` compiled as a
     /// fan-out of projections needs no predicate — but an induction writer
-    /// decision selects on a predicate
-    /// over its whole driver domain: its commit selector is a disjunction of the
-    /// arms' guards, and each guard is complemented against the ones before it
-    /// into a first-match predicate. A projection restricts that domain rather
-    /// than answering over it, so it cannot stand there. A total boolean test
-    /// answers every position, so a `match` in a for-loop body dispatches on
-    /// `variant_is` guards and rides the same first-match `Case` machinery an
-    /// `if` chain does
-    /// (`src/ccl/design/mutability.md`, "A `match` in a for-loop body").
+    /// decision selects on a predicate over its whole driver domain: its commit
+    /// selector is a disjunction of the arms' guards, and each guard is
+    /// complemented against the ones before it into a first-match predicate. A
+    /// projection restricts that domain rather than answering over it, so it
+    /// cannot stand there. A total boolean test answers every position, so a
+    /// `match` in a for-loop body dispatches on `variant_is` guards and rides
+    /// the same first-match `Case` machinery an `if` chain does.
     ///
     /// **A tag the scrutinee does not carry is not an error** — it answers `false`
     /// everywhere, matching [`Self::VariantProject`]'s empty projection.

--- a/src/ccl/symbolic.rs
+++ b/src/ccl/symbolic.rs
@@ -236,6 +236,10 @@ fn fmt_inner(expr: &Expr, opts: &SymbolicOpts) -> (Precedence, String) {
             (Precedence::Atom, format!("variant_wrap(`{tag})"))
         }
 
+        TypedExprNode::Builtin(Builtin::VariantIs(tag)) => {
+            (Precedence::Atom, format!("variant_is(`{tag})"))
+        }
+
         TypedExprNode::Builtin(b) => (Precedence::Atom, b.name().to_string()),
 
         TypedExprNode::BinOp { left, op, right } => {

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -2141,11 +2141,11 @@ fn build_writer(
     writes.ty = Type::Tuple(write_tys.clone());
 
     // Decision record `{commit, writes, to_<defer>*}` — built by the shared
-    // `writer_decision_record` (the one place the tap/`__fire` encoding lives, so
-    // the induction writer and this transaction writer stay in lockstep). The
-    // in-block feeds ride as `to_<defer>` taps (read-your-writes value + a
-    // `__fire` gate when their path is narrower than the commit); `feed_sites`
-    // records the defer/field/type the phase hoists.
+    // `writer_decision_record` (the one place the tap encoding lives, so the
+    // induction writer and this transaction writer stay in lockstep). The in-block
+    // feeds ride as `to_<defer>` taps, each holding its read-your-writes value
+    // under `` `fired `` on the positions its own path admits; `feed_sites` records
+    // the defer/field/type the phase hoists.
     let feed_sites: Vec<FeedSite> = collected_feeds
         .iter()
         .map(|(defer, field, val, _)| FeedSite {
@@ -2330,8 +2330,8 @@ fn walk_block(
                 // (its path == commit). A feed under one arm of genuine cross-key
                 // *routing* (path ⊊ commit) would over-fire on a sibling route's
                 // commit — so the feed records its own `path`, and the decision
-                // assembler emits a per-tap `__fire` field (this path) the engine
-                // checks, unless the path *is* the commit (then it always fires).
+                // assembler makes that path the tap's `` `fired `` condition,
+                // unless the path *is* the commit (then it wraps unconditionally).
                 TypedExprNode::Feed { name, value } => {
                     let val = Subst::discharge_env_in_place(value.as_ref().clone(), env);
                     let field = format!("to_{}_{}", name.base(), *feed_counter);

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -1152,6 +1152,26 @@ fn strip(
         let TypedExprNode::Begin { body: block } = effect.node else {
             unreachable!("guarded above")
         };
+        // ``match m: case `tag(w): <writes>`` in the block reaches here as a
+        // statement-position tag-`Case`. Convert the whole block once rather than
+        // at each consumer: `collect_footprint` separates a guard's spine reads
+        // from an arm's conditional ones, and `walk_block` scopes each arm's
+        // writes to its path — neither reads a `Pattern`, and after the rewrite an
+        // arm's scrutinee test sits in the guard where the footprint scan wants it
+        // ([`statement_tag_cases_to_guards`](crate::ccl::ccl_utils::statement_tag_cases_to_guards)).
+        let block = {
+            // The rewrite duplicates the scrutinee once per arm, so it needs a
+            // recording of its own: it runs before either block path opens one,
+            // and it applies to both (a writing block and a read-only one may each
+            // dispatch on a tag).
+            let g = provenance::enter(
+                stmt_id,
+                "transact.tag_guards",
+                provenance::Nature::Expansion,
+            );
+            g.blame(&[begin_id]);
+            Box::new(crate::ccl::ccl_utils::statement_tag_cases_to_guards(*block))
+        };
         if block_writes_txn(&block, txn_mut_vars) {
             // A writing block → a commit-record site keyed on the *enclosing*
             // loop. Partition it by mutable variable domain: the transactional remainder is
@@ -1505,10 +1525,10 @@ pub fn check_no_guarded_induction_write_in_block(
         && let Some(name) = guarded_non_txn_write(body, txn_mut_vars, false)
     {
         return Err(format!(
-            "`{name}` is written under an `if` inside a `with begin():` block. A guarded \
-             induction write in a transaction block is not supported — move the write outside \
-             the block, or (if it should be shared across the transaction) declare it \
-             `Mut(…, Txn)` and write it directly, not under a branch"
+            "`{name}` is written under an `if` or a `match` arm inside a `with begin():` \
+             block. A branch-guarded induction write in a transaction block is not supported \
+             — move the write outside the block, or (if it should be shared across the \
+             transaction) declare it `Mut(…, Txn)` and write it directly, not under a branch"
         ));
     }
     let mut result = Ok(());
@@ -1826,9 +1846,9 @@ fn contains_await_final(e: &Expr) -> bool {
 }
 
 /// The first non-txn `MutWrite` target that appears **inside a statement-`Case`**
-/// (an `if` arm) within `block` — a guarded induction write. `in_case` marks
-/// whether the walk is currently under such an arm; a guard is spine-evaluated,
-/// so only arm *bodies* set it.
+/// (an `if` or `match` arm) within `block` — a guarded induction write. `in_case`
+/// marks whether the walk is currently under such an arm; a guard is
+/// spine-evaluated, so only arm *bodies* set it.
 fn guarded_non_txn_write(
     block: &Expr,
     txn_mut_vars: &HashSet<Name>,
@@ -1838,10 +1858,10 @@ fn guarded_non_txn_write(
         TypedExprNode::MutWrite { name, .. } if in_case && !txn_mut_vars.contains(name) => {
             return Some(name.clone());
         }
-        TypedExprNode::Case {
-            scrutinee: None,
-            branches,
-        } => {
+        // Both `Case` forms: an `if` arm and a `match` arm are equally
+        // conditional, and this walk runs before the tag-to-guard rewrite, so it
+        // has to recognize the tag form as it stands.
+        TypedExprNode::Case { branches, .. } => {
             for b in branches {
                 if let Some(n) = guarded_non_txn_write(&b.body, txn_mut_vars, true) {
                     return Some(n);

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -2698,7 +2698,12 @@ fn record_field_ty(ty: &Type, field: &str) -> Type {
 struct HoistedFeed {
     defer: Name,
     tap: Name,
+    /// The raw tap stream's type — `` 𝐼 ⇒ {`fired{𝑉} | `idle} ``, as the decision
+    /// carries it.
     tap_ty: Type,
+    /// The fed value type `𝑉`, which the channel carries after `` `fired `` is
+    /// eliminated.
+    value_ty: Type,
 }
 
 /// Assemble the transaction `letrec` from the built writers/keys/feeds and
@@ -2870,12 +2875,18 @@ fn plan_store(
             // The tap is the commit log read through the field, so it is a collection at
             // the log's kind — and `recognize_txn_group` takes the history record's tap
             // field type straight off this binding.
-            let tap_ty = Type::fun_like(&commits_ty, dom.clone(), f.value_ty.clone());
+            let tap_value_ty = crate::ccl::ccl_utils::tap_variant_ty(f.value_ty.clone());
+            let tap_ty = Type::fun_like(&commits_ty, dom.clone(), tap_value_ty.clone());
             let mut dec_proj = Expr::proj_field(F_DECISION);
             dec_proj.ty = Type::fun(rec_ty.clone(), decision_ty.clone());
             let vp = crate::ccl::ccl_utils::commit_project(&decision_ty);
+            // The decision carries the tap as `` {`fired{𝑉} | `idle} ``, and the
+            // binding is that stream verbatim — recognition reads the history
+            // record's tap field type off it, and the store holds what the
+            // decision put there. The `` `fired `` elimination happens at the feed
+            // hoist below, where the channel wants the fed value.
             let mut field_proj = Expr::proj_field(f.field.clone());
-            field_proj.ty = Type::fun(payload_ty.clone(), f.value_ty.clone());
+            field_proj.ty = Type::fun(payload_ty.clone(), tap_value_ty.clone());
             let mut tap_expr = Expr::compose(vec![
                 tvar(&commits[j], commits_ty.clone()),
                 dec_proj,
@@ -2888,6 +2899,7 @@ fn plan_store(
                 defer: f.defer,
                 tap: tap_name,
                 tap_ty,
+                value_ty: f.value_ty.clone(),
             });
         }
     }
@@ -3103,7 +3115,20 @@ impl StorePlan {
     fn feed_views(&self) -> Vec<(Name, Expr)> {
         self.hoisted
             .iter()
-            .map(|f| (f.defer.clone(), tvar(&f.tap, f.tap_ty.clone())))
+            .map(|f| {
+                // The channel carries the fed value at the positions the tap
+                // fired, so the hoist eliminates `` `fired `` off the raw tap.
+                let mut view = Expr::compose(vec![
+                    tvar(&f.tap, f.tap_ty.clone()),
+                    crate::ccl::ccl_utils::fired_project(f.value_ty.clone()),
+                ]);
+                view.ty = Type::fun_like(
+                    &f.tap_ty,
+                    f.tap_ty.domain().unwrap_or(Type::Hole),
+                    f.value_ty.clone(),
+                );
+                (f.defer.clone(), view)
+            })
             .collect()
     }
 }

--- a/src/interpreter/commit_operator.rs
+++ b/src/interpreter/commit_operator.rs
@@ -1454,13 +1454,13 @@ impl TileProducer for InductionStoreProducer {
                         .collect(),
                 )
             } else {
-                // Carry: no change is appended, so a tap (fired or not) contributes
-                // nothing at this position — an *ungated* tap (one whose fire path
-                // is the commit itself, so it carries no `__fire` gate) reads
-                // `tap_fired = true` by default, but a carry position records it
-                // nowhere, which is correct: the letrec phase folds every feed-fire
-                // path into `commit`, so a position that genuinely fires a tap
-                // commits (and takes the branch above) rather than carrying here.
+                // Carry: no change is appended, so a tap contributes nothing at this
+                // position, whatever its tag. A tap whose fire path is the commit
+                // itself is `` `fired `` at every position the decision exists at,
+                // and a carry position records it nowhere — which is correct: the
+                // letrec phase folds every feed-fire path into `commit`, so a
+                // position that genuinely fires a tap commits (and takes the branch
+                // above) rather than carrying here.
                 None // the accumulator holds from tick 0 / the latest change
             };
             self.engine.step(pos + 1, write_set);

--- a/src/interpreter/commit_operator.rs
+++ b/src/interpreter/commit_operator.rs
@@ -3384,6 +3384,12 @@ fn is_commit_tag(tag: &crate::ccl::FieldKey) -> bool {
     matches!(tag, crate::ccl::FieldKey::Name(n) if n == crate::ccl::V_COMMIT)
 }
 
+/// The `` `fired `` tag of a tap variant `` {`fired{𝑉} | `idle} ``. Matched by name
+/// for the reason [`is_commit_tag`] is.
+fn is_fired_tag(tag: &crate::ccl::FieldKey) -> bool {
+    matches!(tag, crate::ccl::FieldKey::Name(n) if n == crate::ccl::V_FIRED)
+}
+
 /// The newest position present in a body-input tile — the attempt a writer is
 /// currently deciding, superseding any older live one (see the caller). `None`
 /// when the driver has emitted nothing live.
@@ -3424,12 +3430,12 @@ fn next_decided_position(tile: &Tile, pos: usize) -> Option<usize> {
 /// `Scalar(Union)` column, one `Value::Union { tag, inner }` per position.
 /// `abort` (any tag but `commit` — see [`is_commit_tag`]) is a whole-transaction deny — no writes, no
 /// taps (carry / no proposal). `commit` carries the dense payload record `𝑃 =
-/// {writes: (new₀, …), to_<defer>*(, to_<defer>__fire)*}`.
+/// {writes: (new₀, …), to_<defer>*}`, each tap holding `` {`fired{𝑉} | `idle} ``.
 ///
 /// Returns `(commit, writes, tap_fired)`: `commit` gates grant vs deny; `writes[j]`
 /// is the new value for `write_keys[j]` (carry writes then tap values, in that
 /// order); and `tap_fired[t]` says whether tap `tap_fields[t]` fires at this
-/// position (its `__fire` gate inside the payload, or `true` for an ungated tap).
+/// position (its `` `fired ``/`` `idle `` tag).
 /// A committing decision applies a carry write and a *fired* tap, but not a
 /// non-fired tap.
 fn body_decision_at(
@@ -3478,19 +3484,25 @@ fn body_decision_at(
         Value::Unit => {}
         _ => return None,
     }
-    // Per tap, its value and whether it *fires* at this position. A tap with a
-    // companion `<tap>__fire` field in the payload (a feed under cross-key routing)
-    // fires only where that gate holds; a tap without one (a single-guard/spine
-    // feed) always fires with its committing transaction.
+    // Per tap, its value and whether it *fires* at this position. A tap holds
+    // `` {`fired{𝑉} | `idle} ``, so the tag answers both at once: `` `fired ``
+    // carries the fed value, and `` `idle `` is a position the tap's own route did
+    // not admit — a sibling route's commit, which must not over-fire this reply.
+    // An `` `idle `` position still occupies its slot in `writes`, because the
+    // caller indexes that vector by `write_keys` and drops the non-fired entries
+    // by `tap_fired`; `Unit` is the value nothing reads.
     let mut tap_fired = Vec::with_capacity(tap_fields.len());
     for tap in tap_fields {
-        writes.push(payload.get(tap)?.clone());
-        let fire_field = format!("{tap}{}", crate::ccl::F_FIRE_SUFFIX);
-        let fired = match payload.get(&fire_field) {
-            Some(Value::Bool(b)) => *b,
-            _ => true,
+        let value = payload.get(tap)?.clone();
+        let Value::Union { tag, .. } = &value else {
+            return None;
         };
-        tap_fired.push(fired);
+        // The tag is the gate. The *value* goes to the store as it stands, tag and
+        // all: the IR reads a tap through ``variant_project(`fired)``, so the
+        // stream's restriction to fired positions happens there, on a value whose
+        // type says what it is.
+        tap_fired.push(is_fired_tag(tag));
+        writes.push(value);
     }
     Some((true, writes, tap_fired))
 }

--- a/src/interpreter/design-operators.md
+++ b/src/interpreter/design-operators.md
@@ -234,7 +234,7 @@ A single-writer induction store is the degenerate no-conflict case of this same 
 
 ### The decision record
 
-A writer body returns one **decision variant** per transaction, `` {`commit{𝑃} | `abort} `` (`ccl_utils::wrap_decision_variant`). `` `commit `` carries the payload record 𝑃 = `{writes, to_<defer>*}` — the positional tuple of proposed per-key new values, plus one field per reply tap — and `` `abort `` is the nullary whole-transaction deny: carry, no proposal. Making the grant/deny the *tag* rather than a `commit` field leaves "denied yet real writes" unrepresentable. `body_decision_at` decodes the tag by name, so the two ends agree without a canonical arm position. A tap fed under one arm of cross-key *routing* carries a companion `to_<defer>_k__fire : Bool` gate holding that tap's own control-flow path (see [mutability.md](../ccl/design/mutability.md#general-in-transaction-conditionals-and-conditional-writes), "General in-transaction conditionals (and conditional writes)"). The grant path omits a non-fired tap from the commit delta, so a routed reply fires only on its own route. A tap whose path *is* the commit — a single-guard or spine feed — carries no gate and fires with its transaction, keeping unconditional programs at their gate-free shape.
+A writer body returns one **decision variant** per transaction, `` {`commit{𝑃} | `abort} `` (`ccl_utils::wrap_decision_variant`). `` `commit `` carries the payload record 𝑃 = `{writes, to_<defer>*}` — the positional tuple of proposed per-key new values, plus one field per reply tap — and `` `abort `` is the nullary whole-transaction deny: carry, no proposal. Making the grant/deny the *tag* rather than a `commit` field leaves "denied yet real writes" unrepresentable. `body_decision_at` decodes the tag by name, so the two ends agree without a canonical arm position. A tap's value is `` {`fired{𝑉} | `idle} `` — the fed value on the positions its own control-flow path admits, `` `idle `` on the rest (see [mutability.md](../ccl/design/mutability.md#general-in-transaction-conditionals-and-conditional-writes), "General in-transaction conditionals (and conditional writes)"). The grant path omits an `` `idle `` tap from the commit delta, so a routed reply fires only on its own route. A tap whose path *is* the commit — a single-guard or spine feed — wraps unconditionally. Carrying the gate as the value's tag is what lets a fed value be domain-restricted: a value beside a separate `Bool` gate would have to answer wherever the record commits.
 
 ### Convergence: the writer re-arms, one step per pull
 
@@ -549,14 +549,14 @@ the latest *change* tick.
 **Reply feeds ride the changelog as taps.** A feed inside the loop (`out << e`) rides the
 writer decision as a `to_<defer>` field, exactly as a commit writer's reply tap does. Op-
 conversion appends each tap as a write-only changelog key (after the accumulator keys), the
-producer applies the decision's `tap_fired` gate (a fired tap joins the position's delta, a
-non-fired one is omitted — the `__fire`-gate mechanism shared with the commit store), and a
+producer applies the decision's `tap_fired` gate (a `` `fired `` tap joins the position's delta, an
+`` `idle `` one is omitted — the tag mechanism shared with the commit store), and a
 `to_<defer>` read is a **non-carry** `StoreDenseRead` (`carry_forward: false`): for each loop
 position it reads the tap **only if that position's delta actually wrote it**
 (`store_delta_at`), so the feed's per-position stream spans exactly the fired positions. A
-**conditional feed** (`if p: out << e`) is the same shape — the letrec phase gives it a
-`to_<defer>__fire` gate (its guard path) and folds that path into the `commit` gate so a
-feed-only position still appends a change carrying the tap. Because the driver is
+**conditional feed** (`if p: out << e`) is the same shape — the letrec phase makes its guard path the
+tap's `` `fired `` condition and folds that path into the `commit` gate so a feed-only position still
+appends a change carrying the tap. Because the driver is
 position-sorted, the tap stream is position-ordered even over an async source — which is the
 property that matters, since an async domain arrives in arbitrary order and a tap read off
 arrival order would scramble the feed.

--- a/src/interpreter/operator_conversion.rs
+++ b/src/interpreter/operator_conversion.rs
@@ -30,7 +30,7 @@ use crate::{
             Filter, FlattenTupleDomain, IterateExtent, MapAggregate, MapDomain,
             MapExtractAggregate, MapFilter, MapResult, MapResultToConst, MapResultToConstMode,
             MapResultWithSource, Memo, PermuteRecordDomain, Restrict, TileOperator, Tiling,
-            Uncurry, UnionOperator, VariantProject, VariantWrap, fan_in, fan_in_named,
+            Uncurry, UnionOperator, VariantIs, VariantProject, VariantWrap, fan_in, fan_in_named,
         },
         tuple_field,
     },
@@ -1334,6 +1334,25 @@ fn convert_impl_inner(
                         tag.clone(),
                         payload_extent,
                     )))
+                }
+                // `variant_is(c)` — the total tag test. Same scrutinee shapes as
+                // `variant_project(c)`, but every key of the domain is answered,
+                // which is what a writer decision's guard position takes.
+                Builtin::VariantIs(tag) => {
+                    let ok = match input.tiling() {
+                        Tiling::Scalar(Extent::Union(_)) => true,
+                        Tiling::SealedFunction { codomain, .. } => {
+                            matches!(codomain.as_ref(), Tiling::Scalar(Extent::Union(_)))
+                        }
+                        _ => false,
+                    };
+                    if !ok {
+                        return Err(ConversionError::TypeError(format!(
+                            "variant_is({tag}) expects a (Sealed)Union scrutinee, got {}",
+                            input.tiling()
+                        )));
+                    }
+                    Ok(Box::new(VariantIs::new(input, tag.clone())))
                 }
                 // `variant_wrap(c)` — the point-free constructor. Consumes the fed
                 // payload stream and injects it at tag `c`. The union extents come

--- a/src/interpreter/operator_conversion.rs
+++ b/src/interpreter/operator_conversion.rs
@@ -2087,9 +2087,9 @@ fn build_induction_store_single(
     // becomes a write-only changelog key (appended after the accumulator keys), so
     // its per-position value rides the committing change and is read back densely.
     // A tap is a per-position event, not a carried mutable variable (`carry_forward:
-    // false`): it appears only at the position that fired it. Under a conditional
-    // feed the decision also carries a `to_<defer>__fire` gate, which the producer
-    // reads to omit a non-fired tap from the delta.
+    // false`): it appears only at the position that fired it. A tap holds
+    // `` {`fired{𝑉} | `idle} ``, and the producer omits an `` `idle `` one from the
+    // delta.
     let mut write_keys: Vec<Value> = w.write_keys.iter().map(runtime_key).collect();
     let mut tap_fields: Vec<String> = Vec::new();
     for (field, tap_ty) in taps {

--- a/src/interpreter/operator_conversion.rs
+++ b/src/interpreter/operator_conversion.rs
@@ -1668,6 +1668,13 @@ fn build_transact_store(
 /// channelize folded onto the writer body; for a commit store, op-conversion commits
 /// each tap as a write-only key so the reply rides the transaction's commit and is
 /// read back as a value-stream. Empty for a writer with no reply.
+///
+/// The type is the tap's `` {`fired{𝑉} | `idle} ``
+/// ([`tap_variant_ty`](crate::ccl::ccl_utils::tap_variant_ty)) as the decision
+/// carries it. A store holds the tag alongside the value, and the IR's
+/// ``variant_project(`fired)`` on the read eliminates it — so the *stream's*
+/// restriction to fired positions is a typed step rather than a decode the type
+/// cannot see.
 fn body_tap_fields(body_ty: &Type) -> Vec<(String, Type)> {
     let Some(codom) = body_ty.codomain() else {
         return Vec::new();
@@ -1684,9 +1691,8 @@ fn body_tap_fields(body_ty: &Type) -> Vec<(String, Type)> {
     };
     fields
         .into_iter()
-        // `writes` is the decision core; a `*__fire` field is a tap's *fire gate*
-        // (read by `body_decision_at`), not a tap value itself.
-        .filter(|(f, _)| f != F_WRITES && !f.ends_with(crate::ccl::F_FIRE_SUFFIX))
+        // `writes` is the decision core; every other field is a tap.
+        .filter(|(f, _)| f != F_WRITES)
         .collect()
 }
 

--- a/src/interpreter/tile_operators/scalar.rs
+++ b/src/interpreter/tile_operators/scalar.rs
@@ -368,6 +368,11 @@ impl TileProducer for VariantWrapProducer {
 /// step. There is no separate boolean `Restrict` and no tag-discriminating
 /// `Predicate`.
 ///
+/// The projection **narrows** the domain but preserves keys — output key `d` is
+/// scrutinee key `d` — so a domain release, which names keys rather than a
+/// count, forwards to the scrutinee verbatim. That is what lets it sit inside an
+/// induction writer body, whose driver reclaims the prefix it has consumed.
+///
 /// A domain-level `Restrict` could not express this anyway: the tag lives in the
 /// scrutinee's *codomain* (the union value), not its domain, and `Restrict`
 /// consumes a boolean-producing operator over the domain.
@@ -581,6 +586,164 @@ impl TileProducer for VariantProjectProducer {
         if obsolete_guard.expect_universal_or_empty(&self.name()) {
             self.input.release(self.input.tiling().universal_guard());
         }
+    }
+}
+
+/// ``variant_is(c) : Union({cᵢ: Pᵢ}) ⇒ Bool`` — whether each position of a union
+/// stream carries the arm named `c`.
+///
+/// The **total** counterpart of [`VariantProject`]: same scrutinee, same domain
+/// out as in, `true` on the rows the arm holds and `false` on the rest. Reading
+/// an arm is the tag restriction, so dispatching a `match` needs no test at all
+/// where an arm may narrow its domain — a fan-out of projections re-totalled by
+/// a flat [`UnionOperator`]. This exists for the position that takes a boolean
+/// instead.
+///
+/// An induction writer decision selects on a predicate over its whole driver
+/// domain: the commit selector is a disjunction of the arms' guards, and each
+/// guard is complemented against the ones before it into a first-match
+/// predicate. A projection restricts that domain rather than answering over it,
+/// so it cannot stand there. A total test answers every position, which is what
+/// lets a `match` in a for-loop body ride the same first-match `Case` an `if`
+/// chain does.
+///
+/// **An absent arm is not an error** — it answers `false` everywhere, matching
+/// [`VariantProject`]'s empty projection on a width-subtype scrutinee.
+pub struct VariantIs {
+    /// The scrutinee operator, producing a `Scalar(Union)` tile or a
+    /// `SealedFunction { D ⇒ Scalar(Union) }` tile.
+    input: Box<dyn TileOperator>,
+    /// The tag to test for.
+    tag: FieldKey,
+    /// Output tiling — `SealedFunction { <scrutinee domain> ⇒ Bool }`.
+    tiling: Tiling,
+}
+
+impl VariantIs {
+    /// Construct a `VariantIs` testing arm `tag` of the scrutinee's union. The
+    /// domain is the scrutinee's own, as [`VariantProject::new`] derives it; the
+    /// codomain is `Bool` rather than the arm's payload, and unlike a projection
+    /// every key of the domain is answered.
+    pub fn new(input: Box<dyn TileOperator>, tag: FieldKey) -> Self {
+        let domain_extent = match input.tiling() {
+            Tiling::Scalar(Extent::Union(_)) => Extent::Base(BaseType::UInt),
+            Tiling::SealedFunction { domain, codomain } => match codomain.as_ref() {
+                Tiling::Scalar(Extent::Union(_)) => domain.clone(),
+                other => panic!(
+                    "VariantIs: SealedFunction scrutinee must have a Scalar(Union) codomain, \
+                     got {other:?}"
+                ),
+            },
+            other => panic!("VariantIs: scrutinee must be a (Sealed)Union, got {other:?}"),
+        };
+        let tiling = Tiling::SealedFunction {
+            domain: domain_extent,
+            codomain: Box::new(Tiling::Scalar(Extent::Base(BaseType::Bool))),
+        };
+        Self { input, tag, tiling }
+    }
+}
+
+impl TileOperator for VariantIs {
+    fn tiling(&self) -> &Tiling {
+        &self.tiling
+    }
+
+    fn add_inspect_children(&self, node: InspectNode, opts: &VizOptions) -> InspectNode {
+        node.child("scrutinee", self.input.inspect(opts))
+            .annotate(format!("is arm {}", self.tag))
+    }
+
+    fn subscribe(
+        &mut self,
+        intent_guard: TileGuard,
+        consumer: Box<dyn Consumer>,
+        scheduler: &mut Scheduler,
+    ) -> Box<dyn TileProducer> {
+        let input = self.input.subscribe(intent_guard, consumer, scheduler);
+        Box::new(VariantIsProducer {
+            base: ProducerBase::new(VariantIsProducer::alloc_id(), &self.tiling),
+            input,
+            tag: self.tag.clone(),
+        })
+    }
+
+    fn result_correlation(&self) -> Option<Vec<TilePathStep>> {
+        // The codomain is a tag test, unrelated to the domain key, so there is no
+        // domain↔codomain correlation to advertise — as for `VariantProject`.
+        None
+    }
+}
+
+struct VariantIsProducer {
+    base: ProducerBase,
+    /// The subscribed scrutinee producer.
+    input: Box<dyn TileProducer>,
+    tag: FieldKey,
+}
+
+impl TileProducer for VariantIsProducer {
+    impl_producer_base!();
+
+    fn add_inspect_children(&self, node: InspectNode, opts: &VizOptions) -> InspectNode {
+        node.child("scrutinee", self.input.inspect(opts))
+    }
+
+    fn get_impl(&mut self, projection_guard: TileGuard) -> Tile {
+        let tile = self.input.get(projection_guard);
+        let (domain_col, domain_predicate, deleted, cv) = match tile {
+            Tile::Scalar(cv) => (None, Predicate::True, BitSet::new(), cv),
+            Tile::SealedFunction {
+                domain,
+                codomain,
+                domain_predicate,
+                deleted,
+            } => (
+                Some(domain),
+                domain_predicate,
+                deleted,
+                scalar_tile_to_column_value(*codomain),
+            ),
+            other => panic!("VariantIs expects a (Sealed)Union input, got {other:?}"),
+        };
+        let ColumnValue::Union(arms) = cv else {
+            panic!("VariantIs expects a Union codomain, got {cv:?}");
+        };
+        // The arm records which rows carry the tag, so the test is a membership
+        // check per surviving position rather than a walk over the payloads.
+        let carried: BitSet = arms
+            .get(&self.tag)
+            .map(|arm| arm.row_slots().map(|(pos, _)| pos).collect())
+            .unwrap_or_default();
+        let positions: Vec<usize> = match &domain_col {
+            Some(d) => (0..d.len()).filter(|p| !deleted.contains(*p)).collect(),
+            None => (0..arms
+                .values()
+                .flat_map(|a| a.rows())
+                .max()
+                .map_or(0, |m| m + 1))
+                .filter(|p| !deleted.contains(*p))
+                .collect(),
+        };
+        let answers: bit_vec::BitVec = positions.iter().map(|p| carried.contains(*p)).collect();
+        let out_domain = match domain_col {
+            Some(d) => d.select_indices(positions.iter().copied(), positions.len()),
+            None => ColumnValue::from_uints(positions),
+        };
+        Tile::SealedFunction {
+            domain: out_domain,
+            codomain: Box::new(Tile::Scalar(ColumnValue::Bools(answers))),
+            domain_predicate,
+            deleted: BitSet::new(),
+        }
+    }
+
+    fn release_impl(&mut self, obsolete_guard: TileGuard) {
+        // Every key in is a key out, so a released region of the output names
+        // exactly the region of the scrutinee that produced it. `VariantProject`
+        // forwards a release on the same key-preserving argument, over the
+        // narrower domain it emits.
+        self.input.release(obsolete_guard);
     }
 }
 
@@ -903,20 +1066,58 @@ mod tests {
         );
     }
 
-    /// A partial domain release is **rejected, not ignored**. `VariantProject`
-    /// reads its scrutinee in full on every pull, so it cannot stop requesting
-    /// the released rows; dropping the guard silently would leave it re-emitting
-    /// them, against the promise the producer has already recorded.
+    /// A partial domain release forwards to the scrutinee. The projection is
+    /// **key-preserving** — output key `d` is scrutinee key `d`, and no output
+    /// key past `d` reads a scrutinee key at or below it — so "never asked for
+    /// keys ≤ w again" says the same thing on both sides. It narrows the domain
+    /// rather than preserving it, unlike
+    /// [`variant_wrap_forwards_a_partial_domain_release_to_its_payload`], and
+    /// that is what a *count*-based guard would turn on; a domain guard is over
+    /// keys, so it forwards verbatim.
+    ///
+    /// This is what lets a projection sit inside an induction writer body, whose
+    /// driver reclaims the prefix it has consumed.
     #[test]
-    #[should_panic(expected = "cannot honor the partial release guard")]
-    fn variant_project_rejects_a_partial_domain_release() {
-        let scrut = Box::new(commit_abort_scrutinee());
-        let mut op = VariantProject::new(scrut, FieldKey::Index(0), Extent::Base(BaseType::Int));
-        let mut sched = Scheduler::new();
-        let mut producer = op.subscribe(op.tiling().universal_guard(), Box::new(|| {}), &mut sched);
-        producer.release(TileGuard::Function(FunctionGuard::Domain(
-            Predicate::LessThanEq(Value::UInt(0)),
-        )));
+    fn variant_project_forwards_a_partial_domain_release_to_its_scrutinee() {
+        let scrut_tiling = Tiling::SealedFunction {
+            domain: Extent::uint_range(2),
+            codomain: Box::new(Tiling::Scalar(Extent::Union(TagMap::from_arms(vec![(
+                FieldKey::Index(0),
+                Extent::Base(BaseType::Int),
+            )])))),
+        };
+        let (spy, released) = ReleaseSpy::new(
+            Tile::SealedFunction {
+                domain: ColumnValue::from_uints(vec![0, 1]),
+                codomain: Box::new(Tile::Scalar(ColumnValue::Union(TagMap::from_arms(vec![(
+                    FieldKey::Index(0),
+                    UnionArm::new(vec![0, 1], ColumnValue::Ints(vec![10, 20])),
+                )])))),
+                domain_predicate: Predicate::False,
+                deleted: BitSet::new(),
+            },
+            scrut_tiling.clone(),
+        );
+        let out_tiling = Tiling::SealedFunction {
+            domain: Extent::uint_range(2),
+            codomain: Box::new(Tiling::Scalar(Extent::Base(BaseType::Int))),
+        };
+        let mut producer = VariantProjectProducer {
+            base: ProducerBase::new(VariantProjectProducer::alloc_id(), &out_tiling),
+            input: Box::new(spy),
+            tag: FieldKey::Index(0),
+            payload_extent: Extent::Base(BaseType::Int),
+        };
+
+        let prefix =
+            TileGuard::Function(FunctionGuard::Domain(Predicate::LessThanEq(Value::UInt(0))));
+        producer.release(prefix.clone());
+
+        assert_eq!(
+            released.borrow().as_slice(),
+            &[prefix],
+            "a domain release must reach the scrutinee unchanged"
+        );
     }
 
     /// `VariantWrap` is domain-preserving, so output position `d` is payload

--- a/src/interpreter/tile_operators/scalar.rs
+++ b/src/interpreter/tile_operators/scalar.rs
@@ -368,11 +368,6 @@ impl TileProducer for VariantWrapProducer {
 /// step. There is no separate boolean `Restrict` and no tag-discriminating
 /// `Predicate`.
 ///
-/// The projection **narrows** the domain but preserves keys — output key `d` is
-/// scrutinee key `d` — so a domain release, which names keys rather than a
-/// count, forwards to the scrutinee verbatim. That is what lets it sit inside an
-/// induction writer body, whose driver reclaims the prefix it has consumed.
-///
 /// A domain-level `Restrict` could not express this anyway: the tag lives in the
 /// scrutinee's *codomain* (the union value), not its domain, and `Restrict`
 /// consumes a boolean-producing operator over the domain.
@@ -593,19 +588,9 @@ impl TileProducer for VariantProjectProducer {
 /// stream carries the arm named `c`.
 ///
 /// The **total** counterpart of [`VariantProject`]: same scrutinee, same domain
-/// out as in, `true` on the rows the arm holds and `false` on the rest. Reading
-/// an arm is the tag restriction, so dispatching a `match` needs no test at all
-/// where an arm may narrow its domain — a fan-out of projections re-totalled by
-/// a flat [`UnionOperator`]. This exists for the position that takes a boolean
-/// instead.
-///
-/// An induction writer decision selects on a predicate over its whole driver
-/// domain: the commit selector is a disjunction of the arms' guards, and each
-/// guard is complemented against the ones before it into a first-match
-/// predicate. A projection restricts that domain rather than answering over it,
-/// so it cannot stand there. A total test answers every position, which is what
-/// lets a `match` in a for-loop body ride the same first-match `Case` an `if`
-/// chain does.
+/// out as in, `true` on the rows the arm holds and `false` on the rest. Why a
+/// total test rather than a projection is on
+/// [`Builtin::VariantIs`](crate::ccl::Builtin::VariantIs).
 ///
 /// **An absent arm is not an error** — it answers `false` everywhere, matching
 /// [`VariantProject`]'s empty projection on a width-subtype scrutinee.

--- a/tests/compilation_pipeline/transactions.rs
+++ b/tests/compilation_pipeline/transactions.rs
@@ -3285,3 +3285,71 @@ fn a_keyed_write_commits_a_computed_value_at_a_computed_key() {
         vec![(1, 10), (2, 20), (3, 2), (4, 3)]
     );
 }
+
+/// ``match m: case `tag(w): <writes>`` inside a `with begin():` block. The arms
+/// route their writes per path exactly as an `if` arm's do — lowering shares
+/// `match`'s tag rules through `lower_match_over`, and the phase converts the
+/// tag-`Case` to guards before the footprint scan and the decision walk see it.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn match_dispatch_inside_a_transaction_block() {
+    check_scalar(
+        indoc! {"
+            bal: Mut(Int, Txn) := 0
+            for m in [`dep(10), `wd(3)]:
+                with begin():
+                    match m:
+                        case `dep(n):
+                            bal := bal + n
+                        case `wd(k):
+                            bal := bal - k
+            await_final(bal)"},
+        Value::Int(7),
+    );
+}
+
+/// A reply tap fed from one `match` arm inside the block. The tap fires on that
+/// arm's commits only, which is what its `` `fired ``/`` `idle `` tag records.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn match_arm_reply_inside_a_transaction_block() {
+    check_scalar(
+        indoc! {"
+            resp = defer()
+            bal: Mut(Int, Txn) := 0
+            for m in [`dep(10), `wd(3)]:
+                with begin():
+                    match m:
+                        case `dep(n):
+                            bal := bal + n
+                            resp << n
+                        case `wd(k):
+                            bal := bal - k
+            sum(resp)"},
+        Value::Int(10),
+    );
+}
+
+/// A guarded *induction* write inside a block is rejected through a `match` arm as
+/// through an `if` arm. Without the arm the write escapes the pre-strip check and
+/// reaches `transact_phase`'s unrecorded-write-key panic, so the rejection is what
+/// keeps a real diagnostic in front of the author.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn guarded_induction_write_in_a_match_arm_is_rejected() {
+    check_compile_error(
+        indoc! {"
+            bal: Mut(Int, Txn) := 0
+            cnt := 0
+            for m in [`dep(10), `wd(3)]:
+                with begin():
+                    bal := bal + 1
+                    match m:
+                        case `dep(n):
+                            cnt += 1
+                        case `wd(k):
+                            bal := bal - k
+            await_final(bal)"},
+        "is written under an `if` or a `match` arm inside",
+    );
+}

--- a/tests/compilation_pipeline/variants.rs
+++ b/tests/compilation_pipeline/variants.rs
@@ -1441,3 +1441,105 @@ p"#;
 fn test_const_lifted_arm_is_point_free(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
+
+// A `match` in a for-loop body dispatches on `variant_is` guards, so its arms
+// are the boolean-guard `Case` an `if` chain builds and the writer decision
+// merges them the same way (`src/ccl/design/mutability.md`, "A `match` in a
+// for-loop body").
+//
+// Selecting an arm by *reading* it — the fan-out of `variant_project`s a `match`
+// compiles to everywhere else — cannot drive a writer body: the decision selects
+// on a predicate over its whole driver domain, and a projection restricts that
+// domain rather than answering over it.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case(indoc! {"
+    acc := 0
+    for m in [`a, `b, `a]:
+        match m:
+            case `a:
+                acc += 1
+            case `b:
+                acc += 10
+    acc"}, Value::Int(12))]
+// `case _:` is already the fallback the trailing `true` guard names.
+#[case(indoc! {"
+    acc := 0
+    for m in [`a, `b, `a]:
+        match m:
+            case `a:
+                acc += 1
+            case _:
+                acc += 10
+    acc"}, Value::Int(12))]
+// An arm that writes nothing is the carry position, as an `if` without an
+// `else` is.
+#[case(indoc! {"
+    acc := 0
+    for m in [`a, `b, `a]:
+        match m:
+            case `a:
+                acc += 1
+            case `b:
+                acc += 0
+    acc"}, Value::Int(2))]
+fn test_match_in_a_for_loop_body(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// An arm reading its payload projects it out of the scrutinee, inside a writer
+// body whose driver reclaims the prefix it has consumed. The projection narrows
+// the domain but preserves keys, so it forwards that release to the scrutinee
+// rather than refusing it.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case(indoc! {"
+    acc := 0
+    for m in [`a(2), `b(3), `a(5)]:
+        match m:
+            case `a(n):
+                acc += n
+            case `b(k):
+                acc += k
+    acc"}, Value::Int(10))]
+fn test_match_arm_reading_its_payload_in_a_loop(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+/// A `yield` or `<<` inside a `match` arm in a for-loop body is rejected: a
+/// conditional feed rides its path's predicate as a fire gate, and a `match`
+/// arm is selected by its tag rather than by a predicate.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn test_feed_inside_a_match_arm_in_a_loop_is_rejected() {
+    check_compile_error(
+        indoc! {"
+            acc := 0
+            for m in [`a(2), `b(3)]:
+                match m:
+                    case `a(n):
+                        yield n
+                    case `b(k):
+                        acc += k
+            acc"},
+        "inside a `match` arm in a for-loop body is not",
+    );
+}
+
+// The program `docs/chl-spec.md`, "4.10 `match` — tag dispatch" states: a
+// payload-binding arm and a payload-less one, both writing.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case(indoc! {"
+    msgs = [`ping(3), `close, `ping(4)]
+    acc := 0
+    for m in msgs:
+        match m:
+            case `ping(seq):
+                acc += seq
+            case `close:
+                acc += 1
+    acc"}, Value::Int(8))]
+fn test_the_spec_match_in_a_loop_example(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}

--- a/tests/compilation_pipeline/variants.rs
+++ b/tests/compilation_pipeline/variants.rs
@@ -1466,17 +1466,29 @@ fn test_const_lifted_arm_is_point_free(#[case] code: &str, #[case] expected: Val
             case _:
                 acc += 10
     acc"}, Value::Int(12))]
-// An arm that writes nothing is the carry position, as an `if` without an
-// `else` is.
+// An arm that does not write an accumulator is that accumulator's carry
+// position, as an `if` without an `else` is. Each arm here writes one of the
+// two, so each is a non-writing arm for the other.
 #[case(indoc! {"
     acc := 0
+    other := 0
     for m in [`a, `b, `a]:
         match m:
             case `a:
                 acc += 1
             case `b:
-                acc += 0
+                other += 100
     acc"}, Value::Int(2))]
+#[case(indoc! {"
+    acc := 0
+    other := 0
+    for m in [`a, `b, `a]:
+        match m:
+            case `a:
+                acc += 1
+            case `b:
+                other += 100
+    other"}, Value::Int(100))]
 fn test_match_in_a_for_loop_body(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
@@ -1520,8 +1532,8 @@ fn test_feed_inside_a_match_arm_in_a_loop_is_rejected() {
     );
 }
 
-// The program `docs/chl-spec.md`, "4.10 `match` — tag dispatch" states: a
-// payload-binding arm and a payload-less one, both writing.
+// A payload-binding arm and a payload-less one in the same `match`, both
+// writing — the mixed shape the two tests above take one side of each.
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 #[case(indoc! {"

--- a/tests/compilation_pipeline/variants.rs
+++ b/tests/compilation_pipeline/variants.rs
@@ -1444,13 +1444,7 @@ fn test_const_lifted_arm_is_point_free(#[case] code: &str, #[case] expected: Val
 
 // A `match` in a for-loop body dispatches on `variant_is` guards, so its arms
 // are the boolean-guard `Case` an `if` chain builds and the writer decision
-// merges them the same way (`src/ccl/design/mutability.md`, "A `match` in a
-// for-loop body").
-//
-// Selecting an arm by *reading* it — the fan-out of `variant_project`s a `match`
-// compiles to everywhere else — cannot drive a writer body: the decision selects
-// on a predicate over its whole driver domain, and a projection restricts that
-// domain rather than answering over it.
+// merges them the same way.
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 #[case(indoc! {"

--- a/tests/compilation_pipeline/variants.rs
+++ b/tests/compilation_pipeline/variants.rs
@@ -1512,24 +1512,133 @@ fn test_match_arm_reading_its_payload_in_a_loop(#[case] code: &str, #[case] expe
     check_scalar(code, expected);
 }
 
-/// A `yield` or `<<` inside a `match` arm in a for-loop body is rejected: a
-/// conditional feed rides its path's predicate as a fire gate, and a `match`
-/// arm is selected by its tag rather than by a predicate.
+// A `<<` feed inside a `match` arm in a for-loop body. With no accumulator the
+// loop's feeds fan out one refined-source channel per arm, so an arm's value may
+// read its payload — the arm's channel is the source restricted to that arm's
+// positions, and the projection answers over exactly those.
 #[rstest]
 #[timeout(Duration::from_secs(10))]
-fn test_feed_inside_a_match_arm_in_a_loop_is_rejected() {
-    check_compile_error(
+#[case(indoc! {"
+    o = defer()
+    for m in [`a(2), `b(3), `a(5)]:
+        match m:
+            case `a(n):
+                o << n
+            case `b(k):
+                o << k * 100
+    sum(o)"}, Value::Int(307))]
+// The `case _:` fallback feeds too, so the fan-out spans a tagged arm and the
+// default one.
+#[case(indoc! {"
+    o = defer()
+    for m in [`a(2), `b(3), `a(5)]:
+        match m:
+            case `a(n):
+                o << n
+            case _:
+                o << 100
+    sum(o)"}, Value::Int(107))]
+fn test_feed_inside_a_match_arm_fans_out_per_arm(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
+// A feed and an accumulator in the same `match`. The accumulator makes the loop a
+// single writer and the feed becomes a `to_<defer>` tap on its decision record,
+// gated by the arm's own `variant_is` test — so the tap fires on its arm's
+// positions only, while the record commits on every arm's.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case("sum(o)", Value::Int(2))]
+#[case("acc", Value::Int(3))]
+fn test_feed_and_accumulator_in_one_match(#[case] tail: &str, #[case] expected: Value) {
+    let loop_program = indoc! {"
+        o = defer()
+        acc := 0
+        for m in [`a(2), `b(3), `a(5)]:
+            match m:
+                case `a(n):
+                    o << 1
+                case `b(k):
+                    acc += k
+    "};
+    check_scalar(&format!("{loop_program}{tail}"), expected);
+}
+
+// Every arm feeding, beside an accumulator: one tap per feed site, each with its
+// own gate.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn test_every_arm_feeds_beside_an_accumulator() {
+    check_scalar(
         indoc! {"
+            o = defer()
             acc := 0
-            for m in [`a(2), `b(3)]:
+            for m in [`a(2), `b(3), `a(5)]:
                 match m:
                     case `a(n):
-                        yield n
+                        o << 1
+                    case `b(k):
+                        o << 100
+                        acc += k
+            sum(o)"},
+        Value::Int(102),
+    );
+}
+
+// A tap value may read the accumulator: the writer's snapshot of it answers at
+// every position, so reading it keeps the tap total.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn test_a_tap_value_reads_the_accumulator() {
+    check_scalar(
+        indoc! {"
+            o = defer()
+            acc := 0
+            for m in [`a(2), `b(3), `a(5)]:
+                match m:
+                    case `a(n):
+                        o << acc
                     case `b(k):
                         acc += k
-            acc"},
-        "inside a `match` arm in a for-loop body is not",
+            sum(o)"},
+        Value::Int(3),
     );
+}
+
+/// The one shape the writer's decision record cannot carry: a tap value reading
+/// the arm's **payload**. `variant_project` restricts the domain rather than
+/// answering over it, so the value answers on its arm's positions while the
+/// record commits on every arm's — see `src/ccl/lower/loops.rs`,
+/// `feed_reading_payload_error`. Rejected at lowering rather than stalling the
+/// writer at run time.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case(indoc! {"
+    o = defer()
+    acc := 0
+    for m in [`a(2), `b(3)]:
+        match m:
+            case `a(n):
+                o << n
+            case `b(k):
+                acc += k
+    sum(o)"})]
+// Binding the payload first puts the same projection in the tap, so the
+// rejection follows the value through the `let` rather than matching the
+// spelling.
+#[case(indoc! {"
+    o = defer()
+    acc := 0
+    for m in [`a(2), `b(3)]:
+        match m:
+            case `a(n):
+                v = n * 2
+                o << v
+            case `b(k):
+                acc += k
+    sum(o)"})]
+fn test_a_tap_value_reading_its_payload_is_rejected(#[case] code: &str) {
+    check_compile_error(code, "is built from the arm's payload");
 }
 
 // A payload-binding arm and a payload-less one in the same `match`, both

--- a/tests/compilation_pipeline/variants.rs
+++ b/tests/compilation_pipeline/variants.rs
@@ -1605,40 +1605,72 @@ fn test_a_tap_value_reads_the_accumulator() {
     );
 }
 
-/// The one shape the writer's decision record cannot carry: a tap value reading
-/// the arm's **payload**. `variant_project` restricts the domain rather than
-/// answering over it, so the value answers on its arm's positions while the
-/// record commits on every arm's — see `src/ccl/lower/loops.rs`,
-/// `feed_reading_payload_error`. Rejected at lowering rather than stalling the
-/// writer at run time.
+/// A tap value reading the arm's **payload** — the shape the decision record
+/// could not carry while a tap's value had to answer at every committing
+/// position. The tap holds `` {`fired{𝑉} | `idle} `` now, so the value is asked
+/// for only where the tap fires, which is exactly where an arm's
+/// `variant_project` answers.
 #[rstest]
 #[timeout(Duration::from_secs(10))]
-#[case(indoc! {"
-    o = defer()
-    acc := 0
-    for m in [`a(2), `b(3)]:
-        match m:
-            case `a(n):
-                o << n
-            case `b(k):
-                acc += k
-    sum(o)"})]
-// Binding the payload first puts the same projection in the tap, so the
-// rejection follows the value through the `let` rather than matching the
-// spelling.
-#[case(indoc! {"
-    o = defer()
-    acc := 0
-    for m in [`a(2), `b(3)]:
-        match m:
-            case `a(n):
-                v = n * 2
-                o << v
-            case `b(k):
-                acc += k
-    sum(o)"})]
-fn test_a_tap_value_reading_its_payload_is_rejected(#[case] code: &str) {
-    check_compile_error(code, "is built from the arm's payload");
+#[case("sum(o)", Value::Int(7))]
+#[case("acc", Value::Int(3))]
+fn test_a_tap_value_reads_its_payload(#[case] tail: &str, #[case] expected: Value) {
+    let loop_program = indoc! {"
+        o = defer()
+        acc := 0
+        for m in [`a(2), `b(3), `a(5)]:
+            match m:
+                case `a(n):
+                    o << n
+                case `b(k):
+                    acc += k
+    "};
+    check_scalar(&format!("{loop_program}{tail}"), expected);
+}
+
+/// A tap value reading the payload **and** the accumulator. The payload restricts
+/// the value's domain and the accumulator is the writer's per-position snapshot,
+/// so this shape needs both the tap (for read-your-writes) and the restriction —
+/// neither the fan-out nor a total-valued tap can carry it.
+///
+/// Position 0 reads the seed (`2 + 0`) and position 2 reads the write position 1
+/// made (`5 + 3`); position 1 feeds nothing.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+fn test_a_tap_value_reads_its_payload_and_the_accumulator() {
+    check_scalar(
+        indoc! {"
+            o = defer()
+            acc := 0
+            for m in [`a(2), `b(3), `a(5)]:
+                match m:
+                    case `a(n):
+                        o << n + acc
+                    case `b(k):
+                        acc += k
+            sum(o)"},
+        Value::Int(10),
+    );
+}
+
+/// Partitioning a tagged stream: one arm forwards its payload to a channel, the
+/// other counts. The shape a `match` in a loop is written for.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case("sum(out)", Value::Int(30))]
+#[case("errors", Value::Int(1))]
+fn test_a_match_in_a_loop_partitions_a_tagged_stream(#[case] tail: &str, #[case] expected: Value) {
+    let loop_program = indoc! {"
+        out = defer()
+        errors := 0
+        for msg in [`data(10), `error(404), `data(20)]:
+            match msg:
+                case `data(v):
+                    out << v
+                case `error(code):
+                    errors += 1
+    "};
+    check_scalar(&format!("{loop_program}{tail}"), expected);
 }
 
 // A payload-binding arm and a payload-less one in the same `match`, both


### PR DESCRIPTION
A `for`-loop body rejected `match` and a `with begin():` block admitted no tag dispatch, so per-element dispatch went through a `def` call — which computes a value per element but cannot write the loop's accumulators or feed from an arm. Both statement contexts now take a `match`: a statement-position tag-`Case` is rewritten into the boolean-guard `Case` its consumers already compile, and a reply tap is retyped `` {`fired{𝑉} | `idle} `` so a fed value may read the arm it sits in. An arm becomes a control-flow path like an `if` arm's, and `` out << v `` inside `` case `data(v): `` compiles beside an accumulator the other arms write.

## Tag dispatch as a boolean guard

`ccl_utils::tag_case_to_guard_case` turns each arm's `Pattern` into a ``variant_is(`tag)`` guard over the scrutinee and substitutes ``variant_project(`tag)`` for the payload binder rather than binding it; a `match` with no `case _:` gains the trailing `true → unit` carry. `Builtin::VariantIs` is the new total tag test — its doc comment carries why a decision's guard position cannot hold a restricting projection — with a tile operator beside `VariantProject`. `mut_elim` and `channelize` convert at their own consumption points; `transact_phase::strip` converts a whole block once, since a footprint scan and a decision walk both read it.

## A tap's tag replaces its gate

`F_FIRE_SUFFIX` and its companion `to_<defer>__fire : Bool` field are gone: a tap holds `` {`fired{𝑉} | `idle} `` (`V_FIRED`/`V_IDLE`), and a channel read composes ``variant_project(`fired)`` onto the field. A gate beside a same-position value obliged the value to answer wherever the record commits, which an arm's payload projection cannot. [mutability.md](src/ccl/design/mutability.md#general-in-transaction-conditionals-and-conditional-writes) and [design-operators.md](src/interpreter/design-operators.md#the-decision-record) hold the encoding, and `body_decision_at` reads the tag where it read the gate.

## One `match` production, three contexts

`lower_match_over` generalizes `lower_match` over how an arm's body lowers, so the tag rules and the arm's payload scope are shared by statement lowering, a loop body and a transaction block. The loop's yield, feed and mutation-variable walks recurse into arms, and the guarded-induction-write diagnostic names a `match` arm beside an `if`.

## Tests and spec

`tests/compilation_pipeline/variants.rs` runs from a bare two-arm `match` to a tap value reading its payload and the accumulator; `transactions.rs` adds in-block dispatch, an arm-fed reply and the rejection. `variant_project_forwards_a_partial_domain_release_to_its_scrutinee` replaces a `should_panic` case. The spec updates [`match`](docs/chl-spec.md#410-match--tag-dispatch) and [transactions](docs/chl-spec.md#82-transactions-with-begin).