### PR TITLE
Gate against an item inserted into another item's doc block

### DIFF
--- a/.github/scripts/doc-adoption.py
+++ b/.github/scripts/doc-adoption.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Fail on an item inserted at the bottom of another item's doc block.
+
+The inserted item adopts the doc above it and the item it displaced is left
+undocumented. Both halves are silent: the new item reads as documented, and the
+displaced one is only missing a comment.
+
+The signature is in the diff, not the file. A run of added lines that begins with
+a comment line, whose immediately-preceding context line is also a comment line,
+and that declares an item. An item added *after* an existing one anchors on the
+blank line or the closing brace above it, so it never matches; only an item
+inserted *into* a doc block does.
+
+Scanning per commit rather than the branch diff: a region rewritten by a later
+commit hides the insertion in the squashed diff.
+
+Suppress a deliberate merge with `doc-adoption-ok` on any line of the added run.
+"""
+
+import re
+import subprocess
+import sys
+
+ITEM = {
+    "rs": re.compile(
+        r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:default\s+)?(?:async\s+)?(?:unsafe\s+)?"
+        r'(?:extern\s+"[^"]*"\s+)?(?:fn|enum|struct|trait|impl|type|const|static|mod|union)\b'
+    ),
+    "ts": re.compile(
+        r"^\s*(?:export\s+)?(?:default\s+)?(?:async\s+)?"
+        r"(?:function|class|interface|type|const|enum)\b"
+    ),
+}
+DOC = {"rs": re.compile(r"^\s*(?:///|//!)"), "ts": re.compile(r"^\s*//")}
+ATTR = re.compile(r"^\s*(?:#\[|@)")
+SUPPRESS = "doc-adoption-ok"
+
+
+def lang(path):
+    if path.endswith(".rs"):
+        return "rs"
+    if path.endswith((".ts", ".tsx")):
+        return "ts"
+    return None
+
+
+def scan(diff):
+    """Every (path, context_line, item_line) the diff inserts into a doc block."""
+    hits, path, kind, ctx = [], None, None, None
+    lines = diff.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("+++ b/"):
+            path = line[6:]
+            kind, ctx = lang(path), None
+        elif line.startswith("@@"):
+            ctx = None
+        elif kind and line.startswith("+") and not line.startswith("+++"):
+            run, j = [], i
+            while j < len(lines) and lines[j].startswith("+") and not lines[j].startswith("+++"):
+                run.append(lines[j][1:])
+                j += 1
+            inserted_into_doc = ctx is not None and DOC[kind].match(ctx) and DOC[kind].match(run[0])
+            if inserted_into_doc and not any(SUPPRESS in r for r in run):
+                for n, row in enumerate(run):
+                    if not ITEM[kind].match(row) or DOC[kind].match(row):
+                        continue
+                    m = n - 1
+                    while m >= 0 and ATTR.match(run[m]):
+                        m -= 1
+                    if m >= 0 and DOC[kind].match(run[m]):
+                        hits.append((path, ctx.strip(), row.strip()))
+                    break
+            i, ctx = j, None
+            continue
+        elif kind and line.startswith(" "):
+            ctx = line[1:]
+        elif kind and line.startswith("-"):
+            ctx = None
+        i += 1
+    return hits
+
+
+def main(base, tip):
+    revs = subprocess.run(
+        ["git", "rev-list", f"{base}..{tip}"], capture_output=True, text=True, check=True
+    ).stdout.split()
+    found = 0
+    for rev in revs:
+        diff = subprocess.run(
+            ["git", "show", "--unified=3", "--no-color", "--format=", rev],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        for path, ctx, item in scan(diff):
+            found += 1
+            print(
+                f"{path}: `{item}` was inserted under the doc block ending\n"
+                f"    {ctx}\n"
+                f"  which documents the item below it. Split the block: the new item takes\n"
+                f"  its own doc and the displaced item keeps the one it had ({rev[:9]})."
+            )
+    if found:
+        print(f"\ndoc-adoption: {found} adopted doc block(s).")
+        return 1
+    print(f"doc-adoption OK: {len(revs)} commit(s) checked.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(
+        main(
+            sys.argv[1] if len(sys.argv) > 1 else "origin/main",
+            sys.argv[2] if len(sys.argv) > 2 else "HEAD",
+        )
+    )

--- a/.github/scripts/test_doc_adoption.py
+++ b/.github/scripts/test_doc_adoption.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for `doc-adoption.py`'s diff scan.
+
+Each case is a unified diff, because the defect is a property of the diff and not
+of the file: the same final text is a defect when it arrived by insertion into a
+doc block and fine when the block was written for it.
+"""
+
+import importlib.util
+import pathlib
+import unittest
+
+_spec = importlib.util.spec_from_file_location(
+    "doc_adoption", pathlib.Path(__file__).with_name("doc-adoption.py")
+)
+doc_adoption = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(doc_adoption)
+scan = doc_adoption.scan
+
+
+def diff(path, body):
+    return f"--- a/{path}\n+++ b/{path}\n@@ -1,3 +1,9 @@\n{body}"
+
+
+class ScanTest(unittest.TestCase):
+    def test_item_inserted_into_a_doc_block_is_reported(self):
+        d = diff(
+            "src/a.rs",
+            " /// Compile the thing.\n"
+            " ///\n"
+            "+/// What a binding compiles to.\n"
+            "+enum LetBinding {}\n"
+            "+\n"
+            " /// The rest of the original doc.\n"
+            " fn compile() {}\n",
+        )
+        hits = scan(d)
+        self.assertEqual(len(hits), 1)
+        self.assertIn("enum LetBinding", hits[0][2])
+
+    def test_item_appended_after_an_item_is_not_reported(self):
+        d = diff(
+            "src/a.rs",
+            " fn compile() {}\n"
+            " \n"
+            "+/// What a binding compiles to.\n"
+            "+enum LetBinding {}\n",
+        )
+        self.assertEqual(scan(d), [])
+
+    def test_item_with_no_doc_of_its_own_is_not_reported(self):
+        d = diff("src/a.rs", " /// Compile the thing.\n+enum LetBinding {}\n fn compile() {}\n")
+        self.assertEqual(scan(d), [])
+
+    def test_a_wholly_new_file_is_not_reported(self):
+        d = "--- /dev/null\n+++ b/src/a.rs\n@@ -0,0 +1,2 @@\n+/// Doc.\n+fn f() {}\n"
+        self.assertEqual(scan(d), [])
+
+    def test_attributes_between_doc_and_item_are_skipped(self):
+        d = diff(
+            "src/a.rs",
+            " /// Original doc.\n"
+            " ///\n"
+            "+/// New test.\n"
+            "+#[test]\n"
+            "+fn inserted() {}\n"
+            "+\n"
+            " fn displaced() {}\n",
+        )
+        self.assertEqual(len(scan(d)), 1)
+
+    def test_suppression_marker_silences_the_run(self):
+        d = diff(
+            "src/a.rs",
+            " /// Compile the thing.\n"
+            " ///\n"
+            "+/// Deliberate. doc-adoption-ok\n"
+            "+enum LetBinding {}\n"
+            " fn compile() {}\n",
+        )
+        self.assertEqual(scan(d), [])
+
+    def test_typescript_is_scanned(self):
+        d = diff(
+            "web/src/a.ts",
+            " // Validate the node.\n"
+            "+// Validate the spans.\n"
+            "+function validateSpans() {}\n"
+            "+\n"
+            " function validateNode() {}\n",
+        )
+        self.assertEqual(len(scan(d)), 1)
+
+    def test_an_unscanned_language_is_ignored(self):
+        d = diff("docs/a.md", " # Heading\n+# Another\n+text\n")
+        self.assertEqual(scan(d), [])
+
+    def test_a_removed_context_line_does_not_anchor(self):
+        d = diff("src/a.rs", " /// Doc.\n-/// Removed.\n+/// New.\n+fn inserted() {}\n")
+        self.assertEqual(scan(d), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci.sh
+++ b/ci.sh
@@ -178,6 +178,25 @@ ci_doc_refs() {
   python3 .github/scripts/doc-refs/check_doc_refs.py || return 1
 }
 
+# Gate against an item inserted into another item's doc block, which leaves the
+# displaced item undocumented and the new one wearing a doc that describes
+# something else. Reads the diff of each commit on the branch rather than the
+# working tree, because the defect is a property of how the text arrived.
+# Same ordering rule as `ci_doc_refs`: checker tests first, and `|| return 1` per
+# command because `ci_all` disables errexit for this function's extent.
+ci_doc_adoption() {
+  python3 .github/scripts/test_doc_adoption.py || return 1
+  local base="main"
+  if git rev-parse --verify --quiet origin/main >/dev/null; then base="origin/main"; fi
+  # Under `jj` the git HEAD sits at the working copy's parent, so `base..HEAD`
+  # would silently check nothing. Ask jj for the tip when it owns the repo.
+  local tip="HEAD"
+  if command -v jj >/dev/null 2>&1 && jj root >/dev/null 2>&1; then
+    tip="$(jj log -r @ --no-graph -T 'commit_id')"
+  fi
+  python3 .github/scripts/doc-adoption.py "${base}" "${tip}" || return 1
+}
+
 # Gate the interpreter's no-back-channel invariant: operators exchange tiles
 # through `get`, never through shared mutable state (`src/interpreter/CLAUDE.md`).
 # Same ordering rule as `ci_doc_refs`: checker tests first, and `|| return 1` per
@@ -218,6 +237,9 @@ ci_all() {
   # shellcheck disable=SC2310
   # intentional: || captures failure without exiting
   ci_doc_refs || failed="${failed} doc_refs"
+  # shellcheck disable=SC2310
+  # intentional: || captures failure without exiting
+  ci_doc_adoption || failed="${failed} doc_adoption"
   # shellcheck disable=SC2310
   # intentional: || captures failure without exiting
   ci_shared_state || failed="${failed} shared_state"

--- a/src/ccl/infer/api.rs
+++ b/src/ccl/infer/api.rs
@@ -3366,6 +3366,7 @@ mod tests {
         );
     }
 
+    /// Corrupting a `BoolLogic` operand type away from `Bool` is caught by `typecheck`.
     #[test]
     fn test_typecheck_bool_logic_wrong_operand_type() {
         let mut ctx = TypeInferenceContext::new();

--- a/src/ccl/infer/solve.rs
+++ b/src/ccl/infer/solve.rs
@@ -2137,6 +2137,13 @@ fn recovered_input(domain: &Type, input: &Type) -> Type {
     }
 }
 
+/// Specialize a projection morphism's domain to the value flowing into it — the
+/// projection sibling of [`specialize_lambda_domain`].
+///
+/// A projection's domain coalesces to what the projection reads, which is
+/// narrower than the value the use site supplies, so the domain is recovered
+/// structurally once that value is known. A morphism that is not a `Proj` keeps
+/// the type it has.
 pub(super) fn specialize_projection_domain(morphism: &mut Expr, input: &Type) {
     if matches!(morphism.node, TypedExprNode::Proj(_))
         && let Some(dom) = morphism.ty.domain()

--- a/src/ccl/infer/solver/scheme.rs
+++ b/src/ccl/infer/solver/scheme.rs
@@ -232,6 +232,10 @@ fn freshen_level(ty: &Type) -> Level {
     lvl
 }
 
+/// Copy `ty` with every variable introduced above `lim` replaced by a fresh one
+/// at `target`, reusing `cache` so a variable reached twice freshens once.
+///
+/// A type wholly at or below `lim` is returned unchanged.
 pub fn freshen_above(
     lim: Level,
     ty: &Type,

--- a/src/ccl/transact_phase.rs
+++ b/src/ccl/transact_phase.rs
@@ -617,15 +617,6 @@ struct FeedSite {
     value_ty: Type,
 }
 
-/// Rewrite every `with begin():` writer of a `Mut(_, Txn)` mutable variable into one shared
-/// commit `Transact`. A no-op (returns the input untouched) on programs that
-/// write no transactional mutable variable.
-///
-/// `txn_mut_vars` is the set of α-unique mutable variable [`Name`]s — the `Mut(_, Txn)`
-/// bindings on the inlined, typed tree (see
-/// [`collect_txn_mut_vars`]). Keying on the exact binder identity (not the surface
-/// base name) makes the fold immune to an unrelated local variable merely
-/// *spelled* like a mutable variable.
 /// One commit store's writer sites and their in-block feeds, as [`run`] collects
 /// them before the store is planned.
 ///
@@ -636,6 +627,15 @@ struct FeedSite {
 /// the two vectors stay index-parallel.
 type StoreWriters = (Vec<(NodeId, WriterSite)>, Vec<Vec<FeedSite>>);
 
+/// Rewrite every `with begin():` writer of a `Mut(_, Txn)` mutable variable into one shared
+/// commit `Transact`. A no-op (returns the input untouched) on programs that
+/// write no transactional mutable variable.
+///
+/// `txn_mut_vars` is the set of α-unique mutable variable [`Name`]s — the `Mut(_, Txn)`
+/// bindings on the inlined, typed tree (see
+/// [`collect_txn_mut_vars`]). Keying on the exact binder identity (not the surface
+/// base name) makes the fold immune to an unrelated local variable merely
+/// *spelled* like a mutable variable.
 pub fn run(expr: Expr, txn_mut_vars: &HashSet<Name>) -> Result<Expr, String> {
     // Strip whenever a `with begin():` block is present. A block need not write a
     // transactional mutable variable — a read-only block (`out << balance`) has no write

--- a/tests/compilation_pipeline/sources_incremental.rs
+++ b/tests/compilation_pipeline/sources_incremental.rs
@@ -611,7 +611,9 @@ o";
     );
 }
 
-/// `MapAggregate`.  Verifies that the induction cycle correctly:
+/// Mutation loop summing values from an incremental source, semantically
+/// equivalent to `sum(source1())` but exercising the induction cycle instead of
+/// `MapAggregate`. Verifies that the induction cycle correctly:
 /// - Re-reads its `domain` input as the source grows in batches.
 /// - Holds back the final emission until the source signals it's done.
 /// - Fires notifications when each batch arrives and again on terminal.

--- a/tests/predicate_sharing.rs
+++ b/tests/predicate_sharing.rs
@@ -170,6 +170,8 @@ fn a_cast_target_does_not_carry_its_value_s_refinements() {
     );
 }
 
+/// A comprehension nested in another's source keeps each distinct filter
+/// predicate as one `Rc`, at both depths.
 #[test]
 fn nested_comprehension_shares_predicate_rcs() {
     assert_no_split(


### PR DESCRIPTION
An item added at the bottom of an existing doc block adopts that doc and leaves the item below it undocumented. Nothing catches this today: the finished file reads as documented, and only the diff shows what happened. This adds `.github/scripts/doc-adoption.py`, a per-commit diff scan wired into `ci.sh` as `ci_doc_adoption`, and repairs the six blocks already merged that way.

Start with the script's module docstring for the diff signature it matches and the `doc-adoption-ok` suppression marker; `.github/scripts/test_doc_adoption.py` pins `scan` against nine diffs, including the appended-item and new-file cases that must stay quiet. The `ci.sh` comment covers the `jj` tip lookup — under `jj` the git `HEAD` is the working copy's parent, so `main..HEAD` would check nothing. The doc repairs span `src/ccl/` and `tests/`; only `src/ccl/transact_phase.rs` needed a move, where the `StoreWriters` alias had landed inside `run`'s doc block.
