### PR TITLE
Serve the inspector frontend from the `cambra` binary and document fixture re-blessing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,8 @@ After making code changes, run the formatter before running the code; prefer run
 
 When planning, include updates to the appropriate docs to reflect the changes; validate the docs are up to date before creating a PR. This includes `docs/design.md` and other `*/design-*.md` files close to source files that were changed.
 
+The inspector crate has its own pinned-expectation suite (the golden wire fixtures) with a re-bless procedure; see `cambra-inspector/CLAUDE.md` before touching anything that moves it. Anything that changes `Display for Type`, or that shifts how many `NodeId`s a phase mints, moves the whole corpus.
+
 ### Compact instructions
 
 When you are using compact, focus on test output and code changes.

--- a/cambra-inspector/CLAUDE.md
+++ b/cambra-inspector/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this directory — the inspector's `web/` frontend and its golden-fixture corpus. The Rust half lives in the `cambra` crate at `src/inspector_model/` and `src/inspector_server/`.
+
+## The golden fixtures
+
+`web/src/__fixtures__/*.snapshot.json` are full `/api/snapshot` payloads for the
+corpus in `scripts/fixtures.manifest` — shared by the regen script, the
+`ci_fixtures` byte gate, and `tests/inspector_goldens.rs`. Re-bless via:
+
+```bash
+cambra-inspector/scripts/regen-fixtures.sh   # from the repo root
+```
+
+**Re-bless discipline:** classify every diff into a named, explained class
+before committing — id renumbering vs label rename vs structural change —
+and state the classes in the commit message. A diff you cannot explain is a
+bug, not a re-bless: stop and investigate. `NodeId` is a process-global mint
+counter, so anything shifting upstream mint *counts* renumbers every later id
+and rewrites the whole corpus; that diff is expected and still has to be named
+as that.
+
+**What a re-bless pins, beyond the shape.** Each node's `type` is `Display for
+Type`'s rendering — `src/ccl/ty.rs`'s `Serialize` hands `collect_str` that
+string — so the corpus pins the type notation on every node in every pane. A
+literal's singleton spelling is part of that. Changing any of the notation is a
+deliberate corpus-wide re-bless.
+
+## Frontend
+
+- **Never run `npm run dev`** — it starts a Vite server that does not exit.
+  `typecheck` / `test` / `build` (from `web/`) are all one-shot.
+  `cambra --inspect-only` also blocks forever; for scripted inspection use
+  `--dump-snapshot`.
+- `web/dist/index.html` is **committed and embedded** at compile time. After
+  changing anything under `web/src/`, rerun `npm run build` and commit the
+  regenerated bundle — the `ci_web` gate compares it against a fresh build.
+
+## Wire-shape changes
+
+The Rust validator (`src/inspector_server/wire_check.rs`) and the TypeScript
+validator (`web/src/wireValidate.ts`) assert the same contract and are always
+updated together. A schema change means: update both validators, regenerate fixtures
+(classified), rebuild the bundle.
+
+`SCHEMA_VERSION` stays at 1 through all of it. Nothing durable consumes the
+payload — this frontend is rebuilt from this repo — so a breaking change costs
+no version until a consumer exists that an old version could reach. What a bump
+means once one does: `src/inspector_model/design.md`, "The schema version".

--- a/cambra-inspector/README.md
+++ b/cambra-inspector/README.md
@@ -3,16 +3,12 @@
 A read-only web view of a compiled Cambra program: the source alongside one IR
 tree pane per retained compiler pane, cross-linked by true node→node
 provenance. It is served by the `cambra` binary itself — `cambra --inspect-only
-<program>` — and this directory holds the CodeMirror frontend that renders what
-that server sends.
+<program>` — and this directory holds the CodeMirror frontend it embeds and
+serves.
 
 > **Milestone 1 — static, no values.** The inspector shows the *program*, not an
 > execution: types and structure, no runtime values or ticks. It is strictly
 > read-only (no mutation endpoints).
