### PR TITLE
Read both sides at an invariant position however the walk reached it

### DIFF
--- a/docs/chl-spec.md
+++ b/docs/chl-spec.md
@@ -138,8 +138,8 @@ where
 ```
 
 `where` is the refinement predicate separator (§6.4). It is lexed so the name is
-**reserved** — refinements are not parsed yet, so every use is a parse error
-today.
+**reserved**: a bare `where` is a keyword rather than an identifier. The refinement
+syntax itself is parsed, in every annotation position that takes a type (§6.4).
 
 `with` is a keyword: it introduces a transaction block, `with begin():`
 (§8.2). It does **not** carry Python's general context-manager meaning.
@@ -978,10 +978,11 @@ n-arg call.
 
 Parameters are bare identifiers today. Because `->` (not `:`) terminates
 the binder list, `:` is free for a per-parameter annotation `\x: T -> body`
-(**[Planned]** — not yet parsed); refinement annotations are likewise not
-writable, though some built-ins (e.g. `groupby`, §7.2) produce refined
-lambdas internally. `\x -> x -> 1` (a lambda returning a pair, §2.4) is
-unusual but unambiguous — the first `->` closes the binder, the rest is
+(**[Planned]** — not yet parsed), which is also what makes a refinement
+unwritable on a *lambda* parameter; one parses on a `def` parameter, on a
+`def` result, and in a binding's annotation (§6.4). Some built-ins (e.g.
+`groupby`, §7.2) produce refined lambdas internally. `\x -> x -> 1` (a lambda
+returning a pair, §2.4) is unusual but unambiguous — the first `->` closes the binder, the rest is
 body.
 
 ### 3.11 List, tuple, record literals

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -365,25 +365,33 @@ and the marker then claims the remainder is exhaustive. No program observes the 
 a default arm being compiled from the `Case` (`test_default_arm_under_a_record_field`); the
 reading itself is pinned by `a_settled_negative_position_closes_an_open_child_demand`.
 
-**The merge is gated as if it were the collapse, and one variable therefore has two readings
-at one polarity.** `fallback_allowed` answers both, so a variable entered as a position reads
-the merge while the same variable reached through another variable's bound chain reads the
-demand side alone. Only the collapse needs that gate: a choice does not propagate along
-subtyping edges, and a narrowing does. What the difference leaves open is a mutable `Map`
-seeded with a one-entry literal — `box`'s instantiated domain reaches the key variable
-through a chain and keeps the bare reading, which invariance then rejects against the
-singleton the seed establishes (`a_one_entry_seed_does_not_reach_a_mutable_map`).
+##### An invariant position reads both sides however the walk reached it
 
-Ungating the merge closes that shape and costs two things it does not pay for. Reading the
-opposite side at every negative variable compacts it in full there, so the walk doubles per
-level of type nesting — `def by_key(c, f): groupby(c, f)` applied at two types goes from 1.4s
-to 10s. And where a discharge is suspended on the chain, two data domains meet whose
-refinement sets differ only in the spelling of the discharged binder: `{[0, 2] | 𝑥 == 0}`
-against `{[0, 2] | 𝑥 == __arg}`. [`data_domains_disagree`] compares those sets structurally,
-so it reads one domain reached twice as two domains that disagree, and the position has no
-common answer — which `higher_order_dependent_application_discharges_the_binder` reports.
-Forcing the discharge on both contributions before they meet is the prerequisite for letting
-the merge follow a chain.
+Elsewhere the merge fires only at a position, which `fallback_allowed` answers. That gate
+belongs to the collapse: a collapse is a choice, and a choice does not propagate along
+subtyping edges. Applying it to the merge as well gives one variable **two readings at one
+polarity** — the merge where the walk entered it structurally, the demand side alone where it
+arrived along another variable's bound chain — and inside an invariant position there is no
+variance left to tell those readings apart, so the invariance check rejects the position
+against itself.
+
+A mutable `Map` seeded with a one-entry literal is the shape that reaches it. The seed's key
+type is that key's own singleton, and `box`'s scheme shares one variable between its domain
+and the sum's single candidate, so the key domain arrives at that variable through a chain:
+entered as a position it reads the singleton, reached along the chain it reads the bare
+present-key domain, and the two are the collection the program wrote and a wider one.
+`a_one_entry_seed_reads_as_a_map` and its two keyed-write siblings are the three uses.
+
+**Scoped to an invariant position, not ungated.** Reading the opposite side at *every*
+negative variable compacts it in full there, so the walk doubles per level of type nesting —
+`def by_key(c, f): groupby(c, f)` applied at two types goes from 1.4s to 10s, where the
+scoped read costs 1.5s. It also reaches a function-typed **parameter**, which is a compute
+domain: there a suspended discharge puts two data domains together whose refinement sets
+differ only in the discharged binder's spelling, `{[0, 2] | 𝑥 == 0}` against
+`{[0, 2] | 𝑥 == __arg}`, and `data_domains_disagree` compares those sets structurally, so one
+domain reached twice reads as two that disagree
+(`higher_order_dependent_application_discharges_the_binder`). Identifying those two spellings
+is what letting the merge follow *every* chain would need first.
 
 **The gated merge pays a doubling of its own.** The gate confines the merge to the entered
 position, and a structural child *is* an entered position — `compact_go` resets `parents` to

--- a/src/ccl/design/type-inference.md
+++ b/src/ccl/design/type-inference.md
@@ -365,6 +365,23 @@ and the marker then claims the remainder is exhaustive. No program observes the 
 a default arm being compiled from the `Case` (`test_default_arm_under_a_record_field`); the
 reading itself is pinned by `a_settled_negative_position_closes_an_open_child_demand`.
 
+**The gated merge pays a doubling of its own.** The gate confines the merge to the entered
+position, and a structural child *is* an entered position — `compact_go` takes a fresh
+`Position` at every one — so the merge re-opens one nesting level down and the walk doubles per
+contravariant flip. Measured in debug, median of three runs at equal test counts: the whole
+of `tests/type_check.rs` goes from 0.83s to 1.29s, and `test_groupby_key_relation_is_per_occurrence`
+— `def by_key(c, f): groupby(c, f)` at two types, the same program as above — from 0.56s to
+0.94s. `tests/compilation_pipeline` is flat, its time being execution rather than inference.
+
+What is absent is a **result memo**. `CompactState` carries `in_process`, which prunes cycles
+and caches nothing — it is removed again as each variable's walk returns — so a position
+reached twice is compacted twice. A `(uid, pol)` key would not be a correct memo: a position's
+reading also depends on `subst_acc` and on the refinement scope `st.scope` holds, so two
+entries at one variable and polarity are not interchangeable. Hash consing the rendered
+contribution keys on what was produced instead, and sidesteps that.
+
+**Asking the other question.** Because the collapse answers "what must this position be", a caller that needs "what actually reached it" has to suppress the collapse — `compact_type_polarity_only`, the polarity-correct walk alone. The distinction is not academic: an upper bound deposited on a never-inhabited position (the trait-requirement sweep does exactly this) makes the ordinary resolve report a type. [The unobservable-arm pin](#an-unobservable-arm-payload-is-pinned-to-what-its-uses-require) is the caller that must not confuse the two, since a demand is precisely what an unreachable arm can acquire.
+
 ##### An invariant position reads both sides however the walk reached it
 
 Elsewhere the merge fires only at a position, which `fallback_allowed` answers. That gate
@@ -393,28 +410,13 @@ domain reached twice reads as two that disagree
 (`higher_order_dependent_application_discharges_the_binder`). Identifying those two spellings
 is what letting the merge follow *every* chain would need first.
 
-**The gated merge pays a doubling of its own.** The gate confines the merge to the entered
-position, and a structural child *is* an entered position — `compact_go` resets `parents` to
-`None` at every one — so the merge re-opens one nesting level down and the walk doubles per
-contravariant flip. Measured in debug, median of three runs at equal test counts: the whole
-of `tests/type_check.rs` goes from 0.83s to 1.29s, and `test_groupby_key_relation_is_per_occurrence`
-— `def by_key(c, f): groupby(c, f)` at two types, the same program as above — from 0.56s to
-0.94s. `tests/compilation_pipeline` is flat, its time being execution rather than inference.
+#### Binder slots — filled during the coalesce walk (no lexical scope needed)
 
-What is absent is a **result memo**. `CompactState` carries `in_process`, which prunes cycles
-and caches nothing — it is removed again as each variable's walk returns — so a position
-reached twice is compacted twice. A `(uid, pol)` key would not be a correct memo: a position's
-reading also depends on `subst_acc` and on the refinement scope `st.scope` holds, so two
-entries at one variable and polarity are not interchangeable. Hash consing the rendered
-contribution keys on what was produced instead, and sidesteps that.
-
-**Asking the other question.** Because the collapse answers "what must this position be", a caller that needs "what actually reached it" has to suppress the collapse — `compact_type_polarity_only`, the polarity-correct walk alone. The distinction is not academic: an upper bound deposited on a never-inhabited position (the trait-requirement sweep does exactly this) makes the ordinary resolve report a type. [The unobservable-arm pin](#an-unobservable-arm-payload-is-pinned-to-what-its-uses-require) is the caller that must not confuse the two, since a demand is precisely what an unreachable arm can acquire.
-
-**Binder slots — filled during the coalesce walk (no lexical scope needed).** A `Var` use needs *no*
-scope lookup: it shares its binder's inference variable — a monomorphic `let` binds verbatim
-(`instantiate` freshens nothing) so every use coalesces to exactly what the binder coalesces to, and
-a *generalized* `let`'s uses are rewritten by the walk itself to reference per-type specializations
-(which does carry a scope — the walk's stack of specialization frames and shadow markers; see §3.1).
+A `Var` use needs *no* scope lookup: it shares its binder's inference variable — a monomorphic
+`let` binds verbatim (`instantiate` freshens nothing) so every use coalesces to exactly what the
+binder coalesces to, and a *generalized* `let`'s uses are rewritten by the walk itself to
+reference per-type specializations (which does carry a scope — the walk's stack of specialization
+frames and shadow markers; see §3.1).
 
 What the bottom-up `expr.ty` resolution *doesn't* reach is the **binder slots**: a binder carries a type that is not any node's `expr.ty` — a `Lambda`'s `param.ty`, a `Let`'s `binding.ty`, a `Case` pattern's `binding.ty`, a `For`'s target slot. Each is resolved explicitly in `coalesce_node`, mirroring its definition (inference runs before the mutability/transaction phases, so the recurrence carriers `LetRec`/`Transact` never reach coalesce):
 

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -1349,7 +1349,7 @@ fn compact_type_with(ty: &Type, collapse: bool) -> CompactGraph {
         collapse,
         scope: RefinementScope::default(),
     };
-    let term = compact_go(ty, true, &Subst::id(), None, &mut st);
+    let term = compact_go(ty, true, &Subst::id(), None, false, &mut st);
     debug_assert!(
         refinement_slot_present(&term) && st.rec_vars.values().all(refinement_slot_present),
         "a position carrying content must carry a refinement slot: only a hole and a \
@@ -1622,11 +1622,11 @@ fn compact_type_kind(
         TypeKind::Enumerated(domains) => CompactTypeKind::Enumerated(
             domains
                 .iter()
-                .map(|d| compact_go(d, pol, subst_acc, None, st))
+                .map(|d| compact_go(d, pol, subst_acc, None, false, st))
                 .collect(),
         ),
         TypeKind::SubtypesOf(k) => {
-            CompactTypeKind::SubtypesOf(Box::new(compact_go(k, pol, subst_acc, None, st)))
+            CompactTypeKind::SubtypesOf(Box::new(compact_go(k, pol, subst_acc, None, false, st)))
         }
         TypeKind::UIntRanges => CompactTypeKind::UIntRanges,
         TypeKind::Type => CompactTypeKind::Type,
@@ -1756,11 +1756,18 @@ fn fun_kind_correspondence(fun_kind: &crate::ccl::ty::FunKind, acc: &Subst) -> S
 /// polarity flips — has to be mirrored there in the same change. A divergence is
 /// silent, and what it produces is a shared clone whose interior was resolved
 /// against a different use's argument.
+///
+/// `invariant` says the walk is inside a **data function's domain**, where variance
+/// does not distinguish the two sides. It propagates exactly where `parents` does —
+/// along a variable's bound chain and through a refinement's base, reset at every
+/// other structural child — because it answers a question about the position, and a
+/// structural child is a new one.
 fn compact_go(
     ty: &Type,
     pol: bool,
     subst_acc: &Subst,
     parents: Option<&ParentPath<'_>>,
+    invariant: bool,
     st: &mut CompactState,
 ) -> CompactType {
     match ty {
@@ -1803,7 +1810,7 @@ fn compact_go(
         // The predicate is an immutable term, so a non-vacuous force builds a
         // fresh predicate from the (freshened) bound's content directly.
         Type::Refinement(inner, refinements) => {
-            let mut ct = compact_go(inner, pol, subst_acc, parents, st);
+            let mut ct = compact_go(inner, pol, subst_acc, parents, invariant, st);
             for r in refinements {
                 let r = subst_acc.force_refinement(r);
                 // References to the walk's enclosing binders become indices
@@ -1832,7 +1839,7 @@ fn compact_go(
             // per child mirrors Scala's `Set.empty` argument — cycles
             // span only one variable's bound chain, not across
             // function boundaries.
-            let dom = compact_go(d, !pol, subst_acc, None, st);
+            let dom = compact_go(d, !pol, subst_acc, None, fun_kind.resolved().is_data(), st);
             // A Pi binder shadows the accumulated substitution inside the
             // codomain (it binds the name locally), so restrict it there.
             let cod_acc = match name {
@@ -1842,7 +1849,7 @@ fn compact_go(
             // Entering the codomain crosses this function — named or not, it
             // deepens what a refinement landing below closes against.
             st.scope.enter(name.clone());
-            let cod = compact_go(c, pol, &cod_acc, None, st);
+            let cod = compact_go(c, pol, &cod_acc, None, false, st);
             st.scope.exit();
             debug_assert!(
                 name.as_ref()
@@ -1934,7 +1941,10 @@ fn compact_go(
         Type::Tuple(ts) => {
             let mut compacted = BTreeMap::new();
             for (i, v) in ts.iter().enumerate() {
-                compacted.insert(FieldKey::Index(i), compact_go(v, pol, subst_acc, None, st));
+                compacted.insert(
+                    FieldKey::Index(i),
+                    compact_go(v, pol, subst_acc, None, false, st),
+                );
             }
             CompactType {
                 rec: Some(compacted),
@@ -1946,7 +1956,7 @@ fn compact_go(
             for (n, v) in fs {
                 compacted.insert(
                     FieldKey::Name(SmolStr::from(n.as_str())),
-                    compact_go(v, pol, subst_acc, None, st),
+                    compact_go(v, pol, subst_acc, None, false, st),
                 );
             }
             CompactType {
@@ -1961,7 +1971,7 @@ fn compact_go(
             // payload depth is unaffected.
             let mut compacted = BTreeMap::new();
             for (k, v) in tags {
-                compacted.insert(k.clone(), compact_go(v, pol, subst_acc, None, st));
+                compacted.insert(k.clone(), compact_go(v, pol, subst_acc, None, false, st));
             }
             CompactType {
                 var: Some(CompactVariant {
@@ -1981,8 +1991,8 @@ fn compact_go(
             domain,
             history_kind,
         } => {
-            let value = compact_go(value, pol, subst_acc, None, st);
-            let domain = compact_go(domain, pol, subst_acc, None, st);
+            let value = compact_go(value, pol, subst_acc, None, false, st);
+            let domain = compact_go(domain, pol, subst_acc, None, false, st);
             CompactType {
                 history_slot: Some((Box::new(value), Box::new(domain), *history_kind)),
                 ..CompactType::value()
@@ -2090,7 +2100,7 @@ fn compact_go(
                 // arrives with every edge's morphism composed (design §3.6).
                 // Identity edges leave `subst_acc` unchanged (the common case).
                 let inner_acc = Subst::then(&b.render_subst(), subst_acc);
-                let bc = compact_go(&b.ty, pol, &inner_acc, Some(&new_parents), st);
+                let bc = compact_go(&b.ty, pol, &inner_acc, Some(&new_parents), invariant, st);
                 bound = CompactType::merge(pol, bound, bc);
             }
             // Whether the *shape* collapse fires: the primary walk produced no
@@ -2141,12 +2151,23 @@ fn compact_go(
             // records what the uses demand, the value side what actually arrives (see
             // `src/ccl/design/type-inference.md`, "The collapse happens at the
             // position").
-            let read_opposite = allow_fallback && (no_concrete || !pol);
+            //
+            // **Inside an invariant position it reads both sides however the walk
+            // arrived**, where elsewhere it reads them only at a position. A data
+            // domain reached along a bound chain is the same domain as one entered
+            // structurally, and invariance leaves no variance to tell the two readings
+            // apart — so gating this one on `allow_fallback` gives one variable two
+            // answers at one polarity, which the invariance check then rejects against
+            // itself (`src/ccl/design/type-inference.md`, "An invariant position reads
+            // both sides however the walk reached it"). `allow_fallback` still gates
+            // the shape collapse, which is a choice rather than a narrowing.
+            let read_opposite =
+                (allow_fallback && no_concrete) || (!pol && (allow_fallback || invariant));
             let mut recovered: Option<CompactType> = None;
             if read_opposite {
                 for b in opposite_bounds.iter() {
                     let inner_acc = Subst::then(&b.render_subst(), subst_acc);
-                    let bc = compact_go(&b.ty, !pol, &inner_acc, Some(&new_parents), st);
+                    let bc = compact_go(&b.ty, !pol, &inner_acc, Some(&new_parents), invariant, st);
                     recovered = Some(match recovered {
                         None => bc,
                         Some(acc) => CompactType::merge(!pol, acc, bc),

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -2196,23 +2196,31 @@ fn compact_go(
                     && history_slot.is_none()
                     && !var_is_shape
             };
-            // A negative position reads the opposite side whether or not the shape
-            // needed recovering, because both sides narrow it: the requirement side
-            // records what the uses demand, the value side what actually arrives (see
-            // `src/ccl/design/type-inference.md`, "The collapse happens at the
-            // position").
+            // The two rules that read the opposite side, and they are not the same rule.
             //
-            // **Inside an invariant position it reads both sides however the walk
-            // arrived**, where elsewhere it reads them only at a position. A data
-            // domain reached along a bound chain is the same domain as one entered
+            // The **shape collapse** is a choice, so it fires only at the position the
+            // walk entered, and only where the polarity-correct walk found no shape for
+            // it to overwrite.
+            //
+            // The **merge** is a narrowing: both sides narrow a negative position — the
+            // requirement side records what the uses demand, the value side what
+            // actually arrives — so it fires there whether or not the shape needed
+            // recovering (`src/ccl/design/type-inference.md`, "The collapse happens at
+            // the position"). Inside an invariant position it fires however the walk
+            // arrived, where elsewhere it fires only at a position: a data domain
+            // reached along a bound chain is the same domain as one entered
             // structurally, and invariance leaves no variance to tell the two readings
-            // apart — so gating this one on `allow_fallback` gives one variable two
-            // answers at one polarity, which the invariance check then rejects against
-            // itself (`src/ccl/design/type-inference.md`, "An invariant position reads
-            // both sides however the walk reached it"). `allow_fallback` still gates
-            // the shape collapse, which is a choice rather than a narrowing.
-            let read_opposite =
-                (allow_fallback && no_concrete) || (!pol && (allow_fallback || pos.invariant));
+            // apart, so gating this one on `allow_fallback` gives one variable two
+            // answers at one polarity and the invariance check rejects the position
+            // against itself (`src/ccl/design/type-inference.md`, "An invariant position
+            // reads both sides however the walk reached it").
+            //
+            // Both stay under `st.collapse`, which suppresses the opposite side
+            // walk-wide for [`compact_type_polarity_only`] — a caller whose question is
+            // what reached the position, for which a demand is not an answer.
+            let collapse = allow_fallback && no_concrete;
+            let merge = !pol && (allow_fallback || (st.collapse && pos.invariant));
+            let read_opposite = collapse || merge;
             let mut recovered: Option<CompactType> = None;
             if read_opposite {
                 for b in opposite_bounds.iter() {

--- a/src/ccl/infer/solver/compact.rs
+++ b/src/ccl/infer/solver/compact.rs
@@ -1317,8 +1317,8 @@ pub struct CompactGraph {
 /// Walk a `Type`, transitively expanding variable bounds at the
 /// appropriate polarity, and produce a CompactType.
 ///
-/// The `parents` set tracks variables whose bounds we are currently
-/// walking, so that spurious cycles (`?a <: ?b` and `?b <: ?a`) — which
+/// The walk's [`Position`] tracks the variables whose bounds it is currently
+/// following, so that spurious cycles (`?a <: ?b` and `?b <: ?a`) — which
 /// don't represent real recursive types — get pruned.
 pub fn compact_type(ty: &Type) -> CompactGraph {
     compact_type_with(ty, true)
@@ -1349,7 +1349,7 @@ fn compact_type_with(ty: &Type, collapse: bool) -> CompactGraph {
         collapse,
         scope: RefinementScope::default(),
     };
-    let term = compact_go(ty, true, &Subst::id(), None, false, &mut st);
+    let term = compact_go(ty, true, &Subst::id(), Position::default(), &mut st);
     debug_assert!(
         refinement_slot_present(&term) && st.rec_vars.values().all(refinement_slot_present),
         "a position carrying content must carry a refinement slot: only a hole and a \
@@ -1433,6 +1433,46 @@ impl ParentPath<'_> {
     }
 }
 
+/// Where the walk stands relative to the position it entered.
+///
+/// The two fields say which position the walk is reading and how, and every step moves
+/// them together. Bundling them makes that hold by construction: a structural child takes
+/// `Position::default()`, a step along a variable's bound chain takes
+/// [`Position::under`], and a function's domain takes [`Position::domain_of`]. Nothing
+/// else constructs one, so no call site can reset half of a position.
+#[derive(Clone, Copy, Default)]
+struct Position<'a> {
+    /// The variables whose bounds the walk is currently following, deepest first.
+    /// `None` is the position itself; `Some` is one reached along a chain.
+    parents: Option<&'a ParentPath<'a>>,
+    /// Whether this position is a **data function's domain**, where variance does not
+    /// distinguish the two sides ([`crate::ccl::ty::FunKind::Data`]).
+    invariant: bool,
+}
+
+impl<'a> Position<'a> {
+    /// A function's domain, invariant when the function is a data function. A kind
+    /// variable that compaction has not narrowed resolves to `Unpinned`, which is not
+    /// data, so an undecided kind's domain is read like a compute one — the same
+    /// reading `Display` gives it (`⇒`).
+    fn domain_of(fun_kind: &crate::ccl::ty::FunKind) -> Self {
+        Position {
+            parents: None,
+            invariant: fun_kind.resolved().is_data(),
+        }
+    }
+
+    /// One step along a variable's bound chain: the same position, reached through
+    /// `path`. Whether it is a data domain rides along, because the chain has not left
+    /// the position.
+    fn under<'b>(self, path: &'b ParentPath<'b>) -> Position<'b> {
+        Position {
+            parents: Some(path),
+            invariant: self.invariant,
+        }
+    }
+}
+
 /// Whether any refinement in this position's own set references `binder` by *name*.
 ///
 /// The negation is the compaction boundary's form of **landing closes**: a refinement
@@ -1481,14 +1521,14 @@ fn refinements_name_binder(ct: &CompactType, binder: &Name) -> bool {
 /// and the join sitting there comes back as the domain's demand. See
 /// `design/type-inference.md`, "The collapse happens at the position".
 ///
-/// A structural boundary starts a new position, which is why [`compact_go`] resets
-/// `parents` to `None` at every structural child.
-fn fallback_allowed(parents: Option<&ParentPath<'_>>, st: &CompactState) -> bool {
-    st.collapse && parents.is_none()
+/// A structural boundary starts a new position, which is why [`compact_go`] passes
+/// `Position::default()` at every structural child.
+fn fallback_allowed(pos: Position<'_>, st: &CompactState) -> bool {
+    st.collapse && pos.parents.is_none()
 }
 
 /// Walk-wide state threaded through [`compact_go`]: the cycle-tracking tables.
-/// (`parents` stays a per-path argument — it is scoped to one variable's bound
+/// ([`Position`] stays a per-path argument — it is scoped to one variable's bound
 /// chain and reset across structural boundaries — and the substitution
 /// accumulator composes per edge.)
 struct CompactState {
@@ -1622,12 +1662,16 @@ fn compact_type_kind(
         TypeKind::Enumerated(domains) => CompactTypeKind::Enumerated(
             domains
                 .iter()
-                .map(|d| compact_go(d, pol, subst_acc, None, false, st))
+                .map(|d| compact_go(d, pol, subst_acc, Position::default(), st))
                 .collect(),
         ),
-        TypeKind::SubtypesOf(k) => {
-            CompactTypeKind::SubtypesOf(Box::new(compact_go(k, pol, subst_acc, None, false, st)))
-        }
+        TypeKind::SubtypesOf(k) => CompactTypeKind::SubtypesOf(Box::new(compact_go(
+            k,
+            pol,
+            subst_acc,
+            Position::default(),
+            st,
+        ))),
         TypeKind::UIntRanges => CompactTypeKind::UIntRanges,
         TypeKind::Type => CompactTypeKind::Type,
     }
@@ -1757,17 +1801,17 @@ fn fun_kind_correspondence(fun_kind: &crate::ccl::ty::FunKind, acc: &Subst) -> S
 /// silent, and what it produces is a shared clone whose interior was resolved
 /// against a different use's argument.
 ///
-/// `invariant` says the walk is inside a **data function's domain**, where variance
-/// does not distinguish the two sides. It propagates exactly where `parents` does —
-/// along a variable's bound chain and through a refinement's base, reset at every
-/// other structural child — because it answers a question about the position, and a
-/// structural child is a new one.
+/// `pos` says where the walk stands relative to the position it entered — the bound
+/// chain it is following, and whether that position is a data function's domain, where
+/// variance does not distinguish the two sides ([`Position`]). Both halves are set at a
+/// function's domain from its kind, propagate along a variable's bound chain and through
+/// a refinement's base, and reset at every other structural child, because they answer a
+/// question about the position and a structural child is a new one.
 fn compact_go(
     ty: &Type,
     pol: bool,
     subst_acc: &Subst,
-    parents: Option<&ParentPath<'_>>,
-    invariant: bool,
+    pos: Position<'_>,
     st: &mut CompactState,
 ) -> CompactType {
     match ty {
@@ -1810,7 +1854,7 @@ fn compact_go(
         // The predicate is an immutable term, so a non-vacuous force builds a
         // fresh predicate from the (freshened) bound's content directly.
         Type::Refinement(inner, refinements) => {
-            let mut ct = compact_go(inner, pol, subst_acc, parents, invariant, st);
+            let mut ct = compact_go(inner, pol, subst_acc, pos, st);
             for r in refinements {
                 let r = subst_acc.force_refinement(r);
                 // References to the walk's enclosing binders become indices
@@ -1835,11 +1879,11 @@ fn compact_go(
             // arm's occurrences arrive already spelled in this function's binders.
             let owned_acc = fun_kind_correspondence(fun_kind, subst_acc);
             let subst_acc = &owned_acc;
-            // Function: domain is contravariant. A fresh `parents` set
-            // per child mirrors Scala's `Set.empty` argument — cycles
-            // span only one variable's bound chain, not across
-            // function boundaries.
-            let dom = compact_go(d, !pol, subst_acc, None, fun_kind.resolved().is_data(), st);
+            // Function: domain is contravariant, and each child is a new
+            // position — which for the parent path mirrors Scala's `Set.empty`
+            // argument, cycles spanning only one variable's bound chain and not
+            // crossing a function boundary.
+            let dom = compact_go(d, !pol, subst_acc, Position::domain_of(fun_kind), st);
             // A Pi binder shadows the accumulated substitution inside the
             // codomain (it binds the name locally), so restrict it there.
             let cod_acc = match name {
@@ -1849,7 +1893,7 @@ fn compact_go(
             // Entering the codomain crosses this function — named or not, it
             // deepens what a refinement landing below closes against.
             st.scope.enter(name.clone());
-            let cod = compact_go(c, pol, &cod_acc, None, false, st);
+            let cod = compact_go(c, pol, &cod_acc, Position::default(), st);
             st.scope.exit();
             debug_assert!(
                 name.as_ref()
@@ -1943,7 +1987,7 @@ fn compact_go(
             for (i, v) in ts.iter().enumerate() {
                 compacted.insert(
                     FieldKey::Index(i),
-                    compact_go(v, pol, subst_acc, None, false, st),
+                    compact_go(v, pol, subst_acc, Position::default(), st),
                 );
             }
             CompactType {
@@ -1956,7 +2000,7 @@ fn compact_go(
             for (n, v) in fs {
                 compacted.insert(
                     FieldKey::Name(SmolStr::from(n.as_str())),
-                    compact_go(v, pol, subst_acc, None, false, st),
+                    compact_go(v, pol, subst_acc, Position::default(), st),
                 );
             }
             CompactType {
@@ -1971,7 +2015,10 @@ fn compact_go(
             // payload depth is unaffected.
             let mut compacted = BTreeMap::new();
             for (k, v) in tags {
-                compacted.insert(k.clone(), compact_go(v, pol, subst_acc, None, false, st));
+                compacted.insert(
+                    k.clone(),
+                    compact_go(v, pol, subst_acc, Position::default(), st),
+                );
             }
             CompactType {
                 var: Some(CompactVariant {
@@ -1984,15 +2031,15 @@ fn compact_go(
         // A history's children compact at the same polarity as the reference —
         // invariant in both (enforced at constraint time, so this is
         // materialization only; see the `CompactType::history_slot` docs).
-        // Fresh `parents` per child. The `kind` (overwrite vs
+        // A new position per child. The `kind` (overwrite vs
         // feed) rides along so coalesce rebuilds the same flavour.
         Type::History {
             value,
             domain,
             history_kind,
         } => {
-            let value = compact_go(value, pol, subst_acc, None, false, st);
-            let domain = compact_go(domain, pol, subst_acc, None, false, st);
+            let value = compact_go(value, pol, subst_acc, Position::default(), st);
+            let domain = compact_go(domain, pol, subst_acc, Position::default(), st);
             CompactType {
                 history_slot: Some((Box::new(value), Box::new(domain), *history_kind)),
                 ..CompactType::value()
@@ -2002,7 +2049,7 @@ fn compact_go(
             let uid = state.uid;
             let key = (uid, pol);
             if st.in_process.contains(&key) {
-                if parents.is_some_and(|p| p.contains(uid)) {
+                if pos.parents.is_some_and(|p| p.contains(uid)) {
                     // Spurious cycle (a <: b and b <: a with no
                     // structural intermediary). Drop the bound.
                     return CompactType::empty();
@@ -2091,8 +2138,11 @@ fn compact_go(
             // Whether this variable is the *position* being materialized, which is
             // the only place the opposite-polarity collapse below may happen
             // ([`fallback_allowed`]).
-            let allow_fallback = fallback_allowed(parents, st);
-            let new_parents = ParentPath { uid, prev: parents };
+            let allow_fallback = fallback_allowed(pos, st);
+            let new_parents = ParentPath {
+                uid,
+                prev: pos.parents,
+            };
             let mut bound = CompactType::from_var(uid);
             for b in primary_bounds.iter() {
                 // Compose this edge's morphisms onto the accumulator before
@@ -2100,7 +2150,7 @@ fn compact_go(
                 // arrives with every edge's morphism composed (design §3.6).
                 // Identity edges leave `subst_acc` unchanged (the common case).
                 let inner_acc = Subst::then(&b.render_subst(), subst_acc);
-                let bc = compact_go(&b.ty, pol, &inner_acc, Some(&new_parents), invariant, st);
+                let bc = compact_go(&b.ty, pol, &inner_acc, pos.under(&new_parents), st);
                 bound = CompactType::merge(pol, bound, bc);
             }
             // Whether the *shape* collapse fires: the primary walk produced no
@@ -2162,12 +2212,12 @@ fn compact_go(
             // both sides however the walk reached it"). `allow_fallback` still gates
             // the shape collapse, which is a choice rather than a narrowing.
             let read_opposite =
-                (allow_fallback && no_concrete) || (!pol && (allow_fallback || invariant));
+                (allow_fallback && no_concrete) || (!pol && (allow_fallback || pos.invariant));
             let mut recovered: Option<CompactType> = None;
             if read_opposite {
                 for b in opposite_bounds.iter() {
                     let inner_acc = Subst::then(&b.render_subst(), subst_acc);
-                    let bc = compact_go(&b.ty, !pol, &inner_acc, Some(&new_parents), invariant, st);
+                    let bc = compact_go(&b.ty, !pol, &inner_acc, pos.under(&new_parents), st);
                     recovered = Some(match recovered {
                         None => bc,
                         Some(acc) => CompactType::merge(!pol, acc, bc),

--- a/tests/compilation_pipeline/transactions.rs
+++ b/tests/compilation_pipeline/transactions.rs
@@ -3115,57 +3115,60 @@ fn a_keyed_write_reaches_an_induction_store() {
     );
 }
 
-/// A mutable `Map` seeded with a **one-entry** literal, which does not compile.
+/// A mutable `Map` seeded with a **one-entry** literal, at each of its three uses.
 ///
 /// The seed's key type is that key's own singleton, so its present-key domain is
-/// `{String | __elem == "a", __elem ▷ (… ▷ collection_contains)}`. Meeting both sides at a
-/// negative position settles the re-keying shape — both binders of `lower_rekeyed` read the
-/// singleton — and `box`'s instantiated domain still reads the bare
-/// `{String | __elem ▷ (… ▷ collection_contains)}`, which a data domain's invariance rejects.
+/// `{String | __elem == "a", __elem ▷ (… ▷ collection_contains)}`, and that domain reaches
+/// `box`'s shared candidate variable through a bound chain rather than as a position. A
+/// data domain is invariant, so the position has to read the same way however the walk
+/// arrived — which is what firing the merge inside an invariant position gives it
+/// (`src/ccl/design/type-inference.md`, "An invariant position reads both sides however the
+/// walk reached it").
 ///
-/// **The key variable resolves two ways at one polarity, decided by how the walk reached
-/// it.** Entered as a position it reads the meet (the singleton); reached through another
-/// variable's bound chain — which is how `box`'s type reaches it — it reads the demand side
-/// alone. `fallback_allowed` gates both the shape collapse and the meet, and only the
-/// collapse needs it: a collapse is a choice, which must not propagate along subtyping
-/// edges, while the meet is a narrowing, which may.
-///
-/// Ungating the meet closes all three shapes below and is not the fix as it stands. It costs
-/// `def by_key(c, f): groupby(c, f)` applied at two types 1.4s → 10s. And where a discharge
-/// is suspended on the chain it meets two data domains whose refinement sets differ only in
-/// the discharged binder's spelling — `{[0, 2] | x == 0}` against `{[0, 2] | x == __arg}`.
-/// `data_domains_disagree` compares those sets structurally, so one domain reached twice
-/// reads as two that disagree, which
-/// `higher_order_dependent_application_discharges_the_binder` reports as conflicting
-/// domains.
-///
-/// Pinned on the failure rather than deferred: it reports the day a base closes the gap,
-/// which an `#[ignore]` could not. The sibling below seeds **two** entries for this reason.
-#[rstest]
-#[timeout(Duration::from_secs(30))]
-// Read alone, with no write at all: the seed's own type is enough.
-#[case(indoc! {r#"
-    m: Mut(Map(String, Int)) := box(map([("a", 1)]))
-    sum(m)
-"#})]
-// A keyed write per loop position, over an induction domain.
-#[case(indoc! {r#"
-    m: Mut(Map(String, Int)) := box(map([("a", 1)]))
-    for k in ["b", "c"]:
-        m[k] := 9
-    m
-"#})]
-// The same write inside a transaction.
-#[case(indoc! {r#"
-    m: Mut(Map(String, Int), Txn) := box(map([("a", 1)]))
-    for r in [1, 2]:
-        with begin():
-            m["c"] := 3
-    await_final(m)
-"#})]
-#[should_panic(expected = "produced an invalid tree: [Type mismatch for collection domain")]
-fn a_one_entry_seed_does_not_reach_a_mutable_map(#[case] code: &str) {
-    run_pipeline(code);
+/// Two entries would state none of this: their key type is the join `String`, carrying no
+/// refinement for the two readings to differ over. That is why the sibling below seeds two.
+#[test]
+fn a_one_entry_seed_reads_as_a_map() {
+    check_scalar(
+        indoc! {r#"
+            m: Mut(Map(String, Int)) := box(map([("a", 1)]))
+            sum(m)
+        "#},
+        Value::Int(1),
+    );
+}
+
+#[test]
+fn a_one_entry_seed_reaches_a_keyed_write() {
+    let value = final_mut_var_value(indoc! {r#"
+        m: Mut(Map(String, Int)) := box(map([("a", 1)]))
+        for k in ["b", "c"]:
+            m[k] := 9
+        m
+    "#});
+    assert_eq!(
+        map_entries(&value),
+        vec![
+            ("a".to_string(), 1),
+            ("b".to_string(), 9),
+            ("c".to_string(), 9),
+        ]
+    );
+}
+
+#[test]
+fn a_one_entry_seed_reaches_a_transactional_keyed_write() {
+    let value = final_mut_var_value(indoc! {r#"
+        m: Mut(Map(String, Int), Txn) := box(map([("a", 1)]))
+        for r in [1, 2]:
+            with begin():
+                m["c"] := 3
+        await_final(m)
+    "#});
+    assert_eq!(
+        map_entries(&value),
+        vec![("a".to_string(), 1), ("c".to_string(), 3)]
+    );
 }
 
 /// A keyed write through a `Mut` **parameter**: `fw(m, x)` writes one key of the caller's

--- a/tests/compilation_pipeline/type_annotations.rs
+++ b/tests/compilation_pipeline/type_annotations.rs
@@ -718,3 +718,30 @@ fn a_record_equality_in_a_refinement_predicate_has_no_instance() {
         "No Equatable instance for BinOp",
     )
 }
+
+/// A refinement in a `Map` key type that no key satisfies. The plain annotation reports it,
+/// and the `Mut` form reaches a pass boundary instead.
+///
+/// Neither program is well-typed today: a literal key carries `__elem == "a"`, and a
+/// refinement is discharged by matching the predicate rather than by proving it, so
+/// `__elem != ""` is not satisfied. What differs is the report. The plain
+/// annotation is an `Annotation mismatch` against the whole `Σ`, which names the
+/// annotation the program wrote; the mutable one panics at the post-inference boundary as
+/// an invalid tree, which reads as a compiler bug for a program that is simply rejected.
+///
+/// Pinned on both, so the day the `Mut` form reports a user error the pin says so.
+#[test]
+fn a_refined_map_key_no_key_satisfies() {
+    check_compile_error(
+        "m: Map({String where _ != \"\"}, Int) = map([(\"a\", 1), (\"z\", 2)])\nm\n",
+        "Annotation mismatch: annotated as \u{3a3} (\u{3c3} : SubtypesOf({String | __elem != \"\"}))",
+    )
+}
+
+#[test]
+fn a_refined_map_key_in_a_mut_annotation_reaches_the_boundary() {
+    check_compile_error(
+        "m: Mut(Map({String where _ != \"\"}, Int)) := box(map([(\"a\", 1), (\"z\", 2)]))\nm\n",
+        "produced an invalid tree: [Type mismatch for collection domain",
+    )
+}

--- a/tests/compilation_pipeline/type_annotations.rs
+++ b/tests/compilation_pipeline/type_annotations.rs
@@ -733,15 +733,21 @@ fn a_record_equality_in_a_refinement_predicate_has_no_instance() {
 #[test]
 fn a_refined_map_key_no_key_satisfies() {
     check_compile_error(
-        "m: Map({String where _ != \"\"}, Int) = map([(\"a\", 1), (\"z\", 2)])\nm\n",
-        "Annotation mismatch: annotated as \u{3a3} (\u{3c3} : SubtypesOf({String | __elem != \"\"}))",
+        r#"
+m: Map({String where _ != ""}, Int) = map([("a", 1), ("z", 2)])
+m
+"#,
+        r#"Annotation mismatch: annotated as Σ (σ : SubtypesOf({String | __elem != ""}))"#,
     )
 }
 
 #[test]
 fn a_refined_map_key_in_a_mut_annotation_reaches_the_boundary() {
     check_compile_error(
-        "m: Mut(Map({String where _ != \"\"}, Int)) := box(map([(\"a\", 1), (\"z\", 2)]))\nm\n",
+        r#"
+m: Mut(Map({String where _ != ""}, Int)) := box(map([("a", 1), ("z", 2)]))
+m
+"#,
         "produced an invalid tree: [Type mismatch for collection domain",
     )
 }


### PR DESCRIPTION
A mutable `Map` seeded with a one-entry literal did not compile, in any of its three uses — read alone, a keyed write per loop position, and the same write in a transaction. The seed's key type is that key's own singleton, and `box`'s scheme shares one variable between its domain and the sum's single candidate, so the key domain reaches that variable along a bound chain. Meeting both sides was gated on `fallback_allowed`, which the shape collapse needs and a narrowing does not, so the variable read the singleton where the walk entered it structurally and the bare present-key domain where it arrived along the chain — and a data domain's invariance rejected the position against itself. `compact_go` now carries whether the walk is inside a data function's domain, propagated where `parents` is, and the merge fires throughout an invariant position.

Scoped to an invariant position rather than ungated, for two measured reasons. Reading the opposite side at every negative variable doubles the walk per level of type nesting — `def by_key(c, f): groupby(c, f)` applied at two types goes from 1.4s to 10s, where this costs 1.5s. And it reaches a function-typed parameter, a compute domain, where a suspended discharge puts two data domains together whose refinement sets differ only in the discharged binder's spelling; `data_domains_disagree` compares those structurally, so one domain reached twice reads as two that disagree. Both are recorded beside the rule in [type-inference.md](src/ccl/design/type-inference.md#an-invariant-position-reads-both-sides-however-the-walk-reached-it).

The second commit is unrelated to the solver. `docs/chl-spec.md` said refinements "are not parsed yet, so every use is a parse error today" and that refinement annotations are "not writable"; both are stale — `output_annotation_ref1` has been running `def itsa_nine(a) => {Int where _ == 9}: 9` since it landed. It also pins the two ways a `Map` key type no key satisfies is reported: the plain annotation names what the program wrote, while the `Mut` form panics at the post-inference boundary for a program that is merely ill-typed.