### PR TITLE
Record a mutation loop's products against the body statements that produce them

### DIFF
--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -479,7 +479,8 @@ snapshots: `infer/solve` (`mono.specialize`,
 (`infer.require_trait`), `infer/solver/scheme` (`infer.freshen_predicate`),
 `infer/solver/traits` (`infer.freshen_obligation`), `inline`
 (`inline.alias`, `inline.udf`, `inline.beta`), `mut_elim` (`letrec.loop`,
-`letrec.bare_write`, `letrec.hoist_writer_body`, `letrec.terminalize_write`),
+`letrec.accumulator`, `letrec.feed`, `letrec.bare_write`,
+`letrec.hoist_writer_body`, `letrec.terminalize_write`),
 `transact_phase` (strip, unwrap block, writer, commit record, history binding,
 key rebind, key-init stash, carrier, the cross-domain and await-final rules), and
 `channelize` (`channelize.cluster`, `channelize.defer_lift`,
@@ -545,6 +546,15 @@ Three refinements the shapes above do not cover:
   the same node** inside the arm. The two write disjoint sets of rows on one
   parent, which is what two rewrites attributed to one node should look like. A
   recording carries one label and one nature for its whole extent by design.
+- **An expansion whose products belong to several source constructs** — a
+  mutation loop's `LetRec` carries one recurrence slot per accumulator and one
+  tap per feed, and a single recording on the loop statement claims all of them.
+  Open a **nested recording per construct** inside the enclosing one. The inner
+  recording is innermost while it runs, so the mint hook attaches to it and the
+  outer one keeps only what it built itself: `mut_elim` opens
+  `letrec.accumulator` on each write statement and `letrec.feed` on each feed
+  statement inside `letrec.loop`, and the commit-store builder opens one per
+  writer inside `opconv.convert`.
 
 #### Choosing between `Expansion` and `Machinery`
 

--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -489,10 +489,10 @@ key rebind, key-init stash, carrier, the cross-domain and await-final rules), an
 `lambda_elim.point_free`, `lambda_elim.filter`, `lambda_elim.value_case`). Three
 shared helpers record under whichever phase scope is open around them: `subst`
 (`subst.vacuous`, `subst.transport`, `subst.force_refinement`), `ccl_utils`'
-`PredMemo::rebuild` (`predicate.rebuild`), and `mut_elim`'s
-`fold_induction_loop` (`letrec.accumulator`, `letrec.feed`), which
-`transact_phase` calls for a cross-domain loop and so records a `letrec.*` label
-under `Transact`.
+`PredMemo::rebuild` (`predicate.rebuild`), and `mut_elim`'s induction fold —
+`fold_induction_loop` and `InductionFold::acc_view` (`letrec.accumulator`,
+`letrec.feed`), which `transact_phase` calls for a cross-domain loop and so
+records a `letrec.*` label under `Transact`.
 
 Every phase that rewrites expression nodes runs under a `PhaseScope`, so no
 recording is inert: `simplify`'s rule combinator and `planning/iterate` both sit

--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -554,9 +554,15 @@ Four refinements the shapes above do not cover:
   Open a **nested recording per construct** inside the enclosing one. The inner
   recording is innermost while it runs, so the mint hook attaches to it and the
   outer one keeps only what it built itself: `mut_elim` opens
-  `letrec.accumulator` on each write statement and `letrec.feed` on each feed
+  `letrec.accumulator` per accumulating variable and `letrec.feed` on each feed
   statement inside `letrec.loop`, and `planning/loops` opens `planning.txn_read`
   on each continuation read inside `planning.recognize`.
+
+  A construct the split names can be several source statements. A recurrence slot
+  belongs to its accumulating variable, so a body that writes one variable twice
+  gets one recording, named on the first write with the later ones on its blame
+  column — every write answers with the slot's products, and only the write that
+  created the slot claims ancestry (`mut_elim`'s `AccumulatorVariable::enter`).
 
   Two shapes bound the split. An expansion with **one product covering several
   constructs** cannot be split at all: a conditional feed rides a single lambda

--- a/src/ccl/design/provenance.md
+++ b/src/ccl/design/provenance.md
@@ -486,11 +486,13 @@ key rebind, key-init stash, carrier, the cross-domain and await-final rules), an
 `channelize` (`channelize.cluster`, `channelize.defer_lift`,
 `channelize.defer_collapse`), `transact_phase`'s as-of-read rewrite
 (`transact.as_of_read`), and `lambda_elim` (`lambda_elim.abstract`,
-`lambda_elim.point_free`, `lambda_elim.filter`, `lambda_elim.value_case`). Two
-shared helpers record under whichever phase
-scope is open around them: `subst` (`subst.vacuous`, `subst.transport`,
-`subst.force_refinement`) and `ccl_utils`' `PredMemo::rebuild`
-(`predicate.rebuild`).
+`lambda_elim.point_free`, `lambda_elim.filter`, `lambda_elim.value_case`). Three
+shared helpers record under whichever phase scope is open around them: `subst`
+(`subst.vacuous`, `subst.transport`, `subst.force_refinement`), `ccl_utils`'
+`PredMemo::rebuild` (`predicate.rebuild`), and `mut_elim`'s
+`fold_induction_loop` (`letrec.accumulator`, `letrec.feed`), which
+`transact_phase` calls for a cross-domain loop and so records a `letrec.*` label
+under `Transact`.
 
 Every phase that rewrites expression nodes runs under a `PhaseScope`, so no
 recording is inert: `simplify`'s rule combinator and `planning/iterate` both sit
@@ -533,7 +535,7 @@ recordings are one per rewrite it performs. A recording takes only an
 **id**, so a site that has already moved `expr.node` out can still open one —
 read `expr.node_id()` before the destructure.
 
-Three refinements the shapes above do not cover:
+Four refinements the shapes above do not cover:
 
 - **A product spanning several nodes** — the transaction carrier is what a set of
   scattered `with begin():` blocks and register declarations collectively became.
@@ -553,8 +555,18 @@ Three refinements the shapes above do not cover:
   recording is innermost while it runs, so the mint hook attaches to it and the
   outer one keeps only what it built itself: `mut_elim` opens
   `letrec.accumulator` on each write statement and `letrec.feed` on each feed