-
-> **No `GET /` yet.** The server offers `/api/*` only; the route that delivers
-> the bundle, and the `include_str!` that embeds it in the binary, land
-> separately. Run the frontend from `web/` in the meantime.
 
 ## What it shows
 
@@ -49,15 +45,14 @@ inspected is the compiler:
 - The **read-only model** — the payload shape and the span/name indices it is
   built from — is `src/inspector_model/`. It answers no positional query: every
   lookup is the frontend's, over the shipped tables.
-- The **transport** is `src/inspector_server/`: it turns the model into JSON
-  (`snapshot_json`) and serves it over HTTP (`serve.rs`), and `wire_check.rs`
-  is the structural validator both those tests and `tests/inspector_goldens.rs`
-  assert the wire against. The route that delivers the frontend lands
-  separately.
+- The **transport and delivery vehicle** is `src/inspector_server/`: it turns
+  the model into JSON (`snapshot_json`), serves it over HTTP (`serve.rs`), and
+  embeds the built frontend bundle. `wire_check.rs` is the structural validator
+  both those tests and `tests/inspector_goldens.rs` assert the wire against.
 
 ```
-client ──HTTP──> cambra --inspect-only ──> inspector_server ──> inspector_model ──> compile_program
-     GET /api/snapshot                  tiny_http + serde_json    read-only model
+browser ──HTTP──> cambra --inspect-only ──> inspector_server ──> inspector_model ──> compile_program
+        GET / + /api/snapshot            tiny_http + serde_json    read-only model
 ```
 
 ## Directory contents
@@ -65,6 +60,7 @@ client ──HTTP──> cambra --inspect-only ──> inspector_server ──> 
 | Path | What it is |
 |---|---|
 | `web/` | The CodeMirror 6 / TypeScript frontend. **Has its own [README](web/README.md)** — build, tests, module layout, and the byte↔char bridge. |
+| `web/dist/index.html` | The built, self-contained single-file bundle, committed and `include_str!`-embedded by the server (so `cargo build` needs no Node). |
 | `web/src/__fixtures__/` | The golden snapshot corpus the frontend's tests read, blessed by `scripts/regen-fixtures.sh`. |
 | `scripts/fixtures.manifest` | Which gallery program each committed fixture is dumped from. |
 | `scripts/regen-fixtures.sh` | The re-bless path, and the `ci.sh` drift gate's regenerator. |
@@ -84,8 +80,8 @@ cargo run -- program.cambra --inspect-only=9000                              # c
 
 Then open <http://localhost:8080> — the server binds loopback only.
 
-Routes: `GET /api/snapshot` (the full model — degrades gracefully to source +
-diagnostics on a compile failure) and `GET /api/diagnostics`.
+Routes: `GET /` (the frontend), `GET /api/snapshot` (the full model — degrades
+gracefully to source + diagnostics on a compile failure), `GET /api/diagnostics`.
 
 `--inspect-only` compiles the program and does not run it. Its sibling
 `--inspect` runs the program and serves the live runtime dashboard
@@ -124,8 +120,8 @@ payload is too large to commit is asserted structurally in
 
 ## Editing the frontend
 
-`web/dist/index.html` is committed on purpose: it is the built, self-contained
-single-file bundle. **After changing anything under `web/src/`, rerun
+`web/dist/index.html` is committed on purpose and embedded at compile time, so
+the binary works without Node. **After changing anything under `web/src/`, rerun
 `npm run build` and commit the regenerated bundle** — `ci.sh web` compares it
 against a fresh build (see the "Committed bundle (R7)" section of
 [`web/README.md`](web/README.md)).

--- a/cambra-inspector/scripts/fixtures.manifest
+++ b/cambra-inspector/scripts/fixtures.manifest
@@ -24,12 +24,25 @@
 # A program added for backend coverage alone needs NO row here: ratchet 5 of
 # tests/inspector_goldens.rs already walks every gallery source through the
 # wire validator.
