### PR TITLE
Add the keyed write `m[k] := v` as a whole-collection `insert`

### DIFF
--- a/src/ccl/channelize.rs
+++ b/src/ccl/channelize.rs
@@ -1031,8 +1031,9 @@ fn drop_expr_stmts(expr: Expr) -> Expr {
             iter: Box::new(drop_expr_stmts(*iter)),
             body: Box::new(drop_expr_stmts(*body)),
         },
-        TypedExprNode::MutWrite { name, value } => TypedExprNode::MutWrite {
+        TypedExprNode::MutWrite { name, key, value } => TypedExprNode::MutWrite {
             name,
+            key: key.map(|k| Box::new(drop_expr_stmts(*k))),
             value: Box::new(drop_expr_stmts(*value)),
         },
         TypedExprNode::Begin { body } => TypedExprNode::Begin {
@@ -1152,7 +1153,12 @@ fn assert_no_defer_residue(expr: &Expr) -> Result<(), DeferError> {
             assert_no_defer_residue(iter)?;
             assert_no_defer_residue(body)
         }
-        TypedExprNode::MutWrite { value, .. } => assert_no_defer_residue(value),
+        TypedExprNode::MutWrite { key, value, .. } => {
+            if let Some(key) = key {
+                assert_no_defer_residue(key)?;
+            }
+            assert_no_defer_residue(value)
+        }
         TypedExprNode::Lit(_)
         | TypedExprNode::Var(_)
         | TypedExprNode::Builtin(_)
@@ -1882,7 +1888,12 @@ fn collect_feed_target_names(expr: &Expr) -> Vec<Name> {
                 rec(body, bound, out);
                 bound.pop();
             }
-            TypedExprNode::MutWrite { value, .. } => rec(value, bound, out),
+            TypedExprNode::MutWrite { key, value, .. } => {
+                if let Some(key) = key {
+                    rec(key, bound, out);
+                }
+                rec(value, bound, out);
+            }
             TypedExprNode::Lit(_)
             | TypedExprNode::Var(_)
             | TypedExprNode::Builtin(_)

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -1560,6 +1560,12 @@ fn run_passes(
     // commit. Reject it before the phase strips the sites.
     check_transact_rejections(&expr, &txn_mut_vars)?;
 
+    // A register's seed enters the value type its binder declares — a concrete collection
+    // reaches an abstract one only through an introduction.
+    mut_elim::view_seeds_at_value_type(&mut expr);
+    // `m[k] := v` becomes the whole-value write it denotes, `m := insert(m, k, v)`, so
+    // every phase below sees one kind of `MutWrite` and none of them needs a key.
+    mut_elim::desugar_keyed_writes(&mut expr);
     expr = recorded(capture_provenance, Phase::Transact, || {
         transact_phase::run(expr, &txn_mut_vars)
     })

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -1422,7 +1422,7 @@ fn run_passes(
         return Ok(expr);
     }
 
-    // Register every source (pre-registered + discovered during lowering) with
+    // Mutable variable every source (pre-registered + discovered during lowering) with
     // inference and operator-conversion now that the full source set is known.
     for (_name, source) in ctx.lowering_ctx().take_sources() {
         let name = source.borrow().get_id().to_string();
@@ -1566,7 +1566,7 @@ fn run_passes(
     // reachable.
     expr = recorded(capture_provenance, Phase::Transact, || {
         let mut expr = expr;
-        // A register's seed enters the value type its binder declares — a concrete
+        // A mutable variable's seed enters the value type its binder declares — a concrete
         // collection reaches an abstract one only through an introduction.
         mut_elim::view_seeds_at_value_type(&mut expr);
         // `m[k] := v` becomes the whole-value write it denotes, `m := insert(m, k, v)`, so

--- a/src/ccl/context.rs
+++ b/src/ccl/context.rs
@@ -1560,13 +1560,18 @@ fn run_passes(
     // commit. Reject it before the phase strips the sites.
     check_transact_rejections(&expr, &txn_mut_vars)?;
 
-    // A register's seed enters the value type its binder declares — a concrete collection
-    // reaches an abstract one only through an introduction.
-    mut_elim::view_seeds_at_value_type(&mut expr);
-    // `m[k] := v` becomes the whole-value write it denotes, `m := insert(m, k, v)`, so
-    // every phase below sees one kind of `MutWrite` and none of them needs a key.
-    mut_elim::desugar_keyed_writes(&mut expr);
+    // The two rewrites the transactional slice runs before its own: both mint expression
+    // nodes, so both sit inside the phase's recording — outside it their nodes reach the
+    // audit span opened above as `Leak::Unrecorded`, and the span's floor stops being
+    // reachable.
     expr = recorded(capture_provenance, Phase::Transact, || {
+        let mut expr = expr;
+        // A register's seed enters the value type its binder declares — a concrete
+        // collection reaches an abstract one only through an introduction.
+        mut_elim::view_seeds_at_value_type(&mut expr);
+        // `m[k] := v` becomes the whole-value write it denotes, `m := insert(m, k, v)`, so
+        // every phase below sees one kind of `MutWrite` and none of them needs a key.
+        mut_elim::desugar_keyed_writes(&mut expr);
         transact_phase::run(expr, &txn_mut_vars)
     })
     .map_err(|msg| vec![CompileError::Unsupported(msg)])?;

--- a/src/ccl/design/collections.md
+++ b/src/ccl/design/collections.md
@@ -444,8 +444,8 @@ is a morphism from a zip, `⟨𝑐, 𝑘⟩ ≫ lookup?`, and a collection reach
   optimization: a streamed collection cannot be replicated into every row, because
   broadcasting copies a single present value and a collection is a tile.
 - **One collection per position**, where the leg is a projection of the row. A mutable
-  collection's register read inside a transaction is the only producer: `transact_phase`
-  applies the writer body to a snapshot tuple, so the register arrives as `.n` of that tuple
+  collection's mutable variable read inside a transaction is the only producer: `transact_phase`
+  applies the writer body to a snapshot tuple, so the mutable variable arrives as `.n` of that tuple
   and no eta-reduction makes it closed again. Each row's cell is one materialized map value,
   and the lookup searches that value's bindings.
 

--- a/src/ccl/design/collections.md
+++ b/src/ccl/design/collections.md
@@ -435,13 +435,19 @@ substituting the binder's occurrence does not reach — so a discharge re-run af
 builds a term emission never produced (`Typing::keyed_value_at`).
 
 The operator's domain is a pair, so it never produces a function value. Its point-free form
-is a morphism from a zip, `⟨𝑐, 𝑘⟩ ≫ lookup?`, and a collection reaches that zip one way: one
-collection for the whole iteration, its leg closed in the loop binder. `simplify`'s
-partial-lookup rule rewrites `⟨const(𝑐), 𝑔⟩ ≫ lookup?` to `𝑔 ≫ (𝑐 ▷ curry(lookup?))`, and
-op-conversion compiles that partial application to a collection read once with every key
-answered against it. The rewrite is not an optimization: a streamed collection cannot be
-replicated into every row, because broadcasting copies a single present value and a
-collection is a tile.
+is a morphism from a zip, `⟨𝑐, 𝑘⟩ ≫ lookup?`, and a collection reaches that zip two ways:
+
+- **One collection for the whole iteration**, its leg closed in the loop binder.
+  `simplify`'s partial-lookup rule rewrites `⟨const(𝑐), 𝑔⟩ ≫ lookup?` to
+  `𝑔 ≫ (𝑐 ▷ curry(lookup?))`, and op-conversion compiles that partial application to a
+  collection read once with every key answered against it. The rewrite is not an
+  optimization: a streamed collection cannot be replicated into every row, because
+  broadcasting copies a single present value and a collection is a tile.
+- **One collection per position**, where the leg is a projection of the row. A mutable
+  collection's register read inside a transaction is the only producer: `transact_phase`
+  applies the writer body to a snapshot tuple, so the register arrives as `.n` of that tuple
+  and no eta-reduction makes it closed again. Each row's cell is one materialized map value,
+  and the lookup searches that value's bindings.
 
 **A collection-valued answer does not materialize.** A group-by's rows are themselves
 collections, so the answer would carry a collection as its `` `some `` payload, and a

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -227,11 +227,21 @@ eliminator, stated by content rather than by a "mirrors CHL" adjective.)
   a mutable variable (a pass-by-reference `Mut` parameter aside), which is what makes
   "is this binder mutable?" a question about the node rather than about a type that
   happened to survive inference.
-- `MutWrite { name, value }` — one write to a variable. Value `Unit`. Its target must be
+- `MutWrite { name, key, value }` — one write to a variable. Value `Unit`. Its target must be
   `Mut`-typed: inference peels the target's `Mut(𝑉, 𝐷)` and requires `value ⊑ 𝑉`; a write whose
   target is not `Mut` is a **type error**, never a shadowing rebind (`x += e` on a plain `x` is
   rejected, not silently turned into `x = x + e`). `x += e` lowers to `MutWrite(x, x + e)`, the
   embedded read being the in-context read.
+  `key` is `Some` for a **keyed write** `m[k] := v` — a write to one key of a mutable
+  collection — and `None` for a write of the whole variable. Its rule is application on the
+  left of the assignment: the key is checked against the collection's key type and the value
+  against the codomain that key names, a dependent codomain being discharged to the key term.
+  So `m[k]` denotes one type whether it is read or written. The membership refinement is
+  dropped as it is for `m[k]?`, because a write is what makes a key present; any other domain
+  refinement stands, an inadmissible key being an error rather than an insertion.
+  `mut_elim::desugar_keyed_writes` then rewrites it to the whole-value write it denotes,
+  `m := insert(m, k, v)`, so every phase below sees one kind of `MutWrite` and none of them
+  needs a key.
 - `Begin { body }` — one `with begin():` transaction block, made a *single* `Unit`-valued statement
   (`ExprStmt(Begin{block}, rest)`) so a loop body may freely mix a per-iteration transaction, sibling
   induction writes, and feeds. `body` is the per-transaction statement chain. The transaction phase
@@ -328,6 +338,32 @@ Typing:
   let-generalization of UDF bindings. Whether a write site requires `Txn` is the phase's structural
   check, post-inline — so one `bump` can serve an induction accumulator and a transactional
   mutable variable.
+
+#### A mutable collection's key set varies with the position
+
+`Mut(𝐶, 𝑆)` for a keyed collection denotes `𝑆 ⇒ Σ (𝐷 : SubtypesOf(𝐾)). 𝐷 ⤇ 𝑉`, the sum sitting in
+the codomain. A value of a sum is a domain paired with a map over it, so the history yields a
+different pair at each position and the key set varies with the position. This is the
+quantifier order `∀s. ∃𝐷`, and it admits exactly the histories a register has.
+
+Every contribution injects by kind containment: the seed names one key domain, each write
+names another, and both are members of `SubtypesOf(𝐾)`. So the single value type on `Mut` needs no
+per-position reconciliation — nothing has to relate a write's domain to the seed's.
+
+**The type does not name the domain at a position, and cannot be made to.** A sum is what a
+collection type says when it forgets its domain — the same job `List(𝑇)` does for a length —
+so every use opens it to a fresh opaque domain and no sentence relates `𝐷` at two positions.
+The proven lookup `m[k]` and read-your-writes as a type fact both need `𝐷(s⁻) ⊆ 𝐷(s)`, which
+has no subject here. Reaching them replaces this type rather than extending it. Reads are the
+checked `m[k]?`, answering `Option(𝑉)` with no membership proof.
+
+Two forms that would name it were measured and rejected. A **position-indexed family**,
+`Σ (𝐷 : 𝑆 ⇒ SubtypesOf(𝐾)). ((s: 𝑆) ⇒ 𝐷(s) ⤇ 𝑉)`, needs the witness to range over functions from
+positions to domains, so it needs type-level functions and their application. A **refinement
+naming the position**, `(s: 𝑆) ⇒ ({𝐾 | present(s)} ⤇ 𝑉)`, needs only machinery that exists —
+the Pi binder and a refinement carrying a term — but needs a position term in scope where the
+register is typed, and `with begin():` binds none. The
+[transaction handle](#with-t--begin-transaction-handle) is the binder that would supply one.
 
 #### No aliasing: `Mut` values are second-class (downward-only)
 
@@ -877,10 +913,20 @@ affordable by that complete compile-time knowledge.
   domain is a new *domain*, not a new construct.
 - **Nested `for` loops** — lexicographic product domains; data-dependent bounds meet the
   refinement-types work as dependent sums.
-- **Mutable collections** — sigma types (`List[𝑇] = Σ 𝐼 . 𝐼 ⤇ 𝑇`) as letrec bindings; the
-  append-only `Appendable` case first, as a commit stream whose history is the collection. This
-  is also what first-class `Mut` (returning or storing references) needs: carrying mutable variable identity in
-  types is a sigma/index-types question. Until then the second-class discipline is the aliasing
+- **Append-only mutable collections** — an `Appendable` collection as a letrec binding, its
+  commit stream being the collection's history. A keyed write overwrites; an append needs the
+  domain to grow with the history.
+- **Per-key store keys for a mutable collection** — `m[k] := v` commits today by writing the
+  register's whole collection to one store key, so two transactions touching one map conflict
+  whatever keys they touch. The write is recoverable per key: its decision slot is
+  `` (.i, key, value) ▷ zip ≫ insert ``, whose key and value legs each compile on their own.
+  Narrowing the read footprint alongside it needs `Proposal.reads` to record *absence*, since
+  a transaction that read a missing key must conflict with a concurrent insert. Correctness
+  does not depend on the narrowing — an unrecovered write keeps whole-collection footprints —
+  so it is an optimization with a silent failure mode, and the unrecovered path needs its own
+  coverage.
+- **First-class `Mut`** (returning or storing references) — needs mutable variable identity in
+  types, a sigma/index-types question; until then the second-class discipline is the aliasing
   firewall.
 - **History access / auditing** — `get_prev_*` generalized to user-facing reads at explicit
   positions; the transaction handle (`t = begin()`) already names the position.

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -346,7 +346,7 @@ Typing:
 `Mut(𝐶, 𝑆)` for a `Map` denotes `𝑆 ⇒ Σ (𝐷 : SubtypesOf(𝐾)). 𝐷 ⤇ 𝑉`, the sum sitting in the
 codomain. A value of a sum is a domain paired with a map over it, so the history yields a
 different pair at each position and the key set varies with the position. This is the
-quantifier order `∀s. ∃𝐷`, and it admits exactly the histories a register has.
+quantifier order `∀s. ∃𝐷`, and it admits exactly the histories a mutable variable has.
 
 Every contribution injects by kind containment: the seed names one key domain, each write
 names another, and both are members of `SubtypesOf(𝐾)`. So the single value type on `Mut` needs no
@@ -364,7 +364,7 @@ family**, `Σ (𝐷 : 𝑆 ⇒ SubtypesOf(𝐾)). ((s: 𝑆) ⇒ 𝐷(s) ⤇ �
 functions from positions to domains, so it needs type-level functions and their application.
 A **refinement naming the position**, `(s: 𝑆) ⇒ ({𝐾 | present(s)} ⤇ 𝑉)`, needs only machinery
 that exists — the Pi binder and a refinement carrying a term — but needs a position term in
-scope where the register is typed, and `with begin():` binds none. The
+scope where the mutable variable is typed, and `with begin():` binds none. The
 [transaction handle](#with-t--begin-transaction-handle) is the binder that would supply one.
 
 #### No aliasing: `Mut` values are second-class (downward-only)
@@ -919,8 +919,8 @@ affordable by that complete compile-time knowledge.
   commit stream being the collection's history. A keyed write overwrites; an append needs the
   domain to grow with the history.
 - **Per-key store keys for a mutable collection** — `m[k] := v` commits today by writing the
-  register's whole collection to one store key, so two transactions touching one map conflict
-  whatever keys they touch. The write is recoverable per key: its decision slot is
+  mutable variable's whole collection to one store key, so two transactions touching one
+  map conflict whatever keys they touch. The write is recoverable per key: its decision slot is
   `` (.i, key, value) ▷ zip ≫ insert ``, whose key and value legs each compile on their own.
   Narrowing the read footprint alongside it needs `Proposal.reads` to record *absence*, since
   a transaction that read a missing key must conflict with a concurrent insert. Correctness

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -341,8 +341,8 @@ Typing:
 
 #### A mutable collection's key set varies with the position
 
-`Mut(𝐶, 𝑆)` for a keyed collection denotes `𝑆 ⇒ Σ (𝐷 : SubtypesOf(𝐾)). 𝐷 ⤇ 𝑉`, the sum sitting in
-the codomain. A value of a sum is a domain paired with a map over it, so the history yields a
+`Mut(𝐶, 𝑆)` for a `Map` denotes `𝑆 ⇒ Σ (𝐷 : SubtypesOf(𝐾)). 𝐷 ⤇ 𝑉`, the sum sitting in the
+codomain. A value of a sum is a domain paired with a map over it, so the history yields a
 different pair at each position and the key set varies with the position. This is the
 quantifier order `∀s. ∃𝐷`, and it admits exactly the histories a register has.
 

--- a/src/ccl/design/mutability.md
+++ b/src/ccl/design/mutability.md
@@ -236,9 +236,11 @@ eliminator, stated by content rather than by a "mirrors CHL" adjective.)
   collection — and `None` for a write of the whole variable. Its rule is application on the
   left of the assignment: the key is checked against the collection's key type and the value
   against the codomain that key names, a dependent codomain being discharged to the key term.
-  So `m[k]` denotes one type whether it is read or written. The membership refinement is
-  dropped as it is for `m[k]?`, because a write is what makes a key present; any other domain
-  refinement stands, an inadmissible key being an error rather than an insertion.
+  So `m[k]` denotes one type whether it is read or written. The key owes the key domain's
+  base, its refinements peeled as they are for `m[k]?` — a write is what makes a key present,
+  so demanding a presence proof of the key being written would be backwards. Peeling takes
+  the domain's whole refinement set, membership predicate and any other alike, so a domain
+  refinement that is not about presence is not enforced at a write either.
   `mut_elim::desugar_keyed_writes` then rewrites it to the whole-value write it denotes,
   `m := insert(m, k, v)`, so every phase below sees one kind of `MutWrite` and none of them
   needs a key.
@@ -357,12 +359,12 @@ The proven lookup `m[k]` and read-your-writes as a type fact both need `𝐷(s�
 has no subject here. Reaching them replaces this type rather than extending it. Reads are the
 checked `m[k]?`, answering `Option(𝑉)` with no membership proof.
 
-Two forms that would name it were measured and rejected. A **position-indexed family**,
-`Σ (𝐷 : 𝑆 ⇒ SubtypesOf(𝐾)). ((s: 𝑆) ⇒ 𝐷(s) ⤇ 𝑉)`, needs the witness to range over functions from
-positions to domains, so it needs type-level functions and their application. A **refinement
-naming the position**, `(s: 𝑆) ⇒ ({𝐾 | present(s)} ⤇ 𝑉)`, needs only machinery that exists —
-the Pi binder and a refinement carrying a term — but needs a position term in scope where the
-register is typed, and `with begin():` binds none. The
+Two forms that would name it are rejected on what they require. A **position-indexed
+family**, `Σ (𝐷 : 𝑆 ⇒ SubtypesOf(𝐾)). ((s: 𝑆) ⇒ 𝐷(s) ⤇ 𝑉)`, needs the witness to range over
+functions from positions to domains, so it needs type-level functions and their application.
+A **refinement naming the position**, `(s: 𝑆) ⇒ ({𝐾 | present(s)} ⤇ 𝑉)`, needs only machinery
+that exists — the Pi binder and a refinement carrying a term — but needs a position term in
+scope where the register is typed, and `with begin():` binds none. The
 [transaction handle](#with-t--begin-transaction-handle) is the binder that would supply one.
 
 #### No aliasing: `Mut` values are second-class (downward-only)
@@ -923,8 +925,10 @@ affordable by that complete compile-time knowledge.
   Narrowing the read footprint alongside it needs `Proposal.reads` to record *absence*, since
   a transaction that read a missing key must conflict with a concurrent insert. Correctness
   does not depend on the narrowing — an unrecovered write keeps whole-collection footprints —
-  so it is an optimization with a silent failure mode, and the unrecovered path needs its own
-  coverage.
+  so it is an optimization whose failure mode is silent: a narrowed writer that reads too
+  little still commits, from a stale collection.
+  `keyed_writes_at_distinct_keys_compose_across_transactions` is what the whole-collection
+  footprint buys, and has to keep passing across the change.
 - **First-class `Mut`** (returning or storing references) — needs mutable variable identity in
   types, a sigma/index-types question; until then the second-class discipline is the aliasing
   firewall.

--- a/src/ccl/expr.rs
+++ b/src/ccl/expr.rs
@@ -530,7 +530,16 @@ pub enum TypedExprNode {
     MutWrite {
         /// The mutable variable being written.
         name: Name,
-        /// The written value; must be a subtype of the variable's type.
+        /// The key written, for a write to one key of a mutable collection
+        /// (`m[k] := v`); [`None`] for a whole-variable write (`x := v`).
+        ///
+        /// A scalar register's key is its variable name, which `name` already
+        /// carries, so the two write forms differ in whether a *second* key sits
+        /// below that one — which is what this option says. The store the write
+        /// eliminates to is keyed either way.
+        key: Option<Box<TypedExpr>>,
+        /// The written value. For a whole-variable write it must be a subtype of
+        /// the variable's type; for a keyed write, of the collection's codomain.
         value: Box<TypedExpr>,
     },
 
@@ -1113,10 +1122,20 @@ impl TypedExpr {
         .with_ty(ty)
     }
 
-    /// Construct a feed expression.
+    /// Construct a whole-variable write, `x := value`.
     pub fn mut_write(name: impl Into<Name>, value: Self) -> Self {
         Self::new(TypedExprNode::MutWrite {
             name: name.into(),
+            key: None,
+            value: Box::new(value),
+        })
+    }
+
+    /// Construct a keyed write, `name[key] := value`.
+    pub fn mut_write_keyed(name: impl Into<Name>, key: Self, value: Self) -> Self {
+        Self::new(TypedExprNode::MutWrite {
+            name: name.into(),
+            key: Some(Box::new(key)),
             value: Box::new(value),
         })
     }
@@ -1537,9 +1556,18 @@ impl TypedExpr {
                 f(expr.as_ref());
                 f(body.as_ref());
             }
-            TypedExprNode::Feed { value, .. }
-            | TypedExprNode::Define { value, .. }
-            | TypedExprNode::MutWrite { value, .. } => f(value.as_ref()),
+            TypedExprNode::Feed { value, .. } | TypedExprNode::Define { value, .. } => {
+                f(value.as_ref())
+            }
+            // The key is a child like the value: it is an ordinary expression the
+            // write evaluates, so every walk has to reach it or its nodes go
+            // unvisited by uniquify, substitution, and the provenance fold.
+            TypedExprNode::MutWrite { key, value, .. } => {
+                if let Some(k) = key {
+                    f(k.as_ref());
+                }
+                f(value.as_ref());
+            }
             TypedExprNode::Begin { body } => f(body.as_ref()),
         }
     }
@@ -1716,9 +1744,15 @@ impl TypedExpr {
                 f(expr.as_mut());
                 f(body.as_mut());
             }
-            TypedExprNode::Feed { value, .. }
-            | TypedExprNode::Define { value, .. }
-            | TypedExprNode::MutWrite { value, .. } => f(value.as_mut()),
+            TypedExprNode::Feed { value, .. } | TypedExprNode::Define { value, .. } => {
+                f(value.as_mut())
+            }
+            TypedExprNode::MutWrite { key, value, .. } => {
+                if let Some(k) = key {
+                    f(k.as_mut());
+                }
+                f(value.as_mut());
+            }
             TypedExprNode::Begin { body } => f(body.as_mut()),
         }
     }

--- a/src/ccl/expr.rs
+++ b/src/ccl/expr.rs
@@ -533,7 +533,7 @@ pub enum TypedExprNode {
         /// The key written, for a write to one key of a mutable collection
         /// (`m[k] := v`); [`None`] for a whole-variable write (`x := v`).
         ///
-        /// A scalar register's key is its variable name, which `name` already
+        /// A scalar mutable variable's key is its variable name, which `name` already
         /// carries, so the two write forms differ in whether a *second* key sits
         /// below that one — which is what this option says. The store the write
         /// eliminates to is keyed either way.

--- a/src/ccl/infer/check.rs
+++ b/src/ccl/infer/check.rs
@@ -650,9 +650,16 @@ fn check_node_rule(expr: &mut Expr, ctx: &mut CheckCtx) -> Result<Type, LocatedI
         // maintain (it trusts recorded types), and the contribution/write
         // edge was already recorded during inference. Check the value
         // subtree; the node itself is `Unit`.
-        TypedExprNode::Feed { value, .. }
-        | TypedExprNode::Define { value, .. }
-        | TypedExprNode::MutWrite { value, .. } => {
+        TypedExprNode::Feed { value, .. } | TypedExprNode::Define { value, .. } => {
+            ctx.subexpr(value)?;
+            prim(BaseType::Unit)
+        }
+        // A write checks its value subtree and, for a keyed write, its key: both are
+        // ordinary value positions, and the key's type reaches no other slot.
+        TypedExprNode::MutWrite { key, value, .. } => {
+            if let Some(key) = key {
+                ctx.subexpr(key)?;
+            }
             ctx.subexpr(value)?;
             prim(BaseType::Unit)
         }

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -254,7 +254,7 @@ fn emit_node_inner(expr: &mut Expr, ctx: &mut InferCtx) -> Result<Type, LocatedI
         // Instantiation is a no-op for the monomorphic accumulator bindings
         // lowering produces (a polymorphic init would under-constrain the
         // write and surface as `UnresolvedInfer`).
-        TypedExprNode::MutWrite { name, value } => {
+        TypedExprNode::MutWrite { name, key, value } => {
             let var_ty = match ctx.scopes.lookup(name) {
                 None => return Err(ctx.raise(InferError::UnboundVariable(name.to_string()))),
                 Some(binding) => binding.scheme.instantiate(ctx.level),
@@ -267,6 +267,12 @@ fn emit_node_inner(expr: &mut Expr, ctx: &mut InferCtx) -> Result<Type, LocatedI
             // The *target* is a handle, resolved by name above. The written **value** is
             // an ordinary value position, so a mutable variable mention there reads: `b := a`
             // between two mutable variables writes `a`'s current value into `b`.
+            // The key is an ordinary value position, like the written value: a mutable
+            // variable mentioned there reads rather than passing its handle along.
+            let key_ty = match key {
+                Some(k) => Some(emit_value_read(k, ctx)?),
+                None => None,
+            };
             let value_ty = emit_value_read(value, ctx)?;
             let write_label = name.clone();
             // The written value flows in **verbatim**, as one contribution to the
@@ -290,9 +296,15 @@ fn emit_node_inner(expr: &mut Expr, ctx: &mut InferCtx) -> Result<Type, LocatedI
             // writable in a type annotation — so what a program can exercise today is
             // the demand on an unrefined annotation and the skip on a non-mutable one.)
             if let Some(mut_val) = mut_value {
-                ctx.require_sub(&value_ty, mut_val, &|| {
-                    format!("write to mutable variable `{write_label}`")
-                })?;
+                match key {
+                    None => ctx.require_sub(&value_ty, mut_val, &|| {
+                        format!("write to mutable variable `{write_label}`")
+                    })?,
+                    // The key *term* is not needed: a write states its obligation on the
+                    // value, and the one shape that would discharge against the key — a
+                    // key-dependent codomain — has no write.
+                    Some(_) => emit_keyed_write(mut_val, &key_ty, &value_ty, &write_label, ctx)?,
+                }
             }
             Type::Base(BaseType::Unit)
         }
@@ -984,8 +996,10 @@ pub(super) fn emit_apply<C: Typing>(
 
 /// The value type `𝑚[𝑘]` reads, with the key related to the collection's keys.
 ///
-/// One shape per keyed access, so every use of `m[k]` reads the same type off it rather
-/// than restating the rule. The read ([`emit_lookup_checked`]) wraps it in `Option`.
+/// One shape at both uses. A read ([`emit_lookup_checked`]) wraps it in `Option`; a write
+/// ([`emit_keyed_write`]) requires the written value against it. That is what makes
+/// `m[k] := v` and `m[k]?` agree about what `m[k]` is, rather than two rules kept in step
+/// by hand.
 ///
 /// **Not an application.** A keyed access is reached precisely when the key is *not* known
 /// to lie in the collection's domain, and application demands that it does — so typing one
@@ -1048,6 +1062,62 @@ fn emit_lookup_checked<C: Typing>(
         result.clone(),
     );
     Ok(result)
+}
+
+/// Type a **keyed write** `m[k] := v`: check `k` against the collection's key type and
+/// `v` against the value type at that key.
+///
+/// One rule with the checked lookup ([`keyed_access_value`]), so `m[k]` names the same
+/// value type whether it is being read or written. Neither is an application: a read is
+/// reached when the key is not known to be present, and a write is what *makes* it
+/// present, so demanding a presence proof of the key being written would be backwards.
+fn emit_keyed_write<C: Typing>(
+    collection: &Type,
+    key_ty: &Option<Type>,
+    value_ty: &Type,
+    label: &Name,
+    ctx: &mut C,
+) -> Result<(), LocatedInferError> {
+    let key_ty = key_ty
+        .as_ref()
+        .expect("a keyed write emits its key's type alongside the key");
+    let (keys, binder, value) = keyed_access_types(collection)
+        .ok_or_else(|| {
+            if matches!(collection, Type::Infer(_) | Type::Hole) {
+                return InferError::Unsupported(format!(
+                    "keyed write `{label}[k] := …` needs the collection's type at this \
+                     point, but `{collection}` is not resolved yet — annotate the \
+                     introduction (`{label}: Mut(Map(K, V), Txn) := …`)"
+                ));
+            }
+            not_a_keyed_access(collection, &format!("keyed write `{label}[k] := …`"))
+        })
+        .map_err(|e| ctx.raise(e))?;
+    // A **dependent** codomain has no write. The read discharges the key binder to the key
+    // term and answers `Option` of the result; a write would have to state the obligation
+    // on the value at a key the write itself is what makes present, and a `Mut(Map(𝐾, 𝑉))`
+    // register holds a fixed `𝑉` besides, so no register reaches this.
+    if let Some(binder) = binder.as_ref()
+        && crate::ccl::subst::codomain_depends_on(binder, &value)
+    {
+        return Err(ctx.raise(InferError::Unsupported(format!(
+            "keyed write `{label}[k] := …` on a collection whose values depend on the \
+             key: `{collection}`'s codomain names its key binder, so the value written \
+             at one key is a different type from the value written at another"
+        ))));
+    }
+    // A write is `Unit`-valued, so nothing downstream would resolve a fresh variable
+    // standing in for the value type; the obligation is stated here directly.
+    let expected = keyed_access_value(
+        &keys,
+        value,
+        key_ty,
+        &|| format!("keyed write key of `{label}`"),
+        ctx,
+    )?;
+    ctx.require_sub(value_ty, &expected, &|| {
+        format!("keyed write to mutable variable `{label}`")
+    })
 }
 
 /// Why `what` has no keyed access on `collection`.

--- a/src/ccl/infer/emit.rs
+++ b/src/ccl/infer/emit.rs
@@ -1096,7 +1096,7 @@ fn emit_keyed_write<C: Typing>(
     // A **dependent** codomain has no write. The read discharges the key binder to the key
     // term and answers `Option` of the result; a write would have to state the obligation
     // on the value at a key the write itself is what makes present, and a `Mut(Map(𝐾, 𝑉))`
-    // register holds a fixed `𝑉` besides, so no register reaches this.
+    // mutable variable holds a fixed `𝑉` besides, so no mutable variable reaches this.
     if let Some(binder) = binder.as_ref()
         && crate::ccl::subst::codomain_depends_on(binder, &value)
     {
@@ -1409,7 +1409,7 @@ pub(super) fn read_through(ty: &Type) -> Type {
 ///
 /// Every tail is walked, [`TypedExprNode::MutDecl`] included: a mutable variable does not
 /// escape its introduction either, so a function whose body ends in a read of a
-/// register it declared is the same escape as one that returns a parameter. Each of
+/// mutable variable it declared is the same escape as one that returns a parameter. Each of
 /// these nodes reports its continuation's value, and none of them is a place a
 /// handle stops being one.
 fn denoted_expr(e: &Expr) -> &Expr {

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -1490,11 +1490,21 @@ fn coalesce_node_inner(expr: &mut Expr, level: Level, ctx: &mut CoalesceCtx) {
         // A `Defer` leaf's `Feed(ρ)` resolves through the standard
         // end-of-function `resolve_var_type` like any other node type.
         TypedExprNode::Defer => {}
-        // Feed/Define/MutWrite: recurse into the contributed/written value;
-        // the node's own `Unit` type needs no resolution.
-        TypedExprNode::Feed { value, .. }
-        | TypedExprNode::Define { value, .. }
-        | TypedExprNode::MutWrite { value, .. } => {
+        // Feed/Define: recurse into the contributed value; the node's own `Unit` type
+        // needs no resolution.
+        TypedExprNode::Feed { value, .. } | TypedExprNode::Define { value, .. } => {
+            coalesce_node(value, level, ctx);
+        }
+        // A write: the written value, and a keyed write's **key**. The key is a value
+        // position like the value, and its type reaches no other slot — a write is
+        // `Unit`, so nothing downstream carries it. A variable left raw here therefore
+        // survives inference silently: the pre-desugar wall tolerates residual `Infer`
+        // (`collect_type_errors`, [`Strictness`]), so it surfaces only once a later phase
+        // reads the slot and puts the type somewhere reachable.
+        TypedExprNode::MutWrite { key, value, .. } => {
+            if let Some(key) = key {
+                coalesce_node(key, level, ctx);
+            }
             coalesce_node(value, level, ctx);
         }
         // A `Begin` block: recurse into its body chain; the block's own `Unit`

--- a/src/ccl/lower/loops.rs
+++ b/src/ccl/lower/loops.rs
@@ -611,7 +611,9 @@ fn lower_for_body_terminal(
 fn mutation_target_name(stmt: &Spanned<ChlStmt>) -> Option<&str> {
     match &stmt.node {
         ChlStmt::AugAssign { target, .. } => name_target_as_name(target),
-        ChlStmt::MutAssign { target, .. } => name_target_as_name(target),
+        // `write_target_name`, not `name_target_as_name`: `m[k] := v` mutates `m`, so
+        // the loop carries `m` as an accumulator even though the target binds nothing.
+        ChlStmt::MutAssign { target, .. } => write_target_name(target),
         _ => None,
     }
 }
@@ -932,13 +934,30 @@ fn lower_loop_body_chain(
             // by name (`src/ccl/design/mutability.md`, "Sequencing domains"),
             // discarding every update at the iteration boundary.
             ChlStmt::MutAssign { target, value, .. } => {
-                let name = extract_name_target(target, "mutable assignment")?;
+                let name = write_target_name(target)
+                    .ok_or_else(|| {
+                        LoweringError::unsupported(
+                            target.span,
+                            "mutable assignment: only simple name targets are supported",
+                        )
+                    })?
+                    .to_string();
                 if !acc_names.contains(&name) {
                     return Err(in_loop_mut_var_error(stmt.span, &name));
                 }
-                check_mut_write_context(&name, stmt.span, ctx)?;
-                let val = lower_assigned_value(value, &[], outer_bindings, ctx)?;
-                let write = ctx.tag_image(Expr::mut_write(name, val), stmt.span);
+                // A keyed write writes one key of the accumulator; the unkeyed form
+                // replaces it wholesale. Both are writes to the same accumulator, so
+                // only the emitted node differs.
+                let write = match &target.node {
+                    AssignTarget::Subscript { target, index } => {
+                        lower_keyed_write(target, index, value, stmt.span, ctx)?
+                    }
+                    _ => {
+                        check_mut_write_context(&name, stmt.span, ctx)?;
+                        let val = lower_assigned_value(value, &[], outer_bindings, ctx)?;
+                        ctx.tag_image(Expr::mut_write(name, val), stmt.span)
+                    }
+                };
                 ctx.tag_image(Expr::expr_stmt(write, chain), stmt.span)
             }
             // `y: T = value` — an ordinary annotated per-iteration local, the

--- a/src/ccl/lower/loops.rs
+++ b/src/ccl/lower/loops.rs
@@ -949,9 +949,15 @@ fn lower_loop_body_chain(
                 // replaces it wholesale. Both are writes to the same accumulator, so
                 // only the emitted node differs.
                 let write = match &target.node {
-                    AssignTarget::Subscript { target, index } => {
-                        lower_keyed_write(target, index, value, stmt.span, ctx)?
-                    }
+                    AssignTarget::Subscript { target, index } => lower_keyed_write(
+                        target,
+                        index,
+                        value,
+                        &[],
+                        outer_bindings,
+                        stmt.span,
+                        ctx,
+                    )?,
                     _ => {
                         check_mut_write_context(&name, stmt.span, ctx)?;
                         let val = lower_assigned_value(value, &[], outer_bindings, ctx)?;

--- a/src/ccl/lower/mod.rs
+++ b/src/ccl/lower/mod.rs
@@ -1058,13 +1058,10 @@ pub(crate) mod test_helpers {
 
 #[cfg(test)]
 mod tests {
-    /// `yield` without a value is rejected.
-    /// Constructs that CHL deliberately doesn't support. Each used to be
-    /// rejected by lowering (since `rustpython_parser` accepted them all);
-    /// the new CHL parser rejects them at parse time — bare `yield`,
-    /// decorators, and `for/else` because they aren't in the grammar, and
-    /// subscript / attribute assignment targets because `AssignTarget` is
-    /// restricted to bare names and tuple patterns.
+    /// Constructs that CHL deliberately doesn't support, rejected at parse time
+    /// because they aren't in the grammar: bare `yield`, decorators, `for/else`,
+    /// and an attribute assignment target (`AssignTarget` admits names, tuple
+    /// patterns, and a subscript, but no attribute).
     #[test]
     fn parser_rejects_constructs_outside_chl_grammar() {
         let cases: &[&str] = &[
@@ -1074,8 +1071,6 @@ mod tests {
             "@some_decorator\ndef f(x):\n    x + 1\nf",
             // `for/else`.
             "def bad(xs):\n    for x in xs:\n        yield x\n    else:\n        pass\nbad",
-            // Subscript augmented-assignment target.
-            "x = [1]\nx[0] += 1\nx",
             // Attribute augmented-assignment target.
             "x = 0\nx.field += 1\nx",
         ];
@@ -1084,6 +1079,27 @@ mod tests {
             assert!(
                 !result.errors.is_empty(),
                 "expected parse error for:\n{code}"
+            );
+        }
+    }
+
+    /// A subscript target parses, so the statement forms that cannot perform a keyed
+    /// write reject it at **lowering** rather than at parse time. `:=` is the only
+    /// one that can: `=` binds, and `+=` would need to read `m[k]` first, which is
+    /// the proven lookup that does not exist yet.
+    #[test]
+    fn a_subscript_target_is_rejected_by_every_form_but_mut_assign() {
+        for code in ["x = [1]\nx[0] += 1\nx", "x = [1]\nx[0] = 1\nx"] {
+            let module = crate::chl_parser::parse_module(code)
+                .into_result()
+                .expect("a subscript target parses");
+            let mut ctx = super::LoweringContext::default();
+            let errs = super::lower_stmts(&module.body, &mut ctx)
+                .into_result()
+                .expect_err("expected a lowering error");
+            assert!(
+                format!("{errs:?}").contains("keyed write"),
+                "expected the keyed-write diagnostic for:\n{code}\ngot {errs:?}"
             );
         }
     }

--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -395,6 +395,19 @@ pub(super) fn lower_final_stmt(
             let val = lower_assigned_value(value, preceding, outer_bindings, ctx)?;
             Ok(ctx.tag_image(Expr::mut_write(name, val), last.span))
         }
+        // A keyed write as the final statement, the `m[k] := v` sibling of the bare
+        // write above. `Unit`-valued like any write, so it cannot be the program's
+        // value; it falls through to the "must end in a value" error the same way.
+        ChlStmt::MutAssign {
+            target,
+            annotation: None,
+            value,
+        } if matches!(target.node, AssignTarget::Subscript { .. }) => {
+            let AssignTarget::Subscript { target, index } = &target.node else {
+                unreachable!("guarded by the match arm above")
+            };
+            lower_keyed_write(target, index, value, last.span, ctx)
+        }
         // A standalone `with begin():` as the program's final statement: one
         // transaction whose value is `Unit` (a trailing transaction produces no
         // value — its replies ride the feed, and a program that wants a committed
@@ -608,6 +621,27 @@ pub(super) fn lower_middle_stmt(
         //    stamped `Mut(V, _)` so inference binds `x` at `Mut` and reads deref
         //    (domain inferred for an induction accumulator).
         // In-loop writes are handled by `lower_direct_mirror_loop`, not here.
+        // `m[k] := v` — a write to one key, handled before the name cases because it
+        // is the one `:=` that binds nothing.
+        ChlStmt::MutAssign {
+            target,
+            annotation,
+            value,
+        } if matches!(target.node, AssignTarget::Subscript { .. }) => {
+            if annotation.is_some() {
+                return Err(LoweringError::unsupported(
+                    stmt.span,
+                    "a keyed write `m[k] := …` takes no annotation: it writes one key \
+                     of an existing collection, and the type belongs on the \
+                     collection's introduction",
+                ));
+            }
+            let AssignTarget::Subscript { target, index } = &target.node else {
+                unreachable!("guarded by the match arm above")
+            };
+            let write = lower_keyed_write(target, index, value, stmt.span, ctx)?;
+            Ok(ctx.tag_machinery(Expr::expr_stmt(write, body), stmt.span, "lower.stmt_seq"))
+        }
         ChlStmt::MutAssign {
             target,
             annotation,
@@ -875,7 +909,63 @@ pub(super) fn extract_name_target(
             target.span,
             format!("{context}: only simple name targets are supported"),
         )),
+        // A keyed write is a write to one key of a mutable collection, so it has
+        // meaning only for `:=`, which `lower_mut_assign` handles before reaching
+        // here. Every other statement form binds, and a subscript names no binder.
+        AssignTarget::Subscript { .. } => Err(LoweringError::unsupported(
+            target.span,
+            format!(
+                "{context}: `m[k]` is a keyed write and only `:=` performs one \
+                 (write it as `m[k] := …`)"
+            ),
+        )),
     }
+}
+
+/// The mutable variable a write targets, for either spelling: `x := v` names it
+/// directly, `m[k] := v` names it as the subscript's collection.
+///
+/// Distinct from [`name_target_as_name`], which asks whether a target *binds* a simple
+/// name — a keyed write binds nothing, so the two questions have different answers on
+/// the same target and a single accessor would conflate them.
+pub(super) fn write_target_name(target: &Spanned<AssignTarget>) -> Option<&str> {
+    match &target.node {
+        AssignTarget::Name(id) => Some(id.as_str()),
+        AssignTarget::Subscript { target, .. } => match &target.node {
+            ChlExpr::Name(id) => Some(id.as_str()),
+            _ => None,
+        },
+        AssignTarget::Tuple(_) => None,
+    }
+}
+
+/// Lower a **keyed write** `m[k] := v` to a keyed [`TypedExprNode::MutWrite`].
+///
+/// Always a write, never an introduction: writing one key of a collection presumes the
+/// collection, so there is no spelling of `:=` at a subscript that declares one. That is
+/// why this takes no annotation and consults no scope — an unbound `m` surfaces as an
+/// unbound variable from inference, where every other use of a name does.
+pub(super) fn lower_keyed_write(
+    target: &Spanned<ChlExpr>,
+    index: &Spanned<ChlExpr>,
+    value: &Spanned<ChlExpr>,
+    span: Span,
+    ctx: &mut LoweringContext,
+) -> Result<Expr, LoweringError> {
+    // Only a bare name resolves to a mutable variable today. A path (`a.b[k] := v`)
+    // parses, so say what is missing rather than failing on the shape.
+    let ChlExpr::Name(id) = &target.node else {
+        return Err(LoweringError::unsupported(
+            target.span,
+            "a keyed write's collection must be a variable; writing through a path \
+             (`a.b[k] := …`) is not supported",
+        ));
+    };
+    let name = id.as_str().to_string();
+    check_mut_write_context(&name, span, ctx)?;
+    let key = lower_expr(index, ctx)?;
+    let val = lower_expr(value, ctx)?;
+    Ok(ctx.tag_image(Expr::mut_write_keyed(name, key, val), span))
 }
 
 /// Infallible variant of [`extract_name_target`]: returns the name when

--- a/src/ccl/lower/stmts.rs
+++ b/src/ccl/lower/stmts.rs
@@ -395,9 +395,11 @@ pub(super) fn lower_final_stmt(
             let val = lower_assigned_value(value, preceding, outer_bindings, ctx)?;
             Ok(ctx.tag_image(Expr::mut_write(name, val), last.span))
         }
-        // A keyed write as the final statement, the `m[k] := v` sibling of the bare
-        // write above. `Unit`-valued like any write, so it cannot be the program's
-        // value; it falls through to the "must end in a value" error the same way.
+        // A keyed write as the final statement, the `m[k] := v` sibling of the bare write
+        // above. It needs no in-scope guard: a subscript declares nothing, so the form is a
+        // write wherever it appears, and there is no introduction to fall through to the
+        // "must end in a value" error. `Unit`-valued like any write, so a program ending in
+        // one has value `unit`.
         ChlStmt::MutAssign {
             target,
             annotation: None,
@@ -406,7 +408,15 @@ pub(super) fn lower_final_stmt(
             let AssignTarget::Subscript { target, index } = &target.node else {
                 unreachable!("guarded by the match arm above")
             };
-            lower_keyed_write(target, index, value, last.span, ctx)
+            lower_keyed_write(
+                target,
+                index,
+                value,
+                preceding,
+                outer_bindings,
+                last.span,
+                ctx,
+            )
         }
         // A standalone `with begin():` as the program's final statement: one
         // transaction whose value is `Unit` (a trailing transaction produces no
@@ -639,7 +649,15 @@ pub(super) fn lower_middle_stmt(
             let AssignTarget::Subscript { target, index } = &target.node else {
                 unreachable!("guarded by the match arm above")
             };
-            let write = lower_keyed_write(target, index, value, stmt.span, ctx)?;
+            let write = lower_keyed_write(
+                target,
+                index,
+                value,
+                preceding,
+                outer_bindings,
+                stmt.span,
+                ctx,
+            )?;
             Ok(ctx.tag_machinery(Expr::expr_stmt(write, body), stmt.span, "lower.stmt_seq"))
         }
         ChlStmt::MutAssign {
@@ -943,12 +961,21 @@ pub(super) fn write_target_name(target: &Spanned<AssignTarget>) -> Option<&str> 
 ///
 /// Always a write, never an introduction: writing one key of a collection presumes the
 /// collection, so there is no spelling of `:=` at a subscript that declares one. That is
-/// why this takes no annotation and consults no scope — an unbound `m` surfaces as an
-/// unbound variable from inference, where every other use of a name does.
+/// why this takes no annotation — an unbound `m` surfaces as an unbound variable from
+/// inference, where every other use of a name does.
+///
+/// The **value** is an assignment's right-hand side like any other, so it carries
+/// `preceding`/`outer_bindings` through [`lower_assigned_value`]: a block in that position
+/// reads the scope to tell a write from an introduction, and lowering it with an empty one
+/// silently turns an inner `n := n + 1` into a branch-local binding
+/// ([`super::lower_expr`] states the invariant). The **key** is an ordinary expression, not
+/// an assigned value, so it takes no scope.
 pub(super) fn lower_keyed_write(
     target: &Spanned<ChlExpr>,
     index: &Spanned<ChlExpr>,
     value: &Spanned<ChlExpr>,
+    preceding: &[Spanned<ChlStmt>],
+    outer_bindings: &HashSet<String>,
     span: Span,
     ctx: &mut LoweringContext,
 ) -> Result<Expr, LoweringError> {
@@ -964,7 +991,7 @@ pub(super) fn lower_keyed_write(
     let name = id.as_str().to_string();
     check_mut_write_context(&name, span, ctx)?;
     let key = lower_expr(index, ctx)?;
-    let val = lower_expr(value, ctx)?;
+    let val = lower_assigned_value(value, preceding, outer_bindings, ctx)?;
     Ok(ctx.tag_image(Expr::mut_write_keyed(name, key, val), span))
 }
 

--- a/src/ccl/lower/transactions.rs
+++ b/src/ccl/lower/transactions.rs
@@ -20,7 +20,7 @@ use smol_str::SmolStr;
 use super::*;
 use crate::{
     ccl::{Branch, Expr, Lit, Type, TypedBinding, TypedExprNode},
-    chl_parser::ast::{Expr as ChlExpr, IfBranch, Span, Spanned, Stmt as ChlStmt},
+    chl_parser::ast::{AssignTarget, Expr as ChlExpr, IfBranch, Span, Spanned, Stmt as ChlStmt},
 };
 
 /// Validate that a `with` block's context is the `begin()` transaction marker.
@@ -207,6 +207,19 @@ fn lower_tx_block_inner(
             // sole variable-write operator; `write_or_let` gates it (a write to a
             // mutable variable commits; a `:=` to anything else is a
             // per-transaction local `let`).
+            // `store[k] := value` — the keyed write, a write to one key of a
+            // transactional collection. Never a local `let`: a subscript binds nothing,
+            // so `write_or_let`'s fallback does not apply and the target must already
+            // be a mutable variable.
+            ChlStmt::MutAssign { target, value, .. }
+                if matches!(target.node, AssignTarget::Subscript { .. }) =>
+            {
+                let AssignTarget::Subscript { target, index } = &target.node else {
+                    unreachable!("guarded by the match arm above")
+                };
+                let write = lower_keyed_write(target, index, value, stmt.span, ctx)?;
+                ctx.tag_machinery(Expr::expr_stmt(write, chain), stmt.span, "lower.stmt_seq")
+            }
             ChlStmt::MutAssign { target, value, .. } => {
                 let name = extract_name_target(target, "mutable assignment")?;
                 let val = lower_assigned_value(value, &[], outer_bindings, ctx)?;

--- a/src/ccl/lower/transactions.rs
+++ b/src/ccl/lower/transactions.rs
@@ -217,7 +217,8 @@ fn lower_tx_block_inner(
                 let AssignTarget::Subscript { target, index } = &target.node else {
                     unreachable!("guarded by the match arm above")
                 };
-                let write = lower_keyed_write(target, index, value, stmt.span, ctx)?;
+                let write =
+                    lower_keyed_write(target, index, value, &[], outer_bindings, stmt.span, ctx)?;
                 ctx.tag_machinery(Expr::expr_stmt(write, chain), stmt.span, "lower.stmt_seq")
             }
             ChlStmt::MutAssign { target, value, .. } => {

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -831,6 +831,14 @@ pub fn view_seeds_at_value_type(expr: &mut Expr) {
     if let TypedExprNode::MutDecl { binding, init, .. } = &mut expr.node {
         let value_ty = value_type_of(&binding.ty);
         if value_ty.peel_refinements().sum().is_some() && init.ty != value_ty {
+            // The `box` this mints stands in for the seed it restates, so the recording
+            // names the seed. Opened around `view_at` alone: the recursion below must
+            // attach its own products to their own nodes.
+            let _g = provenance::enter(
+                init.node_id(),
+                "transact.view_seed_at_value_type",
+                provenance::Nature::Machinery,
+            );
             view_at(init, value_ty);
         }
     }
@@ -875,10 +883,23 @@ pub fn desugar_keyed_writes(expr: &mut Expr) {
     rewrite_keyed_writes(expr, &value_tys);
 }
 
-/// Record each mutable variable's value type, read off its `MutDecl` binder.
+/// Record each mutable variable's value type, read off the binder that introduces it.
+///
+/// Two binders introduce one, and both are read here: [`TypedExprNode::MutDecl`], and a
+/// `Lambda` param that takes a mutable variable *by reference* — the case that genuinely
+/// crosses a function boundary (see [`TypedExprNode::MutDecl`]'s own docs). Reading only
+/// the declaration leaves a keyed write through a `Mut` parameter with no value type,
+/// which `def bump(m: Mut(Map(Int, Int)), k: Int): m[k] := 1` reaches whenever the writer
+/// is not inlined — a returned one is not.
 fn collect_mut_value_types(expr: &Expr, out: &mut HashMap<Name, Type>) {
-    if let TypedExprNode::MutDecl { binding, .. } = &expr.node {
-        out.insert(binding.name.clone(), value_type_of(&binding.ty));
+    match &expr.node {
+        TypedExprNode::MutDecl { binding, .. } => {
+            out.insert(binding.name.clone(), value_type_of(&binding.ty));
+        }
+        TypedExprNode::Lambda { param, .. } if param.ty.mut_value_type().is_some() => {
+            out.insert(param.name.clone(), value_type_of(&param.ty));
+        }
+        _ => {}
     }
     expr.walk_children(&mut |c| collect_mut_value_types(c, out));
 }
@@ -894,14 +915,27 @@ fn value_type_of(ty: &Type) -> Type {
 
 fn rewrite_keyed_writes(expr: &mut Expr, value_tys: &HashMap<Name, Type>) {
     expr.walk_children_mut(&mut |c| rewrite_keyed_writes(c, value_tys));
+    let write_id = expr.node_id();
     let TypedExprNode::MutWrite { name, key, value } = &mut expr.node else {
         return;
     };
     let Some(key) = key.take() else {
         return;
     };
+    // `m := insert(m, k, v)` is what `m[k] := v` denotes, so the nodes below are that
+    // write's faithful expansion and the recording names the write. Opened after the
+    // recursion and after the two returns that abandon it.
+    let _g = provenance::enter(
+        write_id,
+        "transact.keyed_write",
+        provenance::Nature::Expansion,
+    );
     let map_ty = value_tys.get(name).cloned().unwrap_or_else(|| {
-        panic!("desugar_keyed_writes: keyed write to `{name}`, which has no `MutDecl` to read a value type off")
+        panic!(
+            "desugar_keyed_writes: keyed write to `{name}`, which neither a `MutDecl` nor a \
+             `Mut` parameter binds — the two binders of a mutable variable, and an unbound \
+             target is rejected before this phase"
+        )
     });
     let arg_ty = Type::Tuple(vec![map_ty.clone(), key.ty.clone(), value.ty.clone()]);
     let mut arg = Expr::tuple(vec![tvar(name, map_ty.clone()), *key, (**value).clone()]);

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -811,17 +811,17 @@ fn normalize_bare_write(name: Name, value: Expr, cont: Expr) -> Expr {
 ///
 /// A concrete collection is a value of an abstract collection type only through an
 /// introduction: entering a sum is a term and not a subtyping edge
-/// (`src/ccl/design/type-inference.md`, "Only a term builds a sum"). A register annotated
+/// (`src/ccl/design/type-inference.md`, "Only a term builds a sum"). A mutable variable annotated
 /// `Mut(Map(𝐾, 𝑉), _)` holds the abstract map, whose key domain grows with every write,
-/// while its seed names one key domain — so the seed reaches the register's type through
+/// while its seed names one key domain — so the seed reaches the mutable variable's type through
 /// [`Builtin::Box`].
 ///
-/// Stating the register's value type on that introduction is also what keeps it. `unbox`
+/// Stating the mutable variable's value type on that introduction is also what keeps it. `unbox`
 /// erases a box whose **stated** sum lists one candidate, reading the kind off `box`'s own
 /// function type, and a described kind lists none
 /// (`src/ccl/planning/conditionals.rs`). So a seed built by a conditional still realizes —
 /// the fan-out acts on the inner, multi-candidate sum — while the introduction that states
-/// the register's type survives realization and carries the value into it.
+/// the mutable variable's type survives realization and carries the value into it.
 ///
 /// Runs after inference, so it stamps the types it builds and the CHECK-mode `typecheck`
 /// behind it validates them: the reconcile there is `derived <: recorded`, and the derived
@@ -864,12 +864,12 @@ fn view_at(e: &mut Expr, target: Type) {
 /// Rewrite every **keyed write** `m[k] := v` to the whole-value write it denotes:
 /// `m := insert(m, k, v)` ([`Builtin::Insert`]).
 ///
-/// A keyed register's history is `Txn ⇒ Map(𝐾, 𝑉)` under the overwrite law, like any
+/// A keyed mutable variable's history is `Txn ⇒ Map(𝐾, 𝑉)` under the overwrite law, like any
 /// other mutable variable, so a write replaces the whole collection. Every phase below
 /// therefore sees one kind of `MutWrite` and needs no notion of a key.
 ///
-/// **The whole collection is what commits.** The register's collection goes to one store
-/// key, and the rewritten value reads `m`, so the register is in its writer's read
+/// **The whole collection is what commits.** The mutable variable's collection goes to one store
+/// key, and the rewritten value reads `m`, so the mutable variable is in its writer's read
 /// footprint as well as its write set even where the source only wrote one key. Two
 /// transactions touching one map therefore conflict whatever keys they touch. Narrowing
 /// either footprint to the key is unbuilt and is scoped in

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -866,14 +866,14 @@ fn view_at(e: &mut Expr, target: Type) {
 ///
 /// A keyed register's history is `Txn ⇒ Map(𝐾, 𝑉)` under the overwrite law, like any
 /// other mutable variable, so a write replaces the whole collection. Every phase below
-/// therefore sees one kind of `MutWrite` and needs no notion of a key; op-conversion
-/// recovers the per-key store write from the emitted shape, which is a tiling choice and
-/// not a change of meaning (`src/ccl/design/mutability.md`, "The idea in one line").
+/// therefore sees one kind of `MutWrite` and needs no notion of a key.
 ///
-/// The rewritten value reads `m`, so the register joins its writer's read footprint even
-/// where the source only wrote it. That is what the denotation says — the new collection
-/// is a function of the old one — and it is what op-conversion's per-key recovery narrows
-/// again.
+/// **The whole collection is what commits.** The register's collection goes to one store
+/// key, and the rewritten value reads `m`, so the register is in its writer's read
+/// footprint as well as its write set even where the source only wrote one key. Two
+/// transactions touching one map therefore conflict whatever keys they touch. Narrowing
+/// either footprint to the key is unbuilt and is scoped in
+/// `src/ccl/design/mutability.md`, "Future work".
 ///
 /// Runs after inference, so it stamps the types it builds and the CHECK-mode `typecheck`
 /// behind it validates them.

--- a/src/ccl/mut_elim.rs
+++ b/src/ccl/mut_elim.rs
@@ -375,9 +375,9 @@ fn hoist_writer_body(binding: TypedBinding, writer_body: Expr, body: Expr) -> Ex
         // logical write* at a new spine position, so carry the input node's id
         // (a preserve, not a mint) — freshening would sever the write's source
         // span and duplicate the id if the original ever also survived.
-        TypedExprNode::MutWrite { name, value } => {
+        TypedExprNode::MutWrite { name, key, value } => {
             let write = Expr {
-                node: TypedExprNode::MutWrite { name, value },
+                node: TypedExprNode::MutWrite { name, key, value },
                 ty: writer_body.ty,
                 user_annotation: writer_body.user_annotation,
                 // TODO(preserve): hand-rolled preserve — fold into `Expr::preserve`.
@@ -735,7 +735,12 @@ fn rewrite(mut expr: Expr) -> Expr {
         // top-level `cnt += 1`, or an inlined pass-by-reference writer
         // (`bump(cnt)`) spliced between statements. There is no recurrence to
         // build; normalize it to a shadowing `let` (see `normalize_bare_write`).
-        if let TypedExprNode::MutWrite { name, value } = effect.node {
+        if let TypedExprNode::MutWrite {
+            name,
+            key: None,
+            value,
+        } = effect.node
+        {
             // The shadowing `let` this mints is captured against the statement
             // node it replaces, with the `MutWrite` blamed. Neither is claimed
             // dead: both are absent from the output tree, so the boundary
@@ -800,6 +805,112 @@ fn normalize_bare_write(name: Name, value: Expr, cont: Expr) -> Expr {
     rename_uses(&mut cont, &name, &fresh);
     let cont = rewrite(cont);
     Expr::let_in(binding(fresh, vty), value, cont)
+}
+
+/// View each mutable variable's seed at the value type its binder declares.
+///
+/// A concrete collection is a value of an abstract collection type only through an
+/// introduction: entering a sum is a term and not a subtyping edge
+/// (`src/ccl/design/type-inference.md`, "Only a term builds a sum"). A register annotated
+/// `Mut(Map(𝐾, 𝑉), _)` holds the abstract map, whose key domain grows with every write,
+/// while its seed names one key domain — so the seed reaches the register's type through
+/// [`Builtin::Box`].
+///
+/// Stating the register's value type on that introduction is also what keeps it. `unbox`
+/// erases a box whose **stated** sum lists one candidate, reading the kind off `box`'s own
+/// function type, and a described kind lists none
+/// (`src/ccl/planning/conditionals.rs`). So a seed built by a conditional still realizes —
+/// the fan-out acts on the inner, multi-candidate sum — while the introduction that states
+/// the register's type survives realization and carries the value into it.
+///
+/// Runs after inference, so it stamps the types it builds and the CHECK-mode `typecheck`
+/// behind it validates them: the reconcile there is `derived <: recorded`, and the derived
+/// `Σ (σ : [𝑋]). σ ⤇ 𝑉` sits below the stated `Σ (𝐷 : SubtypesOf(𝐾)). 𝐷 ⤇ 𝑉` by kind
+/// containment.
+pub fn view_seeds_at_value_type(expr: &mut Expr) {
+    if let TypedExprNode::MutDecl { binding, init, .. } = &mut expr.node {
+        let value_ty = value_type_of(&binding.ty);
+        if value_ty.peel_refinements().sum().is_some() && init.ty != value_ty {
+            view_at(init, value_ty);
+        }
+    }
+    expr.walk_children_mut(&mut view_seeds_at_value_type);
+}
+
+/// Restate `e`'s introduction at `target`, minting one where `e` has none.
+fn view_at(e: &mut Expr, target: Type) {
+    if let TypedExprNode::Apply { function, argument } = &mut e.node
+        && matches!(function.node, TypedExprNode::Builtin(Builtin::Box))
+    {
+        function.ty = Type::fun(argument.ty.clone(), target.clone());
+        e.ty = target;
+        return;
+    }
+    let inner = std::mem::replace(e, Expr::lit(Lit::Unit));
+    let mut boxed = Expr::builtin(Builtin::Box);
+    boxed.ty = Type::fun(inner.ty.clone(), target.clone());
+    *e = Expr::apply(inner, boxed);
+    e.ty = target;
+}
+
+/// Rewrite every **keyed write** `m[k] := v` to the whole-value write it denotes:
+/// `m := insert(m, k, v)` ([`Builtin::Insert`]).
+///
+/// A keyed register's history is `Txn ⇒ Map(𝐾, 𝑉)` under the overwrite law, like any
+/// other mutable variable, so a write replaces the whole collection. Every phase below
+/// therefore sees one kind of `MutWrite` and needs no notion of a key; op-conversion
+/// recovers the per-key store write from the emitted shape, which is a tiling choice and
+/// not a change of meaning (`src/ccl/design/mutability.md`, "The idea in one line").
+///
+/// The rewritten value reads `m`, so the register joins its writer's read footprint even
+/// where the source only wrote it. That is what the denotation says — the new collection
+/// is a function of the old one — and it is what op-conversion's per-key recovery narrows
+/// again.
+///
+/// Runs after inference, so it stamps the types it builds and the CHECK-mode `typecheck`
+/// behind it validates them.
+pub fn desugar_keyed_writes(expr: &mut Expr) {
+    let mut value_tys: HashMap<Name, Type> = HashMap::new();
+    collect_mut_value_types(expr, &mut value_tys);
+    rewrite_keyed_writes(expr, &value_tys);
+}
+
+/// Record each mutable variable's value type, read off its `MutDecl` binder.
+fn collect_mut_value_types(expr: &Expr, out: &mut HashMap<Name, Type>) {
+    if let TypedExprNode::MutDecl { binding, .. } = &expr.node {
+        out.insert(binding.name.clone(), value_type_of(&binding.ty));
+    }
+    expr.walk_children(&mut |c| collect_mut_value_types(c, out));
+}
+
+/// The value a `Mut(𝑉, 𝐷)` binder holds, peeling refinements on either side.
+fn value_type_of(ty: &Type) -> Type {
+    match ty {
+        Type::History { value, .. } => value_type_of(value),
+        Type::Refinement(inner, _) => value_type_of(inner),
+        other => other.clone(),
+    }
+}
+
+fn rewrite_keyed_writes(expr: &mut Expr, value_tys: &HashMap<Name, Type>) {
+    expr.walk_children_mut(&mut |c| rewrite_keyed_writes(c, value_tys));
+    let TypedExprNode::MutWrite { name, key, value } = &mut expr.node else {
+        return;
+    };
+    let Some(key) = key.take() else {
+        return;
+    };
+    let map_ty = value_tys.get(name).cloned().unwrap_or_else(|| {
+        panic!("desugar_keyed_writes: keyed write to `{name}`, which has no `MutDecl` to read a value type off")
+    });
+    let arg_ty = Type::Tuple(vec![map_ty.clone(), key.ty.clone(), value.ty.clone()]);
+    let mut arg = Expr::tuple(vec![tvar(name, map_ty.clone()), *key, (**value).clone()]);
+    arg.ty = arg_ty.clone();
+    let mut insert = Expr::builtin(Builtin::Insert);
+    insert.ty = Type::fun(arg_ty, map_ty.clone());
+    let mut app = Expr::apply(arg, insert);
+    app.ty = map_ty;
+    **value = app;
 }
 
 /// A `Var` reference stamped with its concrete type.
@@ -1575,7 +1686,7 @@ fn collect_writes_in(
     value_tys: &HashMap<Name, Type>,
     out: &mut Vec<AccumulatorVariable>,
 ) {
-    if let TypedExprNode::MutWrite { name, value } = &expr.node {
+    if let TypedExprNode::MutWrite { name, value, .. } = &expr.node {
         let write = expr.node_id();
         let site = StmtSite::new(stmt.unwrap_or(write), write);
         match out.iter_mut().find(|a| a.name == *name) {
@@ -1825,7 +1936,7 @@ fn transform_chain(
                 // `let` wrapping the decision (which would break the value-`Case`
                 // C-form compilation of the write set), and a feed reached after a
                 // write can be hoisted without stranding a branch-local binder.
-                TypedExprNode::MutWrite { name, value } => {
+                TypedExprNode::MutWrite { name, value, .. } => {
                     // Advance the read-your-writes environment by *inlining* the
                     // written value (point-free over `__p`), not binding a `let` —
                     // the same substitution model `transact_phase::walk_block` uses.

--- a/src/ccl/ops.rs
+++ b/src/ccl/ops.rs
@@ -646,8 +646,9 @@ pub enum Builtin {
     /// "The checked lookup `𝑐[𝑘]?`"). A dependent codomain answers at the key, its
     /// binder discharging to the key term.
     ///
-    /// Applied as a tupled argument, the convention [`Self::GetPrevTxn`] shares:
-    /// `Apply(Tuple([collection, key]), Builtin(LookupChecked))`. It never carries a
+    /// Applied as a tupled argument, the convention [`Self::Insert`] and
+    /// [`Self::GetPrevTxn`] share: `Apply(Tuple([collection, key]), Builtin(LookupChecked))`,
+    /// so the read and the write of one keyed access take the same shape. It never carries a
     /// function value, so its point-free form is an ordinary morphism from a zip. A lookup
     /// whose collection does not vary takes the partial application `𝑐 ▷ lookup?` that
     /// `simplify`'s partial-lookup rule mints — the only shape [`Self::Curry`] takes that
@@ -660,6 +661,27 @@ pub enum Builtin {
     /// and substituting into a compiled one leaves the `const` carrying the binder at the
     /// binder's type (`Typing::keyed_value_at`).
     LookupChecked,
+
+    /// `insert : (Σ (𝐷 : SubtypesOf(𝐾)). 𝐷 ⤇ 𝑉, 𝐾, 𝑉) ⇒ (Σ (𝐷 : SubtypesOf(𝐾)). 𝐷 ⤇ 𝑉)` — the
+    /// collection with one key's value replaced, inserting the key where it was
+    /// absent. Applied as a tupled argument, the convention [`Self::GetPrevTxn`]
+    /// shares: `Apply(Tuple([collection, key, value]), Builtin(Insert))`.
+    ///
+    /// This is what a keyed write `m[k] := v` denotes; the register's history stays
+    /// `Txn ⇒ Map(𝐾, 𝑉)` under the overwrite law and the value written is the whole
+    /// collection ([`crate::ccl::mut_elim::desugar_keyed_writes`]).
+    ///
+    /// The result's key domain is the argument's with `𝐾`'s key adjoined — the same domain
+    /// where the key was already present, which is the read-modify-write shape. Both are
+    /// members of the same [`TypeKind::SubtypesOf`](crate::ccl::TypeKind::SubtypesOf) kind, so the
+    /// type above names neither: an abstract map ranges over every key domain over `𝐾`
+    /// (`src/ccl/design/collections.md`).
+    ///
+    /// Minted by [`crate::ccl::mut_elim::desugar_keyed_writes`] *after* inference,
+    /// so it carries no scheme in [`crate::ccl::infer::OperatorSchemes`]; its type is
+    /// stamped on the node at emission and the post-phase CHECK-mode `typecheck`
+    /// validates it directly, as [`Self::BeginTxn`]'s is.
+    Insert,
 }
 
 impl Builtin {
@@ -707,6 +729,7 @@ impl Builtin {
             Self::VariantWrap(_) => "variant_wrap",
             Self::CollectionContains => "collection_contains",
             Self::LookupChecked => "lookup?",
+            Self::Insert => "insert",
         }
     }
 

--- a/src/ccl/ops.rs
+++ b/src/ccl/ops.rs
@@ -667,7 +667,7 @@ pub enum Builtin {
     /// absent. Applied as a tupled argument, the convention [`Self::GetPrevTxn`]
     /// shares: `Apply(Tuple([collection, key, value]), Builtin(Insert))`.
     ///
-    /// This is what a keyed write `m[k] := v` denotes; the register's history stays
+    /// This is what a keyed write `m[k] := v` denotes; the mutable variable's history stays
     /// `Txn ⇒ Map(𝐾, 𝑉)` under the overwrite law and the value written is the whole
     /// collection ([`crate::ccl::mut_elim::desugar_keyed_writes`]).
     ///

--- a/src/ccl/planning/loops.rs
+++ b/src/ccl/planning/loops.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 use crate::ccl::{
     Builtin, Expr, F_DECISION, F_WRITE_TARGETS, F_WRITES, Name, ProjKey, TransactKey, Type,
     TypedBinding, TypedExprNode, WriterSite,
-    ccl_utils::{commit_payload_ty, count_free, strip_refinements},
+    ccl_utils::{commit_payload_ty, count_free},
     letrec::check_letrec_causal,
     mut_elim::{binding, fun_parts, tvar},
     provenance,
@@ -473,7 +473,15 @@ fn recognize_txn_group(bindings: Vec<(TypedBinding, Expr)>, body: Expr) -> Expr 
                     matches!(which, Builtin::GetPrevTxn),
                     "letrec recognition: transaction history guarded by get_prev_seq"
                 );
-                key_ty.push((b.name.clone(), strip_refinements(&init.ty)));
+                // The value type comes off the history binding, not off the seed it
+                // recovers alongside. A seed is one contribution to the value type —
+                // a keyed register seeded at two keys and written at a third has a
+                // seed narrower than what it holds — and the binding `reg_k : Txn ⇒ 𝑉`
+                // carries the join `transact_phase` stamped.
+                let value_ty =
+                    b.ty.codomain()
+                        .expect("letrec recognition: history binding is a stream");
+                key_ty.push((b.name.clone(), value_ty));
                 keys.push(TransactKey { name: b.name, init });
             }
             TxnBinding::Commit => {

--- a/src/ccl/planning/loops.rs
+++ b/src/ccl/planning/loops.rs
@@ -481,6 +481,19 @@ fn recognize_txn_group(bindings: Vec<(TypedBinding, Expr)>, body: Expr) -> Expr 
                 let value_ty =
                     b.ty.codomain()
                         .expect("letrec recognition: history binding is a stream");
+                // The join is unrefined, so nothing is peeled here. A refinement is a fact
+                // about one value and a register holds a different value at each commit, so
+                // the join over its contributions carries none — the reason reading the seed
+                // needed a `strip_refinements` and reading the binding does not. Stated
+                // rather than re-normalized: a refinement surviving to here would ride into
+                // `TransactKey`'s value type and the extents built off it, which is a
+                // mis-stamped history to fix at the stamp.
+                assert!(
+                    value_ty.refinements().is_empty(),
+                    "letrec recognition: a register's joined value type carries no \
+                     refinement, got {value_ty} for `{}`",
+                    b.name
+                );
                 key_ty.push((b.name.clone(), value_ty));
                 keys.push(TransactKey { name: b.name, init });
             }

--- a/src/ccl/planning/loops.rs
+++ b/src/ccl/planning/loops.rs
@@ -475,14 +475,14 @@ fn recognize_txn_group(bindings: Vec<(TypedBinding, Expr)>, body: Expr) -> Expr 
                 );
                 // The value type comes off the history binding, not off the seed it
                 // recovers alongside. A seed is one contribution to the value type —
-                // a keyed register seeded at two keys and written at a third has a
+                // a keyed mutable variable seeded at two keys and written at a third has a
                 // seed narrower than what it holds — and the binding `reg_k : Txn ⇒ 𝑉`
                 // carries the join `transact_phase` stamped.
                 let value_ty =
                     b.ty.codomain()
                         .expect("letrec recognition: history binding is a stream");
                 // The join is unrefined, so nothing is peeled here. A refinement is a fact
-                // about one value and a register holds a different value at each commit, so
+                // about one value and a mutable variable holds a different value at each commit, so
                 // the join over its contributions carries none — the reason reading the seed
                 // needed a `strip_refinements` and reading the binding does not. Stated
                 // rather than re-normalized: a refinement surviving to here would ride into
@@ -490,7 +490,7 @@ fn recognize_txn_group(bindings: Vec<(TypedBinding, Expr)>, body: Expr) -> Expr 
                 // mis-stamped history to fix at the stamp.
                 assert!(
                     value_ty.refinements().is_empty(),
-                    "letrec recognition: a register's joined value type carries no \
+                    "letrec recognition: a mutable variable's joined value type carries no \
                      refinement, got {value_ty} for `{}`",
                     b.name
                 );

--- a/src/ccl/scope.rs
+++ b/src/ccl/scope.rs
@@ -251,8 +251,18 @@ where
 
         // The write target is a *use* of the binder that introduced the defer
         // handle / mutable variable, so it resolves like any variable.
-        N::Feed { name, value } | N::Define { name, value } | N::MutWrite { name, value } => {
+        N::Feed { name, value } | N::Define { name, value } => {
             f(ScopedItem::VarRef(name));
+            open(f, value);
+        }
+
+        // As above, plus the key: a keyed write's key is an ordinary expression
+        // evaluated in the enclosing scope, so its free variables are uses too.
+        N::MutWrite { name, key, value } => {
+            f(ScopedItem::VarRef(name));
+            if let Some(k) = key {
+                open(f, k);
+            }
             open(f, value);
         }
 
@@ -588,6 +598,7 @@ mod tests {
             }),
             node(N::MutWrite {
                 name: Name::raw("m"),
+                key: None,
                 value: Box::new(var("mv")),
             }),
             node(N::Proj(ProjKey::Index(0))),

--- a/src/ccl/subst.rs
+++ b/src/ccl/subst.rs
@@ -770,9 +770,10 @@ impl Subst {
             // renamed exactly like a Feed target (a discharge to a
             // non-variable term keeps the stale name for the phase's own
             // residue checks to report).
-            MutWrite { name, value } => {
+            MutWrite { name, key, value } => {
+                let key = key.as_ref().map(|k| Box::new(self.apply_expr(k)));
                 let (name, value) = self.apply_handle_use(name, value);
-                MutWrite { name, value }
+                MutWrite { name, key, value }
             }
 
             Lambda { param, body } => {
@@ -2904,6 +2905,7 @@ mod rewrite_tests {
             }),
             TypedExpr::new(TypedExprNode::MutWrite {
                 name: Name::raw("h"),
+                key: None,
                 value: Box::new(int(1)),
             }),
             var("h"),

--- a/src/ccl/symbolic.rs
+++ b/src/ccl/symbolic.rs
@@ -518,9 +518,17 @@ fn fmt_inner(expr: &Expr, opts: &SymbolicOpts) -> (Precedence, String) {
 
         // Mutable-variable write: `x := e` — distinct from let-binding `=`
         // (the name references its introduction; it is not a fresh binder).
-        TypedExprNode::MutWrite { name, value } => (
+        TypedExprNode::MutWrite { name, key, value } => (
             Precedence::Lowest,
-            format!("{} := {}", name, fmt(value, Precedence::Lowest, opts)),
+            match key {
+                Some(k) => format!(
+                    "{}[{}] := {}",
+                    name,
+                    fmt(k, Precedence::Lowest, opts),
+                    fmt(value, Precedence::Lowest, opts)
+                ),
+                None => format!("{} := {}", name, fmt(value, Precedence::Lowest, opts)),
+            },
         ),
 
         TypedExprNode::Source(name) => (Precedence::Atom, format!("source({name})")),

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -776,8 +776,7 @@ pub fn run(expr: Expr, txn_mut_vars: &HashSet<Name>) -> Result<Expr, String> {
             // reads the rewrite mints are recorded inside `resolve_await_finals`.
             let mut init = key_init[&k].init.clone_preserving_ids();
             resolve_await_finals(&mut init, &hist, &key_init);
-            let decl = key_init[&k].decl;
-            key_init.insert(k, MutVarDecl { decl, init });
+            key_init.get_mut(&k).expect("key seed present").init = init;
         }
     }
     assert!(
@@ -1693,7 +1692,7 @@ fn check_store_acyclicity(
                 ..
             } => Some((&binding.name, &**bound_expr)),
             TypedExprNode::MutDecl { binding, init, .. } => Some((&binding.name, &**init)),
-            TypedExprNode::MutWrite { name, value } => Some((name, &**value)),
+            TypedExprNode::MutWrite { name, value, .. } => Some((name, &**value)),
             _ => None,
         };
         if let Some((name, value)) = bound {
@@ -1913,7 +1912,7 @@ fn collect_footprint(block: &Expr, txn_mut_vars: &HashSet<Name>) -> (Vec<Name>, 
             TypedExprNode::Var(n) if txn_mut_vars.contains(n) && !reads.contains(n) => {
                 reads.push(n.clone());
             }
-            TypedExprNode::MutWrite { name, value } => {
+            TypedExprNode::MutWrite { name, value, .. } => {
                 // The write's value is read first (its embedded mutable variable reads are
                 // snapshots), then the target joins the write set.
                 walk(value, txn_mut_vars, in_case, reads, writes);
@@ -1988,7 +1987,7 @@ fn build_writer(
     let value_ty = |k: &Name| {
         key_init
             .get(k)
-            .map(|d| mut_var_value_ty(&d.init.ty))
+            .map(|d| d.value_ty.clone())
             .expect("transact_phase: footprint key must be a mutable variable key")
     };
     let read_tys: Vec<Type> = site.read_keys.iter().map(value_ty).collect();
@@ -2253,7 +2252,7 @@ fn walk_block(
         ),
         TypedExprNode::ExprStmt { expr, body } => {
             match &expr.node {
-                TypedExprNode::MutWrite { name, value } => {
+                TypedExprNode::MutWrite { name, value, .. } => {
                     // Every `MutWrite` in a stripped `with begin():` block must
                     // target a transactional mutable variable the site records as a write
                     // key. `build_writer` only emits `write_keys` into the
@@ -2470,6 +2469,14 @@ struct MutVarDecl {
     /// type — [`StorePlan::reads`], [`final_key`] — borrow it rather than
     /// placing it.
     init: Expr,
+    /// The type of one committed value — the binder's, refinements stripped.
+    ///
+    /// Off the **binder**, not off the seed. A seed is one contribution to the value
+    /// type and the binder carries the join over the seed and every write, so the two
+    /// differ wherever a write widens the seed — a keyed register seeded with two keys
+    /// and written at a third is the case where reading the seed rejects the program
+    /// (`src/ccl/expr.rs`, [`TypedExprNode::MutDecl`]).
+    value_ty: Type,
 }
 
 /// Locate each mutable variable key's `let` binding and record it (keeping the outermost
@@ -2498,6 +2505,7 @@ fn collect_key_inits(expr: &Expr, keys: &[Name], out: &mut HashMap<Name, MutVarD
             MutVarDecl {
                 decl: expr.node_id(),
                 init: (**init).clone(),
+                value_ty: mut_var_value_ty(&binding.ty),
             },
         );
     }
@@ -2733,7 +2741,7 @@ fn plan_store(
     let value_ty = |k: &Name| {
         key_init
             .get(k)
-            .map(|d| mut_var_value_ty(&d.init.ty))
+            .map(|d| d.value_ty.clone())
             .expect("transact_phase: footprint key must be a mutable variable key")
     };
 
@@ -3063,7 +3071,7 @@ impl StorePlan {
                     "transact.key_rebind",
                     provenance::Nature::Expansion,
                 );
-                let v = mut_var_value_ty(&key_init[k].init.ty);
+                let v = key_init[k].value_ty.clone();
                 (binding(k.clone(), v.clone()), as_of_read(&self.hist[k], v))
             })
             .collect()
@@ -3396,13 +3404,15 @@ fn resolve_await_finals(
 /// writers finish. Minted only for a [`Builtin::AwaitFinal`] marker.
 ///
 /// No seed operand, for the same reason [`as_of_read`] has none: this samples the carried
-/// value, and tick 0 of every store is its keys' seeds. The key's `init` is still read
-/// here, for its *type* — the value type of the history the read names — and not as a
-/// term. A key no writer site writes never reaches here at all:
-/// [`resolve_writer_free_awaits`] has replaced its await with the seed.
+/// value, and tick 0 of every store is its keys' seeds. The key's recorded value type is
+/// still read here — it is the value type of the history the read names. A key no writer
+/// site writes never reaches here at all: [`resolve_writer_free_awaits`] has replaced its
+/// await with the seed.
 fn final_key(k: &Name, hist: &HashMap<Name, Name>, key_init: &HashMap<Name, MutVarDecl>) -> Expr {
-    let init = &key_init.get(k).expect("key init present").init;
-    let v = mut_var_value_ty(&init.ty);
+    let v = key_init
+        .get(k)
+        .map(|d| d.value_ty.clone())
+        .expect("key init present");
     sampling_read(&hist[k], v, Builtin::FinalRead)
 }
 

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -553,6 +553,12 @@ pub fn collect_txn_mut_vars(expr: &Expr) -> HashSet<Name> {
 /// value-type reads, so the emitted `LetRec` (and the `Transact` recognition
 /// derives from it) is `Mut`-free by construction, never feeding a `Mut` type
 /// into the commit engine.
+///
+/// Untouched includes a non-`Mut` type's refinements. A register holds a different value at
+/// each position of its domain, so inference stamps the binder's value type without the
+/// refinements any one contribution carries: a register seeded at `Int@100` binds
+/// `Mut(Int, _)`, and a keyed one seeded at a concrete map binds
+/// `Mut(Σ (σ : SubtypesOf(𝐾)). (σ ⤇ 𝑉), _)`.
 fn mut_var_value_ty(ty: &Type) -> Type {
     fn under_mut(ty: &Type) -> Option<&Type> {
         match ty {
@@ -569,7 +575,7 @@ fn mut_var_value_ty(ty: &Type) -> Type {
     }
     match under_mut(ty) {
         Some(v) => mut_var_value_ty(v),
-        None => crate::ccl::ccl_utils::strip_refinements(ty),
+        None => ty.clone(),
     }
 }
 

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -365,7 +365,7 @@ fn build_zip_read(
 
     // reply: λ p:(req, snap) → e[param ↦ p.0, reads ↦ p.1 (bare) / p.1.field].
     let p = Name::fresh("__zp");
-    // The request binder and every register read are discharged *simultaneously*:
+    // The request binder and every mutable variable read are discharged *simultaneously*:
     // they are independent reads of the one new pair binder, and one traversal
     // is both cheaper and the honest reading (a sequential fold would re-enter
     // each replacement it had already installed).
@@ -554,9 +554,9 @@ pub fn collect_txn_mut_vars(expr: &Expr) -> HashSet<Name> {
 /// derives from it) is `Mut`-free by construction, never feeding a `Mut` type
 /// into the commit engine.
 ///
-/// Untouched includes a non-`Mut` type's refinements. A register holds a different value at
+/// Untouched includes a non-`Mut` type's refinements. A mutable variable holds a different value at
 /// each position of its domain, so inference stamps the binder's value type without the
-/// refinements any one contribution carries: a register seeded at `Int@100` binds
+/// refinements any one contribution carries: a mutable variable seeded at `Int@100` binds
 /// `Mut(Int, _)`, and a keyed one seeded at a concrete map binds
 /// `Mut(Σ (σ : SubtypesOf(𝐾)). (σ ⤇ 𝑉), _)`.
 fn mut_var_value_ty(ty: &Type) -> Type {
@@ -2480,7 +2480,7 @@ struct MutVarDecl {
     ///
     /// Off the **binder**, not off the seed. A seed is one contribution to the value
     /// type and the binder carries the join over the seed and every write, so the two
-    /// differ wherever a write widens the seed — a keyed register seeded with two keys
+    /// differ wherever a write widens the seed — a keyed mutable variable seeded with two keys
     /// and written at a third is the case where reading the seed rejects the program
     /// (`src/ccl/expr.rs`, [`TypedExprNode::MutDecl`]).
     value_ty: Type,

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -2475,7 +2475,8 @@ struct MutVarDecl {
     /// type — [`StorePlan::reads`], [`final_key`] — borrow it rather than
     /// placing it.
     init: Expr,
-    /// The type of one committed value — the binder's, refinements stripped.
+    /// The type of one committed value, read off the binder by [`mut_var_value_ty`] —
+    /// so refinements above the `Mut` are peeled and the value type's own are kept.
     ///
     /// Off the **binder**, not off the seed. A seed is one contribution to the value
     /// type and the binder carries the join over the seed and every write, so the two

--- a/src/ccl/uniquify.rs
+++ b/src/ccl/uniquify.rs
@@ -248,11 +248,19 @@ impl Uniquifier {
 
             // The target name is a use of the defer-handle binder
             // (Feed/Define) or of the mutable variable's `let` (MutWrite).
-            TypedExprNode::Feed { name, value }
-            | TypedExprNode::Define { name, value }
-            | TypedExprNode::MutWrite { name, value } => {
+            TypedExprNode::Feed { name, value } | TypedExprNode::Define { name, value } => {
                 if let Some(m) = self.resolve(name) {
                     *name = m;
+                }
+                self.expr(value);
+            }
+
+            TypedExprNode::MutWrite { name, key, value } => {
+                if let Some(m) = self.resolve(name) {
+                    *name = m;
+                }
+                if let Some(k) = key {
+                    self.expr(k);
                 }
                 self.expr(value);
             }

--- a/src/chl_parser/ast.rs
+++ b/src/chl_parser/ast.rs
@@ -355,16 +355,31 @@ pub enum AnnotationMode {
 /// The left-hand side of an assignment, augmented assignment, defer-define,
 /// for-loop, or comprehension `for` clause — i.e. anywhere CHL binds names.
 ///
-/// Restricted to bare names and (possibly-nested) tuple patterns. Subscript
-/// (`xs[0] = ...`) and attribute (`obj.f = ...`) targets are not part of
-/// CHL today; if added later they would extend this enum rather than
-/// reopening the `target: Expr` escape hatch the previous AST allowed.
+/// Restricted to bare names, (possibly-nested) tuple patterns, and a subscript.
+/// Attribute targets (`obj.f = ...`) are not part of CHL today; if added later
+/// they would extend this enum rather than reopening the `target: Expr` escape
+/// hatch the previous AST allowed.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AssignTarget {
     /// A bare identifier: `x = ...`.
     Name(SmolStr),
     /// A tuple destructuring pattern: `(a, b), c = ...`. May nest.
     Tuple(Vec<Spanned<AssignTarget>>),
+    /// One key of a keyed collection: `m[k] := v`.
+    ///
+    /// Not a binding position, unlike the other two: the collection is not being
+    /// bound, one of its keys is being written. Only `:=` accepts it, a keyed write
+    /// being a write to a mutable collection (`src/ccl/design/mutability.md`,
+    /// "Surface-marker nodes: `For`, `MutWrite`, `Begin`, `Feed`"); every other
+    /// statement form rejects it at lowering.
+    ///
+    /// The target is an arbitrary expression rather than a name so that a write
+    /// through a path (`a.b[k] := v`) has somewhere to land; lowering accepts only
+    /// the shapes it can resolve a mutable variable from.
+    Subscript {
+        target: Box<Spanned<Expr>>,
+        index: Box<Spanned<Expr>>,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/src/chl_parser/ast.rs
+++ b/src/chl_parser/ast.rs
@@ -371,7 +371,10 @@ pub enum AssignTarget {
     /// bound, one of its keys is being written. Only `:=` accepts it, a keyed write
     /// being a write to a mutable collection (`src/ccl/design/mutability.md`,
     /// "Surface-marker nodes: `For`, `MutWrite`, `Begin`, `Feed`"); every other
-    /// statement form rejects it at lowering.
+    /// statement form rejects it at lowering, where the message can name the binder
+    /// the form wanted. The checked spelling `m[k]? := v` is refused earlier, in
+    /// [`expr_to_assign_target`](crate::chl_parser::parser), because it is not a
+    /// target this enum can hold rather than a target used in the wrong statement.
     ///
     /// The target is an arbitrary expression rather than a name so that a write
     /// through a path (`a.b[k] := v`) has somewhere to land; lowering accepts only

--- a/src/chl_parser/ast.rs
+++ b/src/chl_parser/ast.rs
@@ -365,7 +365,7 @@ pub enum AssignTarget {
     Name(SmolStr),
     /// A tuple destructuring pattern: `(a, b), c = ...`. May nest.
     Tuple(Vec<Spanned<AssignTarget>>),
-    /// One key of a keyed collection: `m[k] := v`.
+    /// One key of a `Map`: `m[k] := v`.
     ///
     /// Not a binding position, unlike the other two: the collection is not being
     /// bound, one of its keys is being written. Only `:=` accepts it, a keyed write

--- a/src/chl_parser/parser.rs
+++ b/src/chl_parser/parser.rs
@@ -1588,6 +1588,15 @@ fn expr_to_assign_target(spanned: Spanned<Expr>) -> Result<Spanned<AssignTarget>
             }
             AssignTarget::Tuple(out)
         }
+        // `m[k]` in target position. The **checked** form is refused here rather
+        // than at lowering: `m[k]? := v` asks to write at a key that may be
+        // absent, and a write establishes presence rather than testing it, so
+        // there is nothing for the `?` to mean.
+        Expr::Subscript {
+            target,
+            index,
+            checked: false,
+        } => AssignTarget::Subscript { target, index },
         _ => return Err(span),
     };
     Ok(Spanned::new(span, node))
@@ -1980,6 +1989,35 @@ mod tests {
             },
             other => panic!("expected Assign, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn keyed_write_target() {
+        // `m[k] := v` — the collection and the key both survive as expressions, so
+        // lowering can resolve which variable is written and at what key.
+        let m = parse_m("m[k] := 1\n");
+        match &m.body[0].node {
+            Stmt::MutAssign { target, .. } => match &target.node {
+                AssignTarget::Subscript { target, index } => {
+                    assert!(matches!(&target.node, Expr::Name(n) if n == "m"));
+                    assert!(matches!(&index.node, Expr::Name(n) if n == "k"));
+                }
+                other => panic!("expected Subscript target, got {other:?}"),
+            },
+            other => panic!("expected MutAssign, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn checked_subscript_is_not_an_assign_target() {
+        // `m[k]? := v` asks to write at a key that may be absent. A write is what
+        // makes a key present, so the checked form has nothing to mean on the left
+        // and is refused in target position rather than at lowering.
+        let r = parse_module("m[k]? := 1\n");
+        assert!(
+            !r.errors.is_empty(),
+            "expected parse error for a checked subscript in target position"
+        );
     }
 
     #[test]

--- a/src/interpreter/commit_operator.rs
+++ b/src/interpreter/commit_operator.rs
@@ -322,6 +322,32 @@ fn read_initial_scalar(producer: &mut dyn TileProducer) -> Result<Value, InitDra
         let cv = match producer.get(guard.clone()) {
             Tile::Scalar(cv) => cv,
             tile @ Tile::Record(_) => scalar_tile_to_column_value(tile),
+            // A **collection** init — a keyed register's seed. It arrives as the
+            // function it is rather than as a scalar, and one store value is one
+            // map, so it seeds as a single [`map_to_value`] cell. The seed is
+            // acyclic and sealed, so the whole map is present on the pull that
+            // yields it.
+            Tile::SealedFunction {
+                domain,
+                codomain,
+                domain_predicate,
+                ..
+            } => {
+                // Only a **decided** domain is the whole seed. An init is acyclic, so it
+                // settles on the pull that yields it; taking an undecided one would seed the
+                // store with whichever keys had arrived, which is a partial map presented as
+                // the initial state.
+                let Tile::Scalar(values) = *codomain else {
+                    continue;
+                };
+                if !matches!(domain_predicate, Predicate::True) {
+                    continue;
+                }
+                let map: HashMap<Value, Value> = (0..domain.len())
+                    .map(|i| (domain.index_at(i), values.index_at(i)))
+                    .collect();
+                return Ok(map_to_value(&map));
+            }
             _ => continue,
         };
         if !cv.is_empty() {

--- a/src/interpreter/commit_operator.rs
+++ b/src/interpreter/commit_operator.rs
@@ -322,7 +322,7 @@ fn read_initial_scalar(producer: &mut dyn TileProducer) -> Result<Value, InitDra
         let cv = match producer.get(guard.clone()) {
             Tile::Scalar(cv) => cv,
             tile @ Tile::Record(_) => scalar_tile_to_column_value(tile),
-            // A **collection** init — a keyed register's seed. It arrives as the
+            // A **collection** init — a keyed mutable variable's seed. It arrives as the
             // function it is rather than as a scalar, and one store value is one
             // map, so it seeds as a single [`map_to_value`] cell. The seed is
             // acyclic and sealed, so the whole map is present on the pull that

--- a/src/interpreter/operator_conversion.rs
+++ b/src/interpreter/operator_conversion.rs
@@ -1685,10 +1685,13 @@ fn store_key(reg: &str, at: Value) -> Value {
     }
 }
 
-/// The extent of a store's key space — one arm per register, plus one per reply
-/// tap (a tap occupies a write-only arm of its own). An arm is `Unit` where the
-/// register's key space is the single name; a keyed register contributes its data
-/// key extent instead.
+/// The extent of a store's key space — one arm per register, plus one per reply tap (a tap
+/// occupies a write-only arm of its own).
+///
+/// Every arm is `Unit`, a keyed register included: `desugar_keyed_writes` rewrites `m[k] :=
+/// v` into the whole-value write `m := insert(m, k, v)`, so a register holds its whole
+/// collection at the single key `` `reg(unit) `` and the data key never reaches this key
+/// space. The tag is what would keep two registers' keys disjoint if one ever did.
 fn store_key_extent(arms: Vec<(String, Extent)>) -> Extent {
     Extent::Union(TagMap::from_arms(
         arms.into_iter()

--- a/src/interpreter/operator_conversion.rs
+++ b/src/interpreter/operator_conversion.rs
@@ -432,6 +432,25 @@ impl OpConversionContext {
                     .collect();
                 Ok(Extent::record(fields?))
             }
+            // A **keyed** sum, whose witness the value itself carries. `SubtypesOf(𝐾)`'s members
+            // are key types refined by membership, so the extent that describes one is the
+            // key type — a map cell holding only the keys it holds, which is how the store
+            // already describes its own (`map_extent`). That leaves nothing for a runtime
+            // witness to supply, unlike the arms below: a `UIntRanges` sum needs a concrete
+            // bound and a `Type` sum a domain, and neither is recoverable from a value's
+            // shape. Ahead of the general function arm because a sum's domain is its
+            // witness reference, which that arm cannot convert.
+            Type::Fun { codomain, .. }
+                if matches!(ty.witness_kind(), Some(crate::ccl::TypeKind::SubtypesOf(_))) =>
+            {
+                let Some(crate::ccl::TypeKind::SubtypesOf(key)) = ty.witness_kind() else {
+                    unreachable!("guarded by the arm")
+                };
+                Ok(Extent::Function {
+                    domain: Box::new(self.extent_of(&key)?),
+                    codomain: Box::new(self.extent_of(codomain)?),
+                })
+            }
             Type::Fun {
                 domain: a,
                 codomain: b,
@@ -1127,7 +1146,7 @@ fn convert_impl_inner(
             let option_extent = ctx.extent_of(&option_ty)?;
             let collection = convert_impl(argument, None, ctx)?;
             reject_unanswerable_lookup_collection(collection.tiling())?;
-            Ok(Box::new(CheckedLookup::new(
+            Ok(Box::new(CheckedLookup::split(
                 collection,
                 keys,
                 option_extent,
@@ -1159,7 +1178,7 @@ fn convert_impl_inner(
             let collection = convert_impl(coll_expr, None, ctx)?;
             reject_unanswerable_lookup_collection(collection.tiling())?;
             let keys = convert_impl(key_expr, None, ctx)?;
-            Ok(Box::new(CheckedLookup::new(
+            Ok(Box::new(CheckedLookup::split(
                 collection,
                 keys,
                 option_extent,
@@ -1211,6 +1230,71 @@ fn convert_impl_inner(
             let input = expect_input(input, &format!("Builtin({})", b.name()))?;
             match b {
                 Builtin::Id => Ok(input),
+                // Entering a **described** sum is the identity at runtime. A sum's value is
+                // a domain paired with a collection over it, and a collection carries its
+                // own domain — so a described witness is recoverable from the value and
+                // nothing represents it separately (`src/ccl/design/mutability.md`, "A
+                // mutable collection's key set varies with the position").
+                //
+                // Only a described kind goes through here. A box over two or more listed
+                // candidates records a choice the value cannot answer, and realization
+                // leaves it standing for the arm below to reject by name; a box over one is
+                // erased before op-conversion (`src/ccl/planning/conditionals.rs`).
+                Builtin::Box
+                    if expr
+                        .ty
+                        .codomain()
+                        .and_then(|c| {
+                            c.witness_kind()
+                                .map(|k| !matches!(k, crate::ccl::TypeKind::Enumerated(_)))
+                        })
+                        .unwrap_or(false) =>
+                {
+                    Ok(input)
+                }
+                // `insert(m, k, v)` — pointwise over the zipped `(collection, key, value)`
+                // triple, one map in and one map out, the same shape a binop takes over its
+                // pair. The output extent is the node's own codomain: a keyed sum's extent
+                // is its key type mapped to its value type, so the cell it describes is the
+                // map this produces.
+                Builtin::Insert => {
+                    let out_extent = expr.ty.codomain().ok_or_else(|| {
+                        ConversionError::TypeError(format!(
+                            "insert must have function type, got {}",
+                            expr.ty
+                        ))
+                    })?;
+                    let fn_extent = Extent::Function {
+                        domain: Box::new(result_extent(input.tiling())),
+                        codomain: Box::new(ctx.extent_of(&out_extent)?),
+                    };
+                    Ok(Box::new(MapResult::new(
+                        input,
+                        Box::new(Constant::new(
+                            Value::ComputableFunction(FunctionDef::Insert),
+                            fn_extent,
+                        )),
+                    )))
+                }
+                // `lookup?` over an assembled stream of `(collection, key)` rows — what the
+                // point-free form of a lookup inside an iteration composes to. The two
+                // collection representations arrive as two shapes of field 0 and
+                // `CheckedLookup` reads whichever it is given: a nested function tile is one
+                // collection shared by every row, a scalar column is one materialized map
+                // value per row.
+                Builtin::LookupChecked => {
+                    let option_ty = expr.ty.codomain().ok_or_else(|| {
+                        ConversionError::TypeError(format!(
+                            "`lookup?` must have function type, got {}",
+                            expr.ty
+                        ))
+                    })?;
+                    let option_extent = ctx.extent_of(&option_ty)?;
+                    Ok(Box::new(
+                        CheckedLookup::paired(input, option_extent)
+                            .map_err(ConversionError::Unsupported)?,
+                    ))
+                }
                 Builtin::MapDomain => Ok(Box::new(MapDomain::new(input))),
                 // `variant_project(c)` consumes the fed scrutinee stream and
                 // narrows it to that tag's restricted sub-domain, yielding the
@@ -1587,6 +1671,32 @@ fn body_tap_fields(body_ty: &Type) -> Vec<(String, Type)> {
         .collect()
 }
 
+/// The store key of register `reg` at data key `at`.
+///
+/// A store's key space is a tagged sum over its registers, each arm carrying that
+/// register's own key type: `Σ reg. K_reg`. A scalar register's key type is `Unit`,
+/// so it occupies the single key `` `reg(unit) ``. The tag is what keeps one
+/// register's keys disjoint from another's — without it a keyed register holding
+/// the string `"pool"` would alias the scalar register spelled `pool`.
+fn store_key(reg: &str, at: Value) -> Value {
+    Value::Union {
+        tag: FieldKey::Name(reg.into()),
+        inner: Box::new(at),
+    }
+}
+
+/// The extent of a store's key space — one arm per register, plus one per reply
+/// tap (a tap occupies a write-only arm of its own). An arm is `Unit` where the
+/// register's key space is the single name; a keyed register contributes its data
+/// key extent instead.
+fn store_key_extent(arms: Vec<(String, Extent)>) -> Extent {
+    Extent::Union(TagMap::from_arms(
+        arms.into_iter()
+            .map(|(f, e)| (FieldKey::Name(f.into()), e))
+            .collect(),
+    ))
+}
+
 /// Build a [`Type::Txn`] transactional store: a multi-key [`CommitOperator`]
 /// wired in a cyclic [`FanOut`], one *fused* [`CommitWriter`] per writer (a
 /// branch of the shared store output). Each fused writer reads the cyclic store,
@@ -1600,10 +1710,28 @@ fn build_commit_store(
     writers: &[WriterSite],
     ctx: &mut OpConversionContext,
 ) -> Result<StoreReadInfo, ConversionError> {
-    // Each variable becomes a key under its `field_key`'s runtime value; the
-    // store is one `CommitOperator` over them all (one commit clock, so writes
-    // to different keys commit atomically and disjoint footprints concurrently).
-    let key_extent = Extent::Base(BaseType::String);
+    // Each variable becomes an arm of the store's key space, tagged by its
+    // `field_key`; the store is one `CommitOperator` over them all (one commit
+    // clock, so writes to different keys commit atomically and disjoint
+    // footprints concurrently).
+    //
+    // The reply taps join that key space, so their arms are collected before the
+    // operator is built — the extent it carries has to describe every key the
+    // store will hold, and a tap key is written from the first commit on.
+    let per_writer_taps: Vec<Vec<(String, Type)>> = writers
+        .iter()
+        .map(|w| body_tap_fields(&w.body.ty))
+        .collect();
+    let mut key_arms: Vec<(String, Extent)> = keys
+        .iter()
+        .map(|k| (k.name.field_key(), Extent::Base(BaseType::Unit)))
+        .collect();
+    for taps in &per_writer_taps {
+        for (field, _) in taps {
+            key_arms.push((field.clone(), Extent::Base(BaseType::Unit)));
+        }
+    }
+    let key_extent = store_key_extent(key_arms);
     let mut keys_map: HashMap<String, KeyReadInfo> = HashMap::with_capacity(keys.len());
     // Per scalar key, an acyclic init operator seeding its tick-0 value (a literal
     // init is the trivial op; a computed init drains to its scalar).
@@ -1620,7 +1748,7 @@ fn build_commit_store(
     let mut value_extents: Vec<Extent> = Vec::new();
     for k in keys {
         let field = k.name.field_key();
-        let runtime_key = Value::String(field.clone().into());
+        let runtime_key = store_key(&field, Value::Unit);
         let key_value_extent = ctx.extent_of(&k.init.ty)?;
         if !value_extents.contains(&key_value_extent) {
             value_extents.push(key_value_extent.clone());
@@ -1649,7 +1777,7 @@ fn build_commit_store(
         _ => Extent::Union(TagMap::from_positional(value_extents)),
     };
     // Resolve a footprint key's runtime value from its `field_key`.
-    let runtime_key = |n: &Name| Value::String(n.field_key().into());
+    let runtime_key = |n: &Name| store_key(&n.field_key(), Value::Unit);
 
     // Each writer's static write footprint, so the store can close a key once the
     // writers that may touch it have finished rather than only when every writer
@@ -1664,7 +1792,7 @@ fn build_commit_store(
                 .chain(
                     body_tap_fields(&w.body.ty)
                         .into_iter()
-                        .map(|(f, _)| Value::String(f.into())),
+                        .map(|(f, _)| store_key(&f, Value::Unit)),
                 )
                 .collect()
         })
@@ -1681,7 +1809,7 @@ fn build_commit_store(
         .collect();
     let store_fan = Rc::new(FanOut::new_cyclic(Box::new(commit)));
 
-    for (set_writer, w) in setters.into_iter().zip(writers.iter()) {
+    for ((set_writer, w), taps) in setters.into_iter().zip(writers.iter()).zip(per_writer_taps) {
         let item_ty = w.source.ty.codomain().ok_or_else(|| {
             ConversionError::TypeError(format!(
                 "transact writer source must have function type, got {}",
@@ -1722,16 +1850,15 @@ fn build_commit_store(
         // keys), so the reply rides this transaction's commit and is read back as a
         // `Fun(Txn, V)` value-stream off the shared log. A tap takes no `init_op` —
         // it has no tick-0 value, so its stream starts at the first reply.
-        let taps = body_tap_fields(&w.body.ty);
         let mut write_keys: Vec<Value> = w.write_keys.iter().map(runtime_key).collect();
         let mut tap_fields: Vec<String> = Vec::with_capacity(taps.len());
         for (field, tap_ty) in taps {
             let tap_value_extent = ctx.extent_of(&tap_ty)?;
-            write_keys.push(Value::String(field.clone().into()));
+            write_keys.push(store_key(&field, Value::Unit));
             let prior = keys_map.insert(
                 field.clone(),
                 KeyReadInfo {
-                    runtime_key: Value::String(field.clone().into()),
+                    runtime_key: store_key(&field, Value::Unit),
                     value_extent: tap_value_extent,
                     index: 0, // unused for `commit` reads (keyed by `runtime_key`)
                     // A reply tap is a per-commit event, not a persistent value:
@@ -1837,8 +1964,15 @@ fn build_induction_store_single(
     w: &WriterSite,
     ctx: &mut OpConversionContext,
 ) -> Result<StoreReadInfo, ConversionError> {
-    let key_extent = Extent::Base(BaseType::String);
-    let runtime_key = |n: &Name| Value::String(n.field_key().into());
+    let taps = body_tap_fields(&w.body.ty);
+    let key_extent = store_key_extent(
+        keys.iter()
+            .map(|k| k.name.field_key())
+            .chain(taps.iter().map(|(f, _)| f.clone()))
+            .map(|f| (f, Extent::Base(BaseType::Unit)))
+            .collect(),
+    );
+    let runtime_key = |n: &Name| store_key(&n.field_key(), Value::Unit);
 
     // Each accumulator becomes a mutable variable key: its init op (the fold default, read
     // once at subscribe) plus a dense-read entry carrying the init as the
@@ -1848,7 +1982,7 @@ fn build_induction_store_single(
     let mut value_extents: Vec<Extent> = Vec::new();
     for k in keys {
         let field = k.name.field_key();
-        let rk = Value::String(field.clone().into());
+        let rk = store_key(&field, Value::Unit);
         let value_extent = ctx.extent_of(&k.init.ty)?;
         if !value_extents.contains(&value_extent) {
             value_extents.push(value_extent.clone());
@@ -1930,13 +2064,13 @@ fn build_induction_store_single(
     // reads to omit a non-fired tap from the delta.
     let mut write_keys: Vec<Value> = w.write_keys.iter().map(runtime_key).collect();
     let mut tap_fields: Vec<String> = Vec::new();
-    for (field, tap_ty) in body_tap_fields(&w.body.ty) {
+    for (field, tap_ty) in taps {
         let tap_value_extent = ctx.extent_of(&tap_ty)?;
-        write_keys.push(Value::String(field.clone().into()));
+        write_keys.push(store_key(&field, Value::Unit));
         keys_map.insert(
             field.clone(),
             KeyReadInfo {
-                runtime_key: Value::String(field.clone().into()),
+                runtime_key: store_key(&field, Value::Unit),
                 value_extent: tap_value_extent,
                 index: 0,             // unused: dense reads fold by runtime_key
                 carry_forward: false, // a tap fires only at its own position
@@ -2219,12 +2353,13 @@ fn as_curried_builtin(expr: &Expr) -> Option<Builtin> {
 
 /// Reject a lookup whose collection has no answer shape.
 ///
-/// Two requirements, both of which `CheckedLookup` asserts rather than re-checks. The
-/// collection tiles as a **sealed function**: the operator searches a domain column to
-/// decide presence, and any other tiling has nothing to search. Its codomain tiles as a
-/// **scalar**: an answer's `` `some `` payload is one column value, so a codomain of any
-/// other shape — a `CurriedFunction`'s collection-valued rows, a `Record`'s several columns
-/// — has nothing to put there.
+/// Two shapes answer, and `CheckedLookup` asserts rather than re-checks them. A
+/// **streamed** collection tiles as a sealed function over a **scalar** codomain: the
+/// operator searches the domain column to decide presence and carries one codomain value as
+/// the `` `some `` payload, so a codomain of any other shape — a `CurriedFunction`'s
+/// collection-valued rows, a `Record`'s several columns — has nothing to put there. A
+/// **materialized** collection is one map value, as a mutable collection's register holds
+/// it; it carries its own bindings, and any value can be the payload.
 ///
 /// Typing rejects the one producer of a key-dependent codomain today, so this is the
 /// boundary check for a shape that reaches op-conversion by some other route. Naming it
@@ -2232,15 +2367,19 @@ fn as_curried_builtin(expr: &Expr) -> Option<Builtin> {
 /// operator answers `None` for "the collection has not decided this key yet", and a
 /// permanent shape mismatch reported that way is a lookup that spins instead of erroring.
 fn reject_unanswerable_lookup_collection(tiling: &Tiling) -> Result<(), ConversionError> {
-    if let Tiling::SealedFunction { codomain, .. } = tiling
-        && matches!(codomain.as_ref(), Tiling::Scalar(_))
-    {
+    let answerable = match tiling {
+        Tiling::SealedFunction { codomain, .. } => matches!(codomain.as_ref(), Tiling::Scalar(_)),
+        Tiling::Scalar(Extent::Function { .. }) => true,
+        _ => false,
+    };
+    if answerable {
         return Ok(());
     }
     Err(ConversionError::Unsupported(format!(
-        "`c[k]?` needs a collection that tiles as a sealed function over a scalar codomain, \
-         so that its domain can be searched and its values carried as the `some` payload; \
-         this one tiles as {tiling}. A collection-valued codomain is the usual reason"
+        "`c[k]?` needs a collection that tiles either as a sealed function over a scalar \
+         codomain, so that its domain can be searched and its values carried as the `some` \
+         payload, or as one materialized map value; this one tiles as {tiling}. A \
+         collection-valued codomain is the usual reason"
     )))
 }
 

--- a/src/interpreter/operator_conversion.rs
+++ b/src/interpreter/operator_conversion.rs
@@ -117,7 +117,7 @@ pub fn convert_record_fields_to_operators(
             bound_expr,
             body,
         } => {
-            // `let __hist = Transact{…}`: build the shared store and register it
+            // `let __hist = Transact{…}`: build the shared store and mutable variable it
             // (the reads `__hist.k` in the fields project off it), the same as
             // the `convert_impl` `Let` arm. Multi-sink programs (a trailing
             // `Record`) reach the store binding through here.
@@ -299,7 +299,7 @@ pub struct OpConversionContext {
     /// Maps source names to their runtime [`DataSourceDomainExtentImpl`].
     sources: HashMap<String, Rc<RefCell<dyn DataSourceDomainExtentImpl>>>,
     /// Transactional stores in scope, keyed by their `__hist` binder. A
-    /// `let __hist = Transact{…}` builds the shared store once and registers
+    /// `let __hist = Transact{…}` builds the shared store once and mutable variables
     /// it here; each variable read `__hist.k` projects key `k` off the shared
     /// store fan (see [`StoreReadInfo`]). Names are α-unique, so a flat
     /// (unscoped) map suffices.
@@ -340,7 +340,7 @@ impl OpConversionContext {
         Self::default()
     }
 
-    /// Register a data-source implementation under `name`.
+    /// Mutable variable a data-source implementation under `name`.
     ///
     /// After registration, [`Type::DataSource`] resolves to
     /// [`Extent::DataSourceDomain`] in [`Self::extent_of`].
@@ -362,7 +362,7 @@ impl OpConversionContext {
             .ok_or_else(|| ConversionError::TypeError(format!("Unknown data source: {name}")))
     }
 
-    /// Register an output sink under `name`.
+    /// Mutable variable an output sink under `name`.
     ///
     /// Enter a fresh lexical scope, returning a guard that pops it on drop.
     ///
@@ -388,7 +388,7 @@ impl OpConversionContext {
         self.scopes.lookup(name)
     }
 
-    /// Register a built transactional store under its `__hist` binder.
+    /// Mutable variable a built transactional store under its `__hist` binder.
     fn register_store(&mut self, name: Name, info: StoreReadInfo) {
         self.transactional_stores.insert(name, info);
     }
@@ -1671,13 +1671,13 @@ fn body_tap_fields(body_ty: &Type) -> Vec<(String, Type)> {
         .collect()
 }
 
-/// The store key of register `reg` at data key `at`.
+/// The store key of mutable variable `reg` at data key `at`.
 ///
-/// A store's key space is a tagged sum over its registers, each arm carrying that
-/// register's own key type: `Σ reg. K_reg`. A scalar register's key type is `Unit`,
+/// A store's key space is a tagged sum over its mutable variables, each arm carrying that
+/// mutable variable's own key type: `Σ reg. K_reg`. A scalar mutable variable's key type is `Unit`,
 /// so it occupies the single key `` `reg(unit) ``. The tag is what keeps one
-/// register's keys disjoint from another's — without it a keyed register holding
-/// the string `"pool"` would alias the scalar register spelled `pool`.
+/// mutable variable's keys disjoint from another's — without it a keyed mutable variable holding
+/// the string `"pool"` would alias the scalar mutable variable spelled `pool`.
 fn store_key(reg: &str, at: Value) -> Value {
     Value::Union {
         tag: FieldKey::Name(reg.into()),
@@ -1685,13 +1685,13 @@ fn store_key(reg: &str, at: Value) -> Value {
     }
 }
 
-/// The extent of a store's key space — one arm per register, plus one per reply tap (a tap
+/// The extent of a store's key space — one arm per mutable variable, plus one per reply tap (a tap
 /// occupies a write-only arm of its own).
 ///
-/// Every arm is `Unit`, a keyed register included: `desugar_keyed_writes` rewrites `m[k] :=
-/// v` into the whole-value write `m := insert(m, k, v)`, so a register holds its whole
+/// Every arm is `Unit`, a keyed mutable variable included: `desugar_keyed_writes` rewrites `m[k] :=
+/// v` into the whole-value write `m := insert(m, k, v)`, so a mutable variable holds its whole
 /// collection at the single key `` `reg(unit) `` and the data key never reaches this key
-/// space. The tag is what would keep two registers' keys disjoint if one ever did.
+/// space. The tag is what would keep two mutable variables' keys disjoint if one ever did.
 fn store_key_extent(arms: Vec<(String, Extent)>) -> Extent {
     Extent::Union(TagMap::from_arms(
         arms.into_iter()
@@ -1958,7 +1958,7 @@ fn build_induction_store(
 /// [`InductionDriver`] reads the changelog back to produce the body's
 /// `(prev…, item)` input. Mirrors [`build_commit_store`]'s writer setup, but
 /// driven by iteration position — one writer, no conflict, no retry. Reads
-/// register as [`StoreReadKind::InductionChangelog`]:
+/// mutable variable as [`StoreReadKind::InductionChangelog`]:
 /// each `__hist.k` folds the changelog densely over the loop extent via
 /// [`StoreDenseRead`], serving both a scalar-final read (`ExtractFinal` over it)
 /// and a co-iterated read (the dense `Fun(D, V)` itself).
@@ -2361,7 +2361,7 @@ fn as_curried_builtin(expr: &Expr) -> Option<Builtin> {
 /// operator searches the domain column to decide presence and carries one codomain value as
 /// the `` `some `` payload, so a codomain of any other shape — a `CurriedFunction`'s
 /// collection-valued rows, a `Record`'s several columns — has nothing to put there. A
-/// **materialized** collection is one map value, as a mutable collection's register holds
+/// **materialized** collection is one map value, as a mutable collection's mutable variable holds
 /// it; it carries its own bindings, and any value can be the payload.
 ///
 /// Typing rejects the one producer of a key-dependent codomain today, so this is the

--- a/src/interpreter/tile_operators/lookup.rs
+++ b/src/interpreter/tile_operators/lookup.rs
@@ -5,7 +5,7 @@ use crate::{
     ccl::FieldKey,
     interpreter::{
         ColumnValue, Consumer, Scheduler, Value, forwarding_consumer, shared_consumer,
-        tiling::FunctionGuard,
+        tiling::FunctionGuard, tuple_field,
     },
     pretty_graph::VizOptions,
     pretty_tree::InspectNode,
@@ -31,37 +31,107 @@ use crate::{
 /// domain is decided this operator emits nothing, exactly as any operator awaiting its
 /// input does.
 pub struct CheckedLookup {
-    /// The collection to look keys up in — a streamed `SealedFunction`, or a `Scalar`
-    /// holding one materialized map value as a mutable collection's register does.
-    collection: Box<dyn TileOperator>,
-    /// The keys, taking the shape the surrounding chain feeds.
-    keys: Box<dyn TileOperator>,
+    /// Where the collection and the keys come from — see [`LookupSource`].
+    source: LookupSource,
     /// The answer, one `` {`none | `some{𝑉}} `` per key.
     tiling: Tiling,
 }
 
+/// The two ways a lookup's operands reach this operator.
+///
+/// Which one it is follows from where the lookup sits, not from the collection: `lookup?` is
+/// applied to a `(collection, key)` pair, and op-conversion either still has that pair as a
+/// term or has already assembled it into a stream of rows.
+enum LookupSource {
+    /// Both operands still terms, so each compiles as its own source: the collection is read
+    /// once and every key answered against it.
+    Split {
+        collection: Box<dyn TileOperator>,
+        keys: Box<dyn TileOperator>,
+    },
+    /// One stream of `(collection, key)` rows, the point-free form of a lookup inside an
+    /// iteration. Field 0 carries either a nested function tile — one collection shared by
+    /// every row — or a scalar column of materialized map values, one per row.
+    Paired(Box<dyn TileOperator>),
+}
+
 impl CheckedLookup {
-    /// Look keys up in `collection`. `keys` is the input the surrounding chain feeds — a
-    /// scalar for `m[1]?`, a stream wherever the lookup sits in an iteration — and the
-    /// answer takes its shape from it.
-    pub fn new(
+    /// Look keys up in `collection`, with both operands as their own sources. The answer
+    /// takes the keys' shape: a scalar for `m[1]?`, a stream wherever the keys are one.
+    pub fn split(
         collection: Box<dyn TileOperator>,
         keys: Box<dyn TileOperator>,
         option_extent: Extent,
     ) -> Self {
-        let tiling = match keys.tiling() {
-            Tiling::Scalar(_) => Tiling::Scalar(option_extent),
-            Tiling::SealedFunction { domain, .. } => Tiling::SealedFunction {
-                domain: domain.clone(),
-                codomain: Box::new(Tiling::Scalar(option_extent)),
-            },
-            other => panic!("CheckedLookup keys must be a scalar or a stream, got {other}"),
-        };
+        let tiling = answer_tiling(keys.tiling(), option_extent);
         Self {
-            collection,
-            keys,
+            source: LookupSource::Split { collection, keys },
             tiling,
         }
+    }
+
+    /// Look each row's key up in that row's collection, over an assembled stream of
+    /// `(collection, key)` pairs. The answer's domain is the stream's own.
+    pub fn paired(pairs: Box<dyn TileOperator>, option_extent: Extent) -> Result<Self, String> {
+        let Tiling::SealedFunction { domain, codomain } = pairs.tiling() else {
+            return Err(format!(
+                "`lookup?` over an assembled pair needs a stream of rows, got {}",
+                pairs.tiling()
+            ));
+        };
+        let Tiling::Record(fields) = codomain.as_ref() else {
+            return Err(format!(
+                "`lookup?`'s input rows must be `(collection, key)` pairs, got {codomain}"
+            ));
+        };
+        // Field 0 is the collection. A nested function tiling is one collection shared by
+        // every row; a scalar is a materialized map value per row. Anything else is a
+        // collection whose values are themselves collections, which has no answer shape.
+        let collection = fields
+            .get(&tuple_field(0))
+            .ok_or_else(|| "`lookup?`'s input rows have no collection field".to_string())?;
+        match collection {
+            Tiling::SealedFunction { .. } | Tiling::Scalar(Extent::Function { .. }) => {}
+            other => {
+                return Err(format!(
+                    "`c[k]?` over a collection whose values are themselves collections is not \
+                     supported yet: the answer would carry a collection as its `some` \
+                     payload, and its tiling is {other}"
+                ));
+            }
+        }
+        // Field 1 is the key, and a key is one value — so the runtime reads a key column
+        // rather than deciding what to do with a structured one.
+        match fields.get(&tuple_field(1)) {
+            Some(Tiling::Scalar(_)) => {}
+            other => {
+                return Err(format!(
+                    "`lookup?`'s input rows carry one key each, so field 1 tiles as a scalar; \
+                     got {}",
+                    other.map_or_else(|| "no field".to_string(), Tiling::to_string)
+                ));
+            }
+        }
+        let tiling = Tiling::SealedFunction {
+            domain: domain.clone(),
+            codomain: Box::new(Tiling::Scalar(option_extent)),
+        };
+        Ok(Self {
+            source: LookupSource::Paired(pairs),
+            tiling,
+        })
+    }
+}
+
+/// The answer's tiling for a given key tiling: one option per key, in the keys' own shape.
+fn answer_tiling(keys: &Tiling, option_extent: Extent) -> Tiling {
+    match keys {
+        Tiling::Scalar(_) => Tiling::Scalar(option_extent),
+        Tiling::SealedFunction { domain, .. } => Tiling::SealedFunction {
+            domain: domain.clone(),
+            codomain: Box::new(Tiling::Scalar(option_extent)),
+        },
+        other => panic!("CheckedLookup keys must be a scalar or a stream, got {other}"),
     }
 }
 
@@ -71,8 +141,12 @@ impl TileOperator for CheckedLookup {
     }
 
     fn add_inspect_children(&self, node: InspectNode, opts: &VizOptions) -> InspectNode {
-        node.child("collection", self.collection.inspect(opts))
-            .child("keys", self.keys.inspect(opts))
+        match &self.source {
+            LookupSource::Split { collection, keys } => node
+                .child("collection", collection.inspect(opts))
+                .child("keys", keys.inspect(opts)),
+            LookupSource::Paired(pairs) => node.child("pairs", pairs.inspect(opts)),
+        }
     }
 
     fn subscribe(
@@ -81,25 +155,35 @@ impl TileOperator for CheckedLookup {
         consumer: Box<dyn Consumer>,
         scheduler: &mut Scheduler,
     ) -> Box<dyn TileProducer> {
-        // Both legs wake the same consumer. The collection is what decides an absence, so
-        // when it settles after the keys it is the input that completes the answer — and a
-        // collection subscribed with a consumer of its own would settle with nobody
-        // scheduled to read it (see [`SharedConsumer`]).
-        let shared = shared_consumer(consumer);
-        let keys = self.keys.subscribe(
-            self.keys.tiling().universal_guard(),
-            forwarding_consumer(&shared),
-            scheduler,
-        );
-        let collection = self.collection.subscribe(
-            self.collection.tiling().universal_guard(),
-            forwarding_consumer(&shared),
-            scheduler,
-        );
+        let source = match &mut self.source {
+            // Two inputs, so both wake the same consumer. The collection is what decides an
+            // absence, so when it settles after the keys it is the input that completes the
+            // answer — subscribed with a consumer of its own it would settle with nobody
+            // scheduled to read it (see `shared_consumer`).
+            LookupSource::Split { collection, keys } => {
+                let shared = shared_consumer(consumer);
+                let keys = keys.subscribe(
+                    keys.tiling().universal_guard(),
+                    forwarding_consumer(&shared),
+                    scheduler,
+                );
+                let collection = collection.subscribe(
+                    collection.tiling().universal_guard(),
+                    forwarding_consumer(&shared),
+                    scheduler,
+                );
+                ProducerSource::Split { collection, keys }
+            }
+            // One input, carrying both operands, so there is nothing to share.
+            LookupSource::Paired(pairs) => ProducerSource::Paired(pairs.subscribe(
+                pairs.tiling().universal_guard(),
+                consumer,
+                scheduler,
+            )),
+        };
         Box::new(CheckedLookupProducer {
             base: ProducerBase::new(CheckedLookupProducer::alloc_id(), &self.tiling),
-            collection,
-            keys,
+            source,
             released: false,
         })
     }
@@ -107,9 +191,17 @@ impl TileOperator for CheckedLookup {
 
 struct CheckedLookupProducer {
     base: ProducerBase,
-    collection: Box<dyn TileProducer>,
-    keys: Box<dyn TileProducer>,
+    source: ProducerSource,
     released: bool,
+}
+
+/// [`LookupSource`] after subscription.
+enum ProducerSource {
+    Split {
+        collection: Box<dyn TileProducer>,
+        keys: Box<dyn TileProducer>,
+    },
+    Paired(Box<dyn TileProducer>),
 }
 
 /// `` `some(v) `` — the tag a present key answers with.
@@ -128,33 +220,88 @@ fn none() -> Value {
     }
 }
 
+/// The answer for one key against a **materialized** map value.
+///
+/// A map value is a binding list, so it carries its own keys: it is complete wherever it is
+/// present, and absence needs no terminality wait. This is how a mutable collection's
+/// register holds its collection, at one store key.
+fn answer_in_value(key: &Value, m: &Value) -> Value {
+    match m {
+        Value::Function(bindings) => bindings
+            .iter()
+            .find(|b| &b.input == key)
+            .map_or_else(none, |b| some_of(b.output.clone())),
+        other => panic!("CheckedLookup: collection is not a map value: {other:?}"),
+    }
+}
+
+/// The answer for one key against a collection tile, or `None` while it is still deciding.
+///
+/// A **streamed** collection carries its keys in the domain column, so an absent key is only
+/// an answer once that domain is decided. A **materialized** one is a single map value and
+/// answers immediately ([`answer_in_value`]).
+fn answer_for(key: &Value, coll: &Tile) -> Option<Value> {
+    match coll {
+        Tile::SealedFunction {
+            domain, codomain, ..
+        } => match (0..domain.len()).find(|&i| &domain.index_at(i) == key) {
+            Some(i) => {
+                // `None` here would read as "still deciding" for a shape that will never
+                // change, and the lookup would spin instead of answering. Op-conversion's
+                // `reject_unanswerable_lookup_collection` is what makes this unreachable.
+                let Tile::Scalar(values) = codomain.as_ref() else {
+                    panic!(
+                        "CheckedLookup: an answer's `some` payload is one column value, so the \
+                         collection's codomain tiles as a scalar; got {codomain:?}"
+                    )
+                };
+                Some(some_of(values.index_at(i)))
+            }
+            None if coll.is_terminal() => Some(none()),
+            None => None,
+        },
+        Tile::Scalar(col) if !col.is_empty() => Some(answer_in_value(key, &col.index_at(0))),
+        // A materialized collection that has not arrived yet.
+        Tile::Scalar(_) => None,
+        other => panic!("CheckedLookup: collection is not a collection: {other:?}"),
+    }
+}
+
+/// How the rows of an assembled `(collection, key)` stream supply their collection.
+enum RowCollection<'a> {
+    /// One collection shared by every row — the collection leg was closed in the iteration,
+    /// so `zip` fanned it in as a constant and it arrives as a nested function tile.
+    Shared(&'a Tile),
+    /// One materialized map value per row, as a mutable collection's register gives.
+    PerRow(&'a ColumnValue),
+}
+
 impl CheckedLookupProducer {
-    /// The answer for one key, or `None` while the collection is still deciding.
+    /// The rows' answers, paired with the domain positions they were answered at.
     ///
-    /// A collection carries its keys in the domain column, so an absent key is only an
-    /// answer once that domain is decided.
-    fn answer_for(&self, key: &Value, coll: &Tile) -> Option<Value> {
-        match coll {
-            Tile::SealedFunction {
-                domain, codomain, ..
-            } => match (0..domain.len()).find(|&i| &domain.index_at(i) == key) {
-                Some(i) => {
-                    // `None` here would read as "still deciding" for a shape that will never
-                    // change, and the lookup would spin instead of answering. Op-conversion's
-                    // `reject_unanswerable_lookup_collection` is what makes this unreachable.
-                    let Tile::Scalar(values) = codomain.as_ref() else {
-                        panic!(
-                            "CheckedLookup: an answer's `some` payload is one column value, so \
-                             the collection's codomain tiles as a scalar; got {codomain:?}"
-                        )
-                    };
-                    Some(some_of(values.index_at(i)))
+    /// A key the collection has not decided yet contributes no row, so the answer is a
+    /// *prefix* of the key stream and grows with it. Keeping the rows aligned means carrying
+    /// each answered key's own domain position.
+    fn answer_rows(
+        domain: &ColumnValue,
+        keys: &ColumnValue,
+        collection: &RowCollection<'_>,
+    ) -> (Vec<Value>, Vec<Value>) {
+        let mut kept = Vec::with_capacity(domain.len());
+        let mut answers = Vec::with_capacity(domain.len());
+        for i in 0..domain.len() {
+            let answer = match collection {
+                RowCollection::Shared(tile) => answer_for(&keys.index_at(i), tile),
+                RowCollection::PerRow(col) => {
+                    Some(answer_in_value(&keys.index_at(i), &col.index_at(i)))
                 }
-                None if coll.is_terminal() => Some(none()),
-                None => None,
-            },
-            other => panic!("CheckedLookup: collection is not a stream: {other:?}"),
+            };
+            if let Some(v) = answer {
+                kept.push(domain.index_at(i));
+                answers.push(v);
+            }
         }
+        (kept, answers)
     }
 }
 
@@ -162,8 +309,12 @@ impl TileProducer for CheckedLookupProducer {
     impl_producer_base!();
 
     fn add_inspect_children(&self, node: InspectNode, opts: &VizOptions) -> InspectNode {
-        node.child("collection", self.collection.inspect(opts))
-            .child("keys", self.keys.inspect(opts))
+        match &self.source {
+            ProducerSource::Split { collection, keys } => node
+                .child("collection", collection.inspect(opts))
+                .child("keys", keys.inspect(opts)),
+            ProducerSource::Paired(pairs) => node.child("pairs", pairs.inspect(opts)),
+        }
     }
 
     fn get_impl(&mut self, _projection_guard: TileGuard) -> Tile {
@@ -176,96 +327,146 @@ impl TileProducer for CheckedLookupProducer {
         if self.released {
             return empty_scalar;
         }
-        // Both legs are searched by position, and a release marks rows deleted rather than
+        // Every leg is searched by position, and a release marks rows deleted rather than
         // removing them (`Tile::mark_deleted`), so a tile still carrying deletions answers a
         // released or filtered-out key as present. Compacting drops those rows and clears the
-        // bitset, which is what leaves the answer below with no deletions of its own.
-        let mut key_tile = self.keys.get(self.keys.tiling().universal_guard());
-        key_tile.compact();
-        let mut coll = self
-            .collection
-            .get(self.collection.tiling().universal_guard());
-        coll.compact();
-        match key_tile {
-            // No key has arrived yet, so there is nothing to answer.
-            Tile::Scalar(ref keys) if keys.is_empty() => empty_scalar,
-            // One key: the scalar form `m[k]?`.
-            Tile::Scalar(ref keys) => match self.answer_for(&keys.index_at(0), &coll) {
-                Some(v) => Tile::Scalar(ColumnValue::from_values(vec![v], &out_extent)),
-                None => empty_scalar,
-            },
-            // A stream of keys: the lookup sits in an iteration, and each row is answered
-            // against the same collection — read once, not lifted into every row.
-            Tile::SealedFunction {
-                ref domain,
-                ref codomain,
-                ref domain_predicate,
-                ..
-            } => {
-                let Tile::Scalar(key_col) = codomain.as_ref() else {
-                    panic!(
-                        "CheckedLookup: a key is one value, so the key stream's codomain tiles as a scalar; got {codomain:?}"
-                    )
-                };
-                // A key the collection has not decided yet contributes no row, so the
-                // answer is a *prefix* of the key stream and grows with it. Keeping the
-                // rows aligned means carrying each answered key's own domain position.
-                let mut kept: Vec<Value> = Vec::with_capacity(domain.len());
-                let mut answers: Vec<Value> = Vec::with_capacity(domain.len());
-                for i in 0..domain.len() {
-                    if let Some(v) = self.answer_for(&key_col.index_at(i), &coll) {
-                        kept.push(domain.index_at(i));
-                        answers.push(v);
+        // bitset, which is also what leaves the answer with no deletions of its own.
+        match &mut self.source {
+            ProducerSource::Split { collection, keys } => {
+                let mut key_tile = keys.get(keys.tiling().universal_guard());
+                key_tile.compact();
+                let mut coll = collection.get(collection.tiling().universal_guard());
+                coll.compact();
+                match key_tile {
+                    // No key has arrived yet, so there is nothing to answer.
+                    Tile::Scalar(ref keys) if keys.is_empty() => empty_scalar,
+                    // One key: the scalar form `m[k]?`.
+                    Tile::Scalar(ref keys) => match answer_for(&keys.index_at(0), &coll) {
+                        Some(v) => Tile::Scalar(ColumnValue::from_values(vec![v], &out_extent)),
+                        None => empty_scalar,
+                    },
+                    // A stream of keys, each answered against the same collection — read
+                    // once, not lifted into every row.
+                    Tile::SealedFunction {
+                        ref domain,
+                        ref codomain,
+                        ref domain_predicate,
+                        ..
+                    } => {
+                        let Tile::Scalar(key_col) = codomain.as_ref() else {
+                            panic!(
+                                "CheckedLookup: a key is one value, so the key stream's codomain \
+                                 tiles as a scalar; got {codomain:?}"
+                            )
+                        };
+                        let (kept, answers) =
+                            Self::answer_rows(domain, key_col, &RowCollection::Shared(&coll));
+                        self.stream_tile(kept, answers, domain, domain_predicate, &out_extent)
+                    }
+                    other => {
+                        panic!("CheckedLookup keys tile as a scalar or a stream, got {other:?}")
                     }
                 }
-                let Tiling::SealedFunction {
-                    domain: dom_ext, ..
-                } = self.tiling()
-                else {
-                    panic!("CheckedLookup answers a stream when its keys are one")
-                };
-                let domain_extent = dom_ext.clone();
-                // The answer seals only where it holds a row for every key. A key the
-                // collection has not decided is a *missing* row, not a decided absence, so
-                // passing the keys' own seal through would let a consumer read the whole
-                // answer as complete while those rows are still outstanding.
-                let domain_predicate = if kept.len() == domain.len() {
-                    domain_predicate.clone()
-                } else {
-                    Predicate::False
-                };
-                Tile::SealedFunction {
-                    domain: ColumnValue::from_values(kept, &domain_extent),
-                    codomain: Box::new(Tile::Scalar(ColumnValue::from_values(
-                        answers,
-                        &out_extent,
-                    ))),
-                    domain_predicate,
-                    // The rows are the live keys the collection has decided, a subsequence of
-                    // an already-compacted domain. Carrying the keys' bitset forward would
-                    // name positions of a column this one no longer shares.
-                    deleted: BitSet::new(),
-                }
             }
-            other => panic!("CheckedLookup keys tile as a scalar or a stream, got {other:?}"),
+            // An assembled stream of `(collection, key)` rows.
+            ProducerSource::Paired(pairs) => {
+                let mut tile = pairs.get(pairs.tiling().universal_guard());
+                tile.compact();
+                // Not a shape error: a stream that has produced nothing yet answers with an
+                // empty scalar, and this operator does the same until its rows arrive.
+                let Tile::SealedFunction {
+                    ref domain,
+                    ref codomain,
+                    ref domain_predicate,
+                    ..
+                } = tile
+                else {
+                    return empty_scalar;
+                };
+                // The row shape, on the other hand, `Self::paired` has already checked.
+                let Tile::Record(fields) = codomain.as_ref() else {
+                    panic!(
+                        "CheckedLookup: input rows are `(collection, key)` pairs; got {codomain:?}"
+                    )
+                };
+                let (Some(coll_tile), Some(Tile::Scalar(key_col))) =
+                    (fields.get(&tuple_field(0)), fields.get(&tuple_field(1)))
+                else {
+                    panic!(
+                        "CheckedLookup: input rows carry a collection at .0 and one key at .1; got {codomain:?}"
+                    )
+                };
+                let collection = match coll_tile {
+                    Tile::Scalar(col) => RowCollection::PerRow(col),
+                    shared => RowCollection::Shared(shared),
+                };
+                let (kept, answers) = Self::answer_rows(domain, key_col, &collection);
+                self.stream_tile(kept, answers, domain, domain_predicate, &out_extent)
+            }
         }
     }
 
     fn release_impl(&mut self, obsolete_guard: TileGuard) {
         // A **domain** release names positions of the answer, and the answer is one option per
         // key at the key's own domain position — so it names key positions and passes through
-        // to the keys. The **collection** is not positional: every key is answered against the
-        // whole of it, so no key being finished releases any part of it. That asymmetry is why
-        // the two legs are released separately rather than together.
+        // to whatever supplies them. The **collection** is not positional: every key is
+        // answered against the whole of it, so no key being finished releases any part of it.
+        // That asymmetry is why the two legs are released separately rather than together.
         if let TileGuard::Function(FunctionGuard::Domain(_)) = &obsolete_guard {
-            self.keys.release(obsolete_guard);
+            match &mut self.source {
+                ProducerSource::Split { keys, .. } => keys.release(obsolete_guard),
+                ProducerSource::Paired(pairs) => pairs.release(obsolete_guard),
+            }
             return;
         }
         if obsolete_guard.expect_universal_or_empty(&self.name()) {
             self.released = true;
-            self.collection
-                .release(self.collection.tiling().universal_guard());
-            self.keys.release(self.keys.tiling().universal_guard());
+            match &mut self.source {
+                ProducerSource::Split { collection, keys } => {
+                    collection.release(collection.tiling().universal_guard());
+                    keys.release(keys.tiling().universal_guard());
+                }
+                ProducerSource::Paired(pairs) => pairs.release(pairs.tiling().universal_guard()),
+            }
+        }
+    }
+}
+
+impl CheckedLookupProducer {
+    /// Assemble the answered rows into this producer's own stream tiling.
+    ///
+    /// `domain` is the input's domain column, which `kept` is a subsequence of.
+    fn stream_tile(
+        &self,
+        kept: Vec<Value>,
+        answers: Vec<Value>,
+        domain: &ColumnValue,
+        domain_predicate: &Predicate,
+        out_extent: &Extent,
+    ) -> Tile {
+        let Tiling::SealedFunction {
+            domain: dom_ext, ..
+        } = self.tiling()
+        else {
+            panic!("CheckedLookup answers a stream when its keys are one")
+        };
+        // The answer seals only where it holds a row for every key. A key the collection has
+        // not decided is a *missing* row, not a decided absence, so passing the input's own
+        // seal through would let a consumer read the whole answer as complete while those
+        // rows are still outstanding.
+        let domain_predicate = if kept.len() == domain.len() {
+            domain_predicate.clone()
+        } else {
+            Predicate::False
+        };
+        Tile::SealedFunction {
+            domain: ColumnValue::from_values(kept, dom_ext),
+            codomain: Box::new(Tile::Scalar(ColumnValue::from_values(answers, out_extent))),
+            domain_predicate,
+            // The rows are the live keys the collection has decided, a subsequence of an
+            // already-compacted domain. Carrying the input's bitset forward would name
+            // positions of a column this one no longer shares.
+            deleted: BitSet::new(),
         }
     }
 }

--- a/src/interpreter/tile_operators/lookup.rs
+++ b/src/interpreter/tile_operators/lookup.rs
@@ -224,7 +224,7 @@ fn none() -> Value {
 ///
 /// A map value is a binding list, so it carries its own keys: it is complete wherever it is
 /// present, and absence needs no terminality wait. This is how a mutable collection's
-/// register holds its collection, at one store key.
+/// mutable variable holds its collection, at one store key.
 fn answer_in_value(key: &Value, m: &Value) -> Value {
     match m {
         Value::Function(bindings) => bindings
@@ -272,7 +272,7 @@ enum RowCollection<'a> {
     /// One collection shared by every row — the collection leg was closed in the iteration,
     /// so `zip` fanned it in as a constant and it arrives as a nested function tile.
     Shared(&'a Tile),
-    /// One materialized map value per row, as a mutable collection's register gives.
+    /// One materialized map value per row, as a mutable collection's mutable variable gives.
     PerRow(&'a ColumnValue),
 }
 

--- a/src/interpreter/types/value.rs
+++ b/src/interpreter/types/value.rs
@@ -22,6 +22,10 @@ pub enum FunctionDef {
     /// Unary arithmetic or boolean operation applied element-wise to a single column.
     UnaryOp(UnaryOpKind),
     RecordField(String),
+    /// `insert(m, k, v)` — the collection with one key's value replaced, inserting the key
+    /// where it was absent. Applied to a `Records` column of the tupled argument
+    /// ([`crate::ccl::Builtin::Insert`]), pointwise: one map in, one map out.
+    Insert,
 }
 
 impl FunctionDef {
@@ -36,9 +40,41 @@ impl FunctionDef {
             (FunctionDef::RecordField(f), ColumnValue::Records(mut fields)) => fields
                 .remove(f)
                 .unwrap_or_else(|| panic!("Missing field {f}")),
+            (FunctionDef::Insert, ColumnValue::Records(mut fields)) => {
+                let maps = fields
+                    .remove(&tuple_field(0))
+                    .expect("insert: no collection");
+                let keys = fields.remove(&tuple_field(1)).expect("insert: no key");
+                let values = fields.remove(&tuple_field(2)).expect("insert: no value");
+                ColumnValue::Variants(
+                    (0..maps.len())
+                        .map(|i| {
+                            insert_binding(maps.index_at(i), keys.index_at(i), values.index_at(i))
+                        })
+                        .collect(),
+                )
+            }
             _ => panic!("Invalid function application"),
         }
     }
+}
+
+/// `m` with `key` bound to `value` — replacing an existing binding, appending a new one.
+///
+/// A map value is a [`Value::Function`] binding list, so a key is present at most once and
+/// replacement is positional. A non-function `m` is a shape error the type system rules out.
+fn insert_binding(m: Value, key: Value, value: Value) -> Value {
+    let Value::Function(mut bindings) = m else {
+        panic!("insert: the collection operand is not a function value, got {m:?}");
+    };
+    match bindings.iter_mut().find(|b| b.input == key) {
+        Some(b) => b.output = value,
+        None => bindings.push(FuncBinding {
+            input: key,
+            output: value,
+        }),
+    }
+    Value::Function(bindings)
 }
 
 impl std::fmt::Display for FunctionDef {
@@ -47,6 +83,7 @@ impl std::fmt::Display for FunctionDef {
             FunctionDef::UnaryOp(op) => write!(f, "UnaryOp({op:?})"),
             FunctionDef::BinOp(op) => write!(f, "BinOp({})", fmt_binop(op)),
             FunctionDef::RecordField(field) => write!(f, ".{field}"),
+            FunctionDef::Insert => write!(f, "insert"),
         }
     }
 }

--- a/tests/compilation_pipeline/transactions.rs
+++ b/tests/compilation_pipeline/transactions.rs
@@ -3013,3 +3013,176 @@ fn a_variant_match_inside_a_block_releases_per_commit() {
     "#});
     assert_eq!(value, Value::Int(3));
 }
+
+/// A `Map`-valued transactional register, read inside a block and never written.
+///
+/// The register's value type is the abstract map `Σ (𝐷 : SubtypesOf(𝐾)). 𝐷 ⤇ 𝑉`, so the whole path
+/// from seed to store runs on a sum: the seed's introduction states that type and survives
+/// realization, entering the sum compiles to the identity, and the seed drains to one map
+/// cell rather than to a scalar.
+#[test]
+fn a_map_valued_register_reads_inside_a_block() {
+    let value = final_mut_var_value(indoc! {r#"
+        m: Mut(Map(String, Int), Txn) := box(map([("a", 1), ("b", 2)]))
+        n: Mut(Int, Txn) := 0
+        for r in [1, 2, 3]:
+            with begin():
+                hit = m["a"]?
+                n := n + 1
+        await_final(n)
+    "#});
+    assert_eq!(value, Value::Int(3));
+}
+
+/// A keyed write `m[k] := v` reaching a transactional store.
+///
+/// The write denotes the whole-value write `m := insert(m, k, v)`
+/// ([`cambra::ccl::Builtin::Insert`]), so the register's history stays an ordinary
+/// overwrite one and the store holds the collection it names. Asserting the *value* is what
+/// makes this more than a compile check: the seed's two keys survive and the written key
+/// joins them, so neither the seed nor the write replaced the other.
+#[test]
+fn a_keyed_write_reaches_a_transactional_store() {
+    let value = final_mut_var_value(indoc! {r#"
+        m: Mut(Map(String, Int), Txn) := box(map([("a", 1), ("b", 2)]))
+        for r in [1, 2, 3]:
+            with begin():
+                m["c"] := 3
+        await_final(m)
+    "#});
+    assert_eq!(
+        map_entries(&value),
+        vec![
+            ("a".to_string(), 1),
+            ("b".to_string(), 2),
+            ("c".to_string(), 3),
+        ]
+    );
+}
+
+/// A keyed write over an **induction** domain.
+///
+/// The key is the **loop binder**, which is what makes this more than the transactional
+/// case repeated over another domain: a variable key's type is reachable from no other slot,
+/// since a write is `Unit`, so a pass that skips the key slot leaves it an unresolved
+/// inference variable and nothing downstream notices.
+#[test]
+fn a_keyed_write_reaches_an_induction_store() {
+    let value = final_mut_var_value(indoc! {r#"
+        m: Mut(Map(Int, Int)) := box(map([(1, 10), (2, 20)]))
+        for x in [3, 4]:
+            m[x] := 99
+        m
+    "#});
+    assert_eq!(
+        map_entries_int(&value),
+        vec![(1, 10), (2, 20), (3, 99), (4, 99)]
+    );
+}
+
+/// A map value's bindings, key-sorted — a `Value::Function`'s order follows construction,
+/// which is not what a test about *contents* should depend on.
+fn map_entries(v: &Value) -> Vec<(String, i64)> {
+    let Value::Function(bindings) = v else {
+        panic!("expected a map value, got {v:?}");
+    };
+    let mut out: Vec<(String, i64)> = bindings
+        .iter()
+        .map(|b| match (&b.input, &b.output) {
+            (Value::String(k), Value::Int(n)) => (k.to_string(), *n),
+            other => panic!("expected String ↦ Int, got {other:?}"),
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// [`map_entries`] for an `Int`-keyed map.
+fn map_entries_int(v: &Value) -> Vec<(i64, i64)> {
+    let Value::Function(bindings) = v else {
+        panic!("expected a map value, got {v:?}");
+    };
+    let mut out: Vec<(i64, i64)> = bindings
+        .iter()
+        .map(|b| match (&b.input, &b.output) {
+            (Value::Int(k), Value::Int(n)) => (*k, *n),
+            other => panic!("expected Int ↦ Int, got {other:?}"),
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// A keyed write and a keyed read, round trip: `m[k] := v` commits and `m[k]?` reads it
+/// back. This is the pair that makes a mutable collection usable rather than write-only.
+///
+/// The read goes through the **materialized** path in `CheckedLookup`: a register holds its
+/// collection as one map value at one store key, so the lookup searches that value's
+/// bindings rather than a domain column. A map value carries its own bindings, so it is
+/// complete wherever it is present and absence needs no terminality wait.
+#[test]
+fn a_keyed_write_reads_back_through_a_checked_lookup() {
+    check_scalar(
+        indoc! {r#"
+            m: Mut(Map(String, Int), Txn) := box(map([("a", 1), ("b", 2)]))
+            for r in [1, 2, 3]:
+                with begin():
+                    m["c"] := 3
+            final: Map(String, Int) = await_final(m)
+            match final["c"]?:
+                case `some(v):
+                    v
+                case `none:
+                    0
+        "#},
+        Value::Int(3),
+    );
+}
+
+/// A key the register never held answers `` `none `` — the seed's keys and the written one
+/// are what it has, and nothing else.
+#[test]
+fn a_checked_lookup_on_a_register_answers_none_for_an_absent_key() {
+    check_scalar(
+        indoc! {r#"
+            m: Mut(Map(String, Int), Txn) := box(map([("a", 1), ("b", 2)]))
+            for r in [1, 2, 3]:
+                with begin():
+                    m["c"] := 3
+            final: Map(String, Int) = await_final(m)
+            match final["zzz"]?:
+                case `some(v):
+                    v
+                case `none:
+                    0
+        "#},
+        Value::Int(0),
+    );
+}
+
+/// A keyed read at the **loop item** inside a block — the register's snapshot is a per-row
+/// column, so the lookup's collection varies by position.
+///
+/// This is the shape only a transaction produces: `transact_phase` applies the writer body
+/// to a snapshot tuple, so the register arrives as a projection of that tuple rather than as
+/// a free variable, and no eta-reduction makes it closed again. The collection leg being a
+/// projection is what distinguishes it from the same source expression in a comprehension,
+/// where the collection is closed in the loop binder and read once.
+#[test]
+fn a_keyed_read_at_the_loop_item_reads_the_snapshot() {
+    let value = final_mut_var_value(indoc! {r#"
+        def or_zero(o: Option(Int)) => Int:
+            match o:
+                case `some(v):
+                    v
+                case `none:
+                    0
+        m: Mut(Map(Int, Int), Txn) := box(map([(1, 10), (2, 20)]))
+        n: Mut(Int, Txn) := 0
+        for r in [1, 2]:
+            with begin():
+                n := n + or_zero(m[r]?)
+        await_final(n)
+    "#});
+    assert_eq!(value, Value::Int(30));
+}

--- a/tests/compilation_pipeline/transactions.rs
+++ b/tests/compilation_pipeline/transactions.rs
@@ -3094,7 +3094,7 @@ fn a_keyed_write_reaches_an_induction_store() {
 /// == 1, __elem ▷ (… ▷ collection_contains)}` and fails the invariance check on a
 /// collection domain downstream; the arity is the workaround, not part of what this pins.
 ///
-/// Two adjacent shapes are absent because neither is about a keyed collection. A
+/// Two adjacent shapes are absent because neither is about a `Map`. A
 /// *constant* whole-collection write through a parameter (`m := box(map(…))`) reaches
 /// `letrec recognition: decision is not a compose`, which a scalar `c := 5` through a
 /// parameter does too. Transactional pass-by-reference is refused at lowering: a `with

--- a/tests/compilation_pipeline/transactions.rs
+++ b/tests/compilation_pipeline/transactions.rs
@@ -3014,14 +3014,14 @@ fn a_variant_match_inside_a_block_releases_per_commit() {
     assert_eq!(value, Value::Int(3));
 }
 
-/// A `Map`-valued transactional register, read inside a block and never written.
+/// A `Map`-valued transactional mutable variable, read inside a block and never written.
 ///
-/// The register's value type is the abstract map `Σ (𝐷 : SubtypesOf(𝐾)). 𝐷 ⤇ 𝑉`, so the whole path
-/// from seed to store runs on a sum: the seed's introduction states that type and survives
-/// realization, entering the sum compiles to the identity, and the seed drains to one map
+/// The mutable variable's value type is the abstract map `Σ (𝐷 : SubtypesOf(𝐾)). 𝐷 ⤇ 𝑉`, so the
+/// whole path from seed to store runs on a sum: the seed's introduction states that type and
+/// survives realization, entering the sum compiles to the identity, and the seed drains to one map
 /// cell rather than to a scalar.
 #[test]
-fn a_map_valued_register_reads_inside_a_block() {
+fn a_map_valued_mut_var_reads_inside_a_block() {
     let value = final_mut_var_value(indoc! {r#"
         m: Mut(Map(String, Int), Txn) := box(map([("a", 1), ("b", 2)]))
         n: Mut(Int, Txn) := 0
@@ -3037,7 +3037,7 @@ fn a_map_valued_register_reads_inside_a_block() {
 /// A keyed write `m[k] := v` reaching a transactional store.
 ///
 /// The write denotes the whole-value write `m := insert(m, k, v)`
-/// ([`cambra::ccl::Builtin::Insert`]), so the register's history stays an ordinary
+/// ([`cambra::ccl::Builtin::Insert`]), so the mutable variable's history stays an ordinary
 /// overwrite one and the store holds the collection it names. Asserting the *value* is what
 /// makes this more than a compile check: the seed's two keys survive and the written key
 /// joins them, so neither the seed nor the write replaced the other.
@@ -3087,43 +3087,6 @@ fn keyed_writes_at_distinct_keys_compose_across_transactions() {
     );
 }
 
-/// A keyed write whose **key and value are both computed**, on the transactional domain.
-///
-/// Every other keyed write in these tests has a literal right-hand side, and the
-/// transactional ones a literal key besides — which matters because the `Txn` path is where
-/// the value type is read off the binder rather than the seed (`transact_phase`,
-/// `plan_loops::recognize_txn_group`), so a constant key and a constant value exercise
-/// neither half of that. Here the key is the loop binder and the value reads another mutable
-/// variable written earlier in the same transaction, so the write's key slot and its value
-/// slot both carry a type nothing else in the program states.
-///
-/// It is also the shape that survives constant folding. A program whose seed, key and value
-/// are all literals can be settled at compile time, and when that pass lands
-/// (`src/ccl/design/collections.md`, "Constructor lowering: runtime `groupby` now,
-/// constant-folding later") the all-literal cases stop reaching the runtime path while
-/// staying green. This one cannot be folded.
-///
-/// The key still ranges over a literal extent. A key off a request stream — the storefront's
-/// `inventory[req.body.sku] := stock - qty` — has none, and no test reaches that yet.
-#[test]
-fn a_keyed_write_commits_a_computed_value_at_a_computed_key() {
-    let value = final_mut_var_value(indoc! {r#"
-        m: Mut(Map(Int, Int), Txn) := box(map([(1, 10), (2, 20)]))
-        n: Mut(Int, Txn) := 0
-        for x in [3, 4]:
-            with begin():
-                n := n + 1
-                m[x] := n + 1
-        await_final(m)
-    "#});
-    // `n` advances with the loop and the write reads it after its own update in the same
-    // transaction, so the two keys take different values.
-    assert_eq!(
-        map_entries_int(&value),
-        vec![(1, 10), (2, 20), (3, 2), (4, 3)]
-    );
-}
-
 /// A keyed write over an **induction** domain.
 ///
 /// The key is the **loop binder**, which is what makes this more than the transactional
@@ -3145,10 +3108,10 @@ fn a_keyed_write_reaches_an_induction_store() {
 }
 
 /// A keyed write through a `Mut` **parameter**: `fw(m, x)` writes one key of the caller's
-/// register, the pass-by-reference shape `def fw(c: Mut(Int))` already supports for a
+/// mutable variable, the pass-by-reference shape `def fw(c: Mut(Int))` already supports for a
 /// scalar accumulator.
 ///
-/// The write crosses a function boundary, so the register's own value type is what the
+/// The write crosses a function boundary, so the mutable variable's own value type is what the
 /// write is typed against — the parameter binder carries `Mut(Σ (σ : SubtypesOf(Int)). (σ
 /// ⤇ Int), _)`, not the seed's concrete key domain — and `desugar_keyed_writes` reads that
 /// binder as well as the `MutDecl`, both being binders of a mutable variable.
@@ -3215,7 +3178,7 @@ fn map_entries_int(v: &Value) -> Vec<(i64, i64)> {
 /// A keyed write and a keyed read, round trip: `m[k] := v` commits and `m[k]?` reads it
 /// back. This is the pair that makes a mutable collection usable rather than write-only.
 ///
-/// The read goes through the **materialized** path in `CheckedLookup`: a register holds its
+/// The read goes through the **materialized** path in `CheckedLookup`: a mutable variable holds its
 /// collection as one map value at one store key, so the lookup searches that value's
 /// bindings rather than a domain column. A map value carries its own bindings, so it is
 /// complete wherever it is present and absence needs no terminality wait.
@@ -3238,10 +3201,10 @@ fn a_keyed_write_reads_back_through_a_checked_lookup() {
     );
 }
 
-/// A key the register never held answers `` `none `` — the seed's keys and the written one
+/// A key the mutable variable never held answers `` `none `` — the seed's keys and the written one
 /// are what it has, and nothing else.
 #[test]
-fn a_checked_lookup_on_a_register_answers_none_for_an_absent_key() {
+fn a_checked_lookup_on_a_mut_var_answers_none_for_an_absent_key() {
     check_scalar(
         indoc! {r#"
             m: Mut(Map(String, Int), Txn) := box(map([("a", 1), ("b", 2)]))
@@ -3259,14 +3222,14 @@ fn a_checked_lookup_on_a_register_answers_none_for_an_absent_key() {
     );
 }
 
-/// A keyed read at the **loop item** inside a block — the register's snapshot is a per-row
+/// A keyed read at the **loop item** inside a block — the mutable variable's snapshot is a per-row
 /// column, so the lookup's collection varies by position.
 ///
-/// This is the shape only a transaction produces: `transact_phase` applies the writer body
-/// to a snapshot tuple, so the register arrives as a projection of that tuple rather than as
-/// a free variable, and no eta-reduction makes it closed again. The collection leg being a
-/// projection is what distinguishes it from the same source expression in a comprehension,
-/// where the collection is closed in the loop binder and read once.
+/// This is the shape only a transaction produces: `transact_phase` applies the writer body to a
+/// snapshot tuple, so the mutable variable arrives as a projection of that tuple rather than as a
+/// free variable, and no eta-reduction makes it closed again. The collection leg being a projection
+/// is what distinguishes it from the same source expression in a comprehension, where the
+/// collection is closed in the loop binder and read once.
 #[test]
 fn a_keyed_read_at_the_loop_item_reads_the_snapshot() {
     let value = final_mut_var_value(indoc! {r#"
@@ -3284,4 +3247,41 @@ fn a_keyed_read_at_the_loop_item_reads_the_snapshot() {
         await_final(n)
     "#});
     assert_eq!(value, Value::Int(30));
+}
+
+/// A keyed write whose **key and value are both computed**, on the transactional domain.
+///
+/// Every other keyed write in these tests has a literal right-hand side, and the
+/// transactional ones a literal key besides — which matters because the `Txn` path is where
+/// the value type is read off the binder rather than the seed (`transact_phase`,
+/// `plan_loops::recognize_txn_group`), so a constant key and a constant value exercise
+/// neither half of that. Here the key is the loop binder and the value reads another mutable
+/// variable written earlier in the same transaction, so the write's key slot and its value
+/// slot both carry a type nothing else in the program states.
+///
+/// It is also the shape that survives constant folding. A program whose seed, key and value
+/// are all literals can be settled at compile time, and when that pass lands
+/// (`src/ccl/design/collections.md`, "Constructor lowering: runtime `groupby` now,
+/// constant-folding later") the all-literal cases stop reaching the runtime path while
+/// staying green. This one cannot be folded.
+///
+/// The key still ranges over a literal extent. A key off a request stream — the storefront's
+/// `inventory[req.body.sku] := stock - qty` — has none, and no test reaches that yet.
+#[test]
+fn a_keyed_write_commits_a_computed_value_at_a_computed_key() {
+    let value = final_mut_var_value(indoc! {r#"
+        m: Mut(Map(Int, Int), Txn) := box(map([(1, 10), (2, 20)]))
+        n: Mut(Int, Txn) := 0
+        for x in [3, 4]:
+            with begin():
+                n := n + 1
+                m[x] := n + 1
+        await_final(m)
+    "#});
+    // `n` advances with the loop and the write reads it after its own update in the same
+    // transaction, so the two keys take different values.
+    assert_eq!(
+        map_entries_int(&value),
+        vec![(1, 10), (2, 20), (3, 2), (4, 3)]
+    );
 }

--- a/tests/compilation_pipeline/transactions.rs
+++ b/tests/compilation_pipeline/transactions.rs
@@ -3080,6 +3080,41 @@ fn a_keyed_write_reaches_an_induction_store() {
     );
 }
 
+/// A keyed write through a `Mut` **parameter**: `fw(m, x)` writes one key of the caller's
+/// register, the pass-by-reference shape `def fw(c: Mut(Int))` already supports for a
+/// scalar accumulator.
+///
+/// The write crosses a function boundary, so the register's own value type is what the
+/// write is typed against — the parameter binder carries `Mut(Σ (σ : SubtypesOf(Int)). (σ
+/// ⤇ Int), _)`, not the seed's concrete key domain — and `desugar_keyed_writes` reads that
+/// binder as well as the `MutDecl`, both being binders of a mutable variable.
+///
+/// The seed holds **two** entries deliberately. A single-entry `map(…)` literal resolves
+/// its key type to that key's own singleton, so the present-key domain reads `{Int | __elem
+/// == 1, __elem ▷ (… ▷ collection_contains)}` and fails the invariance check on a
+/// collection domain downstream; the arity is the workaround, not part of what this pins.
+///
+/// Two adjacent shapes are absent because neither is about a keyed collection. A
+/// *constant* whole-collection write through a parameter (`m := box(map(…))`) reaches
+/// `letrec recognition: decision is not a compose`, which a scalar `c := 5` through a
+/// parameter does too. Transactional pass-by-reference is refused at lowering: a `with
+/// begin():` block takes writes, bindings, guards and feeds, not a call.
+#[test]
+fn a_keyed_write_through_a_mut_parameter() {
+    let value = final_mut_var_value(indoc! {r#"
+        def fw(m: Mut(Map(Int, Int)), k: Int):
+            m[k] := 1
+        m: Mut(Map(Int, Int)) := box(map([(1, 10), (2, 20)]))
+        for x in [3, 4]:
+            fw(m, x)
+        m
+    "#});
+    assert_eq!(
+        map_entries_int(&value),
+        vec![(1, 10), (2, 20), (3, 1), (4, 1)]
+    );
+}
+
 /// A map value's bindings, key-sorted — a `Value::Function`'s order follows construction,
 /// which is not what a test about *contents* should depend on.
 fn map_entries(v: &Value) -> Vec<(String, i64)> {

--- a/tests/compilation_pipeline/transactions.rs
+++ b/tests/compilation_pipeline/transactions.rs
@@ -3060,6 +3060,33 @@ fn a_keyed_write_reaches_a_transactional_store() {
     );
 }
 
+/// Two transactions writing **different** keys of one map, both landing.
+///
+/// The sibling above rewrites one key, so a transaction computing its write from the seed
+/// instead of from the previous transaction's collection would produce the same answer
+/// there. Here it would not: `m` is in each writer's read footprint because
+/// `desugar_keyed_writes` rewrote the write to `m := insert(m, k, v)`, and that is what
+/// carries key `3` past the transaction that writes key `4`.
+///
+/// This is the whole-collection footprint's own coverage. Narrowing it to the written key
+/// is future work (`src/ccl/design/mutability.md`, "Future work"), and its failure mode is
+/// silent — a narrowed writer that reads too little still commits, just from a stale
+/// collection — so this case has to keep passing across that change.
+#[test]
+fn keyed_writes_at_distinct_keys_compose_across_transactions() {
+    let value = final_mut_var_value(indoc! {r#"
+        m: Mut(Map(Int, Int), Txn) := box(map([(1, 10), (2, 20)]))
+        for x in [3, 4]:
+            with begin():
+                m[x] := 99
+        await_final(m)
+    "#});
+    assert_eq!(
+        map_entries_int(&value),
+        vec![(1, 10), (2, 20), (3, 99), (4, 99)]
+    );
+}
+
 /// A keyed write over an **induction** domain.
 ///
 /// The key is the **loop binder**, which is what makes this more than the transactional

--- a/tests/compilation_pipeline/transactions.rs
+++ b/tests/compilation_pipeline/transactions.rs
@@ -3087,6 +3087,43 @@ fn keyed_writes_at_distinct_keys_compose_across_transactions() {
     );
 }
 
+/// A keyed write whose **key and value are both computed**, on the transactional domain.
+///
+/// Every other keyed write in these tests has a literal right-hand side, and the
+/// transactional ones a literal key besides — which matters because the `Txn` path is where
+/// the value type is read off the binder rather than the seed (`transact_phase`,
+/// `plan_loops::recognize_txn_group`), so a constant key and a constant value exercise
+/// neither half of that. Here the key is the loop binder and the value reads another mutable
+/// variable written earlier in the same transaction, so the write's key slot and its value
+/// slot both carry a type nothing else in the program states.
+///
+/// It is also the shape that survives constant folding. A program whose seed, key and value
+/// are all literals can be settled at compile time, and when that pass lands
+/// (`src/ccl/design/collections.md`, "Constructor lowering: runtime `groupby` now,
+/// constant-folding later") the all-literal cases stop reaching the runtime path while
+/// staying green. This one cannot be folded.
+///
+/// The key still ranges over a literal extent. A key off a request stream — the storefront's
+/// `inventory[req.body.sku] := stock - qty` — has none, and no test reaches that yet.
+#[test]
+fn a_keyed_write_commits_a_computed_value_at_a_computed_key() {
+    let value = final_mut_var_value(indoc! {r#"
+        m: Mut(Map(Int, Int), Txn) := box(map([(1, 10), (2, 20)]))
+        n: Mut(Int, Txn) := 0
+        for x in [3, 4]:
+            with begin():
+                n := n + 1
+                m[x] := n + 1
+        await_final(m)
+    "#});
+    // `n` advances with the loop and the write reads it after its own update in the same
+    // transaction, so the two keys take different values.
+    assert_eq!(
+        map_entries_int(&value),
+        vec![(1, 10), (2, 20), (3, 2), (4, 3)]
+    );
+}
+
 /// A keyed write over an **induction** domain.
 ///
 /// The key is the **loop binder**, which is what makes this more than the transactional

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -5625,3 +5625,66 @@ fn checked_lookup_on_a_map_answers_the_value() {
         "a String key must not reach an Int-keyed map"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Keyed writes: `m[k] := v`
+// ---------------------------------------------------------------------------
+
+/// A keyed write is **application on the left of the assignment**: the collection at
+/// the key names the codomain the written value must satisfy, so `m[k]` means the same
+/// type whether it is read or written. Both sequencing domains take one, the domain
+/// being a property of the register rather than of the write.
+#[rstest]
+#[case::induction(indoc! {r#"
+    m: Mut(Map(Int, Int)) := box(map([(1, 10), (2, 20)]))
+    for x in [1, 2, 3]:
+        m[x] := 99
+    0
+"#})]
+#[case::transactional(indoc! {r#"
+    m: Mut(Map(String, Int), Txn) := box(map([("a", 1), ("b", 2)]))
+    for r in [1, 2, 3]:
+        with begin():
+            m["c"] := 3
+    0
+"#})]
+fn a_keyed_write_types_against_the_collection(#[case] code: &str) {
+    assert_eq!(infer_program(code).to_string(), "Int@0");
+}
+
+/// The key is checked against the collection's **key type** and the value against its
+/// **codomain**, and the two obligations are separate: each names which half of the
+/// write is wrong.
+#[rstest]
+#[case::wrong_key("m[7] := 3", "keyed write key of `m`")]
+#[case::wrong_value("m[\"c\"] := \"nope\"", "keyed write to mutable variable `m`")]
+fn a_keyed_write_checks_key_and_value_separately(#[case] write: &str, #[case] expected: &str) {
+    let code = format!(
+        "m: Mut(Map(String, Int), Txn) := box(map([(\"a\", 1), (\"b\", 2)]))\n\
+         for r in [1, 2, 3]:\n    with begin():\n        {write}\n0\n"
+    );
+    let errs = infer_program_err(&code);
+    assert!(
+        format!("{errs:?}").contains(expected),
+        "expected `{expected}` in {errs:?}"
+    );
+}
+
+/// Writing a key of something that is not a keyed collection needs the target's type,
+/// and a mutable variable's value type is still open where the rule runs. So the
+/// diagnostic names the missing resolution rather than reporting a shape mismatch —
+/// the same boundary the checked lookup has through a parameter
+/// (`checked_lookup_boundaries`).
+#[test]
+fn a_keyed_write_needs_the_collection_s_type() {
+    let errs = infer_program_err(indoc! {r#"
+        t := 0
+        for x in [1, 2, 3]:
+            t[x] := 1
+        0
+    "#});
+    assert!(
+        format!("{errs:?}").contains("is not resolved yet"),
+        "expected the unresolved-target diagnostic, got {errs:?}"
+    );
+}

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -5633,7 +5633,7 @@ fn checked_lookup_on_a_map_answers_the_value() {
 /// A keyed write is **application on the left of the assignment**: the collection at
 /// the key names the codomain the written value must satisfy, so `m[k]` means the same
 /// type whether it is read or written. Both sequencing domains take one, the domain
-/// being a property of the register rather than of the write.
+/// being a property of the mutable variable rather than of the write.
 #[rstest]
 #[case::induction(indoc! {r#"
     m: Mut(Map(Int, Int)) := box(map([(1, 10), (2, 20)]))

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -5670,7 +5670,7 @@ fn a_keyed_write_checks_key_and_value_separately(#[case] write: &str, #[case] ex
     );
 }
 
-/// Writing a key of something that is not a keyed collection needs the target's type,
+/// Writing a key of something that is not a `Map` needs the target's type,
 /// and a mutable variable's value type is still open where the rule runs. So the
 /// diagnostic names the missing resolution rather than reporting a shape mismatch —
 /// the same boundary the checked lookup has through a parameter


### PR DESCRIPTION
CHL could declare a mutable `Map` and replace it wholesale, but not write one key: `m[k] := v` had no assignment target, no typing rule, and no runtime. This adds it on both sequencing domains — a loop's induction store and a `with begin():` transaction — by rewriting the write to what it denotes, `m := insert(m, k, v)`, before any phase that builds a recurrence. A mutable collection is now written and read back in one program, and the whole collection is the unit of commit: two transactions touching one map conflict whatever keys they touch.

## The write

`AssignTarget::Subscript` holds the collection and the key as expressions, and only `:=` takes one: every other statement form rejects it at lowering, and `m[k]? := v` is refused in target position. Typing is one rule with the checked lookup, so `m[k]` names the same value type read or written — the key against the key type, the value against the codomain, a key-dependent codomain rejected.

`MutWrite` gains `key: Option<Box<TypedExpr>>`, and its lifetime is one window: lowering mints it, `mut_elim::desugar_keyed_writes` erases it at the head of the transact phase, so every phase below sees one write shape. Within that window `walk_children`/`walk_children_mut` reach the key, carrying every pass built on them; the walks that hand-roll their own match are extended alongside, and `scope.rs`'s corpus instance stays `key: None`, so its child-agreement assertion never sees a keyed write.

## The abstract map type

A `Mut(Map(K, V), _)` binder holds a sum, so a concrete seed reaches it through a `box` introduction, not a subtyping edge ([type-inference.md](src/ccl/design/type-inference.md#only-a-term-builds-a-sum)); op-conversion compiles that box to the identity. `transact_phase` now reads a mutable variable's value type off that binder and `recognize_txn_group` off the history binding's codomain, in place of deriving it from the seed. A seed is one contribution to that type: a map seeded at two keys and written at a third holds more. Reading the binder is what lets `mut_var_value_ty` stop stripping refinements.

## Reading it back

A mutable variable holds its collection as one materialized map value, so `CheckedLookup` answers from that value's bindings rather than from a domain column, and gains a second operand shape for the `(collection, key)` rows a transaction's snapshot tuple produces. A store seeds itself from a collection init. Store keys become a tagged sum, one arm per mutable variable and per reply tap, replacing a bare `String`; every arm is `Unit` today, and the tag is what will keep a keyed variable's keys from aliasing another variable's name.

## Tests and docs

Nine pipeline tests cover both domains, a write through a `Mut` parameter, a read-back through `m[k]?`, and a computed key with a computed value; `type_check.rs` pins the key and value obligations separately. `keyed_writes_at_distinct_keys_compose_across_transactions` is what the whole-collection footprint buys, and has to survive [narrowing it](src/ccl/design/mutability.md#future-work). The type itself is stated in [mutability.md](src/ccl/design/mutability.md#a-mutable-collections-key-set-varies-with-the-position).