-  statement inside `letrec.loop`, and the commit-store builder opens one per
-  writer inside `opconv.convert`.
+  statement inside `letrec.loop`, and `planning/loops` opens `planning.txn_read`
+  on each continuation read inside `planning.recognize`.
+
+  Two shapes bound the split. An expansion with **one product covering several
+  constructs** cannot be split at all: a conditional feed rides a single lambda
+  over the whole loop body, so no per-feed recording has anything to adopt, and
+  the products stay on the enclosing recording. An expansion where the **enclosing
+  construct mints nothing** inverts it: every product of an accumulator-free
+  mutation loop belongs to one of its feeds, so the inner recordings take the
+  whole expansion and the `for` around them rides their blame column
+  (`mut_elim`'s `StmtSite::blamed_in`). Blame is what a construct that produced
+  nothing gets, rather than an ancestry edge it did not earn or no edge at all.
 
 #### Choosing between `Expansion` and `Machinery`
 

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -1146,8 +1146,18 @@ impl InductionFold {
     /// A per-position cross-domain read of that accumulator (`acc(pos)`) is this
     /// applied at `pos`; the transaction phase uses it to resolve a `commits(r)`
     /// decision that reads an induction accumulator at its request position.
+    ///
+    /// The view is the accumulator's product, so the recording is the
+    /// accumulator's: one slot's stream, named on the statement that writes it.
+    /// Opening it here rather than at the call site is what puts it on the write
+    /// statement at all — the caller is `transact_phase`, which holds the
+    /// enclosing `transact.cross_domain_fold` recording on the *loop* statement
+    /// and has no access to [`Accumulator`]'s site.
     pub(crate) fn acc_view(&self, i: usize) -> Expr {
-        let vty = &self.accs[i].ty;
+        let acc = &self.accs[i];
+        let _g = acc
+            .site
+            .enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
         writes_index_view(
             &self.hist,
             &self.hist_ty,
@@ -1155,7 +1165,7 @@ impl InductionFold {
             &self.writes_ty,
             &self.decision_ty,
             i,
-            vty,
+            &acc.ty,
         )
     }
 }
@@ -2315,5 +2325,93 @@ mod tests {
         // Assert through the real checker rather than a local copy of its walk:
         // uniqueness within a tree is one invariant with one implementation.
         crate::ccl::context::assert_unique_node_ids(&out, "flatten_spine");
+    }
+
+    /// **An accumulator's cross-domain view is recorded against the statement
+    /// that writes it, not against the recording its caller holds.**
+    /// [`InductionFold::acc_view`] is called from
+    /// `transact_phase::fold_cross_domain_loops`, which has
+    /// `transact.cross_domain_fold` open on the *loop* statement — so a view
+    /// minted with no recording of its own resolves to the loop, and the write
+    /// that produced the accumulator answers with nothing about the stream a
+    /// transaction reads it through. The nested recording is what splits it, the
+    /// same rule the slot machinery follows (`src/ccl/design/provenance.md`,
+    /// "Where to open a recording").
+    ///
+    /// Asserted here rather than through a compiled program because the products
+    /// are five nodes of a shape the fold also builds for the trailing final read
+    /// — reachable in a pane pair, indistinguishable from their neighbours once
+    /// there. The parent of a mint is what changed, so the parent is what this
+    /// reads.
+    #[test]
+    fn a_cross_domain_view_is_recorded_against_the_write_statement() {
+        use crate::ccl::context::Phase;
+        use crate::ccl::provenance::{PhaseScope, TableSession};
+
+        let (tree, ..) = direct_mirror_sum();
+        let TypedExprNode::MutDecl { body: stmt, .. } = tree.node else {
+            unreachable!("`direct_mirror_sum` is a `MutDecl`")
+        };
+        let loop_stmt_id = stmt.node_id();
+        let TypedExprNode::ExprStmt {
+            expr: effect,
+            body: cont,
+        } = stmt.node
+        else {
+            unreachable!("the introduction's body is the loop statement")
+        };
+        let TypedExprNode::For { target, iter, body } = effect.node else {
+            unreachable!("the statement's effect is the loop")
+        };
+        // The write statement inside the loop body, and the marker that is its
+        // effect — the two nodes the recording names and blames.
+        let write_stmt_id = body.node_id();
+        let TypedExprNode::ExprStmt { expr: write, .. } = &body.node else {
+            unreachable!("the loop body is one write statement")
+        };
+        let write_id = write.node_id();
+        let value_tys = mut_var_value_tys([&*body, &*cont]);
+
+        let session = TableSession::install();
+        let view_ids = {
+            let _scope = PhaseScope::enter(Phase::Transact);
+            // The recording the transaction phase holds across the call, named on
+            // the loop statement. Without one the mints would land nowhere and the
+            // assertion below would pass for the wrong reason.
+            let _enclosing = provenance::enter(
+                loop_stmt_id,
+                "transact.cross_domain_fold",
+                provenance::Nature::Expansion,
+            );
+            let fold = fold_induction_loop(&target, &iter, *body, &value_tys);
+            let view = fold.acc_view(0);
+            let mut ids = Vec::new();
+            fn collect(e: &Expr, out: &mut Vec<NodeId>) {
+                out.push(e.node_id());
+                e.walk_children(|c| collect(c, out));
+            }
+            collect(&view, &mut ids);
+            ids
+        };
+        let table = session.into_table();
+
+        assert!(!view_ids.is_empty(), "the view is a tree of minted nodes");
+        for id in view_ids {
+            assert_eq!(
+                table.parents(id),
+                [write_stmt_id],
+                "a view node descends from the write statement, not from {loop_stmt_id:?}",
+            );
+            assert_eq!(
+                table.blame(id),
+                [write_id],
+                "and blames the `MutWrite`, so either node answers with it",
+            );
+            assert_eq!(
+                table.tag(id).map(|t| t.label),
+                Some(ACCUMULATOR_LABEL),
+                "under the accumulator's own label",
+            );
+        }
     }
 }

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -59,12 +59,20 @@ use crate::ccl::{
 // Phase: For/MutWrite → LetRec
 // ---------------------------------------------------------------------------
 
+/// A `for` statement's whole expansion, minus what a nested recording claims:
+/// the history binder and its guard, the decision variant, the writer lambda.
+const LOOP_LABEL: RewriteLabel = "letrec.loop";
+
 /// One accumulator's recurrence slot: its snapshot projection, its seed in the
 /// guard, and its trailing final read.
 const ACCUMULATOR_LABEL: RewriteLabel = "letrec.accumulator";
 
-/// One in-loop feed's tap: the projected view of its field on the decision.
+/// One feed's tap: the projected view of its field on the decision in an
+/// induction loop, and the whole mapped source in an accumulator-free one.
 const FEED_LABEL: RewriteLabel = "letrec.feed";
+
+/// The shadowing `let` a mutable write outside any loop normalizes to.
+const BARE_WRITE_LABEL: RewriteLabel = "letrec.bare_write";
 
 /// The two nodes one statement occupies: the `ExprStmt` holding it and the
 /// marker that is its effect (`For`, `MutWrite`, `Feed`).
@@ -87,10 +95,28 @@ impl StmtSite {
     }
 
     /// Open a recording over what this statement became.
+    ///
+    /// The marker is blamed only when it is a node beside the named one. A site
+    /// that fell back to the marker for both (see [`collect_writes_in`]) would
+    /// otherwise put one pair in both the ancestry and the blame relation,
+    /// which says nothing the ancestry edge does not already say.
     fn enter(self, label: RewriteLabel, nature: provenance::Nature) -> RecordingGuard {
         let g = provenance::enter(self.stmt, label, nature);
-        g.blame(&[self.effect]);
+        if self.effect != self.stmt {
+            g.blame(&[self.effect]);
+        }
         g
+    }
+
+    /// Relate this statement to a recording another site opened: both of its
+    /// nodes ride the blame column, so either answers with the products without
+    /// claiming to have produced them.
+    ///
+    /// The enclosing construct uses this where it mints nothing of its own —
+    /// [`transform_feed_only_loop`], where every product belongs to a feed and
+    /// the `for` around them would otherwise reach nothing at all.
+    fn blamed_in(self, g: &RecordingGuard) {
+        g.blame(&[self.stmt, self.effect]);
     }
 }
 
@@ -697,8 +723,8 @@ fn rewrite(mut expr: Expr) -> Expr {
             // predict it. Predicting it meant re-running `collect_writes` and
             // `body_has_feed` here to guess what `transform_loop` would decide
             // ~140 lines away.
-            let _g = site.enter("letrec.loop", provenance::Nature::Expansion);
-            return transform_loop(target, *iter, *loop_body, *body);
+            let _g = site.enter(LOOP_LABEL, provenance::Nature::Expansion);
+            return transform_loop(site, target, *iter, *loop_body, *body);
         }
         // A `MutWrite` outside any `For` is a *sequential* mutation — a
         // top-level `cnt += 1`, or an inlined pass-by-reference writer
@@ -709,7 +735,7 @@ fn rewrite(mut expr: Expr) -> Expr {
             // node it replaces, with the `MutWrite` blamed. Neither is claimed
             // dead: both are absent from the output tree, so the boundary
             // difference reports them.
-            let _g = site.enter("letrec.bare_write", provenance::Nature::Machinery);
+            let _g = site.enter(BARE_WRITE_LABEL, provenance::Nature::Machinery);
             return normalize_bare_write(name, *value, *body);
         }
         // Not a loop/write statement: rebuild and recurse.
@@ -989,7 +1015,13 @@ pub(crate) fn hoist_feeds(mut body: Expr, feeds: Vec<(Name, Expr)>) -> Expr {
 /// projection* of the history (causal — see `check_letrec_causal`); each
 /// feed rides the decision as a `to_<feed>` field, hoisted to
 /// `Feed(defer, __hist ≫ .to_<feed>)` for `channelize` to route.
-fn transform_loop(target: TypedBinding, iter: Expr, loop_body: Expr, cont: Expr) -> Expr {
+fn transform_loop(
+    loop_site: StmtSite,
+    target: TypedBinding,
+    iter: Expr,
+    loop_body: Expr,
+    cont: Expr,
+) -> Expr {
     // Every reference to an accumulator is either in the loop (a read-your-writes
     // read) or downstream of it (the trailing final read), so these two trees
     // carry every `Mut(V, D)` this loop's mutable variables have.
@@ -1022,6 +1054,11 @@ fn transform_loop(target: TypedBinding, iter: Expr, loop_body: Expr, cont: Expr)
                 // `{gᵢ → Feed; true → unit}` shape `channelize::try_extract_fanout_feed`
                 // recognizes — the same shape a non-transactional conditional feed
                 // lowers to directly.
+                //
+                // The products stay on the enclosing `letrec.loop`, unlike the two
+                // paths that split per feed. One lambda carries the whole body
+                // here, however many arms feed, so there is no product to hand to
+                // any one feed statement.
                 let body = strip_trailing_unit(loop_body.clone());
                 let mut lambda = Expr::lambda(target.name.clone(), target.ty.clone(), body);
                 lambda.ty = Type::fun(target.ty.clone(), loop_body.ty.clone());
@@ -1032,7 +1069,7 @@ fn transform_loop(target: TypedBinding, iter: Expr, loop_body: Expr, cont: Expr)
                 stmt.ty = cont_ty;
                 return stmt;
             }
-            return transform_feed_only_loop(target, iter, loop_body, cont);
+            return transform_feed_only_loop(loop_site, target, iter, loop_body, cont);
         }
         return rewrite(cont);
     }
@@ -1068,7 +1105,6 @@ fn transform_loop(target: TypedBinding, iter: Expr, loop_body: Expr, cont: Expr)
 /// projection, the guard's seed, the trailing final read — so each accumulator
 /// of a two-accumulator loop resolves to the line that writes it rather than
 /// both resolving to the loop.
-#[derive(Clone)]
 pub(crate) struct Accumulator {
     pub name: Name,
     pub ty: Type,
@@ -1337,10 +1373,16 @@ pub(crate) fn fold_induction_loop(
 /// as-of read to every loop position; `transact_phase::rewrite_as_of_reads`
 /// (post-`channelize`, pre-lambda-elim) then pairs it with this loop as its trigger,
 /// which is where the outer-indexed as-of join gets the position it reads at.
-fn transform_feed_only_loop(target: TypedBinding, iter: Expr, loop_body: Expr, cont: Expr) -> Expr {
+fn transform_feed_only_loop(
+    loop_site: StmtSite,
+    target: TypedBinding,
+    iter: Expr,
+    loop_body: Expr,
+    cont: Expr,
+) -> Expr {
     let (domain_ty, _item_ty) = fun_parts(&iter.ty);
     let mut env: HashMap<Name, Expr> = HashMap::new();
-    let mut feeds: Vec<(Name, Expr)> = Vec::new();
+    let mut feeds: Vec<(Name, Expr, StmtSite)> = Vec::new();
     collect_feed_only(loop_body, &mut env, &mut feeds);
     debug_assert!(
         !feeds.is_empty(),
@@ -1351,7 +1393,16 @@ fn transform_feed_only_loop(target: TypedBinding, iter: Expr, loop_body: Expr, c
     // Emit in reverse so the first source feed ends up outermost — channelize
     // collects feeds outermost-first into the channel union, preserving source
     // order (mirrors the accumulator path's hoist ordering).
-    for (defer, value) in feeds.into_iter().rev() {
+    for (defer, value, site) in feeds.into_iter().rev() {
+        // The map is what this feed became: one per feed, so each is recorded
+        // against its own statement rather than all of them against the loop.
+        // The enclosing `letrec.loop` mints nothing of its own on this path —
+        // an accumulator-free loop is its feeds — so the `For` rides the blame
+        // column instead: the map iterates, and the loop keyword is what that
+        // is about, without being an ancestor of a node the feed produced.
+        let g = site.enter(FEED_LABEL, provenance::Nature::Expansion);
+        loop_site.blamed_in(&g);
+
         let value_ty = value.ty.clone();
         let mut lambda = Expr::lambda(target.name.clone(), target.ty.clone(), value);
         lambda.ty = Type::fun(target.ty.clone(), value_ty.clone());
@@ -1367,8 +1418,16 @@ fn transform_feed_only_loop(target: TypedBinding, iter: Expr, loop_body: Expr, c
 
 /// Walk an accumulator-free loop body (a read-only `with begin():` block:
 /// `Let`s, `Feed`s, terminal `Unit` — no `MutWrite`), threading `Let` values
-/// through `env` and collecting each feed's `(defer, env-resolved value)`.
-fn collect_feed_only(expr: Expr, env: &mut HashMap<Name, Expr>, feeds: &mut Vec<(Name, Expr)>) {
+/// through `env` and collecting each feed's `(defer, env-resolved value, site)`.
+///
+/// The site is the feed statement its map is recorded against, the same
+/// attribution the induction path's [`FeedSite`] carries.
+fn collect_feed_only(
+    expr: Expr,
+    env: &mut HashMap<Name, Expr>,
+    feeds: &mut Vec<(Name, Expr, StmtSite)>,
+) {
+    let stmt_id = expr.node_id();
     match expr.node {
         TypedExprNode::Let {
             binding,
@@ -1380,10 +1439,11 @@ fn collect_feed_only(expr: Expr, env: &mut HashMap<Name, Expr>, feeds: &mut Vec<
             collect_feed_only(*body, env, feeds);
         }
         TypedExprNode::ExprStmt { expr: effect, body } => {
+            let site = StmtSite::new(stmt_id, effect.node_id());
             match effect.node {
                 TypedExprNode::Feed { name, value } => {
                     let val = Subst::discharge_env_in_place(*value, env);
-                    feeds.push((name, val));
+                    feeds.push((name, val, site));
                 }
                 other => panic!(
                     "letrec phase: unexpected statement in read-only `with begin():` block: {}",
@@ -1438,6 +1498,12 @@ pub(crate) fn mut_var_value_tys<'a>(
 /// Collect the loop's accumulators in first-write order, each with its value type
 /// taken from `value_tys` — the join inference recorded on the mutable variable's
 /// `Mut(V, D)` — and the write statement its recurrence slot is recorded against.
+///
+/// One accumulator has one slot however many times the body writes it, so the
+/// recording goes to the first write and a later write to the same variable takes
+/// none. What the later statement contributes is not a mint: [`transform_chain`]
+/// inlines its value into the read-your-writes environment by id, and its marker
+/// and `ExprStmt` die, which the boundary difference reports.
 ///
 /// A mutable variable with no entry is one no reference types as a `Mut`: either nothing
 /// reads it (only writes mention it, so its value type is unobservable), or the

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -50,7 +50,7 @@ use crate::ccl::{
     TypedExprNode,
     ccl_utils::{COMMIT_SELECTOR, strip_refinements, synthesize_arm_predicate, typed_compose},
     letrec::check_letrec_causal,
-    provenance,
+    provenance::{self, NodeId, RecordingGuard, RewriteLabel},
     subst::Subst,
     symbolic::symbolic,
 };
@@ -58,6 +58,41 @@ use crate::ccl::{
 // ---------------------------------------------------------------------------
 // Phase: For/MutWrite → LetRec
 // ---------------------------------------------------------------------------
+
+/// One accumulator's recurrence slot: its snapshot projection, its seed in the
+/// guard, and its trailing final read.
+const ACCUMULATOR_LABEL: RewriteLabel = "letrec.accumulator";
+
+/// One in-loop feed's tap: the projected view of its field on the decision.
+const FEED_LABEL: RewriteLabel = "letrec.feed";
+
+/// The two nodes one statement occupies: the `ExprStmt` holding it and the
+/// marker that is its effect (`For`, `MutWrite`, `Feed`).
+///
+/// A recording names a single node, and a statement's expansion is about both
+/// of these. [`StmtSite::enter`] names the `ExprStmt` — the outermost node the
+/// expansion replaces — and blames the marker, so the attribution carries the
+/// construct's own span as well as the statement's and either node reaches the
+/// products.
+#[derive(Clone, Copy)]
+pub(crate) struct StmtSite {
+    stmt: NodeId,
+    effect: NodeId,
+}
+
+impl StmtSite {
+    /// Both ids are read before the destructure that moves the statement.
+    fn new(stmt: NodeId, effect: NodeId) -> Self {
+        StmtSite { stmt, effect }
+    }
+
+    /// Open a recording over what this statement became.
+    fn enter(self, label: RewriteLabel, nature: provenance::Nature) -> RecordingGuard {
+        let g = provenance::enter(self.stmt, label, nature);
+        g.blame(&[self.effect]);
+        g
+    }
+}
 
 /// Rewrite every direct-mirror loop in `expr` into a causal `LetRec`.
 /// Trees without `For` nodes pass through untouched. Panics on malformed
@@ -639,7 +674,7 @@ fn flatten_spine(mut e: Expr) -> Expr {
 fn rewrite(mut expr: Expr) -> Expr {
     let stmt_id = expr.node_id();
     if let TypedExprNode::ExprStmt { expr: effect, body } = expr.node {
-        let effect_id = effect.node_id();
+        let site = StmtSite::new(stmt_id, effect.node_id());
         if let TypedExprNode::For {
             target,
             iter,
@@ -647,6 +682,14 @@ fn rewrite(mut expr: Expr) -> Expr {
         } = effect.node
         {
             // The recording names the statement: the causal `LetRec` replaces it.
+            // `blame` names the `For` so the products resolve to the loop
+            // keyword's span, not the statement's — [`StmtSite::enter`].
+            //
+            // What this recording adopts is the loop's own scaffolding: the
+            // history binder and its guard, the decision variant, the writer
+            // lambda. A product belonging to one body construct is recorded
+            // against that construct instead, under a nested recording opened
+            // inside this one ([`fold_induction_loop`]).
             //
             // There is deliberately no drop-path test. Whether the whole loop
             // vanishes — no accumulator, no feed, e.g. a transaction-emptied
@@ -654,11 +697,7 @@ fn rewrite(mut expr: Expr) -> Expr {
             // predict it. Predicting it meant re-running `collect_writes` and
             // `body_has_feed` here to guess what `transform_loop` would decide
             // ~140 lines away.
-            //
-            // `blame` names the `For` rather than the `ExprStmt` so the products
-            // resolve to the loop keyword's span, not the statement's.
-            let g = provenance::enter(stmt_id, "letrec.loop", provenance::Nature::Expansion);
-            g.blame(&[effect_id]);
+            let _g = site.enter("letrec.loop", provenance::Nature::Expansion);
             return transform_loop(target, *iter, *loop_body, *body);
         }
         // A `MutWrite` outside any `For` is a *sequential* mutation — a
@@ -667,11 +706,10 @@ fn rewrite(mut expr: Expr) -> Expr {
         // build; normalize it to a shadowing `let` (see `normalize_bare_write`).
         if let TypedExprNode::MutWrite { name, value } = effect.node {
             // The shadowing `let` this mints is captured against the statement
-            // node it replaces. The `MutWrite` marker and the `ExprStmt` wrapper
-            // both vanish, but neither is named: both are absent from the output
-            // tree, so the boundary difference reports them.
-            let g = provenance::enter(stmt_id, "letrec.bare_write", provenance::Nature::Machinery);
-            g.blame(&[effect_id]);
+            // node it replaces, with the `MutWrite` blamed. Neither is claimed
+            // dead: both are absent from the output tree, so the boundary
+            // difference reports them.
+            let _g = site.enter("letrec.bare_write", provenance::Nature::Machinery);
             return normalize_bare_write(name, *value, *body);
         }
         // Not a loop/write statement: rebuild and recurse.
@@ -780,6 +818,9 @@ struct FeedSite {
     defer: Name,
     field: String,
     value: Expr,
+    /// The feed statement this tap is recorded against, so the view resolves to
+    /// the `<<` the user wrote rather than to the enclosing loop.
+    site: StmtSite,
     /// The control-flow path under which this feed fires — `true` for a feed on
     /// the loop spine, a conjunction of enclosing guards for a feed inside an
     /// `if`. A conditional feed (`fire != true`) rides the decision as a
@@ -953,8 +994,8 @@ fn transform_loop(target: TypedBinding, iter: Expr, loop_body: Expr, cont: Expr)
     // read) or downstream of it (the trailing final read), so these two trees
     // carry every `Mut(V, D)` this loop's mutable variables have.
     let value_tys = mut_var_value_tys([&loop_body, &cont]);
-    // Accumulators in first-write order, with their value types.
-    let mut accs: Vec<(Name, Type)> = Vec::new();
+    // Accumulators in first-write order, with their value types and write sites.
+    let mut accs: Vec<Accumulator> = Vec::new();
     collect_writes(&loop_body, &value_tys, &mut accs);
     if accs.is_empty() {
         // A loop with no accumulator. If its body feeds — a stateless generator,
@@ -1020,6 +1061,20 @@ fn transform_loop(target: TypedBinding, iter: Expr, loop_body: Expr, cont: Expr)
     )
 }
 
+/// One accumulator of an induction loop: the mutable variable, the value type its
+/// recurrence slot carries, and the write statement that made it an accumulator.
+///
+/// The site is what the slot's products are recorded against — the snapshot
+/// projection, the guard's seed, the trailing final read — so each accumulator
+/// of a two-accumulator loop resolves to the line that writes it rather than
+/// both resolving to the loop.
+#[derive(Clone)]
+pub(crate) struct Accumulator {
+    pub name: Name,
+    pub ty: Type,
+    site: StmtSite,
+}
+
 /// An induction loop folded into a single decision-factored history binding,
 /// *without* touching the continuation — the reusable core shared by the
 /// induction path ([`transform_loop`], which wraps it in a nested `LetRec`) and
@@ -1046,8 +1101,8 @@ pub(crate) struct InductionFold {
     pub domain_ty: Type,
     pub writes_ty: Type,
     pub decision_ty: Type,
-    /// Accumulators in first-write order (index `i` ↦ `writes.i`), value-typed.
-    pub accs: Vec<(Name, Type)>,
+    /// Accumulators in first-write order (index `i` ↦ `writes.i`).
+    pub accs: Vec<Accumulator>,
 }
 
 impl InductionFold {
@@ -1056,7 +1111,7 @@ impl InductionFold {
     /// applied at `pos`; the transaction phase uses it to resolve a `commits(r)`
     /// decision that reads an induction accumulator at its request position.
     pub(crate) fn acc_view(&self, i: usize) -> Expr {
-        let (_, vty) = &self.accs[i];
+        let vty = &self.accs[i].ty;
         writes_index_view(
             &self.hist,
             &self.hist_ty,
@@ -1081,7 +1136,7 @@ pub(crate) fn fold_induction_loop(
     loop_body: Expr,
     value_tys: &HashMap<Name, Type>,
 ) -> InductionFold {
-    let mut accs: Vec<(Name, Type)> = Vec::new();
+    let mut accs: Vec<Accumulator> = Vec::new();
     collect_writes(&loop_body, value_tys, &mut accs);
     assert!(
         !accs.is_empty(),
@@ -1089,7 +1144,7 @@ pub(crate) fn fold_induction_loop(
     );
 
     let (domain_ty, item_ty) = fun_parts(&iter.ty);
-    let acc_tys: Vec<Type> = accs.iter().map(|(_, t)| t.clone()).collect();
+    let acc_tys: Vec<Type> = accs.iter().map(|a| a.ty.clone()).collect();
     // The proposed write set — always a positional tuple, one element even
     // for a single accumulator (the transaction decision convention).
     let writes_ty = Type::Tuple(acc_tys.clone());
@@ -1109,8 +1164,11 @@ pub(crate) fn fold_induction_loop(
     // destructuring lets): each accumulator reads its snapshot slot
     // `__p ▷ .i`, the loop binder reads the item slot `__p ▷ .k`.
     let mut env: HashMap<Name, Expr> = HashMap::new();
-    for (i, (acc, ty)) in accs.iter().enumerate() {
-        env.insert(acc.clone(), proj_of(&p, &p_ty, i, ty));
+    for (i, acc) in accs.iter().enumerate() {
+        let _g = acc
+            .site
+            .enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
+        env.insert(acc.name.clone(), proj_of(&p, &p_ty, i, &acc.ty));
     }
     env.insert(
         target.name.clone(),
@@ -1126,8 +1184,8 @@ pub(crate) fn fold_induction_loop(
     // `Case` still forces a change (see `conditional_decision`).
     let entering: Vec<Expr> = accs
         .iter()
-        .map(|(n, _)| {
-            env.get(n)
+        .map(|a| {
+            env.get(&a.name)
                 .expect("accumulator seeded in the RYW environment")
                 .clone()
         })
@@ -1162,7 +1220,16 @@ pub(crate) fn fold_induction_loop(
     // history is a causal reference (see `check_letrec_causal`); the
     // defaults are the accumulators' pre-loop bindings, tupled.
     let writes_view = hist_field_view(&h, &hist_ty, &domain_ty, F_WRITES, &writes_ty, &decision_ty);
-    let mut defaults = Expr::tuple(accs.iter().map(|(n, ty)| tvar(n, ty.clone())).collect());
+    let seeds: Vec<Expr> = accs
+        .iter()
+        .map(|a| {
+            let _g = a
+                .site
+                .enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
+            tvar(&a.name, a.ty.clone())
+        })
+        .collect();
+    let mut defaults = Expr::tuple(seeds);
     defaults.ty = writes_ty.clone();
     let guard = {
         let mut arg = Expr::tuple(vec![writes_view, tvar(&r, domain_ty.clone()), defaults]);
@@ -1179,8 +1246,15 @@ pub(crate) fn fold_induction_loop(
     };
 
     // λ r → let __prev = ⟨guard⟩ in (__prev.0, …, r ▷ iter) ▷ __body
-    let mut snap_elts: Vec<Expr> = (0..accs.len())
-        .map(|i| proj_of(&prev, &writes_ty, i, &acc_tys[i]))
+    let mut snap_elts: Vec<Expr> = accs
+        .iter()
+        .enumerate()
+        .map(|(i, a)| {
+            let _g = a
+                .site
+                .enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
+            proj_of(&prev, &writes_ty, i, &acc_tys[i])
+        })
         .collect();
     let mut item_read = Expr::apply(tvar(&r, domain_ty.clone()), iter.clone());
     item_read.ty = item_ty.clone();
@@ -1200,18 +1274,22 @@ pub(crate) fn fold_induction_loop(
     // The read's default is the accumulator's pre-loop binding.
     let mut reads: Vec<(TypedBinding, Expr)> = Vec::new();
     let mut renames: Vec<(Name, Name)> = Vec::new();
-    for (i, (acc, vty)) in accs.iter().enumerate() {
+    for (i, acc) in accs.iter().enumerate() {
+        let _g = acc
+            .site
+            .enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
+        let vty = &acc.ty;
         let view = writes_index_view(&h, &hist_ty, &domain_ty, &writes_ty, &decision_ty, i, vty);
         let view_ty = view.ty.clone();
-        let mut arg = Expr::tuple(vec![view, tvar(acc, vty.clone())]);
+        let mut arg = Expr::tuple(vec![view, tvar(&acc.name, vty.clone())]);
         arg.ty = Type::Tuple(vec![view_ty, vty.clone()]);
         let mut f = Expr::builtin(Builtin::FinalOrDefault);
         f.ty = Type::fun(arg.ty.clone(), vty.clone());
         let mut read = Expr::apply(arg, f);
         read.ty = vty.clone();
 
-        let x_final = Name::fresh(acc.base());
-        renames.push((acc.clone(), x_final.clone()));
+        let x_final = Name::fresh(acc.name.base());
+        renames.push((acc.name.clone(), x_final.clone()));
         reads.push((binding(x_final, vty.clone()), read));
     }
 
@@ -1220,6 +1298,7 @@ pub(crate) fn fold_induction_loop(
     let feed_views = feeds
         .iter()
         .map(|f| {
+            let _g = f.site.enter(FEED_LABEL, provenance::Nature::Expansion);
             let view = hist_field_view(
                 &h,
                 &hist_ty,
@@ -1356,8 +1435,9 @@ pub(crate) fn mut_var_value_tys<'a>(
     out
 }
 
-/// Collect `MutWrite` targets in first-write order with their value types, taken
-/// from `value_tys` — the join inference recorded on the mutable variable's `Mut(V, D)`.
+/// Collect the loop's accumulators in first-write order, each with its value type
+/// taken from `value_tys` — the join inference recorded on the mutable variable's
+/// `Mut(V, D)` — and the write statement its recurrence slot is recorded against.
 ///
 /// A mutable variable with no entry is one no reference types as a `Mut`: either nothing
 /// reads it (only writes mention it, so its value type is unobservable), or the
@@ -1366,17 +1446,40 @@ pub(crate) fn mut_var_value_tys<'a>(
 /// mutable variable takes no refinement from any single contribution, and an unstripped
 /// one would be a refinement acquired by erasure rather than by `cast`
 /// (`src/ccl/design/type-inference.md`, "Refinements on the lattice").
-fn collect_writes(expr: &Expr, value_tys: &HashMap<Name, Type>, out: &mut Vec<(Name, Type)>) {
+fn collect_writes(expr: &Expr, value_tys: &HashMap<Name, Type>, out: &mut Vec<Accumulator>) {
+    collect_writes_in(expr, None, value_tys, out);
+}
+
+/// `stmt` is the `ExprStmt` whose effect `expr` is, when the walk arrived through
+/// one. Post-[`flatten_spine`] every write on a statement chain is a direct
+/// `ExprStmt` effect, so a write reached with `stmt` unset is one in a
+/// hand-built tree; its own node then stands as the whole site.
+fn collect_writes_in(
+    expr: &Expr,
+    stmt: Option<NodeId>,
+    value_tys: &HashMap<Name, Type>,
+    out: &mut Vec<Accumulator>,
+) {
     if let TypedExprNode::MutWrite { name, value } = &expr.node
-        && !out.iter().any(|(n, _)| n == name)
+        && !out.iter().any(|a| a.name == *name)
     {
-        let vty = value_tys
+        let ty = value_tys
             .get(name)
             .cloned()
             .unwrap_or_else(|| strip_refinements(&value.ty));
-        out.push((name.clone(), vty));
+        let write = expr.node_id();
+        out.push(Accumulator {
+            name: name.clone(),
+            ty,
+            site: StmtSite::new(stmt.unwrap_or(write), write),
+        });
     }
-    expr.walk_children(|c| collect_writes(c, value_tys, out));
+    if let TypedExprNode::ExprStmt { expr: effect, body } = &expr.node {
+        collect_writes_in(effect, Some(expr.node_id()), value_tys, out);
+        collect_writes_in(body, None, value_tys, out);
+        return;
+    }
+    expr.walk_children(|c| collect_writes_in(c, None, value_tys, out));
 }
 
 /// Whether `expr` contains a `Feed` marker (backs the no-op-loop invariant
@@ -1500,12 +1603,13 @@ fn splice_after_unit(chain: Expr, tail: Expr) -> Expr {
 fn transform_chain(
     expr: Expr,
     env: &mut HashMap<Name, Expr>,
-    accs: &[(Name, Type)],
+    accs: &[Accumulator],
     writes_ty: &Type,
     entering: &[Expr],
     path: &Expr,
     feeds: &mut Vec<FeedSite>,
 ) -> Expr {
+    let stmt_id = expr.node_id();
     match expr.node {
         TypedExprNode::Let {
             binding: b,
@@ -1592,6 +1696,7 @@ fn transform_chain(
             conditional_decision(writing, carry, entering, writes_ty)
         }
         TypedExprNode::ExprStmt { expr: effect, body } => {
+            let effect_id = effect.node_id();
             match effect.node {
                 // A write advances the read-your-writes environment by *inlining*
                 // the written value (point-free over `__p`), not binding a `let` —
@@ -1624,6 +1729,7 @@ fn transform_chain(
                 // `fire` is the current control-flow path — `true` on the spine, a
                 // guard conjunction inside an `if`.
                 TypedExprNode::Feed { name, value } => {
+                    let site = StmtSite::new(stmt_id, effect_id);
                     let val = Subst::discharge_env_in_place(*value, env);
                     let field = format!("to_{}_{}", name.base(), feeds.len());
                     feeds.push(FeedSite {
@@ -1631,6 +1737,7 @@ fn transform_chain(
                         field,
                         value: val,
                         fire: path.clone(),
+                        site,
                     });
                     transform_chain(*body, env, accs, writes_ty, entering, path, feeds)
                 }
@@ -1676,7 +1783,7 @@ fn transform_chain(
                     .expect("letrec phase: accumulator missing from RYW environment")
                     .clone()
             };
-            let mut writes = Expr::tuple(accs.iter().map(|(n, _)| current(n)).collect());
+            let mut writes = Expr::tuple(accs.iter().map(|a| current(&a.name)).collect());
             writes.ty = writes_ty.clone();
             let mut commit = Expr::new(TypedExprNode::Lit(Lit::Bool(true)));
             commit.ty = Type::Base(BaseType::Bool);
@@ -1911,7 +2018,7 @@ fn attach_feed_fields(decision: Expr, feeds: &[FeedSite]) -> Expr {
         }
         other => panic!(
             "letrec phase: a writer decision is `let* in {{commit, writes}}`, got {}",
-            symbolic(&Expr::preserve(provenance::NodeId::PLACEHOLDER, other).with_ty(decision.ty))
+            symbolic(&Expr::preserve(NodeId::PLACEHOLDER, other).with_ty(decision.ty))
         ),
     }
 }

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -74,8 +74,9 @@ const FEED_LABEL: RewriteLabel = "letrec.feed";
 /// The shadowing `let` a mutable write outside any loop normalizes to.
 const BARE_WRITE_LABEL: RewriteLabel = "letrec.bare_write";
 
-/// The two nodes one statement occupies: the `ExprStmt` holding it and the
-/// marker that is its effect (`For`, `MutWrite`, `Feed`).
+/// The two nodes one statement occupies: the marker that *is* the statement
+/// (`For`, `MutWrite`, `Feed`) and the `ExprStmt` holding it and the statements
+/// after it.
 ///
 /// A recording names a single node, and a statement's expansion is about both
 /// of these. [`StmtSite::enter`] names the `ExprStmt` — the outermost node the
@@ -84,14 +85,18 @@ const BARE_WRITE_LABEL: RewriteLabel = "letrec.bare_write";
 /// products.
 #[derive(Clone, Copy)]
 pub(crate) struct StmtSite {
-    stmt: NodeId,
+    /// The `For`/`MutWrite`/`Feed` marker: the statement itself.
     effect: NodeId,
+    /// The `ExprStmt` holding `effect` and the statements after it. Equal to
+    /// `effect` for a marker reached off any statement chain, where the marker
+    /// stands as the whole site (see [`collect_writes_in`]).
+    expr_stmt: NodeId,
 }
 
 impl StmtSite {
     /// Both ids are read before the destructure that moves the statement.
-    fn new(stmt: NodeId, effect: NodeId) -> Self {
-        StmtSite { stmt, effect }
+    fn new(expr_stmt: NodeId, effect: NodeId) -> Self {
+        StmtSite { effect, expr_stmt }
     }
 
     /// Open a recording over what this statement became.
@@ -101,8 +106,8 @@ impl StmtSite {
     /// otherwise put one pair in both the ancestry and the blame relation,
     /// which says nothing the ancestry edge does not already say.
     fn enter(self, label: RewriteLabel, nature: provenance::Nature) -> RecordingGuard {
-        let g = provenance::enter(self.stmt, label, nature);
-        if self.effect != self.stmt {
+        let g = provenance::enter(self.expr_stmt, label, nature);
+        if self.effect != self.expr_stmt {
             g.blame(&[self.effect]);
         }
         g
@@ -116,7 +121,7 @@ impl StmtSite {
     /// [`transform_feed_only_loop`], where every product belongs to a feed and
     /// the `for` around them would otherwise reach nothing at all.
     fn blamed_in(self, g: &RecordingGuard) {
-        g.blame(&[self.stmt, self.effect]);
+        g.blame(&[self.expr_stmt, self.effect]);
     }
 }
 
@@ -1026,8 +1031,9 @@ fn transform_loop(
     // read) or downstream of it (the trailing final read), so these two trees
     // carry every `Mut(V, D)` this loop's mutable variables have.
     let value_tys = mut_var_value_tys([&loop_body, &cont]);
-    // Accumulators in first-write order, with their value types and write sites.
-    let mut accs: Vec<Accumulator> = Vec::new();
+    // Accumulating variables in first-write order, with their value types and
+    // every write to each.
+    let mut accs: Vec<AccumulatorVariable> = Vec::new();
     collect_writes(&loop_body, &value_tys, &mut accs);
     if accs.is_empty() {
         // A loop with no accumulator. If its body feeds — a stateless generator,
@@ -1098,17 +1104,50 @@ fn transform_loop(
     )
 }
 
-/// One accumulator of an induction loop: the mutable variable, the value type its
-/// recurrence slot carries, and the write statement that made it an accumulator.
+/// One accumulating mutable variable of an induction loop: the variable, the value
+/// type its recurrence slot carries, and every write to it in the loop body.
 ///
-/// The site is what the slot's products are recorded against — the snapshot
-/// projection, the guard's seed, the trailing final read — so each accumulator
-/// of a two-accumulator loop resolves to the line that writes it rather than
-/// both resolving to the loop.
-pub(crate) struct Accumulator {
+/// One entry per variable, not per write. The entry's position in
+/// [`InductionFold::accs`] is the variable's slot index in the decision write set
+/// (`writes.i`), so a variable the body writes five times holds one slot and one
+/// entry, and [`collect_writes`]'s traversal order fixes both the index and the
+/// order of `writes`.
+pub(crate) struct AccumulatorVariable {
     pub name: Name,
     pub ty: Type,
-    site: StmtSite,
+    /// Every write to the variable, in [`collect_writes`]'s pre-order walk order:
+    /// source order along the flattened statement spine, branch order inside a
+    /// `Case`. Non-empty — an entry exists because a write created it.
+    writes: Vec<StmtSite>,
+}
+
+impl AccumulatorVariable {
+    /// Open a recording over one of the slot's products, named on the first write
+    /// and blaming the rest.
+    ///
+    /// The slot belongs to the variable rather than to any one write, so every
+    /// write answers with the slot's products. Only the first is ancestry: a later
+    /// write mints nothing, because [`transform_chain`] inlines its value into the
+    /// read-your-writes environment and its marker and `ExprStmt` die.
+    ///
+    /// TODO: blaming every write says which writes a product is about and not
+    /// which one it came from. Two of the five products — the guard's seed and the
+    /// trailing final read's default — are the variable's pre-loop binding, so they
+    /// belong to its `MutDecl`, and the rest belong to the slot as a whole. Naming
+    /// the `MutDecl` needs its `NodeId` threaded down from [`rewrite`]'s `MutDecl`
+    /// arm, which is an ancestor of the loop statement and outside the body
+    /// [`collect_writes`] walks.
+    fn enter(&self, label: RewriteLabel, nature: provenance::Nature) -> RecordingGuard {
+        let (first, rest) = self
+            .writes
+            .split_first()
+            .expect("an accumulating variable has at least the write that created it");
+        let g = first.enter(label, nature);
+        for w in rest {
+            w.blamed_in(&g);
+        }
+        g
+    }
 }
 
 /// An induction loop folded into a single decision-factored history binding,
@@ -1137,8 +1176,8 @@ pub(crate) struct InductionFold {
     pub domain_ty: Type,
     pub writes_ty: Type,
     pub decision_ty: Type,
-    /// Accumulators in first-write order (index `i` ↦ `writes.i`).
-    pub accs: Vec<Accumulator>,
+    /// Accumulating variables in first-write order (index `i` ↦ `writes.i`).
+    pub accs: Vec<AccumulatorVariable>,
 }
 
 impl InductionFold {
@@ -1147,17 +1186,15 @@ impl InductionFold {
     /// applied at `pos`; the transaction phase uses it to resolve a `commits(r)`
     /// decision that reads an induction accumulator at its request position.
     ///
-    /// The view is the accumulator's product, so the recording is the
-    /// accumulator's: one slot's stream, named on the statement that writes it.
+    /// The view is the slot's product, so the recording is the accumulating
+    /// variable's: one slot's stream, named on the statement that writes it.
     /// Opening it here rather than at the call site is what puts it on the write
     /// statement at all — the caller is `transact_phase`, which holds the
-    /// enclosing `transact.cross_domain_fold` recording on the *loop* statement
-    /// and has no access to [`Accumulator`]'s site.
+    /// enclosing `transact.cross_domain_fold` recording on the loop statement and
+    /// has no access to [`AccumulatorVariable`]'s writes.
     pub(crate) fn acc_view(&self, i: usize) -> Expr {
         let acc = &self.accs[i];
-        let _g = acc
-            .site
-            .enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
+        let _g = acc.enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
         writes_index_view(
             &self.hist,
             &self.hist_ty,
@@ -1182,7 +1219,7 @@ pub(crate) fn fold_induction_loop(
     loop_body: Expr,
     value_tys: &HashMap<Name, Type>,
 ) -> InductionFold {
-    let mut accs: Vec<Accumulator> = Vec::new();
+    let mut accs: Vec<AccumulatorVariable> = Vec::new();
     collect_writes(&loop_body, value_tys, &mut accs);
     assert!(
         !accs.is_empty(),
@@ -1211,9 +1248,7 @@ pub(crate) fn fold_induction_loop(
     // `__p ▷ .i`, the loop binder reads the item slot `__p ▷ .k`.
     let mut env: HashMap<Name, Expr> = HashMap::new();
     for (i, acc) in accs.iter().enumerate() {
-        let _g = acc
-            .site
-            .enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
+        let _g = acc.enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
         env.insert(acc.name.clone(), proj_of(&p, &p_ty, i, &acc.ty));
     }
     env.insert(
@@ -1269,9 +1304,7 @@ pub(crate) fn fold_induction_loop(
     let seeds: Vec<Expr> = accs
         .iter()
         .map(|a| {
-            let _g = a
-                .site
-                .enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
+            let _g = a.enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
             tvar(&a.name, a.ty.clone())
         })
         .collect();
@@ -1296,9 +1329,7 @@ pub(crate) fn fold_induction_loop(
         .iter()
         .enumerate()
         .map(|(i, a)| {
-            let _g = a
-                .site
-                .enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
+            let _g = a.enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
             proj_of(&prev, &writes_ty, i, &acc_tys[i])
         })
         .collect();
@@ -1321,9 +1352,7 @@ pub(crate) fn fold_induction_loop(
     let mut reads: Vec<(TypedBinding, Expr)> = Vec::new();
     let mut renames: Vec<(Name, Name)> = Vec::new();
     for (i, acc) in accs.iter().enumerate() {
-        let _g = acc
-            .site
-            .enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
+        let _g = acc.enter(ACCUMULATOR_LABEL, provenance::Nature::Expansion);
         let vty = &acc.ty;
         let view = writes_index_view(&h, &hist_ty, &domain_ty, &writes_ty, &decision_ty, i, vty);
         let view_ty = view.ty.clone();
@@ -1505,15 +1534,15 @@ pub(crate) fn mut_var_value_tys<'a>(
     out
 }
 
-/// Collect the loop's accumulators in first-write order, each with its value type
-/// taken from `value_tys` — the join inference recorded on the mutable variable's
-/// `Mut(V, D)` — and the write statement its recurrence slot is recorded against.
+/// Collect the loop's accumulating variables in first-write order, each with its
+/// value type taken from `value_tys` — the join inference recorded on the mutable
+/// variable's `Mut(V, D)` — and the statements of every write to it.
 ///
-/// One accumulator has one slot however many times the body writes it, so the
-/// recording goes to the first write and a later write to the same variable takes
-/// none. What the later statement contributes is not a mint: [`transform_chain`]
-/// inlines its value into the read-your-writes environment by id, and its marker
-/// and `ExprStmt` die, which the boundary difference reports.
+/// One variable is one recurrence slot however many times the body writes it, so a
+/// repeat write extends that variable's entry rather than adding one; the entry
+/// order is the order of first writes, which is the slot order
+/// ([`AccumulatorVariable`]). The value type comes from the first write, whose
+/// `value.ty` is the fallback below.
 ///
 /// A mutable variable with no entry is one no reference types as a `Mut`: either nothing
 /// reads it (only writes mention it, so its value type is unobservable), or the
@@ -1522,7 +1551,11 @@ pub(crate) fn mut_var_value_tys<'a>(
 /// mutable variable takes no refinement from any single contribution, and an unstripped
 /// one would be a refinement acquired by erasure rather than by `cast`
 /// (`src/ccl/design/type-inference.md`, "Refinements on the lattice").
-fn collect_writes(expr: &Expr, value_tys: &HashMap<Name, Type>, out: &mut Vec<Accumulator>) {
+fn collect_writes(
+    expr: &Expr,
+    value_tys: &HashMap<Name, Type>,
+    out: &mut Vec<AccumulatorVariable>,
+) {
     collect_writes_in(expr, None, value_tys, out);
 }
 
@@ -1534,21 +1567,25 @@ fn collect_writes_in(
     expr: &Expr,
     stmt: Option<NodeId>,
     value_tys: &HashMap<Name, Type>,
-    out: &mut Vec<Accumulator>,
+    out: &mut Vec<AccumulatorVariable>,
 ) {
-    if let TypedExprNode::MutWrite { name, value } = &expr.node
-        && !out.iter().any(|a| a.name == *name)
-    {
-        let ty = value_tys
-            .get(name)
-            .cloned()
-            .unwrap_or_else(|| strip_refinements(&value.ty));
+    if let TypedExprNode::MutWrite { name, value } = &expr.node {
         let write = expr.node_id();
-        out.push(Accumulator {
-            name: name.clone(),
-            ty,
-            site: StmtSite::new(stmt.unwrap_or(write), write),
-        });
+        let site = StmtSite::new(stmt.unwrap_or(write), write);
+        match out.iter_mut().find(|a| a.name == *name) {
+            Some(acc) => acc.writes.push(site),
+            None => {
+                let ty = value_tys
+                    .get(name)
+                    .cloned()
+                    .unwrap_or_else(|| strip_refinements(&value.ty));
+                out.push(AccumulatorVariable {
+                    name: name.clone(),
+                    ty,
+                    writes: vec![site],
+                });
+            }
+        }
     }
     if let TypedExprNode::ExprStmt { expr: effect, body } = &expr.node {
         collect_writes_in(effect, Some(expr.node_id()), value_tys, out);
@@ -1679,7 +1716,7 @@ fn splice_after_unit(chain: Expr, tail: Expr) -> Expr {
 fn transform_chain(
     expr: Expr,
     env: &mut HashMap<Name, Expr>,
-    accs: &[Accumulator],
+    accs: &[AccumulatorVariable],
     writes_ty: &Type,
     entering: &[Expr],
     path: &Expr,
@@ -2168,6 +2205,12 @@ mod tests {
     /// `x := 0; for i in [1,2,3]: x += i; x` as lowering + inference
     /// leave it: `let x = 0 in ExprStmt(For{i, [1,2,3], x := x+i}, x)`.
     fn direct_mirror_sum() -> (Expr, Name, Name) {
+        mirror_sum_writing(1)
+    }
+
+    /// [`direct_mirror_sum`] with the body's `x += i` repeated `writes` times, so
+    /// the loop has one accumulating variable holding several write statements.
+    fn mirror_sum_writing(writes: usize) -> (Expr, Name, Name) {
         let int = Type::Base(BaseType::Int);
         let list_ty = Type::data_fun(Type::UIntRange(3), int.clone());
         let x = Name::fresh("x");
@@ -2185,18 +2228,21 @@ mod tests {
         ));
         list.ty = list_ty;
 
-        let mut sum = Expr::new(TypedExprNode::BinOp {
-            left: Box::new(tvar(&x, int.clone())),
-            op: crate::ccl::BinOpKind::Arithmetic(crate::ccl::ArithmeticKind::Add),
-            right: Box::new(tvar(&i, int.clone())),
-        });
-        sum.ty = int.clone();
-        let mut write = Expr::mut_write(x.clone(), sum);
-        write.ty = Type::Base(BaseType::Unit);
         let mut unit = Expr::new(TypedExprNode::Lit(Lit::Unit));
         unit.ty = Type::Base(BaseType::Unit);
-        let mut body = Expr::expr_stmt(write, unit);
-        body.ty = Type::Base(BaseType::Unit);
+        let mut body = unit;
+        for _ in 0..writes {
+            let mut sum = Expr::new(TypedExprNode::BinOp {
+                left: Box::new(tvar(&x, int.clone())),
+                op: crate::ccl::BinOpKind::Arithmetic(crate::ccl::ArithmeticKind::Add),
+                right: Box::new(tvar(&i, int.clone())),
+            });
+            sum.ty = int.clone();
+            let mut write = Expr::mut_write(x.clone(), sum);
+            write.ty = Type::Base(BaseType::Unit);
+            body = Expr::expr_stmt(write, body);
+            body.ty = Type::Base(BaseType::Unit);
+        }
 
         let mut for_node = Expr::new(TypedExprNode::For {
             target: TypedBinding {
@@ -2411,6 +2457,93 @@ mod tests {
                 table.tag(id).map(|t| t.label),
                 Some(ACCUMULATOR_LABEL),
                 "under the accumulator's own label",
+            );
+        }
+    }
+    /// **Every write to an accumulating variable answers with its slot's
+    /// products.** The slot belongs to the variable, so a body that writes it
+    /// twice records the products against the first write and blames the second.
+    /// Only the first is ancestry: a later write mints nothing, because
+    /// [`transform_chain`] inlines its value into the read-your-writes
+    /// environment. Blame is the relation for a node a product is about rather
+    /// than descended from (`src/ccl/design/provenance.md`, "Where to open a
+    /// recording").
+    #[test]
+    fn a_repeat_write_blames_the_slot_it_shares() {
+        use crate::ccl::context::Phase;
+        use crate::ccl::provenance::{PhaseScope, TableSession};
+
+        let (tree, ..) = mirror_sum_writing(2);
+        let TypedExprNode::MutDecl { body: stmt, .. } = tree.node else {
+            unreachable!("`mirror_sum_writing` is a `MutDecl`")
+        };
+        let loop_stmt_id = stmt.node_id();
+        let TypedExprNode::ExprStmt {
+            expr: effect,
+            body: cont,
+        } = stmt.node
+        else {
+            unreachable!("the introduction's body is the loop statement")
+        };
+        let TypedExprNode::For { target, iter, body } = effect.node else {
+            unreachable!("the statement's effect is the loop")
+        };
+        // Both write statements, in spine order — the order `collect_writes`
+        // walks, so the first is the one the recording names.
+        let TypedExprNode::ExprStmt {
+            expr: first_write,
+            body: rest,
+        } = &body.node
+        else {
+            unreachable!("the loop body is a write statement")
+        };
+        let (first_stmt_id, first_write_id) = (body.node_id(), first_write.node_id());
+        let TypedExprNode::ExprStmt {
+            expr: second_write, ..
+        } = &rest.node
+        else {
+            unreachable!("the loop body's second statement is the repeat write")
+        };
+        let (second_stmt_id, second_write_id) = (rest.node_id(), second_write.node_id());
+        let value_tys = mut_var_value_tys([&*body, &*cont]);
+
+        let session = TableSession::install();
+        let view_ids = {
+            let _scope = PhaseScope::enter(Phase::Transact);
+            let _enclosing = provenance::enter(
+                loop_stmt_id,
+                "transact.cross_domain_fold",
+                provenance::Nature::Expansion,
+            );
+            let fold = fold_induction_loop(&target, &iter, *body, &value_tys);
+            assert_eq!(fold.accs.len(), 1, "two writes to one variable is one slot");
+            assert_eq!(
+                fold.accs[0].writes.len(),
+                2,
+                "and the variable holds both write statements"
+            );
+            let view = fold.acc_view(0);
+            let mut ids = Vec::new();
+            fn collect(e: &Expr, out: &mut Vec<NodeId>) {
+                out.push(e.node_id());
+                e.walk_children(|c| collect(c, out));
+            }
+            collect(&view, &mut ids);
+            ids
+        };
+        let table = session.into_table();
+
+        assert!(!view_ids.is_empty(), "the view is a tree of minted nodes");
+        for id in view_ids {
+            assert_eq!(
+                table.parents(id),
+                [first_stmt_id],
+                "a view node descends from the first write statement alone",
+            );
+            assert_eq!(
+                table.blame(id),
+                [first_write_id, second_stmt_id, second_write_id],
+                "and blames the first write's marker and both of the second's nodes",
             );
         }
     }

--- a/src/ccl/panes.rs
+++ b/src/ccl/panes.rs
@@ -591,6 +591,90 @@ mod tests {
         );
     }
 
+    /// **A loop-body statement reaches its own products, not the loop's.**
+    /// `mut_elim` turns one `For` statement into a recurrence carrying a slot
+    /// per accumulator and a tap per feed. One recording on the loop statement
+    /// claims all of it, which leaves every write and every feed in the body
+    /// with no descendants: the inspector then has nothing to answer with for
+    /// the lines that do the mutating. The nested `letrec.accumulator` and
+    /// `letrec.feed` recordings are what split it.
+    ///
+    /// Disjointness is the other half of the claim. A product belongs to one of
+    /// the three statements, so a recording that widened instead of splitting —
+    /// blaming the body statements on the loop's own recording — passes the
+    /// non-emptiness check and fails here.
+    #[test]
+    fn a_loop_body_statement_reaches_its_own_products() {
+        // Imported here rather than at the module's top: this test is the only
+        // user, and the enclosing module is shared with the pane declarations.
+        use std::collections::HashSet;
+
+        use crate::ccl::TypedExprNode;
+        use indoc::indoc;
+
+        let program = compile_ok(indoc! {"
+            out = defer()
+            total := 0
+            for n in [1, 2, 3]:
+                total := total + n
+                out << total
+            max(out)
+        "});
+        let panes = program.materialize_panes();
+        let pair = panes.pair("post-inference → post-channelize");
+
+        // The three statements of interest, found by the marker each holds:
+        // the loop, the write inside it, and the feed inside it.
+        let mut sites: Vec<(&'static str, NodeId)> = Vec::new();
+        fn find(e: &Expr, sites: &mut Vec<(&'static str, NodeId)>) {
+            if let TypedExprNode::ExprStmt { expr: effect, .. } = &e.node {
+                let kind = match &effect.node {
+                    TypedExprNode::For { .. } => Some("loop"),
+                    TypedExprNode::MutWrite { .. } => Some("write"),
+                    TypedExprNode::Feed { .. } => Some("feed"),
+                    _ => None,
+                };
+                if let Some(kind) = kind {
+                    sites.push((kind, e.node_id()));
+                }
+            }
+            e.walk_children(|c| find(c, sites));
+        }
+        find(&program.post_inference_ir, &mut sites);
+        assert_eq!(
+            sites.iter().map(|(k, _)| *k).collect::<Vec<_>>(),
+            ["loop", "write", "feed"],
+            "the fixture is one loop statement holding one write and one feed",
+        );
+
+        let images: Vec<(&str, HashSet<NodeId>)> = sites
+            .iter()
+            .map(|(kind, id)| {
+                let image: HashSet<NodeId> = pair
+                    .map
+                    .downstream(id)
+                    .iter()
+                    .filter(|l| l.id != *id)
+                    .map(|l| l.id)
+                    .collect();
+                assert!(
+                    !image.is_empty(),
+                    "the {kind} statement reaches nothing in `post-channelize`",
+                );
+                (*kind, image)
+            })
+            .collect();
+        for (i, (ka, a)) in images.iter().enumerate() {
+            for (kb, b) in &images[i + 1..] {
+                let shared: Vec<NodeId> = a.intersection(b).copied().collect();
+                assert!(
+                    shared.is_empty(),
+                    "the {ka} and {kb} statements both claim {shared:?}",
+                );
+            }
+        }
+    }
+
     /// **Both of a nested join's conditions reach the map**, as blame edges from
     /// `planning.hash_join`.
     ///

--- a/src/ccl/panes.rs
+++ b/src/ccl/panes.rs
@@ -272,11 +272,17 @@ pub(crate) fn gate_leaks(leaks: &[Leak], pair: &str) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
+    use indoc::indoc;
+
     use super::*;
+    use crate::ccl::TypedExprNode;
     use crate::ccl::context::{
         GlobalContext, PERF_REPS_ENV, compile_program, predicate_id_collisions,
         provenance_capture_enabled,
     };
+    use crate::ccl::provenance::Link;
     use crate::interpreter::Consumer;
 
     /// The pane-measurement corpus: every demo-gallery program that compiles
@@ -479,7 +485,7 @@ mod tests {
     /// pinning that turns every corpus edit into a list edit.
     #[test]
     fn the_pane_folds_derive_a_non_vacuous_provenance_map() {
-        let mut exercised: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        let mut exercised: HashSet<usize> = HashSet::new();
         for (name, code) in corpus() {
             let program = compile_ok(&code);
             let panes = program.materialize_panes();
@@ -591,40 +597,33 @@ mod tests {
         );
     }
 
-    /// **A loop-body statement reaches its own products, not the loop's.**
-    /// `mut_elim` turns one `For` statement into a recurrence carrying a slot
-    /// per accumulator and a tap per feed. One recording on the loop statement
-    /// claims all of it, which leaves every write and every feed in the body
-    /// with no descendants: the inspector then has nothing to answer with for
-    /// the lines that do the mutating. The nested `letrec.accumulator` and
-    /// `letrec.feed` recordings are what split it.
+    /// One mutation statement's image across the `post-inference →
+    /// post-channelize` pair, split by what the edge asserts: the nodes that
+    /// descend from it, and the nodes merely related to it.
     ///
-    /// Disjointness is the other half of the claim. A product belongs to one of
-    /// the three statements, so a recording that widened instead of splitting —
-    /// blaming the body statements on the loop's own recording — passes the
-    /// non-emptiness check and fails here.
-    #[test]
-    fn a_loop_body_statement_reaches_its_own_products() {
-        // Imported here rather than at the module's top: this test is the only
-        // user, and the enclosing module is shared with the pane declarations.
-        use std::collections::HashSet;
+    /// The two are kept apart because the claims are different. "This statement
+    /// reaches its own products" is ancestry; blame relates without claiming
+    /// ancestry, and two statements are legitimately blamed on one node
+    /// (`planning.hash_join` blames both of a join's conditions). Folding blame
+    /// in would let a statement that was only mentioned pass for one that
+    /// produced something, and would make disjointness reject a correct pair of
+    /// blame edges.
+    struct StatementImage {
+        kind: &'static str,
+        descendants: HashSet<NodeId>,
+        blamed: HashSet<NodeId>,
+    }
 
-        use crate::ccl::TypedExprNode;
-        use indoc::indoc;
-
-        let program = compile_ok(indoc! {"
-            out = defer()
-            total := 0
-            for n in [1, 2, 3]:
-                total := total + n
-                out << total
-            max(out)
-        "});
+    /// The mutation statements of `program`, in tree order, each with its image.
+    /// `expected` is the statements the fixture is meant to have, named by the
+    /// marker each holds, so a program that stops exercising the shape fails
+    /// here rather than passing vacuously.
+    fn statement_images(program: &str, expected: &[&'static str]) -> Vec<StatementImage> {
+        let program = compile_ok(program);
         let panes = program.materialize_panes();
         let pair = panes.pair("post-inference → post-channelize");
 
-        // The three statements of interest, found by the marker each holds:
-        // the loop, the write inside it, and the feed inside it.
+        // The statements of interest, found by the marker each holds.
         let mut sites: Vec<(&'static str, NodeId)> = Vec::new();
         fn find(e: &Expr, sites: &mut Vec<(&'static str, NodeId)>) {
             if let TypedExprNode::ExprStmt { expr: effect, .. } = &e.node {
@@ -643,36 +642,165 @@ mod tests {
         find(&program.post_inference_ir, &mut sites);
         assert_eq!(
             sites.iter().map(|(k, _)| *k).collect::<Vec<_>>(),
-            ["loop", "write", "feed"],
-            "the fixture is one loop statement holding one write and one feed",
+            expected,
+            "the fixture no longer has the statements the test is about",
         );
 
-        let images: Vec<(&str, HashSet<NodeId>)> = sites
+        sites
             .iter()
             .map(|(kind, id)| {
-                let image: HashSet<NodeId> = pair
-                    .map
-                    .downstream(id)
-                    .iter()
-                    .filter(|l| l.id != *id)
-                    .map(|l| l.id)
+                let links = pair.map.downstream(id);
+                let of = |f: fn(&Link<NodeId>) -> bool| -> HashSet<NodeId> {
+                    links
+                        .iter()
+                        .filter(|l| l.id != *id && f(l))
+                        .map(|l| l.id)
+                        .collect()
+                };
+                StatementImage {
+                    kind,
+                    descendants: of(|l| l.labels.has_ancestry()),
+                    blamed: of(|l| !l.labels.has_ancestry() && l.labels.has_blame()),
+                }
+            })
+            .collect()
+    }
+
+    /// No two statements produced the same node.
+    fn assert_disjoint(images: &[StatementImage]) {
+        for (i, a) in images.iter().enumerate() {
+            for b in &images[i + 1..] {
+                let shared: Vec<NodeId> = a
+                    .descendants
+                    .intersection(&b.descendants)
+                    .copied()
                     .collect();
                 assert!(
-                    !image.is_empty(),
-                    "the {kind} statement reaches nothing in `post-channelize`",
-                );
-                (*kind, image)
-            })
-            .collect();
-        for (i, (ka, a)) in images.iter().enumerate() {
-            for (kb, b) in &images[i + 1..] {
-                let shared: Vec<NodeId> = a.intersection(b).copied().collect();
-                assert!(
                     shared.is_empty(),
-                    "the {ka} and {kb} statements both claim {shared:?}",
+                    "the {} and {} statements both claim {shared:?}",
+                    a.kind,
+                    b.kind,
                 );
             }
         }
+    }
+
+    /// **A loop-body statement reaches its own products, not the loop's.**
+    /// `mut_elim` turns one `For` statement into a recurrence carrying a slot
+    /// per accumulator and a tap per feed. One recording on the loop statement
+    /// claims all of it, which leaves every write and every feed in the body
+    /// with no descendants: the inspector then has nothing to answer with for
+    /// the lines that do the mutating. The nested `letrec.accumulator` and
+    /// `letrec.feed` recordings are what split it.
+    ///
+    /// Disjointness is the other half of the claim. A product belongs to one of
+    /// the three statements, so a recording that widened instead of splitting —
+    /// blaming the body statements on the loop's own recording — passes the
+    /// non-emptiness check and fails here.
+    #[test]
+    fn a_loop_body_statement_reaches_its_own_products() {
+        let images = statement_images(
+            indoc! {"
+                out = defer()
+                total := 0
+                for n in [1, 2, 3]:
+                    total := total + n
+                    out << total
+                max(out)
+            "},
+            &["loop", "write", "feed"],
+        );
+        for image in &images {
+            assert!(
+                !image.descendants.is_empty(),
+                "the {} statement reaches nothing in `post-channelize`",
+                image.kind,
+            );
+        }
+        assert_disjoint(&images);
+    }
+
+    /// **Two accumulators resolve to two write statements.** One recurrence
+    /// carries a slot per accumulator, and the slots differ only by the index
+    /// they project — so a recording that named the loop, or that named the
+    /// first write for both slots, produces exactly the same tree and is
+    /// visible only here.
+    #[test]
+    fn each_accumulator_reaches_the_statement_that_writes_it() {
+        let images = statement_images(
+            indoc! {"
+                out = defer()
+                total := 0
+                count := 0
+                for n in [1, 2, 3]:
+                    total := total + n
+                    count := count + 1
+                    out << total
+                max(out) + count
+            "},
+            &["loop", "write", "write", "feed"],
+        );
+        for image in &images {
+            assert!(
+                !image.descendants.is_empty(),
+                "the {} statement reaches nothing in `post-channelize`",
+                image.kind,
+            );
+        }
+        assert_disjoint(&images);
+    }
+
+    /// **A feed reaches its own products whether or not the loop accumulates,
+    /// and the loop it sits in is blamed for them.** An accumulator-free loop
+    /// takes the plain-map path (`mut_elim::transform_feed_only_loop`), which
+    /// mints one mapped source per feed instead of a recurrence. Every product
+    /// there belongs to a feed — the loop mints nothing beyond them, and with
+    /// two feeds it mints two maps — so the split is the whole expansion moving
+    /// to the feed statements, not a slice of it.
+    ///
+    /// That leaves the `for` line answering with nothing of its own, which is
+    /// why the map blames it: the iteration is what the map is about, and blame
+    /// is how a site widens attribution to a node it did not produce. The
+    /// asymmetry with the accumulator path — where the loop keeps its history
+    /// binder and its guard — is the point being pinned, so the loop's empty
+    /// descent is asserted rather than tolerated.
+    ///
+    /// The read-only `with begin():` block is what reaches that path: a
+    /// non-transactional `for n in xs: out << n` is already a `Compose` by
+    /// `post-inference`, lowered without ever reaching `mut_elim`.
+    #[test]
+    fn a_feed_in_an_accumulator_free_loop_reaches_its_own_products() {
+        let images = statement_images(
+            indoc! {"
+                out = defer()
+                pool: Mut(Int, Txn) := 100
+                for r in [10, 20, 30]:
+                    with begin():
+                        out << pool
+                max(out)
+            "},
+            &["loop", "feed"],
+        );
+        let [loop_stmt, feed] = &images[..] else {
+            unreachable!("two statements, asserted above")
+        };
+        assert!(
+            !feed.descendants.is_empty(),
+            "the feed statement reaches nothing in `post-channelize`",
+        );
+        assert!(
+            loop_stmt.descendants.is_empty(),
+            "the loop statement produced {:?} of its own, so the products no \
+             longer all belong to the feed",
+            loop_stmt.descendants,
+        );
+        assert!(
+            feed.descendants.is_subset(&loop_stmt.blamed),
+            "the loop is not blamed for the feed's products: blamed {:?}, feed produced {:?}",
+            loop_stmt.blamed,
+            feed.descendants,
+        );
+        assert_disjoint(&images);
     }
 
     /// **Both of a nested join's conditions reach the map**, as blame edges from
@@ -698,7 +826,7 @@ mod tests {
                 .iter()
                 .find(|p| p.name == "post-lambda-elim → post-planning")
                 .expect("the planning pane pair");
-            let blamed: std::collections::HashSet<NodeId> = pair
+            let blamed: HashSet<NodeId> = pair
                 .map
                 .edges()
                 .into_iter()

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -1010,19 +1010,19 @@ fn fold_cross_domain_loops(expr: Expr, cross_reads: &HashSet<Name>, out: &mut Cr
         // type inference joined for it.
         let value_tys = mut_var_value_tys([&*body, &*cont]);
         let fold = fold_induction_loop(&target, &iter, *body, &value_tys);
-        for (i, (acc, vty)) in fold.accs.iter().enumerate() {
-            if cross_reads.contains(acc) {
+        for (i, acc) in fold.accs.iter().enumerate() {
+            if cross_reads.contains(&acc.name) {
                 let final_var = fold
                     .renames
                     .iter()
-                    .find(|(a, _)| a == acc)
+                    .find(|(a, _)| *a == acc.name)
                     .map(|(_, x)| x.clone())
                     .expect("a folded cross-read accumulator has a final-value rename");
                 out.acc_views.insert(
-                    acc.clone(),
+                    acc.name.clone(),
                     CrossAcc {
                         view: fold.acc_view(i),
-                        value_ty: vty.clone(),
+                        value_ty: acc.ty.clone(),
                         final_var,
                     },
                 );


### PR DESCRIPTION
`mut_elim` opened one `letrec.loop` recording over everything a `for` statement becomes, so the loop statement claimed every product and the write and feed statements in its body reached nothing — the inspector had no answer for the lines that do the mutating. Each feed statement, and each accumulating variable, now carries the `StmtSite` of its statement (its `ExprStmt` plus its effect marker), and the products of its tap or its recurrence slot are recorded under a nested `letrec.feed` or `letrec.accumulator`. A recurrence slot belongs to the variable rather than to any one write, so a variable the body writes twice is named on its first write and blames the rest: every write answers with the slot's products, and only the first claims ancestry. On a probe loop this moves 9 of the loop statement's 46 operators to the write (6) and the feed (3). Node ids and the golden fixtures are unchanged — the change moves which recording adopts a mint rather than minting anything.

### Reading order

- `StmtSite` and `AccumulatorVariable` in `src/ccl/mut_elim.rs`. `collect_writes_in` threads the enclosing `ExprStmt` the walk arrived through, and `collect_feed_only` does the same for feeds. `AccumulatorVariable` is per variable — its position in `InductionFold::accs` is the variable's slot index — and holds one `StmtSite` per write; `enter` splits those into the named first and the blamed rest, with a `TODO` for the per-product attribution it does not attempt.
- The three places that open the nested recording: `fold_induction_loop`'s slot machinery, `InductionFold::acc_view`, and `transform_feed_only_loop`. `acc_view` opens its own because its only caller, `transact_phase::fold_cross_domain_loops`, holds a recording on the loop statement and cannot see `AccumulatorVariable`'s writes.
- The two bounds on the split. An accumulator-free loop is its feeds, so the whole expansion moves to them and the `for` rides their blame column (`StmtSite::blamed_in`) rather than an ancestry edge it did not earn. A conditional feed rides one lambda over the whole body, so no per-feed recording has anything to adopt and the products stay on `letrec.loop`.

### Tests and docs

`panes.rs` splits each statement's image into what descends from it and what is only blamed on it, and pins three programs' images non-empty and pairwise disjoint. Two unit tests read the parent of a mint, because the products share the shape the fold builds for the trailing final read and a pane pair cannot tell them apart: `acc_view`'s nodes resolve to the write statement, and a two-write body's slot blames both writes. [`provenance.md`](src/ccl/design/provenance.md#where-to-open-a-recording) records the per-construct rule as a fourth refinement, notes that one construct can be several statements, and adds the induction fold to the shared helpers.