### PR TITLE
Cover the conditional-induction shapes with a materialized leak gate

### DIFF
--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -1884,6 +1884,43 @@ mod tests {
         }
     }
 
+    /// Driver for the canary below: compile and unwrap.
+    fn compile_ok(code: &str) -> CompiledProgram {
+        let mut ctx = GlobalContext::default();
+        let consumer: Box<dyn Consumer> = Box::new(|| {});
+        compile_program(&mut ctx, code, consumer).expect("compiles")
+    }
+
+    /// Lowering's own recording overhead, measured rather than gated.
+    ///
+    /// The lowering session installs in every build, recording at leaf grain
+    /// (an ordinary mint opens no frame, so `on_mint` stays a no-op) plus a copy
+    /// frame per uncurry / compare-chain site, followed by one O(nodes) fold.
+    /// This times a representative compile so a regression in that overhead is
+    /// observable. Nothing is asserted.
+    ///
+    /// Run manually, in release, which is the meaningful configuration:
+    /// `cargo test --release -- --ignored lowering_session_cost_canary --nocapture`.
+    #[test]
+    #[ignore = "measurement hook (not a gate); run manually with --release --nocapture"]
+    fn lowering_session_cost_canary() {
+        use std::time::Instant;
+        // A program exercising leaf recording (arithmetic/loop plumbing) plus a
+        // copy frame (the chained comparison's shared operand).
+        let code = "x := 0\nfor i in [1, 2, 3]:\n    x += i\n1 < x < 3\nx\n";
+        let iters = 2_000u32;
+        let start = Instant::now();
+        for _ in 0..iters {
+            let _ = compile_ok(code);
+        }
+        let elapsed = start.elapsed();
+        eprintln!(
+            "lowering-session canary: {iters} compiles in {elapsed:?} \
+             ({:?}/compile)",
+            elapsed / iters,
+        );
+    }
+
     #[test]
     fn rendered_errors_have_exact_format() {
         let code = "\

--- a/src/ccl/panes.rs
+++ b/src/ccl/panes.rs
@@ -890,6 +890,68 @@ mod tests {
         ("feed", 12),
     ];
 
+    /// Every conditional-induction shape reaches every pane pair clean.
+    ///
+    /// The leak gates and `assert_unique_node_ids` at a pane boundary run only
+    /// under [`CompiledProgram::materialize_panes`], so the compilation-pipeline
+    /// suite — which compiles but never materializes — cannot see a leak in a
+    /// rewrite it otherwise exercises heavily. The statement-`Case` arm of the
+    /// letrec phase is exactly that blind spot: it fans the post-`Case` remainder
+    /// and the entering read-your-writes env across every branch, so each shape
+    /// below stresses a different copy/consume pairing.
+    #[test]
+    fn conditional_induction_panes_are_leak_free() {
+        for (name, code) in [
+            // One conditional write: guard preserved into its own arm predicate,
+            // echoed (freshened) into the carry arm's.
+            (
+                "guard_only",
+                "x := 0\nfor i in [1, 2, 3]:\n    if i > 1:\n        x := x + i\nx\n",
+            ),
+            // Unconditional write *before* the `Case`: its inlined value sits in
+            // the read-your-writes env slot every branch clones.
+            (
+                "uncond_before",
+                "x := 0\nfor i in [1, 2, 3]:\n    x := x + 1\n    if i > 1:\n        x := x + 10\nx\n",
+            ),
+            // Unconditional write *after* the `Case`: the remainder is spliced
+            // onto every path, including the trailing carry arm.
+            (
+                "uncond_after",
+                "x := 0\nfor i in [1, 2, 3]:\n    if i > 1:\n        x := x + 10\n    x := x + 1\nx\n",
+            ),
+            // `if`/`else` writing one accumulator on both arms.
+            (
+                "if_else",
+                "t := 0\nfor x in [1, 2, 3]:\n    if x > 2:\n        t := t + x\n    else:\n        t := t + 1\nt\n",
+            ),
+            // Two accumulators, one unconditional and one conditional — the
+            // shape where a branch's write set matches the carry for *some*
+            // accumulator but not all.
+            (
+                "two_accumulators",
+                "cnt := 0\ntotal := 0\nfor i in [1, 2, 3]:\n    cnt := cnt + 1\n    if i > 1:\n        total := total + i\ncnt * 10 + total\n",
+            ),
+            // Sibling `if`s (not `elif`) on one accumulator: two guard-Cases in
+            // one body, so the second one's remainder is itself a spliced copy.
+            (
+                "sibling_ifs",
+                "a := 0\nfor i in [1, 2, 3]:\n    if i > 1:\n        a := a + i\n    if i < 3:\n        a := a + 100\na\n",
+            ),
+        ] {
+            let compiled = compile_ok(code);
+            let panes = compiled.materialize_panes();
+            for pair in panes.gated_pane_pairs() {
+                assert!(
+                    pair.leaks.is_empty(),
+                    "`{name}`: leaks between the {} panes: {:?}",
+                    pair.name,
+                    pair.leaks
+                );
+            }
+        }
+    }
+
     /// Rough compile-time and retained-memory sanity for pane capture. Ignored
     /// by default — it is a measurement, not an assertion.
     ///


### PR DESCRIPTION
A pane boundary's leak gate and `assert_unique_node_ids` run only under `materialize_panes`, and the compilation-pipeline suite compiles without ever materializing — so a rewrite that suite exercises heavily can still leak unobserved. The statement-`Case` arm of the letrec phase is exactly that blind spot: it fans the post-`Case` remainder and the entering read-your-writes env across every branch, so each shape stresses a different copy/consume pairing. This adds six such shapes, materialized, asserting an empty leak vector on every gated pane pair. Also an `#[ignore]`d measurement hook for lowering's own recording overhead, which installs in every build and so is worth being able to observe.
