### PR TITLE
Meet both sides when reading a negative position

### DIFF
--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -379,6 +379,21 @@ common answer — which `higher_order_dependent_application_discharges_the_binde
 Forcing the discharge on both contributions before they meet is the prerequisite for letting
 the merge follow a chain.
 
+**The gated merge pays a doubling of its own.** The gate confines the merge to the entered
+position, and a structural child *is* an entered position — `compact_go` resets `parents` to
+`None` at every one — so the merge re-opens one nesting level down and the walk doubles per
+contravariant flip. Measured in debug, median of three runs at equal test counts: the whole
+of `tests/type_check.rs` goes from 0.83s to 1.29s, and `test_groupby_key_relation_is_per_occurrence`
+— `def by_key(c, f): groupby(c, f)` at two types, the same program as above — from 0.56s to
+0.94s. `tests/compilation_pipeline` is flat, its time being execution rather than inference.
+
+What is absent is a **result memo**. `CompactState` carries `in_process`, which prunes cycles
+and caches nothing — it is removed again as each variable's walk returns — so a position
+reached twice is compacted twice. A `(uid, pol)` key would not be a correct memo: a position's
+reading also depends on `subst_acc` and on the refinement scope `st.scope` holds, so two
+entries at one variable and polarity are not interchangeable. Hash consing the rendered
+contribution keys on what was produced instead, and sidesteps that.
+
 **Asking the other question.** Because the collapse answers "what must this position be", a caller that needs "what actually reached it" has to suppress the collapse — `compact_type_polarity_only`, the polarity-correct walk alone. The distinction is not academic: an upper bound deposited on a never-inhabited position (the trait-requirement sweep does exactly this) makes the ordinary resolve report a type. [The unobservable-arm pin](#an-unobservable-arm-payload-is-pinned-to-what-its-uses-require) is the caller that must not confuse the two, since a demand is precisely what an unreachable arm can acquire.
 
 **Binder slots — filled during the coalesce walk (no lexical scope needed).** A `Var` use needs *no*

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -1125,6 +1125,13 @@ It is never drawn against a bound witness. A sum's domain is its binder's refere
 sum is a term ([Only a term builds a sum](#only-a-term-builds-a-sum)), so equating that reference
 with a free variable escapes the binder instead of relating two positions.
 
+The merge at a negative position takes no matching exclusion, because it states nothing. A
+reference meeting a concrete type is settled where the edge is drawn: `constrain_go` distributes
+the demand over the witness's candidates, one invariant edge each, and reports a mismatch where
+the kind names no candidate. Compaction reads back only what those edges admitted, and a
+reference and a concrete atom arriving at one position are two shapes, which `coalesce_compact`
+reports as `IncompatibleBounds`.
+
 ### Flowing Out: coalescing
 
 Once constraints are resolved (Pass 2), `coalesce_compact` resolves each node's `Type::Infer` variables in place:

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -351,6 +351,14 @@ equation](#a-shared-hole-naming-a-domain-states-an-equation)); without it the sp
 the other only through the argument edge keeps the wider reading. Pinned by
 `a_negative_position_meets_both_sides` and `a_groupby_over_a_singleton_element_literal`.
 
+The meet reaches a **variant** in a child slot, where it intersects the tags and closes an open
+demand's marker — a `case _:` demand is open, and the value side is a producer and so closed.
+Both halves are the approximate meet `CompactVariant::meet_openness` documents, and that
+approximation now has a caller: a tag the value carries and the demand does not name is dropped,
+and the marker then claims the remainder is exhaustive. No program observes the narrowed reading,
+a default arm being compiled from the `Case` (`test_default_arm_under_a_record_field`); the
+reading itself is pinned by `a_settled_negative_position_closes_an_open_child_demand`.
+
 **The merge is gated as if it were the collapse, and one variable therefore has two readings
 at one polarity.** `fallback_allowed` answers both, so a variable entered as a position reads
 the merge while the same variable reached through another variable's bound chain reads the

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -347,6 +347,26 @@ equation](#a-shared-hole-naming-a-domain-states-an-equation)); without it the sp
 the other only through the argument edge keeps the wider reading. Pinned by
 `a_negative_position_meets_both_sides` and `a_groupby_over_a_singleton_element_literal`.
 
+**The merge is gated as if it were the collapse, and one variable therefore has two readings
+at one polarity.** `fallback_allowed` answers both, so a variable entered as a position reads
+the merge while the same variable reached through another variable's bound chain reads the
+demand side alone. Only the collapse needs that gate: a choice does not propagate along
+subtyping edges, and a narrowing does. What the difference leaves open is a mutable `Map`
+seeded with a one-entry literal — `box`'s instantiated domain reaches the key variable
+through a chain and keeps the bare reading, which invariance then rejects against the
+singleton the seed establishes (`a_one_entry_seed_does_not_reach_a_mutable_map`).
+
+Ungating the merge closes that shape and costs two things it does not pay for. Reading the
+opposite side at every negative variable compacts it in full there, so the walk doubles per
+level of type nesting — `def by_key(c, f): groupby(c, f)` applied at two types goes from 1.4s
+to 10s. And where a discharge is suspended on the chain, two data domains meet whose
+refinement sets differ only in the spelling of the discharged binder: `{[0, 2] | 𝑥 == 0}`
+against `{[0, 2] | 𝑥 == __arg}`. [`data_domains_disagree`] compares those sets structurally,
+so it reads one domain reached twice as two domains that disagree, and the position has no
+common answer — which `higher_order_dependent_application_discharges_the_binder` reports.
+Forcing the discharge on both contributions before they meet is the prerequisite for letting
+the merge follow a chain.
+
 **Asking the other question.** Because the collapse answers "what must this position be", a caller that needs "what actually reached it" has to suppress the collapse — `compact_type_polarity_only`, the polarity-correct walk alone. The distinction is not academic: an upper bound deposited on a never-inhabited position (the trait-requirement sweep does exactly this) makes the ordinary resolve report a type. [The unobservable-arm pin](#an-unobservable-arm-payload-is-pinned-to-what-its-uses-require) is the caller that must not confuse the two, since a demand is precisely what an unreachable arm can acquire.
 
 **Binder slots — filled during the coalesce walk (no lexical scope needed).** A `Var` use needs *no*

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -239,7 +239,31 @@ constrain(lhs, rhs):
 
 #### Apply is one-way
 
-**Under-determined domains are recovered as use-site specialization.** The `Apply` rule emits only the textbook constraints — the shape edge `constrain(fn_ty, domain ⇒ codomain)` and the argument edge `constrain(arg_ty, domain)` (`arg <: domain`). A function domain is contravariant, so one-way edges leave a *morphism*'s domain var under-determined: a `Proj` only constrains the one field it touches, so `.1` applied to a 2-tuple compacts to `Fun((?, T₁), T₁)` — a field-narrow / `Infer`-laden shape that never resolves — and a lambda's domain only ever receives what its *body* demands (a record narrowed to the fields the body reads, a sparsely-touched tuple shortened). That shape — the value actually flowing in — is recovered **structurally during the coalesce walk** by *monomorphizing the morphism to its input*: `coalesce_node`'s `Apply` arm rewrites a projection's or directly-applied lambda's domain to the resolved argument (and a lambda passed *as* the argument — the higher-order case: `filter`/`groupby` key functions, comprehension lowering — to the function's resolved inner domain), the `Compose` arm to the preceding morphism's codomain, and refinement predicates (the join-filter / cast-target case) recover the same way since `coalesce_type_predicates` runs `coalesce_node` over them (see [Closing the single-sided blind spots](#closing-the-single-sided-blind-spots-no-separate-pass)). This is the **closed-form case of use-site specialization** — the same operation `specialize_use` performs for a generalized `let` (specialize to the resolved use type), except the morphism's domain *equals* its input, so it collapses to a single overwrite instead of clone+pin+coalesce. See `infer::specialize_projection_domain` / `specialize_lambda_domain`.
+**Under-determined domains are recovered as use-site specialization.** The `Apply` rule emits only
+the textbook constraints — the shape edge `constrain(fn_ty, domain ⇒ codomain)` and the argument
+edge `constrain(arg_ty, domain)` (`arg <: domain`). A function domain is contravariant, so those
+one-way edges put the value on a *morphism*'s domain variable's lower side while its uses accumulate
+above. A **lambda**'s domain needs nothing further: binder and argument share one variable, and a
+negative position reads their meet
+([The collapse happens at the position](#the-collapse-happens-at-the-position)). A **projection**'s
+does, and not because anything was lost: `.𝑘` is polymorphic in its input's width, so a domain that
+does not name that width is its principal type. Op-conversion needs one width to emit a field
+access, and the use site is what has it. Where the argument's own type is concrete when
+`arg <: domain` is drawn, the width reaches the domain variable as a lower bound and the meet
+settles it; where the argument is still a variable there, the width arrives only as its coalesced
+node type. That shape — the value actually flowing in — is supplied **structurally during the
+coalesce walk**: `coalesce_node`'s `Apply` arm rewrites a projection's domain to the resolved
+argument, the `Compose` arm to the preceding morphism's codomain, and refinement predicates (the
+join-filter / cast-target case) are reached the same way since `coalesce_type_predicates` runs
+`coalesce_node` over them (see
+[Closing the single-sided blind spots](#closing-the-single-sided-blind-spots-no-separate-pass)).
+This is the **closed-form case of use-site specialization** — the same operation `specialize_use`
+performs for a generalized `let` (specialize to the resolved use type), except the morphism's domain
+*equals* its input, so it collapses to a single overwrite instead of clone+pin+coalesce. See
+`infer::specialize_projection_domain`. `proj_requirement` still spells the demand as a dense prefix,
+`Tuple([fresh × 𝑘] ++ [field])`, because `Type::Tuple` cannot say "index 𝑘 at 𝑇, arity at least
+𝑘+1"; the fillers are placeholders for positions the projection has no opinion about, and the
+monomorphization overwrites them before any later phase reads one.
 
 The local per-morphism recovery suffices because projections and direct/argument-position lambdas are the morphisms whose domains coalesce under-determined. Function values reached through *opaque* positions (`Var`-bound functions applied at distant call sites, higher-order `Compose` of vars) are outside the closed-form recovery — the same opaque-vs-direct boundary as dependent application. (Genuine polymorphism is handled separately by generalize + per-type monomorphization — see §1, *Roadmap*.)
 
@@ -263,23 +287,73 @@ The three steps take a `Type` whose `Type::Infer` variables carry mutable lower/
 
 ### Closing the single-sided blind spots (no separate pass)
 
-The solver's single-sided `Var <: Var` constrain rule leaves a few *structural* blind spots — positions where a variable receives a bound on only one side, so coalesce (which reads the polarity-correct side) can't materialize it. **Refinements are not among them** — they ride the lattice natively (see §4) and coalesce straight onto each node, including the predicate's own sub-expression types.
+The solver's single-sided `Var <: Var` constrain rule leaves a few *structural* blind spots —
+positions where a variable receives a bound on only one side, so coalesce (which reads the
+polarity-correct side) can't materialize it. Refinements ride the lattice natively (see §4) and
+coalesce straight onto each node, including the predicate's own sub-expression types, but that alone
+does not exempt them: a refinement arriving on the value side of a negative position is single-sided
+like any shape, and what lands it is
+[The collapse happens at the position](#the-collapse-happens-at-the-position).
 
 **Morphism domains (projections and lambdas) — rebuilt during the coalesce walk (`Apply` and `Compose`).** A morphism's domain appears only at a negative position, and the one-way constraints emitted around it (`fn_ty <: domain ⇒ codomain` and `arg <: domain` at an `Apply`; the adjacency `prev_cod <: next_dom` in a `Compose`) deliver the concrete value flowing in only as a *lower* bound, while the uppers carry just what the morphism's own body demands — so negative-polarity coalesce materializes the narrow body-demand shape. A `Proj`'s domain coalesces field-narrow (e.g. `.0` of a multi-accumulator loop's `step` tuple coalesces to a 1-tuple `(T)` instead of the full `(T, U)`); a lambda's record param narrows to the fields its body touches (`{label}` instead of `{id, label}`), with untouched params left `Infer`.
 
-`coalesce_node` rebuilds it **structurally, after coalescing the children**, via the shared `specialize_projection_domain` / `specialize_lambda_domain`: the `Apply` arm replaces a projection's or directly-applied lambda's domain with the resolved argument (and an argument-position lambda's with the function's resolved inner domain), the `Compose` arm with the preceding morphism's already-resolved codomain (and the chain's own type with `Fun(first.domain, last.codomain)`), and refinement predicates recover the same way through `coalesce_type_predicates`. A lambda's body-usage refinements are preserved by re-wrapping them around the new base (deduped by structural `Refinement` equality against refinements the input already carries), and its `param.ty` binder slot is re-derived from the rewritten domain (`refresh_lambda_param_slot`). This is **use-site specialization** — the closed-form sibling of `specialize_use`'s per-`let` specialization (the morphism's domain *equals* its input, so it is one overwrite rather than clone+pin+coalesce; see §2). Doing it post-coalesce — rather than recording a reverse bound at emit time — is what keeps it robust: an emit-time bound is recorded against a specific inference variable, and let-polymorphism's monomorphization re-mints those variables (splicing freshened definitions at use sites), so the bound would not follow to the variable the node's recorded type ends up carrying. Reading the resolved shapes directly sidesteps that entirely.
+`coalesce_node` rebuilds it **structurally, after coalescing the children**, via
+`specialize_projection_domain`: the `Apply` arm replaces a projection's domain with the resolved
+argument, the `Compose` arm with the preceding morphism's already-resolved codomain (and the chain's
+own type with `Fun(first.domain, last.codomain)`), and refinement predicates recover the same way
+through `coalesce_type_predicates`. A lambda needs no counterpart here — its binder is the domain
+variable, so its `param.ty` slot is derived from the coalesced domain (`refresh_lambda_param_slot`)
+and the body-usage refinements it carries are already in that reading. This is **use-site
+specialization** — the closed-form sibling of `specialize_use`'s per-`let` specialization (the
+morphism's domain *equals* its input, so it is one overwrite rather than clone+pin+coalesce; see
+§2). Doing it post-coalesce — rather than recording a reverse bound at emit time — is what keeps it
+robust: an emit-time bound is recorded against a specific inference variable, and let-polymorphism's
+monomorphization re-mints those variables (splicing freshened definitions at use sites), so the
+bound would not follow to the variable the node's recorded type ends up carrying. Reading the
+resolved shapes directly sidesteps that entirely.
 
 #### The collapse happens at the position
 
-The *bare* under-determined variable — a domain variable that receives only `arg` and nothing else — is the half `specialize_lambda_domain` cannot reassemble, and `compact_go` handles it in place: when a variable's polarity-correct bounds yield no shape, it reads the opposite side instead. The principal type of such a variable is `∀α ⊒ 𝐿. …`, and with no `Type::ForAll` and concrete code to emit, the quantifier collapses to its bound. That elimination is how a structurally-typed position acquires a type at all, in both directions: a domain reading the argument that flows in, and a parameter used only through projections reading the open records its uses demand of it.
+The *bare* under-determined variable — a domain variable that receives only `arg` and nothing else —
+is the half `specialize_projection_domain` cannot reassemble, and `compact_go` handles it in place:
+where a variable's polarity-correct bounds yield no shape, the opposite side supplies one. The
+principal type of such a variable is `∀α ⊒ 𝐿. …`, and with no `Type::ForAll` and concrete code to
+emit, the quantifier collapses to its bound. That elimination is how a structurally-typed position
+acquires a type at all, in both directions: a domain reading the argument that flows in, and a
+parameter used only through projections reading the open records its uses demand of it.
 
 A collapse is a *choice*, not a subtyping inference, so it does not propagate along subtyping edges — `𝐿 <: 𝑐` and `𝑎 <: 𝑐` together say nothing about `𝐿` versus `𝑎`. It belongs to the variable whose quantifier is being eliminated: the **position** the walk entered, never one reached by following another variable's bounds, which is why the walk resets its parent path at every structural child. `fallback_allowed` (`src/ccl/infer/solver/compact.rs`) carries the rule and its argument.
 
-**When the polarity-correct walk counts as having answered.** The collapse fires only where that walk found no shape, and a *variant* shape is read differently at the two polarities. Positively it comes off the lower bounds and is the value's own tags — what the thing is — so the collapse has nothing to add, and firing past it would replace the value with its own upper bound (a bounded annotation `𝑥 <: 𝑇` reading back as the binder's type). Negatively it comes off the upper bounds and is the arms a body can *handle*, which is not a determination of what flows in; there the collapse must still fetch the argument, or a domain becomes the sum of everything the `match` accepts. Records and atoms need no such split, being the same claim read from either side.
+**When the polarity-correct walk counts as having answered.** The shape collapse fires only where
+that walk found no shape, and a *variant* shape is read differently at the two polarities.
+Positively it comes off the lower bounds and is the value's own tags — what the thing is — so the
+collapse has nothing to add, and firing past it would replace the value with its own upper bound (a
+bounded annotation `𝑥 <: 𝑇` reading back as the binder's type). Negatively it comes off the upper
+bounds and is the arms a body can *handle*, which is not a determination of what flows in; there the
+collapse must still fetch the argument, or a domain becomes the sum of everything the `match`
+accepts. Records and atoms need no such split, being the same claim read from either side.
+
+**A negative position reads the opposite side whether or not the collapse fires.** Both sides narrow
+it — the uses state what they demand, the lower bounds what arrives — so the reading is their merge
+at the position's own polarity, which is one rule for every slot rather than one per shape. The
+collapse above is the *undetermined* case, and it replaces rather than merges because there is no
+settled structure for two sides to narrow jointly. A positive position is unaffected: its
+polarity-correct side is already the value's own facts, and a demand is not one. Merging is what
+makes an invariant [data domain](#data-domains-are-invariant) resolve to a single type where its
+two readings differ — `groupby([1], λ 𝑥 → 𝑥)`'s key variable carries `Int@1` below and `Int` above.
+That settles one position. Two spellings of one domain also have to be identified, which is what a
+shared hole states ([A shared hole naming a domain states an
+equation](#a-shared-hole-naming-a-domain-states-an-equation)); without it the spelling that reaches
+the other only through the argument edge keeps the wider reading. Pinned by
+`a_negative_position_meets_both_sides` and `a_groupby_over_a_singleton_element_literal`.
 
 **Asking the other question.** Because the collapse answers "what must this position be", a caller that needs "what actually reached it" has to suppress the collapse — `compact_type_polarity_only`, the polarity-correct walk alone. The distinction is not academic: an upper bound deposited on a never-inhabited position (the trait-requirement sweep does exactly this) makes the ordinary resolve report a type. [The unobservable-arm pin](#an-unobservable-arm-payload-is-pinned-to-what-its-uses-require) is the caller that must not confuse the two, since a demand is precisely what an unreachable arm can acquire.
 
-**Binder slots — filled during the coalesce walk (no lexical scope needed).** A `Var` use needs *no* scope lookup: it shares its binder's inference variable — a monomorphic `let` binds verbatim (`instantiate` freshens nothing) so every use coalesces to exactly what the binder coalesces to, and a *generalized* `let`'s uses are rewritten by the walk itself to reference per-type specializations (which does carry a scope — the walk's stack of specialization frames and shadow markers; see §3.1).
+**Binder slots — filled during the coalesce walk (no lexical scope needed).** A `Var` use needs *no*
+scope lookup: it shares its binder's inference variable — a monomorphic `let` binds verbatim
+(`instantiate` freshens nothing) so every use coalesces to exactly what the binder coalesces to, and
+a *generalized* `let`'s uses are rewritten by the walk itself to reference per-type specializations
+(which does carry a scope — the walk's stack of specialization frames and shadow markers; see §3.1).
 
 What the bottom-up `expr.ty` resolution *doesn't* reach is the **binder slots**: a binder carries a type that is not any node's `expr.ty` — a `Lambda`'s `param.ty`, a `Let`'s `binding.ty`, a `Case` pattern's `binding.ty`, a `For`'s target slot. Each is resolved explicitly in `coalesce_node`, mirroring its definition (inference runs before the mutability/transaction phases, so the recurrence carriers `LetRec`/`Transact` never reach coalesce):
 
@@ -981,8 +1055,28 @@ There is no conversion *into* a solver type — the solver consumes `ccl::Type` 
 
 * **Holes (`Type::Hole`):** become fresh `Type::Infer` variables at the current level.
 * **Bounds (`Type::BoundedHole(𝑇)`):** become fresh `Type::Infer` variables at the current level, carrying `𝑇` as an upper bound — `Hole` with a ceiling (see [Annotation kinds: exact and bounded](#annotation-kinds-exact-and-bounded)).
+* **Shared holes (`Type::SharedHole(id)`):** the first occurrence of an id mints a fresh variable
+  and every later one reuses it, so two annotation positions carrying one id resolve to one
+  variable.
 * **Refinements:** are **kept** (recursing to normalize the inner) — they ride the lattice natively (above). A `Refinement(Hole, r)` source annotation thus becomes `Refinement(?fresh, r)`.
 * **Everything else** — including existing `Type::Infer` vars, `Tuple`/`Record` products, and `Type::Variant` sums — is kept verbatim and handled by the solver's structural constraint rules. Tuples and records are width-subtyped positionally/by name; variants are admissible at both polarities (the dual of records), so they need no fresh-var indirection.
+
+#### A shared hole naming a domain states an equation
+
+`bind_annotation` is one-way, and the domain position is contravariant, so a shared id lands below
+every domain annotated with it rather than equal to any of them. That is a common lower bound: it
+orders each domain under the variable and says nothing between the domains. Lowering writes the id
+to claim that two positions are one domain — an unfiltered single-generator comprehension and the
+source it iterates. A [data domain](#data-domains-are-invariant) is invariant, so the claim is an
+equation, and `bind_annotation` draws its other half.
+
+The equation is drawn only where the id names the domain. A domain variable reached any other way
+may receive several domains by design — a conditional collection's arms, a domain-generic consumer's
+parameter — and `constrain_go`'s invariant-domain arm declines to equate those for that reason.
+
+It is never drawn against a bound witness. A sum's domain is its binder's reference, and entering a
+sum is a term ([Only a term builds a sum](#only-a-term-builds-a-sum)), so equating that reference
+with a free variable escapes the binder instead of relating two positions.
 
 ### Flowing Out: coalescing
 
@@ -2212,8 +2306,8 @@ from](#where-the-candidates-come-from)).
 
   Two constraints shape the fix, and both are load-bearing. The standalone read must still
   *happen*, because a parent's structural recovery of a contravariant domain
-  (`specialize_projection_domain`, `specialize_lambda_domain`) reads it — a record-typed
-  parameter's uses are how a projection's domain is recovered at all. And the parameter slot
+  (`specialize_projection_domain`) reads it — a record-typed parameter's uses are how a
+  projection's domain is recovered at all. And the parameter slot
   must only fill uses the read *left* unresolved, because a use whose read succeeded is at
   least as precise as the slot and often more so: a monomorphized parameter's use carries the
   call's literal singleton where the slot, being the coalesced domain, has widened it. So the

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -280,6 +280,10 @@ The three steps take a `Type` whose `Type::Infer` variables carry mutable lower/
    * *Co-occurrence merging:* if variable `v` and variable `w` always occur together at a given polarity (and symmetrically), they carry identical information, so `w` is merged into `v`.
    * *Atomic absorption:* if a concrete atom `A` co-occurs with variable `v` at *both* polarities, `v` is sandwiched between two identical `A` constraints and is redundant, so it is dropped.
    * The pass is currently cosmetic (everything is monomorphic) and becomes load-bearing once let-polymorphism introduces genuine polar asymmetry.
+   * All three rules read the variable sets `compact_type` deposits, and a negative position's
+     set holds both sides' variables — the merge unions identities as it unions fields. The
+     occurrences the analysis sees there are not the ones the coalesced type materializes.
+     Refinements are unaffected, sitting on the position while the rules rewrite variable ids.
 3. **`coalesce_compact`:** Materializes the simplified `CompactGraph` into the final `ccl::Type` by counting the concrete structural contributions (e.g. `Int`, a record, a variant) remaining at each position. Variable contributions never appear in the output — their bounds have already been expanded into the structural bags by `compact_type`.
    * *Zero shapes:* emit a fresh `Type::Infer` placeholder.
    * *Exactly one shape:* emit it as the `ccl::Type`. Records with dense `Index` keys (0..n) become `Type::Tuple`; `Name` keys become `Type::Record`; a *sparse* index product (a gap in the indices, which only an open/under-determined position can produce) coalesces to a fresh `Type::Infer` rather than a concrete product; variant maps preserve their tags and become `Type::Variant`.

--- a/src/ccl/infer/context.rs
+++ b/src/ccl/infer/context.rs
@@ -611,6 +611,41 @@ impl Typing for InferCtx {
                 inferred: inferred_ty,
             })
         })?;
+        // **A `SharedHole` naming a domain is an equation, not an ordering.** The edge
+        // above is contravariant in the domain, so it leaves the shared variable *below*
+        // every domain annotated with it: a common lower bound, which orders each domain
+        // under it and says nothing between them. Lowering writes the id to claim that two
+        // positions are one domain, and a data domain is invariant, so the claim is an
+        // equation and this draws its other half.
+        //
+        // Only where the id names the domain. A domain variable reached any other way may
+        // receive several domains deliberately — a conditional collection's arms, a
+        // domain-generic consumer's parameter — and equating those is what `constrain_go`'s
+        // invariant-domain arm declines to do for a variable-sided edge.
+        //
+        // Never against a **bound witness**. A sum's domain is its binder's reference, and
+        // entering a sum is a term (`src/ccl/design/type-inference.md`, "Only a term builds
+        // a sum"), so an equation between that reference and a free variable is not a claim
+        // about two positions but an escape of the binder — the coercion the one-way rule
+        // above exists to leave to the Σ rule.
+        if let Type::Fun {
+            domain: claimed, ..
+        } = ann_to_normalize.peel_refinements()
+            && matches!(**claimed, Type::SharedHole(_))
+            && let Type::Fun { domain: shared, .. } = ann_simple.peel_refinements()
+            && let Type::Fun {
+                domain: inferred_dom,
+                ..
+            } = inferred.peel_refinements()
+            && !matches!(inferred_dom.peel_refinements(), Type::WitnessRef(_))
+        {
+            constrain_subtype(inferred_dom, shared, &mut self.cache).map_err(|_| {
+                self.raise(InferError::AnnotationMismatch {
+                    annotation: ann.clone(),
+                    inferred: coalesce_for_error(inferred),
+                })
+            })?;
+        }
         Ok(ann_simple)
     }
 

--- a/src/ccl/infer/context.rs
+++ b/src/ccl/infer/context.rs
@@ -601,14 +601,14 @@ impl Typing for InferCtx {
             _ => ann,
         };
         let ann_simple = self.normalize_annotation(ann_to_normalize);
-        // Snapshot the inferred type before the annotation bounds are added so
-        // the error shows what was actually inferred, not the partially
-        // modified state after a failed constrain_subtype.
+        // Snapshot the inferred type before any annotation bound is added. Both reports
+        // below read this one snapshot, so each shows what was inferred rather than the
+        // partially modified state a failed `constrain_subtype` leaves behind.
         let inferred_ty = coalesce_for_error(inferred);
         constrain_subtype(inferred, &ann_simple, &mut self.cache).map_err(|_| {
             self.raise(InferError::AnnotationMismatch {
                 annotation: ann.clone(),
-                inferred: inferred_ty,
+                inferred: inferred_ty.clone(),
             })
         })?;
         // **A `SharedHole` naming a domain is an equation, not an ordering.** The edge
@@ -642,7 +642,7 @@ impl Typing for InferCtx {
             constrain_subtype(inferred_dom, shared, &mut self.cache).map_err(|_| {
                 self.raise(InferError::AnnotationMismatch {
                     annotation: ann.clone(),
-                    inferred: coalesce_for_error(inferred),
+                    inferred: inferred_ty,
                 })
             })?;
         }

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -981,9 +981,9 @@ pub(super) fn emit_apply<C: Typing>(
     // also pins the function/argument shapes with the one-way Apply edges
     // (see `Typing::constrain_argument` for the full story): the shape edge
     // `fn_ty <: (x: domain) ⇒ codomain` and the argument edge `arg <: domain`.
-    // A morphism's contravariant domain, left under-determined by the one-way
+    // A projection's contravariant domain, left under-determined by the one-way
     // edges, is recovered structurally at coalesce
-    // (`specialize_projection_domain` / `specialize_lambda_domain`).
+    // (`specialize_projection_domain`).
     let declared = function
         .user_annotation
         .as_ref()

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -1243,30 +1243,22 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
             // rely on, so the order states it.)
             coalesce_node(function, level, ctx);
             coalesce_node(argument, level, ctx);
-            // A projection or lambda applied to a resolved argument:
-            // monomorphize its domain to the argument flowing in — the
-            // closed-form use-site specialization (see
-            // `specialize_projection_domain` / `specialize_lambda_domain`),
-            // the structural recovery for the one-way Apply edges. The
-            // cast-target / join-filter predicate case is reached the same way:
-            // `coalesce_type_predicates` (end of this fn) runs `coalesce_node` on
-            // each refinement predicate, so its projections recover here too.
+            // A projection applied to a resolved argument: monomorphize its domain
+            // to the argument flowing in (see `specialize_projection_domain`). A
+            // projection is polymorphic in its input's width, so this supplies the
+            // one width the use site needs rather than repairing anything the graph
+            // lost. The cast-target / join-filter predicate case is reached the same
+            // way: `coalesce_type_predicates` (end of this fn) runs `coalesce_node`
+            // on each refinement predicate, so its projections monomorphize here
+            // too.
+            //
+            // A *lambda*'s domain needs no counterpart: its binder is one variable
+            // carrying both the argument (below) and the body's demands (above), and
+            // a negative position reads their meet
+            // (`src/ccl/design/type-inference.md`, "The collapse happens at the
+            // position"). Only a projection's domain is unreassemblable from the graph,
+            // because its untouched positions are variables nothing constrains.
             specialize_projection_domain(function, &argument.ty);
-            specialize_lambda_domain(function, &argument.ty);
-            // Higher-order argument position: a lambda passed *as* the
-            // argument (e.g. the key/filter functions of `filter`/`groupby`
-            // and comprehension lowering). The function's resolved type is
-            // `Fun(Fun(expected_dom, _), _)`; that inner domain is the value
-            // the lambda will be fed, so specialize the lambda to it.
-            if let Type::Fun { domain: param, .. } = function.ty.peel_refinements()
-                && let Type::Fun {
-                    domain: expected_dom,
-                    ..
-                } = param.peel_refinements()
-            {
-                let expected_dom = (**expected_dom).clone();
-                specialize_lambda_domain(argument, &expected_dom);
-            }
         }
         // **A cast's predicates are read once, below, after its two slots converge.** The
         // `target` is a type slot the `expr.ty` walk does not reach, so it needs its own
@@ -1393,10 +1385,6 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
                 };
                 let prev_cod = prev_cod.as_ref().clone();
                 specialize_projection_domain(&mut elts[i], &prev_cod);
-                // Lambda morphisms (for-loop bodies lower to
-                // `Compose([source, Lambda])`) have the same under-determined
-                // domain; recover it from the preceding codomain identically.
-                specialize_lambda_domain(&mut elts[i], &prev_cod);
             }
             if let (Some(first), Some(last)) = (elts.first(), elts.last())
                 && let (
@@ -1573,16 +1561,16 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
     // an untagged sum when read bare.
     //
     // The read still *happens*, because it is load-bearing elsewhere: a parent's structural
-    // recovery of a contravariant domain (`specialize_projection_domain`,
-    // `specialize_lambda_domain`) reads it, so a record-typed parameter's uses are how a
-    // projection's domain is recovered at all. So the binder takes over only for the
-    // failure that *is* the collision above: a positive-polarity `IncompatibleBounds`,
-    // which is what an untagged join of alternatives looks like from a bare position. The
-    // use is then left var-laden, and the parameter slot is what downstream reads.
+    // recovery of a contravariant domain (`specialize_projection_domain`) reads it, so a
+    // record-typed parameter's uses are how a projection's domain is recovered at all. So
+    // the binder takes over only for the failure that *is* the collision above: a
+    // positive-polarity `IncompatibleBounds`, which is what an untagged join of
+    // alternatives looks like from a bare position. The use is then left var-laden, and
+    // the parameter slot is what downstream reads.
     //
     // Note the standing gap: nothing stamps such a use from its binder afterwards, so if
-    // this branch ever fires,
-    // the use reaches the post-inference wall var-laden and is reported there. It does
+    // this branch ever fires, the use reaches the post-inference wall var-laden and is
+    // reported there. It does
     // not fire today: no test in the suite reaches it. Whoever makes it reachable owns
     // giving the use a type at the point of the yield.
     //
@@ -1609,7 +1597,7 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
             // end-of-pass re-resolution sees every bound a later
             // specialization added — and must still yield `ty`. (Parent arms
             // may overwrite `expr.ty` afterwards via *structural* recovery
-            // — `specialize_lambda_domain`, let-closing — which is not a
+            // — `specialize_projection_domain`, let-closing — which is not a
             // graph read and so is not what this guards.)
             ctx.record_read(&expr.ty, &ty, || label.clone());
             expr.ty = ty;
@@ -1710,9 +1698,7 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
     // `refresh_lambda_param_slot`). Run it *after* `coalesce_type_predicates`
     // so the slot copies the domain's *resolved* refinement predicate (the
     // immutable predicate is a distinct `Rc`, so copying it before resolution
-    // would strand the param slot on an unresolved predicate). It is re-derived
-    // again whenever a parent arm later rewrites the domain
-    // (`specialize_lambda_domain`).
+    // would strand the param slot on an unresolved predicate).
     refresh_param_references(expr);
     refresh_lambda_param_slot(expr);
 
@@ -2260,170 +2246,64 @@ fn typecheck_discarded_definition(def: &mut Expr, level: Level, ctx: &mut Coales
     }
 }
 
-/// Specialize a projection morphism to the value flowing into it — the
-/// **closed-form** case of use-site specialization, the sibling of
-/// [`specialize_use`].
+/// The type [`specialize_projection_domain`] writes, given the value `input`
+/// flowing in.
 ///
-/// A projection `.i` is a *polymorphic* morphism: its principal type is
-/// `∀ρ. ρ ⇒ ρ.i` for any record/tuple `ρ` carrying field `i`. the solver never
-/// generalizes it (it is a builtin, not a `let`) and its single-sided
-/// `Var <: Var` rule feeds the domain var only the one field the projection
-/// touches, so the domain coalesces under-determined. Recovering it from the
-/// concrete `input` flowing in at the use site **monomorphizes** the projection
-/// to that use — exactly what [`specialize_use`] does for a generalized `let`
-/// (and what `compact_go`'s opposite-polarity fallback does for a bare
-/// contravariant domain var). The realizations differ only because the
-/// relationship differs: a `let`'s use type relates to its definition by
-/// arbitrary subtyping (so it needs freshen + pin + re-coalesce), whereas a
-/// projection's domain *equals* its input (`domain = ρ`), so the specialization
-/// collapses to a single overwrite — no clone, constraint, or re-coalesce. The
-/// codomain (the field extracted) is preserved.
-///
-/// `input` is supplied by the use site: the argument at an `Apply`, or the
-/// preceding morphism's codomain inside a `Compose`. No-op unless `morphism` is
-/// a `Proj` whose coalesced type is a function.
-///
-/// Invoked from `coalesce_node`'s `Apply`/`Compose` arms, which run bottom-up so
-/// the `input` (argument / preceding codomain) is already resolved. The
-/// cast-target / join-filter predicate case is reached the same way:
-/// `coalesce_type_predicates` runs `coalesce_node` over each refinement
-/// predicate, so its projections recover through the `Apply` arm too.
-/// The type a use-site domain recovery writes, given the position's own coalesced
-/// `domain` and the value `input` flowing in.
-///
-/// A recovery overwrites a domain with the type flowing in, read off the argument
-/// **node** — and a node's recorded type is the mutable variable *handle* wherever one was
-/// passed, because the read [`emit_apply`](super::emit::emit_apply) performed lives
-/// in the `arg <: domain` edge, not on the node. So a recovery has to make that same
-/// decision again, and it is the same decision: **a mutable variable mention reads, unless
-/// the position being specialized is itself a handle position** — which its own
-/// coalesced domain states outright, no spine walk required.
-///
-/// Both recoveries need this, and they need opposite halves of it:
-///
-/// - A **projection**'s domain is never a mutable variable — rule 2 keeps `Mut` out of every
-///   composite, so nothing projects *into* one, only through one — so this always
-///   derefs there. Without it a projection off a mutable variable (`acc.0` on a compound
-///   accumulator) re-acquires the handle here and fails `emit_proj`'s
-///   `domain <: {tuple/record}` requirement at the post-inference wall.
-/// - A **lambda**'s domain *is* a mutable variable exactly when the parameter was declared
-///   `Mut(…)`: pass-by-reference, the one position where the handle must reach the
-///   parameter. Overwriting with the handle is right there and wrong everywhere else
-///   — and wrong *silently*, since it retypes an ordinary value parameter as a
-///   mutable variable that the body still reads at its value type.
-fn recovered_input(domain: &Type, input: &Type) -> Type {
-    if domain.peel_refinements().mut_value_type().is_some() {
-        input.clone()
-    } else {
-        input.mut_value_type().unwrap_or(input).clone()
-    }
+/// The overwrite reads the argument **node**, and a node's recorded type is the
+/// mutable variable *handle* wherever one was passed, because the read
+/// [`emit_apply`](super::emit::emit_apply) performed lives in the `arg <: domain`
+/// edge, not on the node. So this has to make that same decision again, and for a
+/// projection it is always the same one: **deref**. Rule 2
+/// keeps `Mut` out of every composite, so nothing projects *into* a mutable variable,
+/// only through one. Without the deref a projection off a mutable variable (`acc.0` on
+/// a compound accumulator) re-acquires the handle here and fails `emit_proj`'s
+/// `domain <: {tuple/record}` requirement at the post-inference wall.
+fn recovered_input(input: &Type) -> Type {
+    input.mut_value_type().unwrap_or(input).clone()
 }
 
-/// Specialize a projection morphism's domain to the value flowing into it — the
-/// projection sibling of [`specialize_lambda_domain`].
+/// Monomorphize a projection to the value flowing into it — the **closed-form**
+/// case of use-site specialization, the sibling of [`specialize_use`].
 ///
-/// A projection's domain coalesces to what the projection reads, which is
-/// narrower than the value the use site supplies, so the domain is recovered
-/// structurally once that value is known. A morphism that is not a `Proj` keeps
-/// the type it has.
+/// A projection `.i` is a *polymorphic* morphism: its principal type is
+/// `∀ρ. ρ ⇒ ρ.i` for any record/tuple `ρ` carrying field `i`, and that is the type
+/// the solver gives it. The width of `ρ` belongs to the use site rather than to
+/// the projection, so a domain that does not name it is the principal type doing
+/// its job — not information the graph lost. Op-conversion needs one concrete `ρ`
+/// to emit a field access, and the use site is the only thing that has it.
+///
+/// The solver never generalizes `.i` (it is a builtin, not a `let`), so there is
+/// no scheme to instantiate and overwriting the coalesced domain with `input` *is*
+/// the instantiation — what [`specialize_use`] does for a generalized `let`, and
+/// what `compact_go`'s opposite-polarity collapse does for a bare contravariant
+/// domain var. The realizations differ only because the relationship differs: a
+/// `let`'s use type relates to its definition by arbitrary subtyping (so it needs
+/// freshen + pin + re-coalesce), whereas a projection's domain *equals* its input
+/// (`domain = ρ`), so it collapses to a single overwrite — no clone, constraint,
+/// or re-coalesce. The codomain (the field extracted) is preserved.
+///
+/// Where the argument's own type is already concrete when `arg <: domain` is
+/// drawn, the width reaches the domain variable as a lower bound and the negative
+/// reading meets it, so this is a no-op. What it is for is the argument that is
+/// still a variable at that point, whose width arrives only as its coalesced node
+/// type.
+///
+/// `input` is supplied by the use site: the argument at an `Apply`, or the
+/// preceding morphism's codomain inside a `Compose`. No-op unless `morphism` is a
+/// `Proj` whose coalesced type is a function.
+///
+/// Invoked from `coalesce_node`'s `Apply`/`Compose` arms, which run bottom-up so
+/// `input` is already resolved. The cast-target / join-filter predicate case is
+/// reached the same way: `coalesce_type_predicates` runs `coalesce_node` over each
+/// refinement predicate, so its projections monomorphize through the `Apply` arm
+/// too.
 pub(super) fn specialize_projection_domain(morphism: &mut Expr, input: &Type) {
     if matches!(morphism.node, TypedExprNode::Proj(_))
-        && let Some(dom) = morphism.ty.domain()
         && let Some(cod) = morphism.ty.codomain()
     {
         // A projection is non-dependent, so the rebuilt function type keeps `name: None`.
-        morphism.ty = Type::fun(recovered_input(&dom, input), cod);
+        morphism.ty = Type::fun(recovered_input(input), cod);
     }
-}
-
-/// Specialize a lambda's domain to the value flowing into it — the lambda
-/// sibling of [`specialize_projection_domain`].
-///
-/// With both Apply edges one-way (`fn_ty <: domain ⇒ codomain`,
-/// `arg <: domain`), a lambda's domain var only ever receives what its *body*
-/// demands, so it coalesces narrower than the value flowing in: a record
-/// narrowed to the fields the body touches (`{label}` instead of
-/// `{id, label}`), a sparsely-touched tuple shortened, an untouched parameter
-/// left `Infer`. The value actually flowing in is known once the use site's
-/// children have coalesced, so the domain is recovered structurally there.
-/// Overwriting (rather than merging) the base is sound: `arg <: domain` was
-/// constrained at emit, so the input satisfies every body demand.
-///
-/// The lambda's coalesced domain may carry refinements (body-usage facts
-/// that exist only in this negative-polarity position); they are preserved by
-/// re-wrapping them around `input`, deduping against refinements `input` already
-/// carries (structural [`Refinement`](crate::ccl::Refinement) equality). Outer
-/// refinements on the function type itself are likewise preserved.
-///
-/// `input` is supplied by the use site: the argument at a direct-redex
-/// `Apply`, the enclosing function's parameter domain when the lambda is
-/// itself an argument, or the preceding morphism's codomain inside a
-/// `Compose`. No-op unless `lambda` is a `Lambda` with a resolved `Fun` type
-/// and `input` is resolved (an `Infer` input would clobber the domain with
-/// nothing). Function values reached through opaque positions (`Var`-bound
-/// functions applied at distant call sites) are out of scope — the same
-/// opaque-vs-direct boundary as the projection recovery.
-pub(super) fn specialize_lambda_domain(lambda: &mut Expr, input: &Type) {
-    if matches!(input, Type::Infer(_)) {
-        return;
-    }
-    if !matches!(lambda.node, TypedExprNode::Lambda { .. }) {
-        return;
-    }
-    // Split the coalesced function type into its outer (function-level)
-    // refinements and the `Fun` shape.
-    let mut fn_layers = Vec::new();
-    let mut cur = lambda.ty.clone();
-    while let Type::Refinement(inner, r) = cur {
-        fn_layers.push(r);
-        cur = *inner;
-    }
-    let Type::Fun {
-        name,
-        fun_kind,
-        domain: dom,
-        codomain: cod,
-    } = cur
-    else {
-        return;
-    };
-    // Peel the domain's refinements down to the base `input` replaces.
-    let mut dom_layers = Vec::new();
-    let mut base = *dom;
-    while let Type::Refinement(inner, r) = base {
-        dom_layers.push(r);
-        base = *inner;
-    }
-    // Re-wrap the collected refinements around `input`, skipping refinements it
-    // already carries (the argument edge may have deposited the same refinement on both).
-    let mut input_refinements = Vec::new();
-    let mut t = input;
-    while let Type::Refinement(inner, r) = t {
-        input_refinements.push(r);
-        t = inner;
-    }
-    // A mutable variable mention reads unless this parameter was *declared* one — see
-    // [`recovered_input`]. `base` is the peeled domain, so a declared `Mut(V, D)`
-    // parameter is visible here whatever refinements rode in on it.
-    let new_dom = dom_layers
-        .into_iter()
-        .rev()
-        .filter(|r| !input_refinements.contains(&r))
-        .fold(recovered_input(&base, input), Type::refined);
-    lambda.ty = fn_layers.into_iter().rev().fold(
-        // Preserve the Pi binder: specialization rewrites only the domain
-        // *shape*; a dependent codomain still refers to the same binder.
-        Type::Fun {
-            name,
-            fun_kind,
-            domain: Box::new(new_dom),
-            codomain: cod,
-        },
-        Type::refined,
-    );
-    // The param slot was derived from the pre-specialization domain during the
-    // lambda's own `coalesce_node`; re-derive it from the rewritten one.
-    refresh_lambda_param_slot(lambda);
 }
 
 /// Fill a lambda's `param.ty` binder slot from its coalesced function type's
@@ -2549,22 +2429,21 @@ mod tests {
     use crate::ccl::symbolic::symbolic;
     use crate::ccl::{ArithmeticKind, BaseType, BinOpKind, Lit, Type, TypedExpr, TypedExprNode};
 
-    // ----- use-site domain recovery (`recovered_input`) -----
+    // ----- the projection's monomorphization (`recovered_input`) -----
 
-    /// A use-site domain recovery overwrites a morphism's domain with the type read
-    /// off the argument **node**, and that type is the mutable variable *handle* — the read
-    /// `emit_apply` performed lives in the `arg <: domain` edge, not on the node. So
-    /// the recovery has to redo the decision, and it must land on the same answer.
+    /// The projection's monomorphization overwrites a morphism's domain with the type
+    /// read off the argument **node**, and that type is the mutable variable *handle* —
+    /// the read `emit_apply` performed lives in the `arg <: domain` edge, not on the
+    /// node. So it has to redo the decision, and for a projection the answer is always
+    /// to deref.
     ///
-    /// Driven at [`recovered_input`] rather than through a program because neither
-    /// arm is reachable from source today: a lambda in function position is only ever
-    /// the comprehension shape until `inline` runs (after inference), and a lambda
-    /// parameter cannot be annotated at all, so a directly-applied `Mut` parameter has
-    /// no spelling. Both become reachable the moment direct application does, and the
-    /// wrong answer is silent in both directions — a value parameter retyped as a
-    /// mutable variable, or a pass-by-reference parameter degraded to a value copy.
+    /// Driven at [`recovered_input`] rather than through a program because a
+    /// projection off a mutable variable needs a compound accumulator, and the wrong
+    /// answer there is silent: the domain re-acquires the handle and fails
+    /// `emit_proj`'s `domain <: {tuple/record}` requirement at the post-inference
+    /// wall rather than at the projection.
     #[test]
-    fn a_recovery_reads_a_mut_var_unless_the_position_is_a_handle() {
+    fn the_projection_monomorphization_reads_through_a_mut_var() {
         use super::recovered_input;
         use crate::ccl::{HistoryKind, Refinement};
         let mut_var = |value: Type| Type::History {
@@ -2583,22 +2462,13 @@ mod tests {
         let int = Type::Base(BaseType::Int);
         let handle = mut_var(int.clone());
 
-        // An ordinary value position reads through the handle.
-        assert_eq!(recovered_input(&int, &handle), int);
-        // ...including one still unresolved, and one carrying body-usage refinements:
-        // the decision is the *position's*, and neither of those is a handle position.
-        assert_eq!(recovered_input(&Type::Hole, &handle), int);
-        assert_eq!(recovered_input(&refined(int.clone()), &handle), int);
-
-        // A declared `Mut(…)` parameter is the one position the handle must reach —
-        // dereffing here would turn pass-by-reference into a silent value copy.
-        assert_eq!(recovered_input(&handle, &handle), handle);
-        // A refinement on the handle does not stop it being one (a refined mutable variable is
-        // still a mutable variable), so the position is still recognised.
-        assert_eq!(recovered_input(&refined(handle.clone()), &handle), handle);
-
-        // A non-mutable variable input is untouched either way.
-        assert_eq!(recovered_input(&int, &int), int);
+        // The handle reads through to its value type.
+        assert_eq!(recovered_input(&handle), int);
+        // A refinement on the handle does not stop it being one (a refined mutable
+        // variable is still a mutable variable), so it still reads through.
+        assert_eq!(recovered_input(&refined(handle.clone())), int);
+        // A non-mutable variable input is untouched.
+        assert_eq!(recovered_input(&int), int);
     }
 
     // ----- ordering-invariant comparison (`types_agree_modulo_unread`) -----

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -2055,10 +2055,10 @@ fn compact_go(
             // This fallback handles a *bare* under-determined domain var: it
             // materializes the type locally at coalesce from the lower-bound
             // side. The other half of the contravariant-domain story — a
-            // *structured* domain (a tuple/record with `Infer`s inside, which
-            // this per-var read cannot reassemble) — is recovered separately
-            // by `coalesce_node`'s `specialize_projection_domain` /
-            // `specialize_lambda_domain`. Both Apply edges are one-way (no
+            // *structured* domain whose untouched positions are variables no
+            // edge ever reaches, which is a `Proj`'s dense-prefix requirement
+            // and nothing else — is recovered separately by `coalesce_node`'s
+            // `specialize_projection_domain`. Both Apply edges are one-way (no
             // emit-time reverse whose eager cross-component propagation would
             // cover these halves); see `design/type-inference.md` ("Apply is
             // one-way" and "Closing the single-sided blind spots (no separate
@@ -2087,17 +2087,16 @@ fn compact_go(
                 let bc = compact_go(&b.ty, pol, &inner_acc, Some(&new_parents), st);
                 bound = CompactType::merge(pol, bound, bc);
             }
-            // Opposite-polarity fallback: walk the other side too if the
-            // primary walk did not produce any concrete (atom / shape)
-            // contribution. Without this, a variable whose only concrete
-            // information lives on the opposite polarity coalesces to
-            // `Type::Infer(?N)` instead of its real type — most commonly
-            // a fresh lambda param whose Apply-site bound flows in at the
-            // opposite polarity from where the lambda is coalesced. This is the
-            // coalesce-time read of monomorphization; it is sound because every
-            // var reaching coalesce is monomorphically determined (one type or
-            // an `IncompatibleBounds` error). See the rationale above, and
-            // [`fallback_allowed`] for why it happens only at a position.
+            // Whether the *shape* collapse fires: the primary walk produced no
+            // concrete (atom / shape) contribution. Without it a variable whose only
+            // concrete information lives on the opposite polarity coalesces to
+            // `Type::Infer(?N)` instead of its real type — most commonly a fresh
+            // lambda param whose Apply-site bound flows in at the opposite polarity
+            // from where the lambda is coalesced. This is the coalesce-time read of
+            // monomorphization; it is sound because every var reaching coalesce is
+            // monomorphically determined (one type or an `IncompatibleBounds`
+            // error). See the rationale above, and [`fallback_allowed`] for why it
+            // happens only at a position.
             let no_concrete = {
                 let CompactType {
                     atoms,
@@ -2131,7 +2130,13 @@ fn compact_go(
                     && history_slot.is_none()
                     && !var_is_shape
             };
-            if no_concrete && allow_fallback {
+            // A negative position reads the opposite side whether or not the shape
+            // needed recovering, because both sides narrow it: the requirement side
+            // records what the uses demand, the value side what actually arrives (see
+            // `src/ccl/design/type-inference.md`, "The collapse happens at the
+            // position").
+            let read_opposite = allow_fallback && (no_concrete || !pol);
+            let recovered = read_opposite.then(|| {
                 let mut recovered: Option<CompactType> = None;
                 for b in opposite_bounds.iter() {
                     let inner_acc = Subst::then(&b.render_subst(), subst_acc);
@@ -2141,17 +2146,23 @@ fn compact_go(
                         Some(acc) => CompactType::merge(!pol, acc, bc),
                     });
                 }
-                if let Some(mut recovered) = recovered {
+                recovered
+            });
+            match (recovered.flatten(), no_concrete) {
+                (Some(mut recovered), true) => {
                     // Carry what the polarity-correct walk *did* find — variable
                     // identities and refinement demands — across without letting
                     // it into the structural fold.
                     //
-                    // Replacing rather than merging is what the *negative* case
-                    // needs: there the primary result may hold a variant shape,
-                    // and it is the arms the body can handle rather than anything
-                    // that flowed in, so merging would union those tags into the
-                    // domain. (At a positive position `no_concrete` now implies
-                    // there is no shape at all to lose.)
+                    // Replacing rather than meeting is what an *undetermined*
+                    // position needs, and the difference is that the collapse here is
+                    // a choice rather than a narrowing: there is no settled structure
+                    // for the two sides to narrow jointly. At a negative position the
+                    // primary result may still hold a variant shape, and it is the
+                    // arms the body can handle rather than anything that flowed in, so
+                    // meeting would intersect those tags into the domain. (At a
+                    // positive position `no_concrete` implies there is no shape at all
+                    // to lose.)
                     //
                     // Refinements union instead of intersecting: a demanded
                     // predicate is checked against the value the fallback found,
@@ -2165,6 +2176,15 @@ fn compact_go(
                     }
                     bound = recovered;
                 }
+                // Both sides are narrowings of a structure the primary walk already
+                // settled, so the reading is their meet — which is what merging at the
+                // position's own polarity computes. One rule covers every slot: a
+                // refinement set narrows a position exactly as a record's fields do,
+                // and the negative merge unions both.
+                (Some(recovered), false) => {
+                    bound = CompactType::merge(pol, bound, recovered);
+                }
+                (None, _) => {}
             }
             // The variable's kinding constraints join its identity: they are facts
             // about what this position resolves to, and coalesce reads them there.
@@ -2189,8 +2209,67 @@ fn compact_go(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ccl::infer::solver::{CoalesceError, coalesce_compact};
-    use crate::ccl::{BaseType, Refinement, TypedExpr};
+    use crate::ccl::infer::solver::{
+        CoalesceError, ConstrainCache, coalesce_compact, constrain_subtype, fresh_var,
+    };
+    use crate::ccl::{BaseType, Lit, Refinement, TypedExpr};
+
+    /// A negative position's reading is the meet of both sides: the requirement side
+    /// says what the uses demand, the value side what actually arrives, and the
+    /// position accepts only what satisfies both.
+    ///
+    /// One rule covers every slot, so the two cases here differ only in which slot
+    /// carries the value side's contribution. The refinement case is the reachable
+    /// one — the trait sweep deposits a bare `Type::Base` on every operand place it
+    /// resolves, which settles the shape and establishes no refinement, so without
+    /// the meet a data domain and its own binder's occurrences spell one invariant
+    /// position two ways (`src/ccl/design/type-inference.md`, "The collapse happens
+    /// at the position").
+    #[test]
+    fn a_negative_position_meets_both_sides() {
+        let int = || Type::Base(BaseType::Int);
+        let field = |n: &str| (n.to_string(), int());
+        // `demand` is what the body asks of the parameter; `value` is what reaches it.
+        let domain_of = |value: Type, demand: Type| {
+            let dom = fresh_var(0);
+            let mut cache = ConstrainCache::new();
+            constrain_subtype(&value, &dom, &mut cache).expect("the value flows in");
+            constrain_subtype(&dom, &demand, &mut cache).expect("and meets the demand");
+            compact_type(&Type::fun(dom, int()))
+                .term
+                .fun
+                .expect("a function slot")
+                .domain
+                .as_ref()
+                .clone()
+        };
+
+        // Refinements: the demand settles the shape and carries none of its own.
+        let refined = domain_of(crate::ccl::infer::lit_singleton(&Lit::Int(1)), int());
+        assert!(
+            refined.atoms.contains(&AtomKey::Prim(BaseType::Int)),
+            "the demand still settles the shape"
+        );
+        assert_eq!(
+            refined.refinements.as_ref().map(RefinementSet::len),
+            Some(1),
+            "and the singleton the value establishes narrows it further"
+        );
+
+        // Record width, the same rule one slot over: a body that reads `a` demands
+        // only `a`, and the value's `b` survives because the negative merge unions
+        // fields exactly as it unions refinements.
+        let wide = domain_of(
+            Type::Record(vec![field("a"), field("b")]),
+            Type::Record(vec![field("a")]),
+        );
+        let fields = wide.rec.expect("a record shape");
+        assert!(
+            fields.contains_key(&FieldKey::Name(SmolStr::from("a")))
+                && fields.contains_key(&FieldKey::Name(SmolStr::from("b"))),
+            "both the demanded field and the one only the value carries: {fields:?}"
+        );
+    }
 
     /// The landing-closes check asks whether a refinement holds a **free**
     /// reference to the function's binder. A predicate that binds the same
@@ -2238,7 +2317,7 @@ mod tests {
     fn a_data_join_does_not_acquire_one_sides_domain_refinement() {
         let filtered_domain = CompactType {
             refinements: Some(RefinementSet::one(Refinement::born(Rc::new(
-                TypedExpr::lit(crate::ccl::Lit::Bool(true)),
+                TypedExpr::lit(Lit::Bool(true)),
             )))),
             ..CompactType::from_atom(AtomKey::UIntRange(2))
         };
@@ -2272,7 +2351,7 @@ mod tests {
     fn a_data_join_over_one_refined_domain_is_fine() {
         let refined = || CompactType {
             refinements: Some(RefinementSet::one(Refinement::born(Rc::new(
-                TypedExpr::lit(crate::ccl::Lit::Bool(true)),
+                TypedExpr::lit(Lit::Bool(true)),
             )))),
             ..CompactType::from_atom(AtomKey::UIntRange(2))
         };

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -825,10 +825,16 @@ impl CompactVariant {
     ///
     /// The tag *map* still merges by the ordinary rule below. That is an
     /// approximation when exactly one side is open: an exact meet would keep the
-    /// closed side's tag set whole rather than intersecting the two. No program
-    /// reaches it — a scrutinee takes one `Case` demand per `match`, and two open
-    /// demands on one variable meet as `Open`/`Open` — so the exact rule is left
-    /// unstated rather than written and untested.
+    /// closed side's tag set whole rather than intersecting the two, so a value tag
+    /// the open demand does not name is dropped and the marker then claims the
+    /// remainder is exhaustive.
+    ///
+    /// The negative merge in [`compact_go`] reaches that case — an open `case _:`
+    /// demand meets the value side, which is a producer and so closed
+    /// (`a_settled_negative_position_closes_an_open_child_demand` pins the reading).
+    /// No program observes it: the narrowed reading is the domain's, and the default
+    /// arm is compiled from the `Case` rather than from that reading
+    /// (`test_default_arm_under_a_record_field`).
     fn meet_openness(a: Openness, b: Openness) -> Openness {
         match (a, b) {
             (Openness::Open, Openness::Open) => Openness::Open,
@@ -2156,12 +2162,13 @@ fn compact_go(
                     // Replacing rather than meeting is what an *undetermined*
                     // position needs, and the difference is that the collapse here is
                     // a choice rather than a narrowing: there is no settled structure
-                    // for the two sides to narrow jointly. At a negative position the
-                    // primary result may still hold a variant shape, and it is the
+                    // for the two sides to narrow jointly. A negative position reaches
+                    // this arm holding at most a variant shape, and that shape is the
                     // arms the body can handle rather than anything that flowed in, so
                     // meeting would intersect those tags into the domain. (At a
                     // positive position `no_concrete` implies there is no shape at all
-                    // to lose.)
+                    // to lose.) A variant the walk reaches *under* a settled shape is a
+                    // different position and does meet — the arm below.
                     //
                     // Refinements union instead of intersecting: a demanded
                     // predicate is checked against the value the fallback found,
@@ -2180,6 +2187,12 @@ fn compact_go(
                 // position's own polarity computes. One rule covers every slot: a
                 // refinement set narrows a position exactly as a record's fields do,
                 // and the negative merge unions both.
+                //
+                // A variant in a child slot meets here too, and that is the one caller
+                // reaching [`CompactVariant::meet_openness`]'s one-side-open case: the
+                // value side of a `case _:` demand is a producer and so closed, and the
+                // meet both closes the marker and intersects away a tag the demand does
+                // not name (`a_settled_negative_position_closes_an_open_child_demand`).
                 (Some(recovered), false) => {
                     bound = CompactType::merge(pol, bound, recovered);
                 }
@@ -2291,6 +2304,59 @@ mod tests {
         assert!(
             produced_fields.contains_key(&FieldKey::Name(SmolStr::from("b"))),
             "the field the demand omits survives: {produced_fields:?}"
+        );
+    }
+
+    /// `CompactVariant::meet_openness`'s one-side-open case, which the negative merge
+    /// reaches: a `case _:` demand is open and the value side is a producer and so
+    /// closed, so the reading closes the marker and intersects the tags.
+    ///
+    /// Both halves are approximations of the exact meet, which would keep the closed
+    /// side's tag set whole — `` `other `` is a tag the position genuinely carries.
+    /// Pinned rather than fixed: no program observes the narrowed reading
+    /// (`test_default_arm_under_a_record_field`), and the exact rule is a change to the
+    /// variant meet itself.
+    ///
+    /// The variant sits **under** a record field because that is what makes the outer
+    /// position settled. A bare variant demand leaves the position undetermined, which
+    /// takes the replacement instead and drops the demand whole.
+    #[test]
+    fn a_settled_negative_position_closes_an_open_child_demand() {
+        let int = || Type::Base(BaseType::Int);
+        let arm = |n: &str, t: Type| (FieldKey::Name(SmolStr::from(n)), t);
+        let rec = |t: Type| Type::Record(vec![("f".to_string(), t)]);
+        let dom = fresh_var(0);
+        let mut cache = ConstrainCache::new();
+        let value = Type::Variant(
+            vec![arm("some", int()), arm("other", Type::Base(BaseType::Unit))],
+            Openness::Closed,
+        );
+        let demand = Type::Variant(vec![arm("some", int())], Openness::Open);
+        constrain_subtype(&rec(value), &dom, &mut cache).expect("the value flows in");
+        constrain_subtype(&dom, &rec(demand), &mut cache).expect("and meets the demand");
+        let read = compact_type(&Type::fun(dom, int()))
+            .term
+            .fun
+            .expect("a function slot")
+            .domain
+            .as_ref()
+            .clone();
+        let field = read
+            .rec
+            .as_ref()
+            .and_then(|m| m.get(&FieldKey::Name(SmolStr::from("f"))))
+            .expect("the record's field");
+        let variant = field.var.as_ref().expect("a variant shape");
+        assert_eq!(
+            variant.openness,
+            Openness::Closed,
+            "the open demand's marker does not survive the meet"
+        );
+        assert_eq!(
+            variant.tags.keys().collect::<Vec<_>>(),
+            vec![&FieldKey::Name(SmolStr::from("some"))],
+            "and the tag the demand does not name is intersected away: {:?}",
+            variant.tags
         );
     }
 

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -2136,8 +2136,8 @@ fn compact_go(
             // `src/ccl/design/type-inference.md`, "The collapse happens at the
             // position").
             let read_opposite = allow_fallback && (no_concrete || !pol);
-            let recovered = read_opposite.then(|| {
-                let mut recovered: Option<CompactType> = None;
+            let mut recovered: Option<CompactType> = None;
+            if read_opposite {
                 for b in opposite_bounds.iter() {
                     let inner_acc = Subst::then(&b.render_subst(), subst_acc);
                     let bc = compact_go(&b.ty, !pol, &inner_acc, Some(&new_parents), st);
@@ -2146,9 +2146,8 @@ fn compact_go(
                         Some(acc) => CompactType::merge(!pol, acc, bc),
                     });
                 }
-                recovered
-            });
-            match (recovered.flatten(), no_concrete) {
+            }
+            match (recovered, no_concrete) {
                 (Some(mut recovered), true) => {
                     // Carry what the polarity-correct walk *did* find — variable
                     // identities and refinement demands — across without letting
@@ -2229,20 +2228,23 @@ mod tests {
     fn a_negative_position_meets_both_sides() {
         let int = || Type::Base(BaseType::Int);
         let field = |n: &str| (n.to_string(), int());
-        // `demand` is what the body asks of the parameter; `value` is what reaches it.
-        let domain_of = |value: Type, demand: Type| {
-            let dom = fresh_var(0);
+        // `demand` is what the body asks of the variable; `value` is what reaches it.
+        // `negative` places it at a function's domain rather than its codomain.
+        let read_at = |value: Type, demand: Type, negative: bool| {
+            let v = fresh_var(0);
             let mut cache = ConstrainCache::new();
-            constrain_subtype(&value, &dom, &mut cache).expect("the value flows in");
-            constrain_subtype(&dom, &demand, &mut cache).expect("and meets the demand");
-            compact_type(&Type::fun(dom, int()))
-                .term
-                .fun
-                .expect("a function slot")
-                .domain
-                .as_ref()
-                .clone()
+            constrain_subtype(&value, &v, &mut cache).expect("the value flows in");
+            constrain_subtype(&v, &demand, &mut cache).expect("and meets the demand");
+            let f = if negative {
+                Type::fun(v, int())
+            } else {
+                Type::fun(int(), v)
+            };
+            let slot = compact_type(&f).term.fun.expect("a function slot");
+            let read = if negative { slot.domain } else { slot.codomain };
+            read.as_ref().clone()
         };
+        let domain_of = |value: Type, demand: Type| read_at(value, demand, true);
 
         // Refinements: the demand settles the shape and carries none of its own.
         let refined = domain_of(crate::ccl::infer::lit_singleton(&Lit::Int(1)), int());
@@ -2268,6 +2270,27 @@ mod tests {
             fields.contains_key(&FieldKey::Name(SmolStr::from("a")))
                 && fields.contains_key(&FieldKey::Name(SmolStr::from("b"))),
             "both the demanded field and the one only the value carries: {fields:?}"
+        );
+
+        // A **positive** position is unaffected: its polarity-correct side is already
+        // the value's own facts, and a demand is not one. Both slots say so by what a
+        // positive merge would have done instead — intersect, erasing the singleton the
+        // value establishes and the field the body never reads.
+        let produced = read_at(crate::ccl::infer::lit_singleton(&Lit::Int(1)), int(), false);
+        assert_eq!(
+            produced.refinements.as_ref().map(RefinementSet::len),
+            Some(1),
+            "the value's singleton survives a demand carrying none"
+        );
+        let produced_wide = read_at(
+            Type::Record(vec![field("a"), field("b")]),
+            Type::Record(vec![field("a")]),
+            false,
+        );
+        let produced_fields = produced_wide.rec.expect("a record shape");
+        assert!(
+            produced_fields.contains_key(&FieldKey::Name(SmolStr::from("b"))),
+            "the field the demand omits survives: {produced_fields:?}"
         );
     }
 

--- a/src/ccl/infer/solver/spec_key.rs
+++ b/src/ccl/infer/solver/spec_key.rs
@@ -574,8 +574,11 @@ fn key_go(ty: &Type, pol: bool, subst_acc: &Subst, ctx: &mut KeyCtx) -> KeyView 
         // A variable contributes its **polarity-correct** bounds only. Following
         // both here instead is what leaks out of this use's cone and into every
         // other use's arguments; the two root reads are what cover both
-        // directions without ever mixing them at one variable. There is no
-        // opposite-polarity fallback either — the dual read subsumes it.
+        // directions without ever mixing them at one variable. Neither
+        // opposite-polarity read `compact_go` performs is mirrored here — the
+        // undetermined position's collapse or the negative position's meet — because
+        // the dual read already sees every bound either could reach, on whichever
+        // root read follows that side.
         Type::Infer(state) => {
             let visit_key = (state.uid, pol);
             let memo_key = (state.uid, pol, ctx.scope.enclosing().to_vec());
@@ -693,10 +696,12 @@ mod tests {
         assert_eq!(spec_key(&fresh_var(0)), SpecKey::default());
     }
 
-    /// The defect the key exists to fix: an argument's refinement reaches a domain
-    /// variable as a **lower** bound, where a negative-position materialization
-    /// cannot see it. The saturated key sees it, so two calls differing only
-    /// there key apart.
+    /// An argument's refinement reaches a domain variable as a **lower** bound, and
+    /// a negative position meets it there (`src/ccl/design/type-inference.md`,
+    /// "The collapse happens at the position"), so two calls differing only in that
+    /// refinement resolve to different domains. The key must therefore keep them
+    /// apart, which its dual read does — the *negative* root read follows the
+    /// domain's lower bounds.
     #[test]
     fn lower_bound_refinement_is_visible_where_a_materialization_narrows() {
         let mut keys = Vec::new();
@@ -706,8 +711,7 @@ mod tests {
             // The emit-time `arg <: domain` edge, for an argument carrying its
             // literal's singleton.
             constrain_subtype(&singleton(n), &dom, &mut cache).expect("arg flows into domain");
-            // And the definition's demand, which is all a negative resolution of
-            // `dom` would consult.
+            // And the definition's demand, which settles the domain's shape.
             constrain_subtype(&dom, &int(), &mut cache).expect("domain meets the body's demand");
             keys.push(spec_key(&Type::fun(dom, int())));
         }

--- a/src/ccl/infer/typing.rs
+++ b/src/ccl/infer/typing.rs
@@ -275,8 +275,7 @@ pub(super) trait Typing {
     /// the value actually flowing in — is recovered *structurally* in
     /// `coalesce_node` (its `Apply`/`Compose` arms) by monomorphizing the
     /// morphism to its input
-    /// ([`specialize_projection_domain`](super::solve::specialize_projection_domain) /
-    /// [`specialize_lambda_domain`](super::solve::specialize_lambda_domain)),
+    /// ([`specialize_projection_domain`](super::solve::specialize_projection_domain)),
     /// the closed-form case of the same use-site specialization
     /// [`specialize_use`](super::solve::specialize_use) performs for generalized
     /// `let`s.

--- a/src/ccl/lower/comprehension.rs
+++ b/src/ccl/lower/comprehension.rs
@@ -263,19 +263,26 @@ pub(super) fn lower_list_comp(
         // outermost binder is the first generator's, so a source goes in front of the ones
         // already recorded.
         //
-        // Only a source that did not already name its domain is stamped — otherwise the id
-        // came *from* its annotation and re-stamping would discard it — and such a source
-        // contributes the kind that annotation states.
+        // The two branches differ in where the kind comes from, and in whether the shared
+        // domain still has to be stamped: an annotation naming a domain is where the id
+        // came from, and re-stamping would discard it.
         let source = match source.user_annotation.as_ref().and_then(Type::fun_kind) {
             Some(annotated) => {
                 result_kv.contributes_first(annotated.clone());
                 // An annotation states a kind, a domain, or both, and only the domain
-                // answers the question above. A `groupby` source states its keys through
-                // its key binder and annotates the kind alone, so `named_data_domain`
+                // decides whether the id is already there. A source whose annotation
+                // states the kind alone leaves `domain: Hole`, so `named_data_domain`
                 // found no id to adopt and the shared one minted above still has to reach
                 // it — without that the two domains are ordered by the argument edge and
                 // nothing says they are one, which is what lets the two readings of one
                 // invariant position diverge.
+                //
+                // The test is the annotation's shape, `Type::data_fun(Hole, Hole)`, and
+                // not `groupby` in particular: a comprehension can iterate a `groupby`,
+                // the `set` / `map` re-keying constructors (`lower_rekeyed`), or a
+                // conditional comprehension's arm, each annotated that way. The equation
+                // holds for all of them, an unfiltered single-generator comprehension's
+                // domain being its source's domain whatever shape the source has.
                 match (&iter_dom, source.user_annotation.clone()) {
                     (
                         Some(shared),

--- a/src/ccl/lower/comprehension.rs
+++ b/src/ccl/lower/comprehension.rs
@@ -269,7 +269,30 @@ pub(super) fn lower_list_comp(
         let source = match source.user_annotation.as_ref().and_then(Type::fun_kind) {
             Some(annotated) => {
                 result_kv.contributes_first(annotated.clone());
-                source
+                // An annotation states a kind, a domain, or both, and only the domain
+                // answers the question above. A `groupby` source states its keys through
+                // its key binder and annotates the kind alone, so `named_data_domain`
+                // found no id to adopt and the shared one minted above still has to reach
+                // it — without that the two domains are ordered by the argument edge and
+                // nothing says they are one, which is what lets the two readings of one
+                // invariant position diverge.
+                match (&iter_dom, source.user_annotation.clone()) {
+                    (
+                        Some(shared),
+                        Some(Type::Fun {
+                            name,
+                            fun_kind,
+                            domain,
+                            codomain,
+                        }),
+                    ) if matches!(*domain, Type::Hole) => source.with_user_annotation(Type::Fun {
+                        name,
+                        fun_kind,
+                        domain: Box::new(shared.clone()),
+                        codomain,
+                    }),
+                    _ => source,
+                }
             }
             None => {
                 assert!(

--- a/tests/compilation_pipeline/joins_aggregates_groupby.rs
+++ b/tests/compilation_pipeline/joins_aggregates_groupby.rs
@@ -169,37 +169,41 @@ fn test_groupby(#[case] code: &str, #[case] expected: Tile) {
     check_tile(code, expected);
 }
 
-// A group-by over a literal whose elements share **one singleton type** does not compile.
-// `[1]` and `[1, 1]` both have element type `Int@1`, so the key morphism's codomain — and
-// with it the key domain — is `Int@1`, where `[1, 2]`'s is `Int`.
-//
-// The two spellings meet at the consuming lambda. Inference leaves
-// `λ __iter_record : Int → __iter_record:<Int@1> ▷ ⟨the group-by⟩`: the binder is declared
-// at the *widened* `Int` while its own occurrence keeps `Int@1`. A parameter may drop a
-// refinement — a refined argument flows into an unrefined parameter — but a **data**
-// function's domain is invariant (`src/ccl/design/type-inference.md`, "Data domains are
-// invariant"), so the two do not reconcile and `post-lambda-elim` reports
-// `expected Int, found Int@1`.
-//
-// The consuming lambda is the program's result, so nothing applies it and
-// `specialize_lambda_domain` — which recovers an under-determined contravariant domain from
-// the argument flowing in — never runs on it. Reproduces on `main`; `set` and `map` inherit
-// it through the shared re-keying shape rather than causing it.
+// A group-by whose element type is a singleton refinement (`[1]`, `[1, 1]`) keys the same
+// as one whose elements only share a base type (`[1, 2]`). The singleton rides the group
+// key's lower bounds, which a domain's reading meets
+// (`src/ccl/design/type-inference.md`, "The collapse happens at the position").
 #[rstest]
 #[timeout(Duration::from_secs(30))]
-#[case("[sum(x) for x in groupby([1], \\x -> x)]")]
-#[case("[sum(x) for x in groupby([1, 1], \\x -> x)]")]
-// Pinned on the failure: it reports the day a base carrying the fix arrives, which an
-// `#[ignore]` could not. The parameter's domain resolves to `Int` while its occurrences
-// resolve to `Int@1`, and a data domain is invariant.
-//
-// The **pass** that catches it is not part of the claim, and it moves: `post-lambda-elim`
-// rejects the collection domain here, while the keyed-collection branches above reach
-// `post-planning` and an `Apply` mismatch on the same program. So the pin is on the
-// post-pass tree check rather than on either message.
-#[should_panic(expected = "produced an invalid tree: [Type mismatch")]
-fn a_groupby_over_a_singleton_element_literal(#[case] code: &str) {
-    run_pipeline(code);
+#[case(
+    "[sum(x) for x in groupby([1], \\x -> x)]",
+    Tile::SealedFunction {
+        domain: ColumnValue::Ints(vec![1]),
+        codomain: Box::new(Tile::Scalar(ColumnValue::Ints(vec![1]))),
+        domain_predicate: Predicate::True,
+        deleted: BitSet::new(),
+    }
+)]
+#[case(
+    "[sum(x) for x in groupby([1, 1], \\x -> x)]",
+    Tile::SealedFunction {
+        domain: ColumnValue::Ints(vec![1]),
+        codomain: Box::new(Tile::Scalar(ColumnValue::Ints(vec![2]))),
+        domain_predicate: Predicate::True,
+        deleted: BitSet::new(),
+    }
+)]
+#[case(
+    "[sum(x) for x in groupby([1, 2], \\x -> x)]",
+    Tile::SealedFunction {
+        domain: ColumnValue::Ints(vec![1, 2]),
+        codomain: Box::new(Tile::Scalar(ColumnValue::Ints(vec![1, 2]))),
+        domain_predicate: Predicate::True,
+        deleted: BitSet::new(),
+    }
+)]
+fn a_groupby_over_a_singleton_element_literal(#[case] code: &str, #[case] expected: Tile) {
+    check_tile(code, expected);
 }
 
 // `set([…])` is a deduplicating re-keying constructor: the distinct
@@ -245,6 +249,10 @@ fn check_set_keys(code: &str, sorted_keys: ColumnValue, n: usize) {
 #[case("set([1,2,2,3])", ColumnValue::Ints(vec![1, 2, 3]), 3)]
 #[case("set([3,1,2,1,3])", ColumnValue::Ints(vec![1, 2, 3]), 3)]
 #[case("set(['a','b','a'])", ColumnValue::strings(&["a", "b"]), 2)]
+// A literal whose elements share one singleton type keys like any other
+// ([`a_groupby_over_a_singleton_element_literal`] carries the group-by it is built on).
+#[case("set([1])", ColumnValue::Ints(vec![1]), 1)]
+#[case("set([1, 1])", ColumnValue::Ints(vec![1]), 1)]
 fn test_set(#[case] code: &str, #[case] sorted_keys: ColumnValue, #[case] n: usize) {
     check_set_keys(code, sorted_keys, n);
 }
@@ -281,6 +289,7 @@ fn check_map_entries(code: &str, mut expected: Vec<(Value, Value)>) {
 #[case("map([(1, 10), (2, 20)])", vec![(Value::Int(1), Value::Int(10)), (Value::Int(2), Value::Int(20))])]
 #[case("map([(3, 30), (1, 10), (2, 20)])", vec![(Value::Int(1), Value::Int(10)), (Value::Int(2), Value::Int(20)), (Value::Int(3), Value::Int(30))])]
 #[case("map([('a', 1), ('b', 2)])", vec![(Value::String("a".into()), Value::Int(1)), (Value::String("b".into()), Value::Int(2))])]
+#[case("map([(1, 10)])", vec![(Value::Int(1), Value::Int(10))])]
 fn test_map(#[case] code: &str, #[case] expected: Vec<(Value, Value)>) {
     check_map_entries(code, expected);
 }
@@ -296,32 +305,6 @@ fn test_map(#[case] code: &str, #[case] expected: Vec<(Value, Value)>) {
 #[should_panic(expected = "elements under one key")]
 fn map_rejects_a_duplicate_key() {
     run_pipeline("map([(1, 10), (2, 20), (1, 99)])");
-}
-
-// A re-keying constructor over a literal whose elements share **one** singleton type does
-// not compile, and neither constructor causes it: a plain `groupby` over the same literal
-// fails identically ([`a_groupby_over_a_singleton_element_literal`] carries the diagnosis).
-// `set` and `map` reach it through the group-by their shared shape is built on, and both
-// spellings are listed because both do.
-//
-// The parameter's domain resolves to `Int` while every occurrence of that domain's binder
-// resolves to `Int@1`, and a data function's domain is invariant, so `post-lambda-elim`
-// rejects the tree. A fix for that — meeting both sides when a negative position is read —
-// is in flight and is not under this stack, so the pin is on the failure: it reports the day
-// a base carrying the fix arrives, which an `#[ignore]` could not.
-//
-// It blocks the single-entry seed a mutable map wants (`map([("tee", 5)])`), so it is
-// recorded here rather than left to be rediscovered.
-#[rstest]
-#[timeout(Duration::from_secs(30))]
-#[case("set([1])")]
-#[case("set([1, 1])")]
-#[case("map([(1, 10)])")]
-#[should_panic(
-    expected = "post-lambda-elim produced an invalid tree: [Type mismatch for collection domain"
-)]
-fn test_rekeying_over_a_singleton_literal(#[case] code: &str) {
-    run_pipeline(code);
 }
 
 // A `set(…)` value **nested as another comprehension's source** is not driven:

--- a/tests/compilation_pipeline/transactions.rs
+++ b/tests/compilation_pipeline/transactions.rs
@@ -3101,6 +3101,59 @@ fn a_keyed_write_reaches_an_induction_store() {
     );
 }
 
+/// A mutable `Map` seeded with a **one-entry** literal, which does not compile.
+///
+/// The seed's key type is that key's own singleton, so its present-key domain is
+/// `{String | __elem == "a", __elem ▷ (… ▷ collection_contains)}`. Meeting both sides at a
+/// negative position settles the re-keying shape — both binders of `lower_rekeyed` read the
+/// singleton — and `box`'s instantiated domain still reads the bare
+/// `{String | __elem ▷ (… ▷ collection_contains)}`, which a data domain's invariance rejects.
+///
+/// **The key variable resolves two ways at one polarity, decided by how the walk reached
+/// it.** Entered as a position it reads the meet (the singleton); reached through another
+/// variable's bound chain — which is how `box`'s type reaches it — it reads the demand side
+/// alone. `fallback_allowed` gates both the shape collapse and the meet, and only the
+/// collapse needs it: a collapse is a choice, which must not propagate along subtyping
+/// edges, while the meet is a narrowing, which may.
+///
+/// Ungating the meet closes all three shapes below and is not the fix as it stands. It costs
+/// `def by_key(c, f): groupby(c, f)` applied at two types 1.4s → 10s. And where a discharge
+/// is suspended on the chain it meets two data domains whose refinement sets differ only in
+/// the discharged binder's spelling — `{[0, 2] | x == 0}` against `{[0, 2] | x == __arg}`.
+/// `data_domains_disagree` compares those sets structurally, so one domain reached twice
+/// reads as two that disagree, which
+/// `higher_order_dependent_application_discharges_the_binder` reports as conflicting
+/// domains.
+///
+/// Pinned on the failure rather than deferred: it reports the day a base closes the gap,
+/// which an `#[ignore]` could not. The sibling below seeds **two** entries for this reason.
+#[rstest]
+#[timeout(Duration::from_secs(30))]
+// Read alone, with no write at all: the seed's own type is enough.
+#[case(indoc! {r#"
+    m: Mut(Map(String, Int)) := box(map([("a", 1)]))
+    sum(m)
+"#})]
+// A keyed write per loop position, over an induction domain.
+#[case(indoc! {r#"
+    m: Mut(Map(String, Int)) := box(map([("a", 1)]))
+    for k in ["b", "c"]:
+        m[k] := 9
+    m
+"#})]
+// The same write inside a transaction.
+#[case(indoc! {r#"
+    m: Mut(Map(String, Int), Txn) := box(map([("a", 1)]))
+    for r in [1, 2]:
+        with begin():
+            m["c"] := 3
+    await_final(m)
+"#})]
+#[should_panic(expected = "produced an invalid tree: [Type mismatch for collection domain")]
+fn a_one_entry_seed_does_not_reach_a_mutable_map(#[case] code: &str) {
+    run_pipeline(code);
+}
+
 /// A keyed write through a `Mut` **parameter**: `fw(m, x)` writes one key of the caller's
 /// mutable variable, the pass-by-reference shape `def fw(c: Mut(Int))` already supports for a
 /// scalar accumulator.

--- a/tests/compilation_pipeline/variants.rs
+++ b/tests/compilation_pipeline/variants.rs
@@ -672,6 +672,46 @@ fn test_match_on_parameter(#[case] code: &str, #[case] expected: Value) {
     check_scalar(code, expected);
 }
 
+/// A default arm on a `match` over a **field** of a parameter, whose value carries a
+/// tag no arm names.
+///
+/// The parameter's domain is a negative position, so its reading is the meet of both
+/// sides (`src/ccl/design/type-inference.md`, "The collapse happens at the position"),
+/// and that meet closes an open demand's marker and intersects its tags
+/// (`a_settled_negative_position_closes_an_open_child_demand`). The default arm fires
+/// regardless, being compiled from the `Case` — `final_or_default`'s default, as above —
+/// rather than from the domain's reading.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[case(
+    indoc! {r#"
+        def pick(r):
+            match r.v:
+                case `a(n):
+                    n
+                case _:
+                    0
+        pick((v=`b(5)))
+    "#},
+    Value::Int(0)
+)]
+// The named arm still matches, so the narrowed reading does not cost the tag it keeps.
+#[case(
+    indoc! {r#"
+        def pick(r):
+            match r.v:
+                case `a(n):
+                    n + 1
+                case _:
+                    0
+        pick((v=`a(5)))
+    "#},
+    Value::Int(6)
+)]
+fn test_default_arm_under_a_record_field(#[case] code: &str, #[case] expected: Value) {
+    check_scalar(code, expected);
+}
+
 // ---------------------------------------------------------------------------
 // Variant *types*
 //

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -1581,12 +1581,17 @@ fn a_bare_key_lookup_on_a_groupby_is_refused() {
 }
 
 /// A **boxed exact `Map`** annotation on a group-by types and cannot be consumed: the `box`
-/// references the comprehension's `__iter_record` from outside its scope.
+/// names the comprehension's `__iter_record` where the group-by's own key binder belongs, so
+/// the two spellings of the one key domain do not reconcile.
 ///
 /// A compiler bug rather than a rule, pinned so its fix is visible. Its exact `FullMap`
 /// counterpart compiles and runs
 /// (`an_exact_keyed_annotation_compiles_and_runs`), so the annotation form is the whole
 /// difference.
+///
+/// The claim is that the two spellings collide, not which check reports it. Pinned on the
+/// two domains the diagnostic names, because that is what says *which* binder each side
+/// carries; the wording around them belongs to whichever check gets there first.
 #[test]
 fn a_consumed_boxed_map_annotation_escapes_its_scope() {
     let errs = infer_program_err(indoc! {r#"
@@ -1596,8 +1601,8 @@ fn a_consumed_boxed_map_annotation_escapes_its_scope() {
     assert!(
         errs.iter()
             .map(|e| format!("{e:?}"))
-            .any(|m| m.contains("out-of-scope binder") && m.contains("__iter_record")),
-        "expected the box to escape the comprehension's binder, got {errs:?}"
+            .any(|m| m.contains("__iter_record") && m.contains("__box_k")),
+        "expected the two spellings of the key domain to collide, got {errs:?}"
     );
 }
 


### PR DESCRIPTION
A domain variable is read from its polarity-correct side alone, so the value flowing in, which the one-way `arg <: domain` edge deposits as a lower bound, is dropped once the uses have settled a shape. The two readings of one invariant data domain then differ: `groupby([1], \x -> x)`'s key variable carries `Int@1` below and `Int` above, which the post-pass tree check rejects. `compact_go` now merges the opposite side into a negative position's reading at the position's own polarity — the uses state what they demand, the lower bounds what arrives — so group-by, `set`, and `map` over a literal whose elements share one singleton type compile and run.

## Only a projection needs a rebuild

`specialize_lambda_domain` is deleted: a lambda's binder is its domain variable, so the meet at the position is the whole reading. `specialize_projection_domain` stays, because a projection is polymorphic in its input's width — its untouched positions are variables no edge reaches, and op-conversion needs the one width the use site has. `recovered_input` loses its position argument and always derefs a mutable-variable handle; [The collapse happens at the position](src/ccl/design/type-inference.md#the-collapse-happens-at-the-position) carries the rule.

## Identifying two spellings of one domain

The merge settles one position; equating two spellings of one domain is separate. `bind_annotation` draws the second half of a `SharedHole`'s equation, since the annotation edge alone leaves the id below every domain naming it, and comprehension lowering writes the id into a `groupby` source annotation that states only a kind. Recorded in [A shared hole naming a domain states an equation](src/ccl/design/type-inference.md#a-shared-hole-naming-a-domain-states-an-equation).

Two `#[should_panic]` tests become value assertions; `a_negative_position_meets_both_sides` pins the merge; `a_consumed_boxed_map_annotation_escapes_its_scope` now names the two colliding domain spellings rather than an out-of-scope binder.