### PR TITLE
ccl: delete the unused cross-phase TypeError

### DIFF
--- a/src/ccl/ops.rs
+++ b/src/ccl/ops.rs
@@ -1,6 +1,6 @@
 //! Scalar primitives shared across the CCL pipeline: base types, literal
 //! constants, the binary / unary operator kinds, the [`Builtin`] combinator
-//! enum, projection keys, and the cross-phase [`TypeError`].
+//! enum, and projection keys.
 
 use std::fmt;
 
@@ -54,12 +54,6 @@ impl BaseType {
             _ => return None,
         })
     }
-}
-
-/// Errors about types that can be used by any phase of compilation
-pub enum TypeError {
-    /// Generic type error
-    Unsupported(String),
 }
 
 /// A literal constant value.


### PR DESCRIPTION
`ccl::ops::TypeError` has no users: nothing constructs it, matches it, or names it in a signature anywhere in the workspace. It also derives nothing — not even `Debug` — so it could not be usefully returned or reported if something wanted to.

Found while auditing how each pipeline error type carries its source location (the lineage stack's `LocatedInferError` work). `ConversionError::TypeError` in `interpreter/operator_conversion.rs` is an unrelated *variant* of a live enum and is untouched.

Deletes the enum and drops it from the module's doc summary. No behavior change.