+#
+# What each row is for. A fixture earns its place by pinning a shape no other
+# row pins, so this is also the list to check before adding one.
+#
+# The identity stitch: a hole resolved by the same NodeId downstream, plus a
+# call site meeting a free variable. The smallest program that pins a whole
+# pane's node table byte-for-byte.
 arithmetic udf_closure
-# Monomorph clones + the Derived(Inline) copies they carry, and the non-identity
-# edges both paneLinks windows get from them.
+# Monomorph clones + the Derived(Inline) copies they carry, so the type-set
+# stitch (_ -> (Int, Int) | (Bool, Bool)) and non-identity edges in both
+# paneLinks windows.
 polymorphic polymorphic
+# The smallest payload in the corpus: one list literal, every node carrying its
+# own span, identity-linked across every pane. The one to read when asking what
+# the wire looks like at all.
 list_min list_min
-# A deliberate type error -> the degraded (payloadKind: "failed") payload.
+# A deliberate type error -> the degraded (payloadKind: "failed") payload: empty
+# panes and paneLinks, non-empty diagnostics. The only row that is not a
+# successful compile.
 failed type_error
 # UDF-of-defer: try_lift_defer fires and the lifted feed head keeps its id, plus
 # the two-site channel union channelization builds.

--- a/cambra-inspector/scripts/regen-fixtures.sh
+++ b/cambra-inspector/scripts/regen-fixtures.sh
@@ -23,6 +23,14 @@
 # gate and the fix path can never disagree about how a fixture is produced.
 set -euo pipefail
 
+# Fail fast with an actionable message rather than a mid-loop "command not
+# found" after some fixtures were already rewritten. cargo is the script's
+# only external dependency (the binary pretty-prints its own output).
+command -v cargo > /dev/null 2>&1 || {
+  echo "regen-fixtures.sh: cargo not found on PATH — install the Rust toolchain (rustup) first" >&2
+  exit 1
+}
+
 cd "$(dirname "$0")/../.." || exit 1 # -> cambra/ repo root
 MANIFEST="cambra-inspector/scripts/fixtures.manifest"
 FIX="${1:-cambra-inspector/web/src/__fixtures__}"
@@ -57,3 +65,5 @@ while read -r name example; do
 done < "${MANIFEST}"
 
 echo "done. Review the diff: git diff ${FIX}"
+echo "If web/src/ changed too, rebuild and commit the bundle:"
+echo "  (cd cambra-inspector/web && npm run build)   # ci_web compares dist/index.html"

--- a/cambra-inspector/web/src/__fixtures__/README.md
+++ b/cambra-inspector/web/src/__fixtures__/README.md
@@ -73,3 +73,9 @@ cargo golden test compares each committed fixture against a fresh dump.
 `store.test.ts` keys its assertions on node **labels/types**, not raw NodeIds, so
 ordinary id churn does not require touching the tests — but a shape change will,
 by design (and `wireValidate.ts` enforces the shape).
