### PR TITLE
Drop the stray bracket a curried tiling renders

### DIFF
--- a/src/interpreter/tiling/tiling_kind.rs
+++ b/src/interpreter/tiling/tiling_kind.rs
@@ -235,7 +235,7 @@ impl fmt::Display for Tiling {
                 domain2,
                 codomain,
             } => {
-                write!(f, "CF({domain1:?} → {domain2:?} → {codomain:?}])")
+                write!(f, "CF({domain1:?} → {domain2:?} → {codomain:?})")
             }
             Tiling::Aggregation { kind, accumulator } => {
                 write!(f, "agg({kind:?}, {accumulator:?})")
@@ -543,12 +543,12 @@ mod tests {
     }
 
     #[test]
-    fn display_lookup_function() {
+    fn display_curried_function() {
+        // The whole rendering, not a substring: a `[` test passes on the range
+        // domain whichever way the brackets fall, which is how an unbalanced
+        // one survived here.
         let s = curried(range(4), int(), bool_ext()).to_string();
-        assert!(
-            s.contains("→") && s.contains('['),
-            "expected '→ [' in '{s}'"
-        );
+        assert_eq!(s, "CF({[0, 3]} → Int → Bool)");
     }
 
     #[test]


### PR DESCRIPTION
`Display for Tiling` prints `CF(A → B → C])`: the format string opens `CF(` and closes with `])`, so every `CurriedFunction` renders a bracket that closes nothing.

The `]` is a leftover. Before the rename of `LookupFunction` to `CurriedFunction`, the arm read `"{domain:?} → [{codomain:?}]"` — a balanced pair around the codomain. The rename added the `CF(` prefix and a second domain, dropped the opening `[`, and kept the close.

That rendering is the wire's `tiling` field, so it reaches every consumer: 19 operator nodes across `groupby_rollup`, `groupby_filtered_rollup`, `inner_join` and `join_then_groupby`, the inspector's operator pane, `--dump-snapshot`, and the pane's copy button. No committed fixture carries a curried tiling, so the golden corpus does not move.

`display_lookup_function` asserted only that the rendering contains `[`, which the range domain the case builds satisfies whichever way the brackets fall — which is why the typo outlived it. It now pins the whole string, and takes the name of the type it covers.