+
+Re-blessing pins more than it looks like. Every node's `type` is `Display for
+Type`'s rendering (`src/ccl/ty.rs` hands `collect_str` that string), so the
+corpus pins the type notation on every node in every pane — a literal's
+singleton spelling included. Changing that notation is a corpus-wide re-bless,
+not a formatting tweak.

--- a/cambra-inspector/web/src/__fixtures__/README.md
+++ b/cambra-inspector/web/src/__fixtures__/README.md
@@ -1,19 +1,24 @@
 # Golden snapshot fixtures
 
-Real `/api/snapshot` payloads emitted by the
-`cambra-inspector` backend, used by `store.test.ts` to test the frontend's
-derived logic (the B5 hole→type stitch, cross-pane resolution) **and** to guard
-the wire-shape contract: if the Rust payload drifts from the TypeScript wire
-types in `../types.ts`, these tests break. The corpus (fixture ↔ program
-mapping) lives in `../../../scripts/fixtures.manifest`, shared by
-`regen-fixtures.sh`, the ci.sh drift gate, and the cargo golden tests
-(`tests/inspector_goldens.rs`).
+Real `/api/snapshot` payloads emitted by the `cambra` backend, used by
+`store.test.ts` to test the frontend's derived logic (the B5 hole→type stitch,
+cross-pane resolution) **and** to guard the wire-shape contract: if the Rust
+payload drifts from the TypeScript wire types in `../types.ts`, these tests
+break. The corpus lives in `../../../scripts/fixtures.manifest`: which program each
+fixture is dumped from, and a comment per row saying what that row pins. It is
+shared by `regen-fixtures.sh`, the ci.sh drift gate, and the cargo golden tests
+(`tests/inspector_goldens.rs`), so a row and the thing it describes move
+together.
 
-A successful payload carries one entry of `panes` per declared pane, in pipeline
-order — `pre-inference` (kind `holes`) then `post-inference` (kind `typed`, the
-anchor), `post-channelize`, `post-as-of-read`, `post-lambda-elim` and
-`post-planning` (all `typed`) — and one `paneLinks` window per adjacent pair, so
-`paneLinks` is always one shorter than `panes`. The pane set is the compiler's
+Every fixture is the whole live wire. A program too large or too volatile to pin
+byte-for-byte carries no fixture at all and a structural assertion over a fresh
+dump instead, in `tests/inspector_goldens.rs`.
+
+A successful **live** payload carries one entry of `panes` per declared pane, in
+pipeline order — `pre-inference` (kind `holes`) then `post-inference` (kind
+`typed`, the anchor), `post-channelize`, `post-as-of-read`, `post-lambda-elim`
+and `post-planning` (all `typed`) — and one `paneLinks` window per adjacent pair,
+so `paneLinks` is always one shorter than `panes`. The pane set is the compiler's
 `PANES` table; `wireValidate.ts` pins it rather than reading it, so an added pane
 fails the validator instead of passing silently. There is no top-level
 `ir`/`spanIndex` (the earlier aliases are retired).
@@ -27,36 +32,6 @@ A refinement predicate riding a type slot is a node like any other, reached unde
 a `where.N`-labelled child edge instead of a positional index. `predicate: true`
 on the edge is what distinguishes a subtree inside a type from an operand; the
 edge label is for display.
-
-- `arithmetic.snapshot.json` — `tests/programs/udf_closure/`. Exercises the
-  **identity** stitch (`_ → Int`, a hole resolved by the same NodeId downstream).
-- `polymorphic.snapshot.json` — `tests/programs/polymorphic/`. A let-polymorphic
-  `dup` applied at four sites, three at `Int` and one at `Bool`, so both
-  duplication mechanisms fire: monomorphization fans out per type, and `inline`
-  duplicates the `Int` specialization's body per call site with
-  `Derived(Inline)` provenance. Exercises the **type-set** stitch
-  (`_ → (Int, Int) | (Bool, Bool)`), a non-empty
-  `pre-inference → post-inference` window, and a non-empty
-  `post-inference → post-channelize` one.
-- `list_min.snapshot.json` — `tests/programs/list_min/` (just `[1, 2, 3, 4]`). The
-  minimal cross-link anchor for the jsdom view-integration test
-  (`src/views.dom.test.ts`): every node carries its own `spans`,
-  identity-linked across the panes, so a node/source selection lights
-  up every pane. Pre-inference holes (type `"_"`) resolve to `Int` downstream.
-- `failed.snapshot.json` — `tests/programs/type_error/` (`1 and 2`). The **degraded**
-  payload: a program that fails to compile, so `panes`/`paneLinks` are empty,
-  `meta.payloadKind` is `"failed"`, and `diagnostics` is non-empty. Drives the
-  degraded-render test (`main.test.ts`) and is validated by `wireValidate.test.ts`,
-  proving the API can represent and the frontend can parse a failed compile.
-- `defer_lift.snapshot.json` — `tests/programs/defer_lift/`. A UDF that returns a
-  defer channel, so inlining produces the `try_lift_defer` shape (the lifted
-  feed head keeps its NodeId, preserving its source span). A loop feeds the
-  returned channel a second time, so channelization also builds the two-site
-  channel union.
-
-Each node carries its type as a rendered string in `type` (e.g. `"Int"`, `"_"`),
-and reaches a predicate riding one of its type slots through a `children` entry
-marked `predicate: true`, naming an id in the same pane's table.
 
 ## Regenerating
 
@@ -74,8 +49,6 @@ cargo golden test compares each committed fixture against a fresh dump.
 ordinary id churn does not require touching the tests — but a shape change will,
 by design (and `wireValidate.ts` enforces the shape).
 
-Re-blessing pins more than it looks like. Every node's `type` is `Display for
-Type`'s rendering (`src/ccl/ty.rs` hands `collect_str` that string), so the
-corpus pins the type notation on every node in every pane — a literal's
-singleton spelling included. Changing that notation is a corpus-wide re-bless,
-not a formatting tweak.
+A re-bless pins more than the shape, and every diff in one has to be classified
+before it is committed: see
+[The golden fixtures](../../../CLAUDE.md#the-golden-fixtures).

--- a/cambra-inspector/web/src/__fixtures__/helpers.test.ts
+++ b/cambra-inspector/web/src/__fixtures__/helpers.test.ts
@@ -1,0 +1,28 @@
+// The fixture loader's *error* path. `fixture()` exists to turn an opaque
+// WireError into the re-bless procedure, so the enrichment is the behaviour
+// worth pinning — a silent regression here costs the next reader the whole
+// "why does this test fail?" detour the helper was added to prevent.
+
+import { describe, expect, it } from "vitest";
+
+import { fixture } from "./helpers";
+import { SCHEMA_VERSION } from "../wireValidate";
+
+import listMinJson from "./list_min.snapshot.json";
+
+describe("fixture()", () => {
+  it("returns the validated snapshot for a good payload", () => {
+    expect(fixture(listMinJson).meta.schema).toBe(SCHEMA_VERSION);
+  });
+
+  it("keeps the underlying wire error and appends the re-bless procedure", () => {
+    // Computed, not a literal: a literal stale version silently stops being
+    // stale the moment SCHEMA_VERSION reaches it.
+    const stale = {
+      ...listMinJson,
+      meta: { ...listMinJson.meta, schema: SCHEMA_VERSION - 1 },
+    };
+    expect(() => fixture(stale)).toThrow(/meta\.schema/);
+    expect(() => fixture(stale)).toThrow(/regen-fixtures\.sh/);
+  });
+});

--- a/cambra-inspector/web/src/__fixtures__/helpers.ts
+++ b/cambra-inspector/web/src/__fixtures__/helpers.ts
@@ -3,6 +3,28 @@
 // NodeIds, so they survive id churn in the compiler.
 
 import type { IrNode, PaneEntry, Snapshot } from "../types";
+import { validateSnapshot } from "../wireValidate";
+
+/**
+ * Validate a golden fixture, enriching any wire error with the fixture
+ * lifecycle: these JSONs are regenerated artifacts, so a mismatch here usually
+ * means stale fixtures or a half-propagated schema change, not a frontend bug.
+ * Production code keeps calling `validateSnapshot` directly — a live payload
+ * error must not tell users to regenerate test fixtures.
+ */
+export function fixture(json: unknown): Snapshot {
+  try {
+    return validateSnapshot(json);
+  } catch (e) {
+    throw new Error(
+      `${String(e)}\n` +
+        "  This is a golden fixture. If the wire shape changed on purpose, regenerate via\n" +
+        "  cambra-inspector/scripts/regen-fixtures.sh, updating any hand-written\n" +
+        "  expectations in the same change — re-bless discipline in\n" +
+        "  web/src/__fixtures__/README.md.",
+    );
+  }
+}
 
 /** The pane with the given id (throws if absent). */
 export function paneById(snap: Snapshot, id: string): PaneEntry {

--- a/cambra-inspector/web/src/main.test.ts
+++ b/cambra-inspector/web/src/main.test.ts
@@ -11,7 +11,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 import { byteLineStarts, formatSpan, lineCol, renderApp } from "./main";
 import { Store } from "./store";
-import { validateSnapshot } from "./wireValidate";
+import { fixture } from "./__fixtures__/helpers";
 
 import failedJson from "./__fixtures__/failed.snapshot.json";
 
@@ -52,7 +52,7 @@ describe("formatSpan", () => {
 });
 
 describe("renderApp: degraded snapshot (failed compile)", () => {
-  const failed = validateSnapshot(failedJson);
+  const failed = fixture(failedJson);
 
   beforeAll(() => {
     // CodeMirror's SourceView (rendered even in the degraded case) calls these.

--- a/cambra-inspector/web/src/sourceView.test.ts
+++ b/cambra-inspector/web/src/sourceView.test.ts
@@ -11,15 +11,15 @@ import { describe, expect, it } from "vitest";
 
 import { Store } from "./store";
 import { hoverPayloadAt, resolveSourceClick } from "./sourceView";
-import { validateSnapshot } from "./wireValidate";
-import { paneById, theNode } from "./__fixtures__/helpers";
+
+import { fixture, paneById, theNode } from "./__fixtures__/helpers";
 import type { Indices } from "./indices";
 
 import arithmeticJson from "./__fixtures__/arithmetic.snapshot.json";
 import listMinJson from "./__fixtures__/list_min.snapshot.json";
 
-const arithmetic = validateSnapshot(arithmeticJson);
-const listMin = validateSnapshot(listMinJson);
+const arithmetic = fixture(arithmeticJson);
+const listMin = fixture(listMinJson);
 
 function anchorOf(store: Store): Indices {
   const idx = store.indicesFor(store.sourceAnchorPaneId!);

--- a/cambra-inspector/web/src/store.test.ts
+++ b/cambra-inspector/web/src/store.test.ts
@@ -14,14 +14,14 @@
 import { describe, expect, it } from "vitest";
 
 import { Store } from "./store";
-import { PANE_IDS, validateSnapshot } from "./wireValidate";
-import { allNodes, paneById, theNode } from "./__fixtures__/helpers";
+import { PANE_IDS } from "./wireValidate";
+import { allNodes, fixture, paneById, theNode } from "./__fixtures__/helpers";
 
 import arithmeticJson from "./__fixtures__/arithmetic.snapshot.json";
 import polymorphicJson from "./__fixtures__/polymorphic.snapshot.json";
 
-const arithmetic = validateSnapshot(arithmeticJson);
-const polymorphic = validateSnapshot(polymorphicJson);
+const arithmetic = fixture(arithmeticJson);
+const polymorphic = fixture(polymorphicJson);
 
 const sorted = (xs: string[]): string[] => [...xs].sort();
 
@@ -31,9 +31,11 @@ describe("T3: wire-shape contract (golden fixture matches the TS types)", () => 
     ["polymorphic", polymorphic],
   ] as const) {
     it(`${name}: the ordered panes + one paneLinks window per adjacent pair`, () => {
-      // A literal, not SCHEMA_VERSION: validateSnapshot already pinned the
-      // payload against the constant, so reading it here would assert it equals
-      // itself. The literal is what fails when the constant moves.
+      // A literal, not SCHEMA_VERSION: `fixture()` already refused to load a
+      // payload whose schema is not the constant, so reading the constant here
+      // would assert it equals itself. The literal is the only spelling of this
+      // line that can fail — it is what a version bump has to come back and
+      // update.
       expect(snap.meta.schema).toBe(1);
       expect(snap.panes.map((s) => s.id)).toEqual([...PANE_IDS]);
       expect(snap.panes.map((s) => s.kind)).toEqual([

--- a/cambra-inspector/web/src/views.dom.test.ts
+++ b/cambra-inspector/web/src/views.dom.test.ts
@@ -17,13 +17,13 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { Store } from "./store";
 import { SourceView } from "./sourceView";
 import { TreeView } from "./treeView";
-import { validateSnapshot } from "./wireValidate";
-import { paneById, theNode } from "./__fixtures__/helpers";
+
+import { fixture, paneById, theNode } from "./__fixtures__/helpers";
 import type { Snapshot } from "./types";
 
 import listMinJson from "./__fixtures__/list_min.snapshot.json";
 
-const listMin = validateSnapshot(listMinJson);
+const listMin = fixture(listMinJson);
 
 // Mount the full app (source + one tree pane per pane entry) into a fresh
 // container, returning the store and the per-pane tree-pane DOM roots.

--- a/ci.sh
+++ b/ci.sh
@@ -145,6 +145,7 @@ ci_fixtures() {
         echo "ci_fixtures FAILED: fixture drift: ${name} (committed ${committed_size} bytes vs regenerated ${regen_size} bytes)" >&2
         diff -u "${fix}/${name}" "${f}" | head -n 12 >&2 || true
         echo "  re-bless via: cambra-inspector/scripts/regen-fixtures.sh, then commit the diff" >&2
+        echo "  (if web/src/ changed too: cd cambra-inspector/web && npm run build, then commit dist/index.html — ci_web compares it)" >&2
         drifted=1
       fi
     done

--- a/src/ccl/ty.rs
+++ b/src/ccl/ty.rs
@@ -928,6 +928,11 @@ impl serde::Serialize for Type {
     }
 }
 
+// This rendering IS the inspector wire format for types — the serde impl above
+// `collect_str`s it, and the golden fixtures pin it byte-exactly on every
+// `type` field. Changing any notation here (`⇒`, `[0, N]`, `Mut(…)`, the
+// singleton spelling, braces) is a deliberate corpus-wide re-bless: rerun
+// cambra-inspector/scripts/regen-fixtures.sh and commit the classified diff.
 /// Renders through [`fmt_type`] with no enclosing function: a self-contained
 /// type carries every function its references name, so the spelling is
 /// complete. A type shown detached from a function that binds one of its references renders that

--- a/src/inspector_server/serve.rs
+++ b/src/inspector_server/serve.rs
@@ -20,11 +20,13 @@
 //! - `GET /api/diagnostics` — [`diagnostics_body`]
 //!   (`{"diagnostics":[]}` on success, structured diagnostics on failure).
 //!   `application/json`.
+//! - `GET /` and `GET /index.html` — the CodeMirror frontend: the built,
+//!   self-contained `cambra-inspector/web/dist/index.html` bundle, which
+//!   fetches `/api/snapshot` and renders the source + IR tree. `text/html`.
+//! - anything else — `404 Not Found`.
 //!
-//! Both bodies come from [`build_bodies`]' single compile, so the diagnostics
-//! the two routes report can never disagree.
-//! - anything else — `404 Not Found`. The frontend's own route lands with the
-//!   frontend.
+//! Both `/api` bodies come from [`build_bodies`]' single compile, so the
+//! diagnostics the two routes report can never disagree.
 //!
 //! # Transport decision: snapshot degrades on failure
 //!
@@ -45,6 +47,16 @@ use crate::inspector_model::{Diagnostic, InspectorPayload, diagnostics_from_comp
 use crate::interpreter::Consumer;
 
 use super::{snapshot_json, snapshot_json_pretty};
+
+/// The CodeMirror frontend, embedded at compile time. This is the built,
+/// self-contained single-file bundle (`cambra-inspector/web/dist/index.html`,
+/// produced by `npm run build`), committed to the repo so `cargo build` needs
+/// no Node toolchain (R7).
+///
+/// The path reaches out of `src/` because the frontend is a sibling directory
+/// rather than a workspace member: `cambra-inspector/` holds the TypeScript
+/// project, and this is the one place the Rust build reads from it.
+const INDEX_HTML: &str = include_str!("../../cambra-inspector/web/dist/index.html");
 
 /// The pre-rendered response bodies for the one static program.
 ///
@@ -127,6 +139,12 @@ fn json_header() -> tiny_http::Header {
         .expect("static header parses")
 }
 
+fn html_header() -> tiny_http::Header {
+    "Content-Type: text/html; charset=utf-8"
+        .parse()
+        .expect("static header parses")
+}
+
 fn text_header() -> tiny_http::Header {
     "Content-Type: text/plain; charset=utf-8"
         .parse()
@@ -150,11 +168,13 @@ pub fn serve(code: &str, name: &str, port: u16) -> io::Result<()> {
     eprintln!("cambra: inspecting {name} at http://localhost:{port} — Ctrl+C to stop");
 
     for request in server.incoming_requests() {
-        // `bodies` outlives the loop, so a response borrows it: the snapshot is
-        // megabytes on a large program and every request would otherwise copy it.
+        // `bodies` and `INDEX_HTML` both outlive the loop, so a response
+        // borrows: the snapshot is megabytes on a large program and the bundle
+        // is a quarter of one, and every request would otherwise copy it.
         let (body, status, header) = match request.url() {
             "/api/snapshot" => (bodies.snapshot.as_bytes(), 200, json_header()),
             "/api/diagnostics" => (bodies.diagnostics.as_bytes(), 200, json_header()),
+            "/" | "/index.html" => (INDEX_HTML.as_bytes(), 200, html_header()),
             _ => (NOT_FOUND, 404, text_header()),
         };
         let response = tiny_http::Response::new(

--- a/src/pretty_tree.rs
+++ b/src/pretty_tree.rs
@@ -102,6 +102,13 @@ impl InspectNode {
 
     /// Serialize this node tree to a JSON string without serde.
     ///
+    /// DEPRECATED: emits the legacy `web_inspector` dashboard's wire shape (its
+    /// only caller). The program inspector's `/api/snapshot` path
+    /// ([`inspector_server`](crate::inspector_server)) uses the `Serialize` impl
+    /// below instead; this method and `web_inspector` will be removed once the
+    /// program inspector gains the operator-graph and live panes the old
+    /// dashboard still provides.
+    ///
     /// Field names mirror the Rust struct fields. `None` guard fields are
     /// omitted. Children serialize as `{"edge":"...","node":{...}}` pairs,
     /// preserving edge labels.

--- a/src/web_inspector.rs
+++ b/src/web_inspector.rs
@@ -1,4 +1,13 @@
 //! Web inspector: serves a live dashboard of the interpreter's runtime state.
+//!
+//! DEPRECATED. The program inspector (`cambra --inspect-only`, served by
+//! [`inspector_server`](crate::inspector_server)) is the intended replacement,
+//! but cannot fully supplant this yet: it models only the static IR passes (one
+//! per declared pane) and has no operator/dataflow graph pane and no live
+//! per-tick view. Once the operator graph is instrumented (the
+//! `NodeId → OperatorId` provenance edge) and a live/tick layer lands, this
+//! module — and the `InspectNode::to_json` wire it depends on — can be
+//! removed.
 
 use std::sync::{Arc, Mutex};
 use std::thread;


### PR DESCRIPTION
`cambra-inspector/web/dist/index.html` is committed and gated by `ci_web`, but nothing served it: `cambra --inspect-only` offered `/api/*` only, so the frontend had to be run separately out of `web/`. `serve.rs` now `include_str!`s the bundle and answers `GET /` and `GET /index.html` with it, borrowing the static string per request as the snapshot body already does — a `cargo build` with no Node toolchain produces a binary that serves the whole inspector.

The rest is the maintenance surface around the golden corpus: a new `cambra-inspector/CLAUDE.md` holding the re-bless procedure, a `fixture()` wrapper in `web/src/__fixtures__/helpers.ts` that turns a stale-corpus `WireError` into a pointer at `regen-fixtures.sh` (pinned by a new `helpers.test.ts`; the four test files that loaded fixtures through `validateSnapshot` now go through it), and comments marking `web_inspector` and `InspectNode::to_json` removable once the program inspector gains an operator-graph pane and a live view.